### PR TITLE
終了期限を追加して一覧にソートを実装する

### DIFF
--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,10 +1,12 @@
 class TasksController < ApplicationController
   def index
-    Rails.logger.error(params)
-    if params[:end_date] == 'asc' || params[:end_date] == 'desc' 
-      @tasks = Task.order("end_date #{params[:end_date]}")
-    else
-      @tasks = Task.order({created_at: :desc})
+    case params[:end_date]
+      when 'asc'
+        @tasks = Task.order(end_date: :asc)
+      when 'desc' 
+        @tasks = Task.order(end_date: :desc)
+      else
+        @tasks = Task.order({created_at: :desc})
     end
   end
 

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   def index
     Rails.logger.error(params)
-    if params[:end_date].present?
+    if params[:end_date] == 'asc' || params[:end_date] == 'desc' 
       @tasks = Task.order("end_date #{params[:end_date]}")
     else
       @tasks = Task.order({created_at: :desc})

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,12 +1,10 @@
 class TasksController < ApplicationController
   def index
-    case params[:end_date]
-      when 'asc'
-        @tasks = Task.order(end_date: :asc)
-      when 'desc' 
-        @tasks = Task.order(end_date: :desc)
-      else
-        @tasks = Task.order({created_at: :desc})
+    @tasks = if params[:end_date].present?
+      order_option = params[:end_date] == 'asc' ? :asc : :desc
+      Task.order(end_date: order_option)
+    else
+      Task.order(created_at: :desc)
     end
   end
 

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,6 +1,11 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.order({created_at: :desc})
+    Rails.logger.error(params)
+    if params[:end_date].present?
+      @tasks = Task.order("end_date #{params[:end_date]}")
+    else
+      @tasks = Task.order({created_at: :desc})
+    end
   end
 
   def show

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -9,8 +9,9 @@ class Task < ApplicationRecord
   private
 
   def end_date_valid
-    # ActiveRecordによって強制的にcastされる値('abc'など)は入力として正しく無いのでエラーにする
-    unless end_date_before_type_cast.to_s == end_date.to_s
+    # ActiveRecordによって強制的にcastされる値('abc'など)はnilになるので
+    # end_date_before_type_castが存在してend_dateがnullなら不正な値として除外する
+    if end_date_before_type_cast.present? && end_date.blank?
       errors.add(:end_date, I18n.t('errors.messages.end_date.invalid'))
       return false
     end

--- a/training/app/views/tasks/_task_form.html.erb
+++ b/training/app/views/tasks/_task_form.html.erb
@@ -18,6 +18,9 @@
   <%= f.text_area :description %>
   <br/>
 
+  <%= f.label :end_date %>
+  <%= f.date_select :end_date %>
+  <br/>
 
   <% if request.path_info == new_task_path %>
     <%= f.submit I18n.t('tasks.view.partial.create'), data: { disable_with: I18n.t('tasks.view.partial.creating')} %>

--- a/training/app/views/tasks/_task_form.html.erb
+++ b/training/app/views/tasks/_task_form.html.erb
@@ -18,12 +18,15 @@
   <%= f.text_area :description %>
   <br/>
 
+  <%= f.label :end_date %>
+  <%= f.date_select :end_date %>
+  <br/>
+
   <% #DB制約を実装した関係で値が必要なのでダミー値をセット　-> 今後の機能実装に合わせて解放する %>
   <%= f.hidden_field :user_id, value: 0 %>
   <%= f.hidden_field :priority, value: 0 %>
   <%= f.hidden_field :status, value: 0 %>
   <%= f.hidden_field :label_id, value: 0 %>
-  <%= f.hidden_field :end_date, value: Time.now %>
 
   <% if request.path_info == new_task_path %>
     <%= f.submit I18n.t('tasks.view.partial.create'), data: { disable_with: I18n.t('tasks.view.partial.creating')} %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -3,6 +3,12 @@
 </div>
 <div>
   <%= link_to(I18n.t('tasks.view.index.new_task'), new_task_path) %>
