### PR TITLE
ユーザの管理画面を実装

### DIFF
--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -1,0 +1,63 @@
+class Admin::UsersController < ApplicationController
+
+  def index
+    @users = User.all
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to [:admin, @user], notice: I18n.t('tasks.controller.messages.created')
+    else
+      render :new
+    end
+  end
+
+  def update
+    @user = User.find(params[:id])
+
+    if @user.update_attributes(update_params)
+      redirect_to [:admin, @user], notice: I18n.t('tasks.controller.messages.updated')
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    User.find(params[:id]).destroy!
+    redirect_to admin_users_path, notice: I18n.t('tasks.controller.messages.deleted')
+  end
+
+  private
+
+  def update_params
+    params[:password].present? ? user_params_without_password : user_params
+  end
+
+  def user_params
+    params.require(:user).permit(
+      :name,
+      :email,
+      :password,
+    )
+  end
+
+  def user_params_without_password
+    params.require(:user).permit(
+      :name,
+      :email,
+    )
+  end
+end

--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -23,7 +23,8 @@ class Admin::UsersController < ApplicationController
     else
       render :new
     end
-  rescue
+  rescue => e
+    Rails.logger.error(e)
     flash.now[:alert] = I18n.t('admin.controller.messages.create_failed')
     render :new
   end
@@ -36,7 +37,8 @@ class Admin::UsersController < ApplicationController
     else
       render :edit
     end
-  rescue
+  rescue => e
+    Rails.logger.error(e)
     flash.now[:alert] = I18n.t('admin.controller.messages.update_failed')
     render :edit
   end
@@ -44,7 +46,8 @@ class Admin::UsersController < ApplicationController
   def destroy
     User.find(params[:id]).destroy!
     redirect_to admin_users_path, notice: I18n.t('admin.controller.messages.deleted')
-  rescue
+  rescue => e
+    Rails.logger.error(e)
     redirect_to admin_users_path, alert: I18n.t('admin.controller.messages.delete_failed')
   end
 

--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -19,7 +19,7 @@ class Admin::UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to [:admin, @user], notice: I18n.t('tasks.controller.messages.created')
+      redirect_to [:admin, @user], notice: I18n.t('admin.controller.messages.created')
     else
       render :new
     end
@@ -29,7 +29,7 @@ class Admin::UsersController < ApplicationController
     @user = User.find(params[:id])
 
     if @user.update_attributes(update_params)
-      redirect_to [:admin, @user], notice: I18n.t('tasks.controller.messages.updated')
+      redirect_to [:admin, @user], notice: I18n.t('admin.controller.messages.updated')
     else
       render :edit
     end
@@ -37,7 +37,7 @@ class Admin::UsersController < ApplicationController
 
   def destroy
     User.find(params[:id]).destroy!
-    redirect_to admin_users_path, notice: I18n.t('tasks.controller.messages.deleted')
+    redirect_to admin_users_path, notice: I18n.t('admin.controller.messages.deleted')
   end
 
   private

--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -23,6 +23,9 @@ class Admin::UsersController < ApplicationController
     else
       render :new
     end
+  rescue
+    flash.now[:alert] = I18n.t('admin.controller.messages.create_failed')
+    render :new
   end
 
   def update
@@ -33,11 +36,16 @@ class Admin::UsersController < ApplicationController
     else
       render :edit
     end
+  rescue
+    flash.now[:alert] = I18n.t('admin.controller.messages.update_failed')
+    render :edit
   end
 
   def destroy
     User.find(params[:id]).destroy!
     redirect_to admin_users_path, notice: I18n.t('admin.controller.messages.deleted')
+  rescue
+    redirect_to admin_users_path, alert: I18n.t('admin.controller.messages.delete_failed')
   end
 
   private

--- a/training/app/helpers/admin/users_helper.rb
+++ b/training/app/helpers/admin/users_helper.rb
@@ -4,6 +4,6 @@ module Admin::UsersHelper
   end
 
   def new_page?
-    request.path_info == new_admin_user_path
+    request.path_info.in?([new_admin_user_path, admin_users_path])
   end
 end

--- a/training/app/helpers/admin/users_helper.rb
+++ b/training/app/helpers/admin/users_helper.rb
@@ -1,0 +1,9 @@
+module Admin::UsersHelper
+  def convert_date_format(date)
+    date.strftime("%Y年%m月%d日 %H時%M分")
+  end
+
+  def new_page?
+    request.path_info == new_admin_user_path
+  end
+end

--- a/training/app/helpers/admin/users_helper.rb
+++ b/training/app/helpers/admin/users_helper.rb
@@ -1,6 +1,6 @@
 module Admin::UsersHelper
   def convert_date_format(date)
