### PR TITLE
i18nによる日本語部分の共通化

### DIFF
--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -18,7 +18,7 @@ class TasksController < ApplicationController
   def create
     @task = Task.new(task_params)
     if @task.save
-      redirect_to @task, notice: I18n.t("tasks.controller.messages.created")
+      redirect_to @task, notice: I18n.t('tasks.controller.messages.created')
     else
       render :new
     end
@@ -27,7 +27,7 @@ class TasksController < ApplicationController
   def update
     @task = Task.find(params[:id])
     if @task.update_attributes(task_params)
-      redirect_to @task, notice: I18n.t("tasks.controller.messages.updated")
+      redirect_to @task, notice: I18n.t('tasks.controller.messages.updated')
     else
       render :edit
     end
@@ -35,7 +35,7 @@ class TasksController < ApplicationController
 
   def destroy
     Task.find(params[:id]).destroy!
-    redirect_to tasks_path, notice: I18n.t("tasks.controller.messages.deleted")
+    redirect_to tasks_path, notice: I18n.t('tasks.controller.messages.deleted')
   end
 
   private

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -18,7 +18,7 @@ class TasksController < ApplicationController
   def create
     @task = Task.new(task_params)
     if @task.save
-      redirect_to @task, notice: '作成しました'
+      redirect_to @task, notice: I18n.t("tasks.model.messages.created")
     else
       render :new
     end
@@ -27,7 +27,7 @@ class TasksController < ApplicationController
   def update
     @task = Task.find(params[:id])
     if @task.update_attributes(task_params)
-      redirect_to @task, notice: '更新しました'
+      redirect_to @task, notice: I18n.t("tasks.model.messages.updated")
     else
       render :edit
     end
@@ -35,7 +35,7 @@ class TasksController < ApplicationController
 
   def destroy
     Task.find(params[:id]).destroy!
-    redirect_to tasks_path, notice: '削除しました'
+    redirect_to tasks_path, notice: I18n.t("tasks.model.messages.deleted")
   end
 
   private

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -18,7 +18,7 @@ class TasksController < ApplicationController
   def create
     @task = Task.new(task_params)
     if @task.save
-      redirect_to @task, notice: I18n.t("tasks.model.messages.created")
+      redirect_to @task, notice: I18n.t("tasks.controller.messages.created")
     else
       render :new
     end
@@ -27,7 +27,7 @@ class TasksController < ApplicationController
   def update
     @task = Task.find(params[:id])
     if @task.update_attributes(task_params)
-      redirect_to @task, notice: I18n.t("tasks.model.messages.updated")
+      redirect_to @task, notice: I18n.t("tasks.controller.messages.updated")
     else
       render :edit
     end
@@ -35,7 +35,7 @@ class TasksController < ApplicationController
 
   def destroy
     Task.find(params[:id]).destroy!
-    redirect_to tasks_path, notice: I18n.t("tasks.model.messages.deleted")
+    redirect_to tasks_path, notice: I18n.t("tasks.controller.messages.deleted")
   end
 
   private

--- a/training/app/views/tasks/_task_form.html.erb
+++ b/training/app/views/tasks/_task_form.html.erb
@@ -19,8 +19,8 @@
   <br/>
 
   <% if request.path_info == new_task_path %>
-    <%= f.submit '作成', data: { disable_with: '作成中...'} %>
+    <%= f.submit I18n.t('tasks.view.partial.create'), data: { disable_with: I18n.t('tasks.view.partial.creating')} %>
   <% else %>
-    <%= f.submit '更新', data: { disable_with: '更新中...'} %>
+    <%= f.submit I18n.t('tasks.view.partial.update'), data: { disable_with: I18n.t('tasks.view.partial.updating')} %>
   <% end %>
 <% end %>

--- a/training/app/views/tasks/edit.html.erb
+++ b/training/app/views/tasks/edit.html.erb
@@ -1,9 +1,9 @@
 <div>
