### PR TITLE
登録のみ可能なタスクモデルとmigrationを作成

### DIFF
--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -1,0 +1,7 @@
+class Task < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 255 }
+
+  def self.create_task(name, description = nil)
+    create(name: name, description: description)
+  end
+end

--- a/training/db/migrate/20171130104904_create_tasks.rb
+++ b/training/db/migrate/20171130104904_create_tasks.rb
@@ -1,0 +1,10 @@
+class CreateTasks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :tasks do |t|
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -1,0 +1,22 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20171130104904) do
+
+  create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
### 対応課題
ステップ6: タスクモデルを作成しましょう

### 実装内容

`タスクを管理するためのCRUDを作成します。 まずは名前と詳細だけが登録できるシンプルな構成で作りましょう。`

と言う内容に従い `name` と `description` のみを持つ`Task`テーブルと
登録を行う為に必要なメソッドの実装、及びバリデーションの設定を行いました。

### 補足
テストの作成については`ステップ8: テスト（feature spec）を書こう`でRSpecの
セットアップを行うので、その際に合わせて作成する形にしようかと考えております。