-    date.strftime("%Y年%m月%d日 %H時%M分")
+    date.strftime("%Y/%m/%d %H:%M")
   end
 
   def new_page?

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -7,5 +7,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }, uniqueness: true
-  validates :password, presence: true, length: { in: 8..72 }, format: { with: VALID_PASSWORD_REGEX }
+  validates :password, on: :create, presence: true, length: { in: 8..72 }, format: { with: VALID_PASSWORD_REGEX }
+  validates :password, on: :update, presence: true, length: { in: 8..72 }, format: { with: VALID_PASSWORD_REGEX }, allow_blank: true
 end

--- a/training/app/views/admin/users/_form.html.erb
+++ b/training/app/views/admin/users/_form.html.erb
@@ -1,0 +1,35 @@
+<%= form_for [:admin, @user] do |f| %>
+
+  <% if @user.errors.any?%>
+    <div>
+      <ul>
+      <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= f.hidden_field :id, :value => @user.id %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <br/>
+
+  <%= f.label :email %>
+  <%= f.text_field :email %>
+  <br/>
+
+  <%= f.label :password %>
+  <%= f.text_field :password %>
+  <% unless new_page? %>
+    <p>※パスワードは変更時のみ入力</p>
+  <% end %>
+  <br/>
+
+  <% if new_page? %>
+    <%= f.submit I18n.t('helpers.submit.create'), data: { disable_with: I18n.t('tasks.view.partial.creating')} %>
+  <% else %>
+    <%= f.submit I18n.t('helpers.submit.update'), data: { disable_with: I18n.t('tasks.view.partial.updating')} %>
+  <% end %>
+<% end %>

--- a/training/app/views/admin/users/_form.html.erb
+++ b/training/app/views/admin/users/_form.html.erb
@@ -28,8 +28,8 @@
   <br/>
 
   <% if new_page? %>
-    <%= f.submit I18n.t('admin.view.partial.create'), data: { disable_with: I18n.t('admin.view.partial.creating')} %>
+    <%= f.submit I18n.t('admin.view.partial.create'), data: { disable_with: I18n.t('admin.view.partial.creating') } %>
   <% else %>
-    <%= f.submit I18n.t('admin.view.partial.update'), data: { disable_with: I18n.t('admin.view.partial.updating')} %>
+    <%= f.submit I18n.t('admin.view.partial.update'), data: { disable_with: I18n.t('admin.view.partial.updating') } %>
   <% end %>
 <% end %>

--- a/training/app/views/admin/users/_form.html.erb
+++ b/training/app/views/admin/users/_form.html.erb
@@ -23,13 +23,13 @@
   <%= f.label :password %>
   <%= f.text_field :password %>
   <% unless new_page? %>
-    <p>※パスワードは変更時のみ入力</p>
+    <p><%= I18n.t('admin.view.partial.password_guide') %></p>
   <% end %>
   <br/>
 
   <% if new_page? %>
-    <%= f.submit I18n.t('helpers.submit.create'), data: { disable_with: I18n.t('tasks.view.partial.creating')} %>
+    <%= f.submit I18n.t('admin.view.partial.create'), data: { disable_with: I18n.t('admin.view.partial.creating')} %>
   <% else %>
-    <%= f.submit I18n.t('helpers.submit.update'), data: { disable_with: I18n.t('tasks.view.partial.updating')} %>
+    <%= f.submit I18n.t('admin.view.partial.update'), data: { disable_with: I18n.t('admin.view.partial.updating')} %>
   <% end %>
 <% end %>

--- a/training/app/views/admin/users/edit.html.erb
+++ b/training/app/views/admin/users/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>ユーザー編集</h1>
+
+<%= render 'form', admin_user: @admin_user %>
+
+<%= link_to '詳細', admin_user_path(@user.id) %> |
+<%= link_to '一覧', admin_users_path %>

--- a/training/app/views/admin/users/edit.html.erb
+++ b/training/app/views/admin/users/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>ユーザー編集</h1>
+<h1><%= I18n.t('admin.view.edit.title') %></h1>
 
 <%= render 'form', admin_user: @admin_user %>
 
-<%= link_to '詳細', admin_user_path(@user.id) %> |
-<%= link_to '一覧', admin_users_path %>
+<%= link_to I18n.t('admin.view.edit.show_page'), admin_user_path(@user.id) %> |
+<%= link_to I18n.t('admin.view.edit.index_page'), admin_users_path %>

--- a/training/app/views/admin/users/edit.html.erb
+++ b/training/app/views/admin/users/edit.html.erb
@@ -1,6 +1,6 @@
 <h1><%= I18n.t('admin.view.edit.title') %></h1>
 
-<%= render 'form', admin_user: @admin_user %>
+<%= render 'form' %>
 
 <%= link_to I18n.t('admin.view.edit.show_page'), admin_user_path(@user.id) %> |
 <%= link_to I18n.t('admin.view.edit.index_page'), admin_users_path %>

