### PR TITLE
ステータスを追加する

### DIFF
--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :convert_params_to_int, only: [:create , :update]
+  before_action :convert_params_to_int, only: %i(create update)
 
   def index
     @name = params[:name]

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -60,8 +60,6 @@ class TasksController < ApplicationController
 
   def convert_params_to_int
     return false if params[:task].nil?
-    params[:task][:status] = Integer(params[:task][:status]) if params[:task][:status].present?
-  rescue ArgumentError
-    return false
+    params[:task][:status] = params[:task][:status].to_i
   end
 end

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :convert_params_to_enum
+  before_action :convert_params_to_int
 
   def index
     @name = params[:name]
@@ -58,7 +58,7 @@ class TasksController < ApplicationController
     )
   end
 
-  def convert_params_to_enum
+  def convert_params_to_int
     return false if params[:task].nil?
     params[:task][:status] = Integer(params[:task][:status]) if params[:task][:status].present?
   rescue ArgumentError

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :convert_params_to_int
+  before_action :convert_params_to_int, only: [:create , :update]
 
   def index
     @name = params[:name]

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   def index
     Rails.logger.error(params)
-    if params[:end_date].present?
+    if params[:end_date] == 'asc' || params[:end_date] == 'desc' 
       @tasks = Task.order("end_date #{params[:end_date]}")
     else
       @tasks = Task.order({created_at: :desc})

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,4 +1,6 @@
 class TasksController < ApplicationController
+  before_action :convert_params_to_enum
+
   def index
     Rails.logger.error(params)
     if params[:end_date] == 'asc' || params[:end_date] == 'desc' 
@@ -55,5 +57,12 @@ class TasksController < ApplicationController
       :label_id,
       :end_date,
     )
+  end
+
+  def convert_params_to_enum
+    return false if params[:task].nil?
+    params[:task][:status] = Integer(params[:task][:status]) if params[:task][:status].present?
+  rescue ArgumentError
+    return false
   end
 end

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,6 +1,11 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.order({created_at: :desc})
+    Rails.logger.error(params)
+    if params[:end_date].present?
+      @tasks = Task.order("end_date #{params[:end_date]}")
+    else
+      @tasks = Task.order({created_at: :desc})
+    end
   end
 
   def show

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -9,8 +9,9 @@ class Task < ApplicationRecord
   private
 
   def end_date_valid
-    # ActiveRecordによって強制的にcastされる値('abc'など)は入力として正しく無いのでエラーにする
-    unless end_date_before_type_cast.to_s == end_date.to_s
+    # ActiveRecordによって強制的にcastされる値('abc'など)はnilになるので
+    # end_date_before_type_castが存在してend_dateがnullなら不正な値として除外する
+    if end_date_before_type_cast.present? && end_date.blank?
       errors.add(:end_date, I18n.t('errors.messages.end_date.invalid'))
       return false
     end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -11,7 +11,7 @@ class Task < ApplicationRecord
   def end_date_valid
     # ActiveRecordによって強制的にcastされる値('abc'など)は入力として正しく無いのでエラーにする
     unless end_date_before_type_cast.to_s == end_date.to_s
-      errors.add(:end_date, ": 入力された日付が正しくありません")
+      errors.add(:end_date, I18n.t('errors.messages.end_date.invalid'))
       return false
     end
 
@@ -19,8 +19,7 @@ class Task < ApplicationRecord
     Rails.logger.error(end_date)
     Rails.logger.error(date_valid?(end_date).class)
     unless date_valid?(end_date)
-      # Todo i18n化する
-      errors.add(:end_date, ": 入力された日付は存在しません")
+      errors.add(:end_date, I18n.t('errors.messages.end_date.not_exist'))
       return false
     end
   end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -6,7 +6,7 @@ class Task < ApplicationRecord
   validate :end_date_valid?
 
   enum status: { not_started: 0, underway: 1, done: 2 }
-  validates :status, presence: true, inclusion: {in: Task.statuses.keys}
+  validates :status, presence: true, inclusion: { in: Task.statuses.keys }
 
   before_validation :set_dummy_value
 

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -16,8 +16,6 @@ class Task < ApplicationRecord
     end
 
     return true if end_date.blank? || end_date.instance_of?(Date)