-  <h1>タスク編集</h1>
+  <h1><%= I18n.t('tasks.view.edit.title') %></h1>
 </div>
 
 <%= render partial: 'task_form' %>
 
 <div>
-  <%= link_to('一覧', tasks_path) %> / <%= link_to('詳細', task_path(@task)) %>
+  <%= link_to(I18n.t('tasks.view.edit.index_page'), tasks_path) %> / <%= link_to(I18n.t('tasks.view.edit.show_page'), task_path(@task)) %>
 </div>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <h1><%= I18n.t('tasks.view.index.title') %> </h1>
+  <h1><%= I18n.t('tasks.view.index.title') %></h1>
 </div>
 <div>
   <%= link_to(I18n.t('tasks.view.index.new_task'), new_task_path) %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -2,7 +2,7 @@
   <h1>タスク一覧</h1>
 </div>
 <div>
-  <%= link_to('タスクの作成', new_task_path) %>
+  <%= link_to(I18n.t('tasks.view.index.title'), new_task_path) %>
 </div>
 <div>
   <% @tasks.each do |task| %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -1,13 +1,13 @@
 <div>
-  <h1>タスク一覧</h1>
+  <h1><%= I18n.t('tasks.view.index.title') %> </h1>
 </div>
 <div>
-  <%= link_to(I18n.t('tasks.view.index.title'), new_task_path) %>
+  <%= link_to(I18n.t('tasks.view.index.new_task'), new_task_path) %>
 </div>
 <div>
   <% @tasks.each do |task| %>
     <h4><%= link_to(task.name, task_path(task)) %></h4>
-    <p>説明：<%= task.description %></p>
+    <p><%= I18n.t('tasks.view.index.description') %> : <%= task.description %></p>
     <hr />
   <% end %>
 </div>

--- a/training/app/views/tasks/new.html.erb
+++ b/training/app/views/tasks/new.html.erb
@@ -1,9 +1,9 @@
 <div>
-  <h1>タスク作成</h1>
+  <h1><%= I18n.t('tasks.view.new.title') %></h1>
 </div>
 
 <%= render partial: 'task_form' %>
 
 <div>
-  <%= link_to('一覧', tasks_path) %>
+  <%= link_to(I18n.t('tasks.view.new.index_page'), tasks_path) %>
 </div>

--- a/training/app/views/tasks/show.html.erb
+++ b/training/app/views/tasks/show.html.erb
@@ -1,10 +1,11 @@
 <div>
-  <h1>タスク詳細</h1>
+  <h1><%= I18n.t('tasks.view.show.title') %></h1>
 </div>
 <div>
   <h4><%= @task.name %></h4>
-  <p>説明：<%= @task.description %></p>
+  <p><%= I18n.t('tasks.view.show.description') %> : <%= @task.description %></p>
 </div>
 <div>
-  <%= link_to('一覧', tasks_path) %> / <%= link_to('編集', edit_task_path(@task)) %> / <%= link_to('削除', task_path(@task), method: :delete, data: { confirm: '削除しますか？' } ) %>
+  <%= link_to(I18n.t('tasks.view.show.index_page'), tasks_path) %> / <%= link_to(I18n.t('tasks.view.show.edit_page'), edit_task_path(@task)) %> / 
+  <%= link_to(I18n.t('tasks.view.show.delete'), task_path(@task), method: :delete, data: { confirm: I18n.t('tasks.view.show.delete_confirm') } ) %>
 </div>

--- a/training/config/application.rb
+++ b/training/config/application.rb
@@ -25,5 +25,7 @@ module Training
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -1,0 +1,205 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      short: "%y/%m/%d %H:%M"
+    pm: 午後

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
   tasks:
     view:
       index:
+        title: タスクの作成
       new:
       edit:
       show:

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -7,6 +7,10 @@ ja:
       edit:
       show:
       partial:
+        create: 作成
+        creating: 作成中
+        update: 更新
+        updating: 更新中
     controller:
       messages:
         created: 作成しました

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -1,5 +1,17 @@
 ---
 ja:
