### PR TITLE
検索ロジックのテストを追加

### DIFF
--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -25,6 +25,38 @@ RSpec.describe 'Task', type: :feature do
       end
     end
 
+    context '検索機能でタスクを絞り込む' do
+      let!(:task_saerch_1) { FactoryBot.create(:task, name: 'hoge', status: 0, end_date: '2010-01-01') }
+      let!(:task_saerch_2) { FactoryBot.create(:task, name: 'fuga', status: 1, end_date: '2010-01-02') }
+
+      context 'ステータス　着手中　で検索したとき' do
+        it '対象のタスクのみが表示される' do
+          select '着手中', from: 'ステータス'
+          click_button '検索する'
+          expect(all('h4')[0]).to have_content task_saerch_2.name
+          expect(all('h4')[1]).to be nil
+        end
+      end
+
+      context 'タスク名 hoge で検索したとき' do
+        it '対象のタスクのみが表示される' do
+          fill_in 'タスク名', with: 'hoge'
+          click_button '検索する'
+          expect(all('h4')[0]).to have_content task_saerch_1.name
+          expect(all('h4')[1]).to be nil
+        end
+      end
+
+      context '終了期限 昇順 でソートしたとき' do
+        it '終了期限の昇順でタスクが表示される' do
+          choose 'order_end_date_asc'
+          click_button '検索する'
+          expect(all('h4')[0]).to have_content task_saerch_1.name
+          expect(all('h4')[1]).to have_content task_saerch_2.name
+        end
+      end
+    end
+
     context 'タスクの作成をクリックしたとき' do
       it 'タスク作成ページに遷移する' do
         click_on I18n.t('tasks.view.index.new_task')

--- a/training/spec/models/tasks_spec.rb
+++ b/training/spec/models/tasks_spec.rb
@@ -173,4 +173,104 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe '#search' do
+    subject { Task.search(params) }
+
+    context '検索ロジック' do
+      context 'ステータス検索' do
+        let!(:task_0) { FactoryBot.create(:task, status: 0, created_at: '2017-01-03') }
+        let!(:task_1) { FactoryBot.create(:task, status: 1, created_at: '2017-01-02') }
+        let!(:task_2) { FactoryBot.create(:task, status: 2, created_at: '2017-01-01') }
+
+        context '指定しない場合' do
+          let(:params) { {} }
+          it '全てのタスクが出力される' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to eq task_1
+            expect(subject[2]).to eq task_2
+          end
+        end
+
+        context '未着手の場合' do
+          let(:params) { { status: 0 } }
+          it '未着手のタスクが絞り込まれる' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to be nil
+            expect(subject[2]).to be nil
+          end
+        end
+
+        context '着手中の場合' do
+          let(:params) { { status: 1 } }
+          it '着手中のタスクが絞り込まれる' do
+            expect(subject[0]).to eq task_1
+            expect(subject[1]).to be nil
+            expect(subject[2]).to be nil
+          end
+        end
+
+        context '完了の場合' do
+          let(:params) { { status: 2 } }
+          it '完了のタスクが絞り込まれる' do
+            expect(subject[0]).to eq task_2
+            expect(subject[1]).to be nil
+            expect(subject[2]).to be nil
+          end
+        end
+      end
+
+      context 'タスク名検索' do
+        let!(:task_0) { FactoryBot.create(:task, name: 'hoge', created_at: '2017-01-02') }
+        let!(:task_1) { FactoryBot.create(:task, name: 'fuga', created_at: '2017-01-01') }
+
+        context '指定しない場合' do
+          let(:params) { {} }
+          it '全てのタスクが出力される' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to eq task_1
+          end
+        end
+
+        context '指定した場合' do
+          let(:params) { { name: 'hoge' } }
+          it '全てのタスクが出力される' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to be nil
+          end
+        end
+      end
+    end
+
+    context 'ソートロジック' do
+      let!(:task_0) { FactoryBot.create(:task, end_date: '2017-02-02', created_at: '2017-01-02') }
+      let!(:task_1) { FactoryBot.create(:task, end_date: '2017-02-01', created_at: '2017-01-01') }
+
+      context '指定しない場合' do
+        let(:params) { {} }
+        it '作成日時の降順ソートになる' do
+          expect(subject[0]).to eq task_0
+          expect(subject[1]).to eq task_1
+        end
+      end
+
+      context '終了期限ソートの場合' do
+        context '昇順' do
+          let(:params) { { order: 'end_date_asc' } }
+          it '終了期限の昇順ソートになる' do
+            expect(subject[0]).to eq task_1
+            expect(subject[1]).to eq task_0
+          end
+        end
+
+        context '降順' do
+          let(:params) { { order: 'end_date_desc' } }
+          it '終了期限の降順ソートになる' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to eq task_1
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### 対応課題
ステップ14 :  ステータスを追加して、検索できるようにしよう

今回は分割PRになります
 - ステータス（未着手・着手中・完了）を追加してみよう(Done!)
 - 一覧画面でタイトルとステータスで検索ができるようにしよう(Done!)
 - 検索インデックスを貼りましょう / 検索に対してテストを追加してみよう(本PR)

### 実装内容

 - 検索インデックスを貼りましょう
DB設計の段階でインデックスを貼るカラムはTaskテーブルでは`user_id `のみと定義しているので
今回の検索機能ではインデックスを貼りませんでした。

 - 検索に対してテストを追加してみよう
テストを追加しました。

### 補足
主な変更点
- training/spec/models/tasks_spec.rb
検索ロジックに対して ステータス / タスク名 / 終了期限ソート での各選択時の動作をテストしました。

 - training/spec/features/task_spec.rb
検索ボックスでステータス / タスク名 / 終了期限ソートをした場合のテストを追記しました。
