### PR TITLE
Userモデルの追加

### DIFF
--- a/training/Gemfile
+++ b/training/Gemfile
@@ -51,6 +51,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'bullet'
 end
 
 group :test do

--- a/training/Gemfile
+++ b/training/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'capistrano-rails', group: :development
 
 gem 'kaminari'
+gem 'bcrypt'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/training/Gemfile.lock
+++ b/training/Gemfile.lock
@@ -43,6 +43,9 @@ GEM
     arel (8.0.0)
     bindex (0.5.0)
     builder (3.2.3)
+    bullet (5.7.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     byebug (9.1.0)
     capybara (2.16.1)
       addressable
@@ -202,6 +205,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.0.1)
       execjs (>= 0.3.0, < 3)
+    uniform_notifier (1.10.0)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -217,6 +221,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bullet
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)

--- a/training/Gemfile.lock
+++ b/training/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
+    bcrypt (3.1.7)
     bindex (0.5.0)
     builder (3.2.3)
     bullet (5.7.0)
@@ -221,6 +222,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt
   bullet
   byebug
   capybara (~> 2.13)

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
+  belongs_to :user
+
   validates :name, presence: true, length: { maximum: 255 }
   validates :user_id, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :label_id, numericality: { greater_than_or_equal_to: 0, allow_blank: true }

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ApplicationRecord
+  has_many :tasks
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :email, presence: true, length: { maximum: 255 }, uniqueness: true
+  validates :password, presence: true, length: { maximum: 255 }
+end

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -1,7 +1,10 @@
 class User < ApplicationRecord
   has_many :tasks
 
+  VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
+  VALID_PASSWORD_REGEX = /\A[a-zA-Z0-9]+\z/
+
   validates :name, presence: true, length: { maximum: 255 }
-  validates :email, presence: true, length: { maximum: 255 }, uniqueness: true
-  validates :password, presence: true, length: { maximum: 255 }
+  validates :email, presence: true, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }, uniqueness: true
+  validates :password, presence: true, length: { in: 8..255 }, format: { with: VALID_PASSWORD_REGEX }
 end

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_secure_password
   has_many :tasks, dependent: :destroy
 
   VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
@@ -6,5 +7,5 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }, uniqueness: true
-  validates :password, presence: true, length: { in: 8..255 }, format: { with: VALID_PASSWORD_REGEX }
+  validates :password, presence: true, length: { in: 8..72 }, format: { with: VALID_PASSWORD_REGEX }
 end

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
 
   VALID_EMAIL_REGEX = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
   VALID_PASSWORD_REGEX = /\A[a-zA-Z0-9]+\z/

--- a/training/config/environments/development.rb
+++ b/training/config/environments/development.rb
@@ -51,4 +51,12 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
 end

--- a/training/db/migrate/20171214095443_create_users.rb
+++ b/training/db/migrate/20171214095443_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :password, null: false
+
+      t.timestamps null: false
+    end
+    add_index :users, :email, unique: true
+  end
+end

--- a/training/db/migrate/20171214095443_create_users.rb
+++ b/training/db/migrate/20171214095443_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[5.1]
     create_table :users do |t|
       t.string :name, null: false
       t.string :email, null: false
-      t.string :password, null: false
+      t.string :password_digest, null: false
 
       t.timestamps null: false
     end

--- a/training/db/migrate/20171214102346_add_index_to_task.rb
+++ b/training/db/migrate/20171214102346_add_index_to_task.rb
@@ -1,0 +1,5 @@
+class AddIndexToTask < ActiveRecord::Migration[5.1]
+  def change
+    add_index :tasks, :user_id
+  end
+end

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20171214102346) do
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
     t.string "email", null: false
-    t.string "password", null: false
+    t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171208052520) do
+ActiveRecord::Schema.define(version: 20171214095443) do
 
   create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false, unsigned: true
@@ -22,6 +22,15 @@ ActiveRecord::Schema.define(version: 20171208052520) do
     t.date "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171214095443) do
+ActiveRecord::Schema.define(version: 20171214102346) do
 
   create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false, unsigned: true
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20171214095443) do
     t.date "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/training/db/seeds.rb
+++ b/training/db/seeds.rb
@@ -6,4 +6,4 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.create(name: 'test_user', email: 'test@example.com', password: 'hoge1234' )
+User.create(name: 'test_user', email: 'test@example.com', password_digest: '$2a$10$XSBMiPduKNzXD5gf2FxU7ODQtmj5h6K1ZPw1yPtHHj7As5wyRiKae' )