-    Rails.logger.error(end_date)
-    Rails.logger.error(date_valid?(end_date).class)
     unless date_valid?(end_date)
       errors.add(:end_date, I18n.t('errors.messages.end_date.not_exist'))
       return false

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -38,7 +38,6 @@ class Task < ApplicationRecord
     if Rails.env == "development"
       self.user_id = 0
       self.priority = 0
-      self.status = 0
     end
   end
 end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -11,19 +11,19 @@ class Task < ApplicationRecord
   before_validation :set_dummy_value
 
   def self.search(params)
-    result = Task
-    result = result.where('status = ?', params[:status]) if params[:status].present?
-    result = result.where('name = ?', params[:name]) if params[:name].present?
-
     # memo : 初回読み込み時にorderがnilでinclude?が実行できないので先にpresent?で確認
     #      : 現状ではend_dateのみなのでinclude?使わなくても判定できるが
     #      : 次のstepで優先順位検索を実装する時の為にあえてinclude?を利用（step15実装時にこのメモを消す）
     result = if params[:order].present? && params[:order].include?('end_date')
                order_option = params[:order] == 'end_date_asc' ? :asc : :desc
-               result.order(end_date: order_option)
+               self.order(end_date: order_option)
              else
-               result.order(created_at: :desc)
+               self.order(created_at: :desc)
              end
+
+    result = result.where('status = ?', params[:status]) if params[:status].present?
+    result = result.where('name = ?', params[:name]) if params[:name].present?
+    result
   end
 
   private

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -1,10 +1,12 @@
 class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :user_id, presence: true, numericality: { greater_than_or_equal_to: 0 }
-  validates :priority, presence: true, numericality: { greater_than_or_equal_to: 0 }
-  validates :status, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :priority, presence: true, numericality: { greater_than_or_equal_to: 0 }  
   validates :label_id, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
   validate :end_date_valid?
+
+  enum status: { not_started: 0, underway: 1, done: 2 }
+  validates :status, presence: true, inclusion: {in: Task.statuses.keys}
 
   before_validation :set_dummy_value
 

--- a/training/app/views/tasks/_task_form.html.erb
+++ b/training/app/views/tasks/_task_form.html.erb
@@ -18,6 +18,10 @@
   <%= f.text_area :description %>
   <br/>
 
+  <%= f.label :status %>
+  <%= f.select :status, Task.statuses.map { |k, v| [I18n.t("tasks.model.status.#{k}"), v] }, selected: @task.status_before_type_cast %>
+  <br/>
+
   <%= f.label :end_date %>
   <%= f.date_select :end_date %>
   <br/>

--- a/training/app/views/tasks/_task_form.html.erb
+++ b/training/app/views/tasks/_task_form.html.erb
@@ -18,6 +18,9 @@
   <%= f.text_area :description %>
   <br/>
 
+  <%= f.label :end_date %>
+  <%= f.date_select :end_date %>
+  <br/>
 
   <% if request.path_info == new_task_path %>
     <%= f.submit I18n.t('tasks.view.partial.create'), data: { disable_with: I18n.t('tasks.view.partial.creating')} %>

--- a/training/app/views/tasks/_task_form.html.erb
+++ b/training/app/views/tasks/_task_form.html.erb
@@ -18,12 +18,15 @@
   <%= f.text_area :description %>
   <br/>
 
+  <%= f.label :end_date %>
+  <%= f.date_select :end_date %>
+  <br/>
+
   <% #DB制約を実装した関係で値が必要なのでダミー値をセット　-> 今後の機能実装に合わせて解放する %>
   <%= f.hidden_field :user_id, value: 0 %>
   <%= f.hidden_field :priority, value: 0 %>
   <%= f.hidden_field :status, value: 0 %>
   <%= f.hidden_field :label_id, value: 0 %>
-  <%= f.hidden_field :end_date, value: Time.now %>
 
   <% if request.path_info == new_task_path %>
     <%= f.submit I18n.t('tasks.view.partial.create'), data: { disable_with: I18n.t('tasks.view.partial.creating')} %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -3,6 +3,12 @@
 </div>
 <div>
   <%= link_to(I18n.t('tasks.view.index.new_task'), new_task_path) %>
