### PR TITLE
タスク一覧を作成日時でソートする

### DIFF
--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @tasks = Task.order({id: :desc})
   end
 
   def show

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.order({id: :desc})
+    @tasks = Task.order({created_at: :desc})
   end
 
   def show

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe 'Task', type: :feature do
       expect(page).to have_content task.description
     end
 
+    context '複数のタスクが登録されているとき' do
+      let!(:task_new) { FactoryBot.create(:task, name: 'test_new') }
+
+      it 'id降順ソートで表示される' do
+        visit current_path
+        expect(all('h4')[0]).to have_link task_new.name, href: task_path(task_new.id)
+        expect(all('h4')[1]).to have_link task.name, href: task_path(task.id)
+      end
+    end
+
     context 'タスクの作成をクリックしたとき' do
       it 'タスク作成ページに遷移する' do
         click_on I18n.t('tasks.view.index.new_task')

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -14,12 +14,14 @@ RSpec.describe 'Task', type: :feature do
     end
 
     context '複数のタスクが登録されているとき' do
-      let!(:task_new) { FactoryBot.create(:task, name: 'test_new') }
+      # 処理速度の関係で後から作ってもtaskと同じ作成日時になるので意図的に1秒後を指定する
+      let!(:task_new) { FactoryBot.create(:task, name: 'test_new', created_at: Time.now + 1.second) }
 
-      it 'id降順ソートで表示される' do
+      it '作成日時の降順ソートで表示される' do
         visit current_path
-        expect(all('h4')[0]).to have_link task_new.name, href: task_path(task_new.id)
-        expect(all('h4')[1]).to have_link task.name, href: task_path(task.id)
+        expect(task_new.created_at.time > task.created_at.time).to be true
+        expect(all('h4')[0]).to have_content task_new.name
+        expect(all('h4')[1]).to have_content task.name
       end
     end
 


### PR DESCRIPTION
### 対応課題
ステップ11 : タスク一覧を作成日時の順番で並び替えましょう

### 実装内容

`現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう`
の内容に従ってタスク一覧を開いた際に作成日時の降順で並べて表示する様にしました。

`並び替えがうまく行っていることをfeature specで書いてみましょう`
同様にfeature specも追記しました

主な変更点
 - feature specに並び順のテストを追記
 - indexアクションに作成日時の降順を指定

### 補足