--- a/training/app/views/admin/users/index.html.erb
+++ b/training/app/views/admin/users/index.html.erb
@@ -1,0 +1,29 @@
+<h1>ユーザー一覧</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>ユーザー名</th>
+      <th>メールアドレス</th>
+      <th>作成日</th>
+      <th colspan="3" ></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.name %></td>
+        <td><%= user.email %></td>
+        <td><%= convert_date_format(user.created_at) %></td>
+        <td><%= link_to '詳細', admin_user_path(user.id) %></td>
+        <td><%= link_to '編集', edit_admin_user_path(user) %></td>
+        <td><%= link_to '削除', admin_user_path(user.id), method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'ユーザーを追加する', new_admin_user_path %>

--- a/training/app/views/admin/users/index.html.erb
+++ b/training/app/views/admin/users/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th><%= I18n.t('admin.view.index.name') %></th>
       <th><%= I18n.t('admin.view.index.email') %></th>
+      <th><%= I18n.t('admin.view.index.task_count') %></th>
       <th><%= I18n.t('admin.view.index.created_at') %></th>
       <th colspan="3" ></th>
     </tr>
@@ -15,6 +16,7 @@
       <tr>
         <td><%= user.name %></td>
         <td><%= user.email %></td>
+        <td><%= user.tasks.count %></td>
         <td><%= convert_date_format(user.created_at) %></td>
         <td><%= link_to I18n.t('admin.view.index.show_page'), admin_user_path(user.id) %></td>
         <td><%= link_to I18n.t('admin.view.index.edit_page'), edit_admin_user_path(user) %></td>

--- a/training/app/views/admin/users/index.html.erb
+++ b/training/app/views/admin/users/index.html.erb
@@ -1,11 +1,11 @@
-<h1>ユーザー一覧</h1>
+<h1><%= I18n.t('admin.view.index.title') %></h1>
 
 <table>
   <thead>
     <tr>
-      <th>ユーザー名</th>
-      <th>メールアドレス</th>
-      <th>作成日</th>
+      <th><%= I18n.t('admin.view.index.name') %></th>
+      <th><%= I18n.t('admin.view.index.email') %></th>
+      <th><%= I18n.t('admin.view.index.created_at') %></th>
       <th colspan="3" ></th>
     </tr>
   </thead>
@@ -16,9 +16,9 @@
         <td><%= user.name %></td>
         <td><%= user.email %></td>
         <td><%= convert_date_format(user.created_at) %></td>
-        <td><%= link_to '詳細', admin_user_path(user.id) %></td>
-        <td><%= link_to '編集', edit_admin_user_path(user) %></td>
-        <td><%= link_to '削除', admin_user_path(user.id), method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
+        <td><%= link_to I18n.t('admin.view.index.show_page'), admin_user_path(user.id) %></td>
+        <td><%= link_to I18n.t('admin.view.index.edit_page'), edit_admin_user_path(user) %></td>
+        <td><%= link_to I18n.t('admin.view.index.delete'), admin_user_path(user.id), method: :delete, data: { confirm: I18n.t('admin.view.index.delete_confirm') } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -26,4 +26,4 @@
 
 <br>
 
-<%= link_to 'ユーザーを追加する', new_admin_user_path %>
+<%= link_to I18n.t('admin.view.index.new_page'), new_admin_user_path %>

--- a/training/app/views/admin/users/new.html.erb
+++ b/training/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<h1>ユーザーの作成</h1>
+
+<%= render 'form' %>
+
+<%= link_to '一覧', admin_users_path %>

--- a/training/app/views/admin/users/new.html.erb
+++ b/training/app/views/admin/users/new.html.erb
@@ -1,5 +1,5 @@
-<h1>ユーザーの作成</h1>
+<h1><%= I18n.t('admin.view.new.title') %></h1>
 
 <%= render 'form' %>
 
-<%= link_to '一覧', admin_users_path %>
+<%= link_to I18n.t('admin.view.new.index_page'), admin_users_path %>

--- a/training/app/views/admin/users/show.html.erb
+++ b/training/app/views/admin/users/show.html.erb
@@ -1,21 +1,21 @@
-<h1>ユーザー詳細</h1>
+<h1><%= I18n.t('admin.view.show.title') %></h1>
 
 <br/>
 
-<h1>ユーザー情報</h1>
+<h1><%= I18n.t('admin.view.show.user_info') %></h1>
 <div>
-<p>ユーザーID : <%= @user.id %></p>
-<p>ユーザー名 : <%= @user.name %></p>
-<p>メールアドレス : <%= @user.email %></p>
-<p>作成日 : <%= convert_date_format(@user.created_at) %></p>
-<p>更新日 : <%= convert_date_format(@user.updated_at) %></p>
+<p><%= I18n.t('admin.view.show.user_id') %> : <%= @user.id %></p>
+<p><%= I18n.t('admin.view.show.name') %> : <%= @user.name %></p>
+<p><%= I18n.t('admin.view.show.email') %> : <%= @user.email %></p>
+<p><%= I18n.t('admin.view.show.created_at') %> : <%= convert_date_format(@user.created_at) %></p>
+<p><%= I18n.t('admin.view.show.updated_at') %> : <%= convert_date_format(@user.updated_at) %></p>
 </div>
 <br/>
 
 <hr/>
