### PR TITLE
一覧画面でタイトルとステータスで検索が出来る様にする

### DIFF
--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -4,6 +4,7 @@ class TasksController < ApplicationController
   def index
     @name = params[:name]
     @status = params[:status]
+    @order = params[:order]
 
     @tasks = search(params)
   end
@@ -62,13 +63,15 @@ class TasksController < ApplicationController
     result = result.where('status = ?', params[:status]) if params[:status].present?
     result = result.where('name = ?', params[:name]) if params[:name].present?
 
-    # memo:優先順位検索実装する時にcaseに変更する
-    result = if params[:end_date].present?
-      order_option = params[:end_date] == 'asc' ? :asc : :desc
-      result.order(end_date: order_option)
-    else
-      result.order(created_at: :desc)
-    end
+    # memo : 初回読み込み時にorderがnilでinclude?が実行できないので先にpresent?で確認
+    #      : 現状ではend_dateのみなのでinclude?使わなくても判定できるが
+    #      : 次のstepで優先順位検索を実装する時の為にあえてinclude?を利用（step15実装時にこのメモを消す）
+    result = if params[:order].present? && params[:order].include?('end_date')
+               order_option = params[:order] == 'end_date_asc' ? :asc : :desc
+               result.order(end_date: order_option)
+             else
+               result.order(created_at: :desc)
+             end
   end
 
   def convert_params_to_enum

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -2,11 +2,13 @@ class TasksController < ApplicationController
   before_action :convert_params_to_enum
 
   def index
-    Rails.logger.error(params)
-    if params[:end_date] == 'asc' || params[:end_date] == 'desc' 
-      @tasks = Task.order("end_date #{params[:end_date]}")
-    else
-      @tasks = Task.order({created_at: :desc})
+    case params[:end_date]
+      when 'asc'
+        @tasks = Task.order(end_date: :asc)
+      when 'desc' 
+        @tasks = Task.order(end_date: :desc)
+      else
+        @tasks = Task.order({created_at: :desc})
     end
   end
 

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   before_action :convert_params_to_enum
 
   def index
+
     case params[:end_date]
       when 'asc'
         @tasks = Task.order(end_date: :asc)
@@ -10,6 +11,14 @@ class TasksController < ApplicationController
       else
         @tasks = Task.order({created_at: :desc})
     end
+    if params[:status].present?
+      @tasks = Task.where('status = ?', params[:status])
+    end
+    if params[:name].present?
+      @tasks = Task.where('name = ?', params[:name])
+    end
+    #todo and検索実装する
+    #todo 検索した単語の持ち回し機能
   end
 
   def show

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -6,7 +6,7 @@ class TasksController < ApplicationController
     @status = params[:status]
     @order = params[:order]
 
-    @tasks = search(params)
+    @tasks = Task.search(params)
   end
 
   def show
@@ -56,22 +56,6 @@ class TasksController < ApplicationController
       :label_id,
       :end_date,
     )
-  end
-
-  def search(params)
-    result = Task
-    result = result.where('status = ?', params[:status]) if params[:status].present?
-    result = result.where('name = ?', params[:name]) if params[:name].present?
-
-    # memo : 初回読み込み時にorderがnilでinclude?が実行できないので先にpresent?で確認
-    #      : 現状ではend_dateのみなのでinclude?使わなくても判定できるが
-    #      : 次のstepで優先順位検索を実装する時の為にあえてinclude?を利用（step15実装時にこのメモを消す）
-    result = if params[:order].present? && params[:order].include?('end_date')
-               order_option = params[:order] == 'end_date_asc' ? :asc : :desc
-               result.order(end_date: order_option)
-             else
-               result.order(created_at: :desc)
-             end
   end
 
   def convert_params_to_enum

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -2,23 +2,10 @@ class TasksController < ApplicationController
   before_action :convert_params_to_enum
 
   def index
+    @name = params[:name]
+    @status = params[:status]
 
-    case params[:end_date]
-      when 'asc'
-        @tasks = Task.order(end_date: :asc)
-      when 'desc' 
-        @tasks = Task.order(end_date: :desc)
-      else
-        @tasks = Task.order({created_at: :desc})
-    end
-    if params[:status].present?
-      @tasks = Task.where('status = ?', params[:status])
-    end
-    if params[:name].present?
-      @tasks = Task.where('name = ?', params[:name])
-    end
-    #todo and検索実装する
-    #todo 検索した単語の持ち回し機能
+    @tasks = search(params)
   end
 
   def show