+  <hr />
+</div>
+<div>
+  <h3><%= I18n.t('tasks.view.index.sort') %></h3>
+  <%= I18n.t('tasks.view.index.end_date') %>　: <%= link_to( '▲', tasks_path(end_date: 'asc')) %>　<%= link_to( '▼', tasks_path(end_date: 'desc')) %>
+  <hr />
 </div>
 <div>
   <% @tasks.each do |task| %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -14,6 +14,7 @@
   <% @tasks.each do |task| %>
     <h4><%= link_to(task.name, task_path(task)) %></h4>
     <p><%= I18n.t('tasks.view.index.description') %> : <%= task.description %></p>
+    <p><%= I18n.t('tasks.view.index.end_date') %> : <%= task.end_date %></p>
     <hr />
   <% end %>
 </div>

--- a/training/app/views/tasks/show.html.erb
+++ b/training/app/views/tasks/show.html.erb
@@ -4,6 +4,7 @@
 <div>
   <h4><%= @task.name %></h4>
   <p><%= I18n.t('tasks.view.show.description') %> : <%= @task.description %></p>
+  <p><%= I18n.t('tasks.view.show.end_date') %> : <%= @task.end_date %></p>
 </div>
 <div>
   <%= link_to(I18n.t('tasks.view.show.index_page'), tasks_path) %> / <%= link_to(I18n.t('tasks.view.show.edit_page'), edit_task_path(@task)) %> / 

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -4,8 +4,10 @@ ja:
     view:
       index:
         title: タスク一覧
+        sort: ソート
         new_task: タスクの作成
         description: 説明
+        end_date: 終了期限
       new:
         title: タスク作成
         index_page: 一覧

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -16,6 +16,7 @@ ja:
       show:
         title: タスク詳細
         description: 説明
+        end_date: 終了期限
         index_page: 一覧
         edit_page: 編集
         delete: 削除

--- a/training/spec/controllers/tasks_controller_spec.rb
+++ b/training/spec/controllers/tasks_controller_spec.rb
@@ -2,15 +2,43 @@ require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
   describe 'GET #index' do
-    let!(:task) { FactoryBot.create(:task) }
-    it '@tasks にタスク情報を持っている' do
-      get :index
-      expect(assigns(:tasks)[0]).to eq task
+    context 'ソートしない場合' do
+      let!(:task) { FactoryBot.create(:task) }
+
+      it '@tasks にタスク情報を持っている' do
+        get :index
+        expect(assigns(:tasks)[0]).to eq task
+      end
+
+      it 'index テンプレートを表示する' do
+        get :index
+        expect(response).to render_template :index
+      end
     end
 
-    it 'index テンプレートを表示する' do
-      get :index
-      expect(response).to render_template :index
+    context '終了期限でソートをする場合' do
+      let!(:task_1) { FactoryBot.create(:task, end_date: '2017-01-01') }
+      let!(:task_2) { FactoryBot.create(:task, end_date: '2017-01-02') }
+
+      context '昇順の場合' do
+        let(:params) { {end_date: 'asc'} }
+
+        it '@tasks にソートされた情報を持っている' do
+          get :index, params: params
+          expect(assigns(:tasks)[0]).to eq task_1
+          expect(assigns(:tasks)[1]).to eq task_2
+        end
+      end
+
+      context '降順の場合' do
+        let(:params) { {end_date: 'desc'} }
+
+        it '@tasks にソートされた情報を持っている' do
+          get :index, params: params
+          expect(assigns(:tasks)[0]).to eq task_2
+          expect(assigns(:tasks)[1]).to eq task_1
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### 対応課題
ステップ13 :  終了期限を追加しよう

### 実装内容
 - `タスクに対して、終了期限を登録できるようにしてみましょう`
項目を追加し、新規/編集でも内容を入力できる様にしました。
詳細画面にも表示される様になっています

![2017-12-12 11 08 34](https://user-images.githubusercontent.com/26861647/33863798-e53746f2-df2c-11e7-86b4-e27d22b927a5.png)
![2017-12-04 15 47 45](https://user-images.githubusercontent.com/26861647/33863807-f31c3674-df2c-11e7-90f0-f0ce54ac8003.png)

 - `一覧画面で、終了期限でソートできるようにしましょう`
一覧画面にソート用のボタン（▼▲）を設置し終了期限でソートする様にしました
![2017-12-12 11 08 50](https://user-images.githubusercontent.com/26861647/33863810-f7fb418a-df2c-11e7-8ce3-ee7f8ba1417a.png)

 - `specを拡充しましょう`
終了期限ソートをした場合の挙動をコントローラーのテストに追記しました

### 補足