-<h1>タスク情報</h1>
+<h1><%= I18n.t('admin.view.show.task_info') %></h1>
 <div></div>
 <br/>
 
-<%= link_to '編集', edit_admin_user_path(@user.id) %> |
-<%= link_to '一覧', admin_users_path %>
+<%= link_to I18n.t('admin.view.show.edit_page'), edit_admin_user_path(@user.id) %> |
+<%= link_to I18n.t('admin.view.show.index_page'), admin_users_path %>

--- a/training/app/views/admin/users/show.html.erb
+++ b/training/app/views/admin/users/show.html.erb
@@ -1,0 +1,21 @@
+<h1>ユーザー詳細</h1>
+
+<br/>
+
+<h1>ユーザー情報</h1>
+<div>
+<p>ユーザーID : <%= @user.id %></p>
+<p>ユーザー名 : <%= @user.name %></p>
+<p>メールアドレス : <%= @user.email %></p>
+<p>作成日 : <%= convert_date_format(@user.created_at) %></p>
+<p>更新日 : <%= convert_date_format(@user.updated_at) %></p>
+</div>
+<br/>
+
+<hr/>
+<h1>タスク情報</h1>
+<div></div>
+<br/>
+
+<%= link_to '編集', edit_admin_user_path(@user.id) %> |
+<%= link_to '一覧', admin_users_path %>

--- a/training/app/views/admin/users/show.html.erb
+++ b/training/app/views/admin/users/show.html.erb
@@ -14,7 +14,28 @@
 
 <hr/>
 <h1><%= I18n.t('admin.view.show.task_info') %></h1>
-<div></div>
+<table>
+  <thead>
+    <tr>
+      <th><%= I18n.t('tasks.view.index.name') %></th>
+      <th><%= I18n.t('tasks.view.index.description') %></th>
+      <th><%= I18n.t('tasks.view.index.status') %></th>
+      <th><%= I18n.t('tasks.view.index.priority') %></th>
+      <th><%= I18n.t('tasks.view.index.end_date') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @user.tasks.each do |task| %>
+      <tr>
+        <td><%= link_to(task.name, task_path(task)) %></td>
+        <td><%= task.description %></td>
+        <td><%= I18n.t("tasks.model.status.#{task.status}") %></td>
+        <td><%= I18n.t("tasks.model.priority.#{task.priority}") %></td>
+        <td><%= task.end_date %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
 <br/>
 
 <%= link_to I18n.t('admin.view.show.edit_page'), edit_admin_user_path(@user.id) %> |

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -69,6 +69,7 @@ ja:
         title: ユーザー 一覧
         name: ユーザー名
         email: メールアドレス
+        task_count: タスク数
         created_at: 作成日
         show_page: 詳細
         edit_page: 編集

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -63,6 +63,47 @@ ja:
         logged_in: ログインしました
         invalid: メールアドレスまたは、パスワードが違います
         logged_out: ログアウトしました
+  admin:
+    view:
+      index:
+        title: ユーザー 一覧
+        name: ユーザー名
+        email: メールアドレス
+        created_at: 作成日
+        show_page: 詳細
+        edit_page: 編集
+        new_page: ユーザーを追加する
+        delete: 削除
+        delete_confirm: 本当に削除しますか？
+      new:
+        title: ユーザー作成
+        index_page: 一覧
+      show:
+        title: ユーザー詳細
+        user_info: ユーザー情報
+        task_info: タスク情報
+        user_id: ユーザーID
+        name: ユーザー名
+        email: メールアドレス
+        created_at: 作成日
+        updated_at: 更新日  
+        index_page: 一覧
+        edit_page: 編集
+      edit:
+        title: ユーザー編集
+        index_page: 一覧
+        show_page: 詳細
+      partial:
+        password_guide: ※パスワードは変更時のみ入力
+        create: 作成
+        creating: 作成中
+        update: 更新
+        updating: 更新中
+    controller:
+      messages:
+        created: 作成しました
+        updated: 更新しました
+        deleted: 削除しました
   application:
     view:
       logged_out: ログアウトする
@@ -74,6 +115,8 @@ ja:
     status: ステータス
     label_id: ラベル番号
     end_date: 終了期限
+    email: メールアドレス
+    password: パスワード
   activerecord:
     errors:
       messages:

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -105,6 +105,9 @@ ja:
         created: 作成しました
         updated: 更新しました
         deleted: 削除しました
+        create_failed: ユーザーの作成に失敗しました
+        update_failed: ユーザーの更新に失敗しました
+        delete_failed: ユーザーの削除に失敗しました
   application:
     view:
       logged_out: ログアウトする

--- a/training/config/routes.rb
+++ b/training/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root to: 'tasks#index'
   resources :tasks