--- a/training/db/seeds.rb
+++ b/training/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+User.create(name: 'test_user', email: 'test@example.com', password: 'hoge1234' )

--- a/training/spec/controllers/tasks_controller_spec.rb
+++ b/training/spec/controllers/tasks_controller_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe TasksController, type: :controller do
 
   describe 'POST #create' do
     context 'データが正しい場合' do
-      let(:params) { {task: FactoryBot.attributes_for(:task)} }
+      let(:user) { FactoryBot.create(:user) }
+      let(:params) { {task: FactoryBot.attributes_for(:task, user_id: user.id)} }
 
       it 'タスクが新たに作成される' do
         expect{

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :task do
     name 'test_task'
-    user_id 0 # ユーザー機能実装時に修正する
+    user # ユーザー機能実装時に修正する
     description 'description'
     priority 0
     status Task.statuses[:not_started]

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :task do
     name 'test_task'
-    user # ユーザー機能実装時に修正する
+    user
     description 'description'
     priority 0
     status Task.statuses[:not_started]

--- a/training/spec/factories/users.rb
+++ b/training/spec/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    name 'test_user'
+    sequence :email do |n|
+      "test#{n}@example.com"
+    end
+    password 'test1234'
+  end
+end

--- a/training/spec/models/tasks_spec.rb
+++ b/training/spec/models/tasks_spec.rb
@@ -40,8 +40,14 @@ RSpec.describe Task, type: :model do
 
       # TODO : User機能実装時にIDが存在することを検証する
       context '入力が正しい場合' do
-        let(:user_id) { 1 }
+        let(:user) { FactoryBot.create(:user) }
+        let(:user_id) { user.id }
         it { is_expected.to be true }
+      end
+
+      context '存在しないIDを指定した場合' do
+        let(:user_id) { 123 }
+        it { is_expected.to be false }
       end
 
       context '空欄の場合' do

--- a/training/spec/models/user_spec.rb
+++ b/training/spec/models/user_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'validation' do
+    describe 'name' do
+      let(:user) { FactoryBot.build(:user, name: name) }
+      subject { user.valid? }
+
+      context '入力が正しい場合' do
+        let(:name) { 'test' }
+        it { is_expected.to be true }
+      end
+
+      context '空欄の場合' do
+        let(:name) { '' }
+        it { is_expected.to be false }
+      end
+
+      context '文字列の長さ' do
+        context '254以下の場合' do
+          let(:name) { 'a' * 254 }
+          it { is_expected.to be true }
+        end
+
+        context '255の場合' do
+          let(:name) { 'a' * 255 }
+          it { is_expected.to be true }
+        end
+
+        context '256以上の場合' do
+          let(:name) { 'a' * 256 }
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    describe 'email' do
+      let(:user) { FactoryBot.build(:user, email: email) }
+      subject { user.valid? }
+
+      context '入力が正しい場合' do
+        let(:email) { 'test@example.com' }
+        it { is_expected.to be true }
+      end
+
+      context '重複する入力の場合' do
+        let!(:user_email) { FactoryBot.create(:user) }
+        let(:email) { user_email.email }
+        it { is_expected.to be false }
+      end
+
+      context '空欄の場合' do
+        let(:email) { '' }
+        it { is_expected.to be false }
+      end
+
+      context 'emailのフォーマット' do
+        context '正しいメールアドレスの場合' do
+          let(:email) { 'test@example.com' }
+          it { is_expected.to be true }
+        end
+
+        context '単純な文字列の場合' do
+          let(:email) { 'aaaa' }
+          it { is_expected.to be false }
+        end
+
+        context 'ローカル部が存在しない場合' do
+          let(:email) { '@aaa.com' }
+          it { is_expected.to be false }
+        end
+
+        context 'ドメイン部が不完全な場合' do
+          let(:email) { 'aaaa@aaa' }
+          it { is_expected.to be false }
+        end
+
+        context '空白が含まれる場合' do
+          let(:email) { 'test@aaa.com ' }
+          it { is_expected.to be false }
+        end
+      end
+
+      context '文字列の長さ' do
+        context '254以下の場合' do
+          let(:email) { "#{'a' * (254 - 12)}@example.com" }
+          it { is_expected.to be true }
+        end
+
+        context '255の場合' do
+          let(:email) { "#{'a' * (255 - 12)}@example.com" }
+          it { is_expected.to be true }
+        end
+
+        context '256以上の場合' do
+          let(:email) { "#{'a' * (256 - 12)}@example.com" }
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    describe 'password' do
+      let(:user) { FactoryBot.build(:user, password: password) }
+      subject { user.valid? }
+
+      context '入力が正しい場合' do
+        let(:password) { 'test1234' }
+        it { is_expected.to be true }
+      end
+
+      context '空欄の場合' do
+        let(:password) { '' }
+        it { is_expected.to be false }
+      end
+
+      context 'フォーマット' do
+        context '半角英数字のみの場合' do
+          let(:password) { 'test1234' }
+          it { is_expected.to be true }
+        end
+
+        context '記号を含む場合' do
+          let(:password) { 'test1234!' }
+          it { is_expected.to be false }
+        end
+
+        context '全角文字を含む場合' do
+          let(:password) { 'パスワードtest' }
+          it { is_expected.to be false }
+        end
+      end
+
+      context '文字列の長さ' do
+        context '最小文字数' do
+          context '7以下の場合' do
+            let(:password) { 'a' * 7 }
+            it { is_expected.to be false }
+          end
+
+          context '8の場合' do
+            let(:password) { 'a' * 8 }
+            it { is_expected.to be true }
+          end
+
+          context '9以上の場合' do
+            let(:password) { 'a' * 9 }
+            it { is_expected.to be true }
+          end
+        end
+
+        context '最大文字数' do
+          context '254以下の場合' do
+            let(:password) { 'a' * 254 }
+            it { is_expected.to be true }
+          end
+
+          context '255の場合' do
+            let(:password) { 'a' * 255 }
+            it { is_expected.to be true }
+          end
+
+          context '256以上の場合' do
+            let(:password) { 'a' * 256 }
+            it { is_expected.to be false }
+          end
+        end       
+      end
+    end
+  end
+end

--- a/training/spec/models/user_spec.rb
+++ b/training/spec/models/user_spec.rb
@@ -161,19 +161,20 @@ RSpec.describe User, type: :model do
           end
         end
 
+        # has_secure_passwordは標準で最大文字数:72 を検証する
         context '最大文字数' do
-          context '254以下の場合' do
-            let(:password) { 'a' * 254 }
+          context '71以下の場合' do
+            let(:password) { 'a' * 71 }
             it { is_expected.to be true }
           end
 
-          context '255の場合' do
-            let(:password) { 'a' * 255 }
+          context '72の場合' do
+            let(:password) { 'a' * 72 }
             it { is_expected.to be true }
           end
 
-          context '256以上の場合' do
-            let(:password) { 'a' * 256 }
+          context '73以上の場合' do
+            let(:password) { 'a' * 73 }
             it { is_expected.to be false }
           end
         end       

--- a/training/spec/models/user_spec.rb
+++ b/training/spec/models/user_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe 'dependent destroy' do
+    context 'ユーザーが削除された場合' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:task) { FactoryBot.create(:task, user_id: user.id) }
+
+      it '紐づいているタスクも削除される' do
+        expect(Task.find(task.id)).to eq task
+        user.destroy
+        expect{ Task.find(task.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
   describe 'validation' do
     describe 'name' do
       let(:user) { FactoryBot.build(:user, name: name) }


### PR DESCRIPTION
### 対応課題
ステップ18 : 複数人で利用できるようにしよう（ユーザの導入）

### 実装内容
 - ユーザモデルを作成してみましょう
　作成しました
　必要と思われるバリデーションを設定しました
　また、バリデーションに対してのテストを追加しました

 - 最初のユーザをseedで作成してみましょう
　作成しました

 - ユーザとタスクが紐づくようにしましょう
　user 1 対 Task 多の関係で関連付けました

 - 関連に対してインデックスを貼りましょう
　user_idにインデックスを貼りました

 - N+1問題を回避するための仕組みを取り入れましょう
　bulletというgemを導入してN+1問題の発生時に気がつける様にしました
　（動作例 : 意図的にN+1を起こした場合の画面）
![2017-12-14 19 48 27](https://user-images.githubusercontent.com/26861647/33995225-a7a77b86-e120-11e7-8be8-aa47b420748f.png)

### 補足