+  <hr />
+</div>
+<div>
+  <h3><%= I18n.t('tasks.view.index.sort') %></h3>
+  <%= I18n.t('tasks.view.index.end_date') %>　: <%= link_to( '▲', tasks_path(end_date: 'asc')) %>　<%= link_to( '▼', tasks_path(end_date: 'desc')) %>
+  <hr />
 </div>
 <div>
   <% @tasks.each do |task| %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -14,6 +14,7 @@
   <% @tasks.each do |task| %>
     <h4><%= link_to(task.name, task_path(task)) %></h4>
     <p><%= I18n.t('tasks.view.index.description') %> : <%= task.description %></p>
+    <p><%= I18n.t('tasks.view.index.status') %> : <%= I18n.t("tasks.model.status.#{task.status}") %></p>
     <p><%= I18n.t('tasks.view.index.end_date') %> : <%= task.end_date %></p>
     <hr />
   <% end %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -14,6 +14,7 @@
   <% @tasks.each do |task| %>
     <h4><%= link_to(task.name, task_path(task)) %></h4>
     <p><%= I18n.t('tasks.view.index.description') %> : <%= task.description %></p>
+    <p><%= I18n.t('tasks.view.index.end_date') %> : <%= task.end_date %></p>
     <hr />
   <% end %>
 </div>

--- a/training/app/views/tasks/show.html.erb
+++ b/training/app/views/tasks/show.html.erb
@@ -4,6 +4,7 @@
 <div>
   <h4><%= @task.name %></h4>
   <p><%= I18n.t('tasks.view.show.description') %> : <%= @task.description %></p>
+  <p><%= I18n.t('tasks.view.show.status') %> : <%= I18n.t("tasks.model.status.#{@task.status}") %></p>
   <p><%= I18n.t('tasks.view.show.end_date') %> : <%= @task.end_date %></p>
 </div>
 <div>

--- a/training/app/views/tasks/show.html.erb
+++ b/training/app/views/tasks/show.html.erb
@@ -4,6 +4,7 @@
 <div>
   <h4><%= @task.name %></h4>
   <p><%= I18n.t('tasks.view.show.description') %> : <%= @task.description %></p>
+  <p><%= I18n.t('tasks.view.show.end_date') %> : <%= @task.end_date %></p>
 </div>
 <div>
   <%= link_to(I18n.t('tasks.view.show.index_page'), tasks_path) %> / <%= link_to(I18n.t('tasks.view.show.edit_page'), edit_task_path(@task)) %> / 

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -33,6 +33,11 @@ ja:
   attributes:
     name: 名前
     description: 説明
+    user_id: ユーザー番号
+    priority: 優先順位
+    status: ステータス
+    label_id: ラベル番号
+    end_date: 終了期限
   activerecord:
     errors:
       messages:
@@ -166,6 +171,9 @@ ja:
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
       other_than: は%{count}以外の値にしてください
+      end_date:
+        invalid: に入力された日付が正しくありません
+        not_exist: に入力された日付は存在しません
     template:
       body: 次の項目を確認してください
       header:

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -4,8 +4,10 @@ ja:
     view:
       index:
         title: タスク一覧
+        sort: ソート
         new_task: タスクの作成
         description: 説明
+        end_date: 終了期限
       new:
         title: タスク作成
         index_page: 一覧

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -16,6 +16,7 @@ ja:
       show:
         title: タスク詳細
         description: 説明
+        end_date: 終了期限
         index_page: 一覧
         edit_page: 編集
         delete: 削除

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -1,12 +1,18 @@
 ---
 ja:
   tasks:
+    model:
+      status:
+        not_started: 未着手
+        underway: 着手中
+        done: 完了
     view:
       index:
         title: タスク一覧
         sort: ソート
         new_task: タスクの作成
         description: 説明
+        status: ステータス
         end_date: 終了期限
       new:
         title: タスク作成
@@ -18,6 +24,7 @@ ja:
       show:
         title: タスク詳細
         description: 説明