+  namespace :admin do
+    resources :users
+  end
 
   get 'logins/new'
   post 'logins/create'

--- a/training/spec/controllers/admin/users_controller_spec.rb
+++ b/training/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController, type: :controller do
+end

--- a/training/spec/controllers/admin/users_controller_spec.rb
+++ b/training/spec/controllers/admin/users_controller_spec.rb
@@ -206,11 +206,18 @@ RSpec.describe Admin::UsersController, type: :controller do
     describe 'DELETE #destroy' do
       let(:user) { FactoryBot.create(:user) }
       let(:params) { {id: user.id} }
+      let!(:task) { FactoryBot.create(:task, user_id: user.id) }
 
       it 'userを削除する' do
         expect(User.find(user.id)).to eq user
         delete :destroy, params: params
         expect{ User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'userが作成したタスクも削除される' do
+        expect(Task.find(task.id)).to eq task
+        delete :destroy, params: params
+        expect{ Task.find(task.id) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/training/spec/controllers/admin/users_controller_spec.rb
+++ b/training/spec/controllers/admin/users_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     describe 'GET #show' do
       let(:user) { FactoryBot.create(:user) }
-      let(:params) { {id: user.id} }
+      let(:params) { { id: user.id } }
 
       it '@user にユーザー情報を持っている' do
         get :show, params: params
@@ -81,7 +81,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     describe 'GET #edit' do
       let(:user) { FactoryBot.create(:user) }
-      let(:params) { {id: user.id} }
+      let(:params) { { id: user.id } }
 
       it '@user にユーザー情報を持っている' do
         get :edit, params: params
@@ -104,7 +104,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     describe 'POST #create' do
       context 'データが正しい場合' do
-        let(:params) { {user: FactoryBot.attributes_for(:user)} }
+        let(:params) { { user: FactoryBot.attributes_for(:user) } }
 
         it 'userが新たに作成される' do
           expect{
@@ -114,7 +114,7 @@ RSpec.describe Admin::UsersController, type: :controller do
       end
 
       context 'データが不正な場合' do
-        let(:params) { {user: FactoryBot.attributes_for(:user, name: '')} }
+        let(:params) { { user: FactoryBot.attributes_for(:user, name: '') } }
 
         it 'userは作成されない' do
           expect{
@@ -131,14 +131,14 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     describe 'POST #update' do
       let(:user) { FactoryBot.create(:user) }
-      let(:params) { {user: FactoryBot.attributes_for(:user, name: name, email: email, password: password), id: user.id } }
+      let(:params) { { user: FactoryBot.attributes_for(:user, name: name, email: email, password: password), id: user.id } }
 
       context 'データが正しい場合' do
-        let(:name) {'hoge'}
-        let(:email) {'hoge@fuga.com'}
+        let(:name) { 'hoge' }
+        let(:email) { 'hoge@fuga.com' }
 
         context 'パスワードを更新する場合' do
-          let(:password) {'abcdefghijk'}
+          let(:password) { 'abcdefghijk' }
 
           it 'userが更新される' do
             expect(User.find(user.id)).to eq user
@@ -150,7 +150,7 @@ RSpec.describe Admin::UsersController, type: :controller do
         end
 
         context 'パスワードを更新しない場合' do
-          let(:password) {''}
+          let(:password) { '' }
 
           it 'userが更新される' do
             expect(User.find(user.id)).to eq user
@@ -164,9 +164,9 @@ RSpec.describe Admin::UsersController, type: :controller do
 
       context 'データが不正な場合' do
         context 'パスワード以外が間違っている場合' do
-          let(:name) {''}
-          let(:email) {''}
-          let(:password) {'abcdefghijk'}
+          let(:name) { '' }
+          let(:email) { '' }
+          let(:password) { 'abcdefghijk' }
 
           it 'userは更新されない' do
             expect(User.find(user.id)).to eq user
@@ -183,9 +183,9 @@ RSpec.describe Admin::UsersController, type: :controller do
         end
 
         context 'パスワードのみが間違っている場合' do
-          let(:name) {'test_name'}
-          let(:email) {'test@test.co.jp'}
-          let(:password) {'###'}
+          let(:name) { 'test_name' }
+          let(:email) { 'test@test.co.jp' }
+          let(:password) { '###' }
 
           it 'userは更新されない' do
             expect(User.find(user.id)).to eq user
@@ -205,7 +205,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
     describe 'DELETE #destroy' do
       let(:user) { FactoryBot.create(:user) }
-      let(:params) { {id: user.id} }
+      let(:params) { { id: user.id } }
       let!(:task) { FactoryBot.create(:task, user_id: user.id) }
 
       it 'userを削除する' do

--- a/training/spec/controllers/admin/users_controller_spec.rb
+++ b/training/spec/controllers/admin/users_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Admin::UsersController, type: :controller do
     describe 'GET #index' do
       let!(:user) { FactoryBot.create(:user) }
 
-      it '@users にタスク情報を持っている' do
+      it '@users にユーザー情報を持っている' do
         get :index
         #ログインユーザー情報も表示に含まれるので1を指定
         expect(assigns(:users)[1]).to eq user
@@ -67,7 +67,7 @@ RSpec.describe Admin::UsersController, type: :controller do
       let(:user) { FactoryBot.create(:user) }
       let(:params) { {id: user.id} }
 
-      it '@user にタスク情報を持っている' do
+      it '@user にユーザー情報を持っている' do
         get :show, params: params
         expect(assigns(:user)).to eq user
       end
@@ -83,7 +83,7 @@ RSpec.describe Admin::UsersController, type: :controller do
       let(:user) { FactoryBot.create(:user) }
       let(:params) { {id: user.id} }
 
-      it '@user にタスク情報を持っている' do
+      it '@user にユーザー情報を持っている' do
         get :edit, params: params
         expect(assigns(:user)).to eq user
       end

--- a/training/spec/controllers/admin/users_controller_spec.rb
+++ b/training/spec/controllers/admin/users_controller_spec.rb
@@ -1,4 +1,217 @@
 require 'rails_helper'
 
 RSpec.describe Admin::UsersController, type: :controller do
+  describe 'ログインしていない場合' do
+    subject { response }
+
+    #params を検証する前にログインを要求するのでダミーの値を指定する
+    let(:params) { { id: 'dummy' } }
+
+    describe 'GET #index' do
+      before { get :index }
+      it { is_expected.to require_login }
+    end
+
+    describe 'GET #show' do
+      before { get :show, params: params }
+      it { is_expected.to require_login }
+    end
+
+    describe 'GET #new' do
+      before { get :new }
+      it { is_expected.to require_login }
+    end
+
+    describe 'GET #edit' do
+      before { get :edit, params: params }
+      it { is_expected.to require_login }
+    end
+
+    describe 'POST #create' do
+      before { post :create, params: params }
+      it { is_expected.to require_login }
+    end
+
+    describe 'POST #update' do
+      before { post :update, params: params }
+      it { is_expected.to require_login }
+    end
+
+    describe 'DELETE #destroy' do
+      before { delete :destroy, params: params }
+      it { is_expected.to require_login }
+    end
+  end
+
+  describe 'ログインしている場合' do
+    before do
+      set_user_session
+    end
+
+    describe 'GET #index' do
+      let!(:user) { FactoryBot.create(:user) }
+
+      it '@users にタスク情報を持っている' do
+        get :index
+        #ログインユーザー情報も表示に含まれるので1を指定
+        expect(assigns(:users)[1]).to eq user
+      end
+
+      it 'index テンプレートを表示する' do
+        get :index
+        expect(response).to render_template :index
+      end
+    end
+
+    describe 'GET #show' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:params) { {id: user.id} }
+
+      it '@user にタスク情報を持っている' do
+        get :show, params: params
+        expect(assigns(:user)).to eq user
+      end
+
+      it 'show テンプレートを表示する' do
+        get :show, params: params
+        expect(response).to render_template :show
+      end
+
+    end
+
+    describe 'GET #edit' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:params) { {id: user.id} }
+
+      it '@user にタスク情報を持っている' do
+        get :edit, params: params
+        expect(assigns(:user)).to eq user
+      end
+
+      it 'edit テンプレートを表示する' do
+        get :edit, params: params
+        expect(response).to render_template :edit
+      end
+
+    end
+
+    describe 'GET #new' do
+      it 'new テンプレートを表示する' do
+        get :new
+        expect(response).to render_template :new
+      end
+    end
+
+    describe 'POST #create' do
+      context 'データが正しい場合' do
+        let(:params) { {user: FactoryBot.attributes_for(:user)} }
+
+        it 'userが新たに作成される' do
+          expect{
+            post :create, params: params
+          }.to change(User, :count).by(1)
+        end
+      end
+
+      context 'データが不正な場合' do
+        let(:params) { {user: FactoryBot.attributes_for(:user, name: '')} }
+
+        it 'userは作成されない' do
+          expect{
+            post :create, params: params
+          }.not_to change(User, :count)
+        end
+
+        it 'newテンプレートを表示する' do
+          get :create, params: params
+          expect(response).to render_template :new
+        end
+      end
+    end
+
+    describe 'POST #update' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:params) { {user: FactoryBot.attributes_for(:user, name: name, email: email, password: password), id: user.id } }
+
+      context 'データが正しい場合' do
+        let(:name) {'hoge'}
+        let(:email) {'hoge@fuga.com'}
+
+        context 'パスワードを更新する場合' do
+          let(:password) {'abcdefghijk'}
+
+          it 'userが更新される' do
+            expect(User.find(user.id)).to eq user
+            patch :update, params: params
+            expect(User.find(user.id).name).to eq name
+            expect(User.find(user.id).email).to eq email
+            expect(User.find(user.id).password_digest).not_to eq user.password_digest
+          end
+        end
+
+        context 'パスワードを更新しない場合' do
+          let(:password) {''}
+
+          it 'userが更新される' do
+            expect(User.find(user.id)).to eq user
+            patch :update, params: params
+            expect(User.find(user.id).name).to eq name
+            expect(User.find(user.id).email).to eq email
+            expect(User.find(user.id).password_digest).to eq user.password_digest
+          end
+        end
+      end
+
+      context 'データが不正な場合' do
+        context 'パスワード以外が間違っている場合' do
+          let(:name) {''}
+          let(:email) {''}
+          let(:password) {'abcdefghijk'}
+
+          it 'userは更新されない' do
+            expect(User.find(user.id)).to eq user
+            patch :update, params: params
+            expect(User.find(user.id).name).not_to eq name
+            expect(User.find(user.id).name).not_to eq email
+            expect(User.find(user.id).password_digest).to eq user.password_digest
+          end
+
+          it 'editテンプレートを表示する' do
+            put :update, params: params
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'パスワードのみが間違っている場合' do
+          let(:name) {'test_name'}
+          let(:email) {'test@test.co.jp'}
+          let(:password) {'###'}
+
+          it 'userは更新されない' do
+            expect(User.find(user.id)).to eq user
+            patch :update, params: params
+            expect(User.find(user.id).name).not_to eq name
+            expect(User.find(user.id).name).not_to eq email
+            expect(User.find(user.id).password_digest).to eq user.password_digest
+          end
+
+          it 'editテンプレートを表示する' do
+            put :update, params: params
+            expect(response).to render_template :edit
+          end
+        end
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:params) { {id: user.id} }
+
+      it 'userを削除する' do
+        expect(User.find(user.id)).to eq user
+        delete :destroy, params: params
+        expect{ User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/training/spec/features/admin_user_spec.rb
+++ b/training/spec/features/admin_user_spec.rb
@@ -1,0 +1,148 @@
+require 'rails_helper'
+include Admin::UsersHelper
+
+RSpec.describe 'Admin::User', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    visit logins_new_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: user.password
+    click_on I18n.t('logins.view.new.submit')
+  end
+
+  describe '管理者がユーザー一覧にアクセスする' do
+    before do
+      visit admin_users_path
+    end
+
+    it 'ユーザー一覧が表示される' do
+      expect(page).to have_content user.name
+      expect(page).to have_content user.email
+      expect(page).to have_content user.tasks.count
+      expect(page).to have_content convert_date_format(user.created_at)
+    end
+
+    context '詳細ボタンをクリックしたとき' do
+      it 'ユーザー詳細に遷移する' do
+        click_on I18n.t('admin.view.index.show_page')
+        expect(current_path).to eq admin_user_path(user.id)
+      end
+    end
+
+    context '編集ボタンをクリックしたとき' do
+      it 'ユーザー編集に遷移する' do
+        click_on I18n.t('admin.view.index.edit_page')
+        expect(current_path).to eq edit_admin_user_path(user.id)
+      end
+    end
+
+    describe '管理者がユーザーを削除する' do
+      context '削除をクリックしたとき' do
+        let!(:user_2) { FactoryBot.create(:user) }
+
+        it 'ユーザーが削除される' do
+          click_on I18n.t('admin.view.index.delete')
+          expect(current_path).to eq admin_users_path
+          expect(page).to have_content I18n.t('admin.controller.messages.deleted')
+          expect(page).not_to have_content user.email
+          expect(page).to have_content user_2.email
+        end
+      end
+    end
+  end
+
+  describe '管理者がユーザー詳細にアクセスする' do
+    let!(:task) { FactoryBot.create(:task, user_id: user.id) }
+
+    before do
+      visit admin_user_path(user.id)
+    end
+
+    it 'ユーザー詳細が表示される' do
+      expect(page).to have_content user.id
+      expect(page).to have_content user.name
+      expect(page).to have_content user.email
+      expect(page).to have_content convert_date_format(user.created_at)
+      expect(page).to have_content convert_date_format(user.updated_at)
+    end
+
+    it 'ユーザーのタスク一覧が表示される' do
+      expect(page).to have_content task.name
+      expect(page).to have_content task.description
+      expect(page).to have_content I18n.t("tasks.model.status.#{task.status}")
+      expect(page).to have_content I18n.t("tasks.model.priority.#{task.priority}")
+      expect(page).to have_content task.end_date
+    end
+
+    context '編集ボタンをクリックしたとき' do
+      it 'ユーザー編集に遷移する' do
+        click_on I18n.t('admin.view.index.edit_page')
+        expect(current_path).to eq edit_admin_user_path(user.id)
+      end
+    end
+
+    context '一覧ボタンをクリックしたとき' do
+      it 'ユーザー一覧に遷移する' do
+        click_on I18n.t('admin.view.show.index_page')
+        expect(current_path).to eq admin_users_path
+      end
+    end
+  end
+
+  describe '管理者がユーザー編集にアクセスする' do
+    before do
+      visit edit_admin_user_path(user.id)
+    end
+
+    it '編集ページが表示される' do
+      expect(current_path).to eq edit_admin_user_path(user.id)
+    end
+
+    context 'ユーザー情報を変更して更新をクリックしたとき' do
+      before do
+        fill_in I18n.t('attributes.name'), with: 'hogefuga'
+        fill_in I18n.t('attributes.email'), with: 'fuga@fuga.jp'
+        click_on I18n.t('admin.view.partial.update')
+      end
+
+      it 'ユーザー詳細に遷移する' do
+        expect(page).to have_content I18n.t('admin.controller.messages.updated')
+        expect(current_path).to eq admin_user_path(user.id)
+      end
+
+      it 'ユーザー情報が更新されている' do
+        expect(page).to have_content User.last.name
+        expect(page).to have_content User.last.email
+      end
+    end
+  end
+
+  describe '管理者がユーザー作成にアクセスする' do
+    before do
+      visit new_admin_user_path
+    end
+
+    it '作成ページが表示される' do
+      expect(current_path).to eq new_admin_user_path
+    end
+
+    context 'ユーザー情報を入力して作成をクリックしたとき' do
+      before do
+        fill_in I18n.t('attributes.name'), with: 'hogefuga'
+        fill_in I18n.t('attributes.email'), with: 'fuga@fuga.jp'
+        fill_in I18n.t('attributes.password'), with: 'test1234'
+        click_on I18n.t('admin.view.partial.create')
+      end
+
+      it 'ユーザー詳細に遷移する' do
+        expect(current_path).to eq admin_user_path(User.last.id)
+      end
+
+      it '新しいユーザーが作成される' do
+        expect(page).to have_content User.last.name
+        expect(page).to have_content User.last.email
+      end
+    end
+  end
+end

--- a/training/spec/features/admin_user_spec.rb
+++ b/training/spec/features/admin_user_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Admin::User', type: :feature do
     context 'ユーザー情報を変更して更新をクリックしたとき' do
       before do
         fill_in I18n.t('attributes.name'), with: 'hogefuga'
-        fill_in I18n.t('attributes.email'), with: 'fuga@fuga.jp'
+        fill_in I18n.t('attributes.email'), with: 'fuga@example.com'
         click_on I18n.t('admin.view.partial.update')
       end
 
@@ -130,7 +130,7 @@ RSpec.describe 'Admin::User', type: :feature do
     context 'ユーザー情報を入力して作成をクリックしたとき' do
       before do
         fill_in I18n.t('attributes.name'), with: 'hogefuga'
-        fill_in I18n.t('attributes.email'), with: 'fuga@fuga.jp'
+        fill_in I18n.t('attributes.email'), with: 'fuga@example.com'
         fill_in I18n.t('attributes.password'), with: 'test1234'
         click_on I18n.t('admin.view.partial.create')
       end


### PR DESCRIPTION
### 対応課題
ステップ20 : ユーザの管理画面を実装しよう

### 実装内容

 - `管理画面にはかならず /admin というURLを先頭につけるようにしましょう`

　`http://localhost:3000/admin/users`の様なURLになる様に調整しました

 - `ユーザ一覧・作成・更新・削除を実装しましょう`

　**一覧画面**
![2017-12-21 21 05 58](https://user-images.githubusercontent.com/26861647/34255217-eeb3b1b2-e692-11e7-8446-6ba6162b7c53.png)

----

　**作成画面**　
![2017-12-21 21 06 22](https://user-images.githubusercontent.com/26861647/34255223-f830ab82-e692-11e7-84cb-03a92d1a5ae2.png)

----

　**編集画面**　
![2017-12-21 21 06 41](https://user-images.githubusercontent.com/26861647/34255227-fdf87766-e692-11e7-8f73-43d42ee920df.png)

----

　**削除時の動作**
![2017-12-21 21 06 58](https://user-images.githubusercontent.com/26861647/34255240-0ea68742-e693-11e7-8de4-2da23cd009c2.png)

----

 - `ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう`

実は
[step18のUserモデル](https://github.com/Fablic/training/blob/12f3cc4b367b927b3d6381b141037054397c3b05/training/app/models/user.rb#L3)作成時に必要になると思って組み込んだ処理によって
既に実現されていました

Controller Specのテストで動作を担保しています


 - `ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう`

アソシエーションを利用して実現しました
`user.tasks.count`

Feature Specの中で表示されることを担保しています


 - `ユーザが作成したタスクの一覧が見られるようにしてみましょう`

アソシエーションを利用して実現しました
`user.tasks`

Feature Specの中で表示されることを担保しています

### 補足

ユーザー情報更新時の動作は下記の様にしました

```
パスワードの入力があった場合 -> 更新
無かった場合 -> 更新しない
```