@@ -68,6 +55,20 @@ class TasksController < ApplicationController
       :label_id,
       :end_date,
     )
+  end
+
+  def search(params)
+    result = Task
+    result = result.where('status = ?', params[:status]) if params[:status].present?
+    result = result.where('name = ?', params[:name]) if params[:name].present?
+
+    # memo:優先順位検索実装する時にcaseに変更する
+    result = if params[:end_date].present?
+      order_option = params[:end_date] == 'asc' ? :asc : :desc
+      result.order(end_date: order_option)
+    else
+      result.order(created_at: :desc)
+    end
   end
 
   def convert_params_to_enum

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -10,6 +10,22 @@ class Task < ApplicationRecord
 
   before_validation :set_dummy_value
 
+  def self.search(params)
+    result = Task
+    result = result.where('status = ?', params[:status]) if params[:status].present?
+    result = result.where('name = ?', params[:name]) if params[:name].present?
+
+    # memo : 初回読み込み時にorderがnilでinclude?が実行できないので先にpresent?で確認
+    #      : 現状ではend_dateのみなのでinclude?使わなくても判定できるが
+    #      : 次のstepで優先順位検索を実装する時の為にあえてinclude?を利用（step15実装時にこのメモを消す）
+    result = if params[:order].present? && params[:order].include?('end_date')
+               order_option = params[:order] == 'end_date_asc' ? :asc : :desc
+               result.order(end_date: order_option)
+             else
+               result.order(created_at: :desc)
+             end
+  end
+
   private
 
   def end_date_valid?

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -9,7 +9,7 @@
   <h3><%= I18n.t('tasks.view.index.search') %></h3>
   <%= form_tag({action: :index}, {method: :get}) do %>
     <%= label_tag :status, I18n.t('tasks.view.index.status') %>
-    <%= select_tag :status, options_for_select(Task.statuses.map { |k, v| [I18n.t("tasks.model.status.#{k}"), v] }), include_blank: true %>
+    <%= select_tag :status, options_for_select(Task.statuses.map { |k, v| [I18n.t("tasks.model.status.#{k}"), v] }, selected: @status), include_blank: true %>
     <br/>
     <%= label_tag :name, I18n.t('tasks.view.index.name') %>
     <%= text_field_tag :name, @name %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -6,21 +6,24 @@
   <hr />
 </div>
 <div>
-  <h3><%= I18n.t('tasks.view.index.search') %></h3>
   <%= form_tag({action: :index}, {method: :get}) do %>
+    <h3><%= I18n.t('tasks.view.index.search') %></h3>
     <%= label_tag :status, I18n.t('tasks.view.index.status') %>
     <%= select_tag :status, options_for_select(Task.statuses.map { |k, v| [I18n.t("tasks.model.status.#{k}"), v] }, selected: @status), include_blank: true %>
     <br/>
     <%= label_tag :name, I18n.t('tasks.view.index.name') %>
     <%= text_field_tag :name, @name %>
+    
+    <h3><%= I18n.t('tasks.view.index.sort') %></h3>
+    <%= label_tag :order, I18n.t('tasks.view.index.not_sort') %> : <%= radio_button_tag :order, '', @order.blank? %>
+    <%= I18n.t('tasks.view.index.end_date') %> : 
+    <%= label_tag :order, '▲' %> <%= radio_button_tag :order, 'end_date_asc', @order == 'end_date_asc' %> / 
+    <%= label_tag :order, '▼' %> <%= radio_button_tag :order, 'end_date_desc', @order == 'end_date_desc' %>
+
     <br/>
     <%= submit_tag I18n.t('tasks.view.index.submit') %>
+    <hr/>
   <% end %>
-</div>
-<div>
-  <h3><%= I18n.t('tasks.view.index.sort') %></h3>
-  <%= I18n.t('tasks.view.index.end_date') %>　: <%= link_to( '▲', tasks_path(end_date: 'asc')) %>　<%= link_to( '▼', tasks_path(end_date: 'desc')) %>
-  <hr />
 </div>
 <div>
   <% @tasks.each do |task| %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -6,6 +6,18 @@
   <hr />
 </div>
 <div>