+  tasks:
+    view:
+      index:
+      new:
+      edit:
+      show:
+      partial:
+    model:
+      messages:
+        created: 作成しました
+        updated: 更新しました
+        deleted: 削除しました
   attributes:
     name: 名前
     description: 説明

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -7,8 +7,19 @@ ja:
         new_task: タスクの作成
         description: 説明
       new:
+        title: タスク作成
+        index_page: 一覧
       edit:
+        title: タスク編集
+        index_page: 一覧
+        show_page: 詳細
       show:
+        title: タスク詳細
+        description: 説明
+        index_page: 一覧
+        edit_page: 編集
+        delete: 削除
+        delete_confirm: 削除しますか？
       partial:
         create: 作成
         creating: 作成中

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -3,7 +3,9 @@ ja:
   tasks:
     view:
       index:
-        title: タスクの作成
+        title: タスク一覧
+        new_task: タスクの作成
+        description: 説明
       new:
       edit:
       show:

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -7,7 +7,7 @@ ja:
       edit:
       show:
       partial:
-    model:
+    controller:
       messages:
         created: 作成しました
         updated: 更新しました

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -1,5 +1,8 @@
 ---
 ja:
+  attributes:
+    name: 名前
+    description: 説明
   activerecord:
     errors:
       messages:

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Task', type: :feature do
 
     context 'タスクの作成をクリックしたとき' do
       it 'タスク作成ページに遷移する' do
-        click_on 'タスクの作成'
+        click_on I18n.t('tasks.view.index.new_task')
         expect(current_path).to eq new_task_path
       end
     end
@@ -32,9 +32,9 @@ RSpec.describe 'Task', type: :feature do
     context 'タスク情報を入力して作成する' do
       before do
         visit new_task_path
-        fill_in I18n.t("attributes.name"), with: 'hoge'
-        fill_in I18n.t("attributes.description"), with: 'fuga'
-        click_on '作成'
+        fill_in I18n.t('attributes.name'), with: 'hoge'
+        fill_in I18n.t('attributes.description'), with: 'fuga'
+        click_on I18n.t('tasks.view.partial.create')
       end
 
       it 'タスク詳細ページに遷移する' do
@@ -44,7 +44,7 @@ RSpec.describe 'Task', type: :feature do
       end
 
       it '作成しました　とメッセージが表示される' do
-        expect(page).to have_content '作成しました'
+        expect(page).to have_content I18n.t('tasks.controller.messages.created')
       end
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe 'Task', type: :feature do
       let(:update_name) { 'abcde' }
       before do
         fill_in I18n.t("attributes.name"), with: update_name
-        click_on '更新'
+        click_on I18n.t('tasks.view.partial.update')
       end
 
       it '詳細ページに遷移する' do
@@ -67,7 +67,7 @@ RSpec.describe 'Task', type: :feature do
       end
 
       it '更新しました　とメッセージが表示される' do
-        expect(page).to have_content '更新しました'
+        expect(page).to have_content I18n.t('tasks.controller.messages.updated')
       end
     end
   end
@@ -78,7 +78,7 @@ RSpec.describe 'Task', type: :feature do
     end
 
     context '一覧ボタンをクリックしたとき' do
-      before { click_on '一覧' }
+      before { click_on I18n.t('tasks.view.show.index_page') }
 
       it '一覧ページに遷移する' do
         expect(current_path).to eq tasks_path
@@ -86,7 +86,7 @@ RSpec.describe 'Task', type: :feature do
     end
 
     context '編集ボタンをクリックしたとき' do
-      before { click_on '編集' }
+      before { click_on I18n.t('tasks.view.show.edit_page') }
 
       it '編集ページに遷移する' do
         expect(current_path).to eq edit_task_path(task.id)
@@ -94,13 +94,13 @@ RSpec.describe 'Task', type: :feature do
     end
 
     context '削除ボタンをクリックしたとき' do