+        status: ステータス
         end_date: 終了期限
         index_page: 一覧
         edit_page: 編集

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 20171208052520) do
     t.integer "priority", limit: 1, null: false, unsigned: true
     t.integer "status", limit: 1, null: false, unsigned: true
     t.integer "label_id", unsigned: true
-    t.date "end_data"
+    t.date "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/training/spec/controllers/tasks_controller_spec.rb
+++ b/training/spec/controllers/tasks_controller_spec.rb
@@ -2,15 +2,43 @@ require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
   describe 'GET #index' do
-    let!(:task) { FactoryBot.create(:task) }
-    it '@tasks にタスク情報を持っている' do
-      get :index
-      expect(assigns(:tasks)[0]).to eq task
+    context 'ソートしない場合' do
+      let!(:task) { FactoryBot.create(:task) }
+
+      it '@tasks にタスク情報を持っている' do
+        get :index
+        expect(assigns(:tasks)[0]).to eq task
+      end
+
+      it 'index テンプレートを表示する' do
+        get :index
+        expect(response).to render_template :index
+      end
     end
 
-    it 'index テンプレートを表示する' do
-      get :index
-      expect(response).to render_template :index
+    context '終了期限でソートをする場合' do
+      let!(:task_1) { FactoryBot.create(:task, end_date: '2017-01-01') }
+      let!(:task_2) { FactoryBot.create(:task, end_date: '2017-01-02') }
+
+      context '昇順の場合' do
+        let(:params) { {end_date: 'asc'} }
+
+        it '@tasks にソートされた情報を持っている' do
+          get :index, params: params
+          expect(assigns(:tasks)[0]).to eq task_1
+          expect(assigns(:tasks)[1]).to eq task_2
+        end
+      end
+
+      context '降順の場合' do
+        let(:params) { {end_date: 'desc'} }
+
+        it '@tasks にソートされた情報を持っている' do
+          get :index, params: params
+          expect(assigns(:tasks)[0]).to eq task_2
+          expect(assigns(:tasks)[1]).to eq task_1
+        end
+      end
     end
   end
 

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     user_id 0 # ユーザー機能実装時に修正する
     description 'description'
     priority 0
-    status 0
+    status Task.statuses[:not_started]
     label_id 0 # ラベル機能実装時に修正する
     end_date Time.zone.today
   end

--- a/training/spec/models/tasks_spec.rb
+++ b/training/spec/models/tasks_spec.rb
@@ -101,12 +101,12 @@ RSpec.describe Task, type: :model do
 
       context '数値でない場合' do
         let(:status) { 'abc' }
-        it { is_expected.to be false }
+        it { expect { subject }.to raise_error(ArgumentError) }
       end
 
       context '負の数値の場合' do
         let(:status) { -1 }
-        it { is_expected.to be false }
+        it { expect { subject }.to raise_error(ArgumentError) }
       end
     end
 


### PR DESCRIPTION
### 対応課題
ステップ14 :  ステータスを追加して、検索できるようにしよう

今回は分割PRになります
 - ステータス（未着手・着手中・完了）を追加してみよう(本PR)
 - 一覧画面でタイトルとステータスで検索ができるようにしよう（未着手）
 - 検索インデックスを貼りましょう / 検索に対してテストを追加してみよう（未着手）

### 実装内容

 - ステータス（未着手・着手中・完了）を追加してみよう

（編集画面）
![2017-12-12 20 12 58](https://user-images.githubusercontent.com/26861647/33881690-e56f3e4e-df78-11e7-9924-94bd330a64cc.png)

（詳細画面）
![2017-12-12 20 12 51](https://user-images.githubusercontent.com/26861647/33881687-e3d5c1fc-df78-11e7-8035-b3e86b4ae1d3.png)

### 補足
主な変更点
 - training/app/controllers/tasks_controller.rb
フォームから入力した内容はparamsで送られる際に文字列型になり、
enumではエラーになるのでenumで利用できる様に変換する処理を追加
この処理は優先順位の実装などでも利用する予定です

 - training/app/models/task.rb
enumで登録した値を利用してバリデーションを行う様に変更

 - 各種erbファイル
フォームと表示部分を拡張

 - training/spec/models/tasks_spec.rb
enumの挙動に合わせて修正

