### PR TITLE
kaminariによるページネーションを実装

### DIFF
--- a/training/Gemfile
+++ b/training/Gemfile
@@ -34,6 +34,8 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'kaminari'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/training/Gemfile.lock
+++ b/training/Gemfile.lock
@@ -79,6 +79,18 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.1.5)
@@ -211,6 +223,7 @@ DEPENDENCIES
   database_cleaner (~> 1.6.2)
   factory_bot_rails (~> 4.8.2)
   jbuilder (~> 2.5)
+  kaminari
   launchy
   listen (>= 3.0.5, < 3.2)
   mysql2

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -6,7 +6,7 @@ class TasksController < ApplicationController
     @status = params[:status]
     @order = params[:order]
 
-    @tasks = Task.search(params)
+    @tasks = Task.search(params).page(params[:page])
   end
 
   def show

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -31,6 +31,7 @@
   <% end %>
 </div>
 <div>
+  <%= page_entries_info @tasks, entry_name: I18n.t('tasks.view.index.title') %>
   <% @tasks.each do |task| %>
     <h4><%= link_to(task.name, task_path(task)) %></h4>
     <p><%= I18n.t('tasks.view.index.description') %> : <%= task.description %></p>
@@ -39,4 +40,6 @@
     <p><%= I18n.t('tasks.view.index.end_date') %> : <%= task.end_date %></p>
     <hr />
   <% end %>
+  <%= paginate @tasks %>
 </div>
+

--- a/training/config/initializers/kaminari_config.rb
+++ b/training/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  config.default_per_page = 5
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -206,6 +206,20 @@ ja:
       create: 登録する
       submit: 保存する
       update: 更新する
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "%{entry_name} が存在しません"
+          one:  "%{entry_name}  <b>all %{count}</b>　1ページ目のみ"
+          other: "全体で <b> %{count}</b> 件　%{entry_name}"
+      more_pages:
+        display_entries: " %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> までを表示中　全体で <b>%{total}</b> 件"
+  views:
+    pagination:
+      first:    "最初のページ"
+      last:     "最後のページ"
+      previous: "&lsaquo;"
+      next:     "&rsaquo;"
   number:
     currency:
       format:


### PR DESCRIPTION
### 対応課題
ステップ16 : ページネーションを追加しよう

### 実装内容

 - `KaminariというGemを使って一覧画面にページネーションを追加してみましょう`
ページネーションを導入しました。
また、`page_entries_info `ヘルパーを用いて分かりやすい表示にすると同時に
日本語に対応する様に必要な調整を行いました。

（表示例）
![2017-12-13 20 49 34](https://user-images.githubusercontent.com/26861647/33937518-313dca56-e047-11e7-8e13-10b1de9f6459.png)


### 補足
単純にgemを追加するだけでは勿体無いので、少しだけカスタムしてみました。

主な変更点

 - `training/app/controllers/tasks_controller.rb`

ページネーションに対応する様に`page(params[:page])`を追加しました
余談ですが、`page(params[:page])`の位置を入れ替えても同じSQLが発行される事を知りました。

```ruby
Task.search(params).page(params[:page])
Task.page(params[:page]).search(params)

# sql => SELECT  `tasks`.* FROM `tasks` ORDER BY `tasks`.`created_at` DESC LIMIT 5 OFFSET 5
```

 - `training/app/views/tasks/index.html.erb`

ページネーションの実装だけであれば`<%= paginate @tasks %>`を追加するだけですが
表示を分かりやすくする為に`page_entries_info`ヘルパーを使ってみました。

`<%= page_entries_info @tasks %>`

で動きますが下記の例の様な表示になってしまいます。

`tasks 6 - 10 までを表示中　全体で 11 件`

そこで[公式ドキュメント](https://github.com/kaminari/kaminari)の説明を参考にカスタムしました。

`<%= page_entries_info @tasks, entry_name: I18n.t('tasks.view.index.title') %>`

この様に表示されます。

`タスク一覧 6 - 10 までを表示中　全体で 11 件`

 - `training/config/locales/ja.yml`

`page_entries_info`は標準では英語環境でのみ利用可能なので
日本語環境で利用できる様に必要な辞書を追加しました。