-      before { click_on '削除' }
+      before { click_on I18n.t('tasks.view.show.delete') }
 
       it '一覧ページに遷移する' do
         expect(current_path).to eq tasks_path
       end
       it '削除しました　とメッセージが表示される' do
-        expect(page).to have_content '削除しました'
+        expect(page).to have_content I18n.t('tasks.controller.messages.deleted')
       end
     end
   end

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe 'Task', type: :feature do
     context 'タスク情報を入力して作成する' do
       before do
         visit new_task_path
-        fill_in 'Name', with: 'hoge'
-        fill_in 'Description', with: 'fuga'
+        fill_in I18n.t("attributes.name"), with: 'hoge'
+        fill_in I18n.t("attributes.description"), with: 'fuga'
         click_on '作成'
       end
 
@@ -57,7 +57,7 @@ RSpec.describe 'Task', type: :feature do
     context 'タスク情報を入力して更新する' do
       let(:update_name) { 'abcde' }
       before do
-        fill_in 'Name', with: update_name
+        fill_in I18n.t("attributes.name"), with: update_name
         click_on '更新'
       end
 

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Task', type: :feature do
       end
 
       it '作成しました　とメッセージが表示される' do
-        expect(page).to have_content I18n.t("tasks.controller.messages.created")
+        expect(page).to have_content '作成しました'
       end
     end
   end
@@ -67,7 +67,7 @@ RSpec.describe 'Task', type: :feature do
       end
 
       it '更新しました　とメッセージが表示される' do
-        expect(page).to have_content I18n.t("tasks.controller.messages.updated")
+        expect(page).to have_content '更新しました'
       end
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe 'Task', type: :feature do
         expect(current_path).to eq tasks_path
       end
       it '削除しました　とメッセージが表示される' do
-        expect(page).to have_content I18n.t("tasks.controller.messages.deleted")
+        expect(page).to have_content '削除しました'
       end
     end
   end

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Task', type: :feature do
       end
 
       it '作成しました　とメッセージが表示される' do
-        expect(page).to have_content '作成しました'
+        expect(page).to have_content I18n.t("tasks.model.messages.created")
       end
     end
   end
@@ -67,7 +67,7 @@ RSpec.describe 'Task', type: :feature do
       end
 
       it '更新しました　とメッセージが表示される' do
-        expect(page).to have_content '更新しました'
+        expect(page).to have_content I18n.t("tasks.model.messages.updated")
       end
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe 'Task', type: :feature do
         expect(current_path).to eq tasks_path
       end
       it '削除しました　とメッセージが表示される' do
-        expect(page).to have_content '削除しました'
+        expect(page).to have_content I18n.t("tasks.model.messages.deleted")
       end
     end
   end

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Task', type: :feature do
       end
 
       it '作成しました　とメッセージが表示される' do
-        expect(page).to have_content I18n.t("tasks.model.messages.created")
+        expect(page).to have_content I18n.t("tasks.controller.messages.created")
       end
     end
   end
@@ -67,7 +67,7 @@ RSpec.describe 'Task', type: :feature do
       end
 
       it '更新しました　とメッセージが表示される' do
-        expect(page).to have_content I18n.t("tasks.model.messages.updated")
+        expect(page).to have_content I18n.t("tasks.controller.messages.updated")
       end
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe 'Task', type: :feature do
         expect(current_path).to eq tasks_path
       end
       it '削除しました　とメッセージが表示される' do
-        expect(page).to have_content I18n.t("tasks.model.messages.deleted")
+        expect(page).to have_content I18n.t("tasks.controller.messages.deleted")
       end
     end
   end


### PR DESCRIPTION
### 対応課題
ステップ9: Railsのi18nを使ってアプリの日本語部分を共通化しましょう

### 実装内容

今まで作成したアプリケーションの内部で日本語を利用している部分をi18n化しました

主な変更点
 - i18nの設定と必要ファイル(ja.yml)を導入
 - バリデーションメッセージやカラム名のi18n化
 - 各viewのi18n化
 - feature specのi18n化

### 補足
