### PR TITLE
タイムゾーンを日本に設定

### DIFF
--- a/training/config/application.rb
+++ b/training/config/application.rb
@@ -27,5 +27,6 @@ module Training
     # -- all .rb files in that directory are automatically loaded.
 
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
### 対応課題
ステップ10 : Railsのタイムゾーンを設定しましょう

### 実装内容

課題に従ってタイムゾーン（日本）を設定しました

主な変更点
 - config/application.rbにタイムゾーンを設定

### 補足
動作確認済み