+  <h3><%= I18n.t('tasks.view.index.search') %></h3>
+  <%= form_tag({action: :index}, {method: :get}) do %>
+    <%= label_tag :status, I18n.t('tasks.view.index.status') %>
+    <%= select_tag :status, options_for_select(Task.statuses.map { |k, v| [I18n.t("tasks.model.status.#{k}"), v] }), include_blank: true %>
+    <br/>
+    <%= label_tag :name, I18n.t('tasks.view.index.name') %>
+    <%= text_field_tag :name, @name %>
+    <br/>
+    <%= submit_tag I18n.t('tasks.view.index.submit') %>
+  <% end %>
+</div>
+<div>
   <h3><%= I18n.t('tasks.view.index.sort') %></h3>
   <%= I18n.t('tasks.view.index.end_date') %>　: <%= link_to( '▲', tasks_path(end_date: 'asc')) %>　<%= link_to( '▼', tasks_path(end_date: 'desc')) %>
   <hr />

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
       index:
         title: タスク一覧
         sort: ソート
+        not_sort: 並び替えない
         search: 検索
         submit: 検索する
         new_task: タスクの作成

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -10,7 +10,10 @@ ja:
       index:
         title: タスク一覧
         sort: ソート
+        search: 検索
+        submit: 検索する
         new_task: タスクの作成
+        name: タスク名
         description: 説明
         status: ステータス
         end_date: 終了期限

--- a/training/spec/controllers/tasks_controller_spec.rb
+++ b/training/spec/controllers/tasks_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TasksController, type: :controller do
       let!(:task_2) { FactoryBot.create(:task, end_date: '2017-01-02') }
 
       context '昇順の場合' do
-        let(:params) { {end_date: 'asc'} }
+        let(:params) { {order: 'end_date_asc'} }
 
         it '@tasks にソートされた情報を持っている' do
           get :index, params: params
@@ -31,7 +31,7 @@ RSpec.describe TasksController, type: :controller do
       end
 
       context '降順の場合' do
-        let(:params) { {end_date: 'desc'} }
+        let(:params) { {order: 'end_date_desc'} }
 
         it '@tasks にソートされた情報を持っている' do
           get :index, params: params

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -25,6 +25,38 @@ RSpec.describe 'Task', type: :feature do
       end
     end
 
+    context '検索機能でタスクを絞り込む' do
+      let!(:task_saerch_1) { FactoryBot.create(:task, name: 'hoge', status: 0, end_date: '2010-01-01') }
+      let!(:task_saerch_2) { FactoryBot.create(:task, name: 'fuga', status: 1, end_date: '2010-01-02') }
+
+      context 'ステータス　着手中　で検索したとき' do
+        it '対象のタスクのみが表示される' do
+          select '着手中', from: 'ステータス'
+          click_button '検索する'
+          expect(all('h4')[0]).to have_content task_saerch_2.name
+          expect(all('h4')[1]).to be nil
+        end
+      end
+
+      context 'タスク名 hoge で検索したとき' do
+        it '対象のタスクのみが表示される' do
+          fill_in 'タスク名', with: 'hoge'
+          click_button '検索する'
+          expect(all('h4')[0]).to have_content task_saerch_1.name
+          expect(all('h4')[1]).to be nil
+        end
+      end
+
+      context '終了期限 昇順 でソートしたとき' do
+        it '終了期限の昇順でタスクが表示される' do
+          choose 'order_end_date_asc'
+          click_button '検索する'
+          expect(all('h4')[0]).to have_content task_saerch_1.name
+          expect(all('h4')[1]).to have_content task_saerch_2.name
+        end
+      end
+    end
+
     context 'タスクの作成をクリックしたとき' do
       it 'タスク作成ページに遷移する' do
         click_on I18n.t('tasks.view.index.new_task')

--- a/training/spec/models/tasks_spec.rb
+++ b/training/spec/models/tasks_spec.rb
@@ -173,4 +173,104 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe '#search' do
+    subject { Task.search(params) }
+
+    context '検索ロジック' do
+      context 'ステータス検索' do
+        let!(:task_0) { FactoryBot.create(:task, status: 0, created_at: '2017-01-03') }
+        let!(:task_1) { FactoryBot.create(:task, status: 1, created_at: '2017-01-02') }
+        let!(:task_2) { FactoryBot.create(:task, status: 2, created_at: '2017-01-01') }
+
+        context '指定しない場合' do
+          let(:params) { {} }
+          it '全てのタスクが出力される' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to eq task_1
+            expect(subject[2]).to eq task_2
+          end
+        end
+
+        context '未着手の場合' do
+          let(:params) { { status: 0 } }
+          it '未着手のタスクが絞り込まれる' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to be nil
+            expect(subject[2]).to be nil
+          end
+        end
+
+        context '着手中の場合' do
+          let(:params) { { status: 1 } }
+          it '着手中のタスクが絞り込まれる' do
+            expect(subject[0]).to eq task_1
+            expect(subject[1]).to be nil
+            expect(subject[2]).to be nil
+          end
+        end
+
+        context '完了の場合' do
+          let(:params) { { status: 2 } }
+          it '完了のタスクが絞り込まれる' do
+            expect(subject[0]).to eq task_2
+            expect(subject[1]).to be nil
+            expect(subject[2]).to be nil
+          end
+        end
+      end
+
+      context 'タスク名検索' do
+        let!(:task_0) { FactoryBot.create(:task, name: 'hoge', created_at: '2017-01-02') }
+        let!(:task_1) { FactoryBot.create(:task, name: 'fuga', created_at: '2017-01-01') }
+
+        context '指定しない場合' do
+          let(:params) { {} }
+          it '全てのタスクが出力される' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to eq task_1
+          end
+        end
+
+        context '指定した場合' do
+          let(:params) { { name: 'hoge' } }
+          it '全てのタスクが出力される' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to be nil
+          end
+        end
+      end
+    end
+
+    context 'ソートロジック' do
+      let!(:task_0) { FactoryBot.create(:task, end_date: '2017-02-02', created_at: '2017-01-02') }
+      let!(:task_1) { FactoryBot.create(:task, end_date: '2017-02-01', created_at: '2017-01-01') }
+
+      context '指定しない場合' do
+        let(:params) { {} }
+        it '作成日時の降順ソートになる' do
+          expect(subject[0]).to eq task_0
+          expect(subject[1]).to eq task_1
+        end
+      end
+
+      context '終了期限ソートの場合' do
+        context '昇順' do
+          let(:params) { { order: 'end_date_asc' } }
+          it '終了期限の昇順ソートになる' do
+            expect(subject[0]).to eq task_1
+            expect(subject[1]).to eq task_0
+          end
+        end
+
+        context '降順' do
+          let(:params) { { order: 'end_date_desc' } }
+          it '終了期限の降順ソートになる' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to eq task_1
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### 対応課題
ステップ14 :  ステータスを追加して、検索できるようにしよう

今回は分割PRになります
 - ステータス（未着手・着手中・完了）を追加してみよう(Done!)
 - 一覧画面でタイトルとステータスで検索ができるようにしよう(本PR)
 - 検索インデックスを貼りましょう / 検索に対してテストを追加してみよう（未着手）

### 実装内容

 - 一覧画面でタイトルとステータスで検索ができるようにしよう

----

(一覧画面の検索ボックス)
![2017-12-13 15 19 37](https://user-images.githubusercontent.com/26861647/33924377-2ba1c404-e019-11e7-82da-920309c04dcd.png)

----

(検索した時の画面)
![2017-12-13 15 20 01](https://user-images.githubusercontent.com/26861647/33924380-316ba166-e019-11e7-86d7-ebaf04135fe8.png)

### 補足
主な変更点
 - training/app/controllers/tasks_controller.rb
検索処理の肥大化に伴いsearchメソッドへ処理を切り出しました
新たに追加した検索ロジックの処理と、前回のソート処理を統合しました

 - training/app/views/tasks/index.html.erb
検索画面を実装しました

 - training/spec/controllers/tasks_controller_spec.rb
ソートの指定パラメーターが変更になったので修正しました
（検索ロジックのテストは次PRに纏まります）