### PR TITLE
ユーザにロールを追加

### DIFF
--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -78,7 +78,7 @@ class Admin::UsersController < ApplicationController
   end
 
   def convert_params_to_int
-    return false if params[:user].nil?
+    return if params[:user].nil?
     params[:user][:role] = params[:user][:role].to_i
   end
 

--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -73,7 +73,7 @@ class Admin::UsersController < ApplicationController
 
   def check_admin_deletion
     return unless User.find(params[:id]).admin?
-    if User.where(role: User.roles[:admin]).count == 1
+    if User.admin.count == 1
       redirect_to admin_users_path, notice: I18n.t('admin.controller.messages.admin_delete_error')
     end
   end

--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -1,4 +1,5 @@
 class Admin::UsersController < ApplicationController
+  before_action :require_admin_role
 
   def index
     @users = User.all

--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -1,6 +1,7 @@
 class Admin::UsersController < ApplicationController
   before_action :require_admin_role
   before_action :convert_params_to_int, only: %i(create update)
+  before_action :check_admin_deletion, only: :destroy
 
   def index
     @users = User.all
@@ -68,5 +69,12 @@ class Admin::UsersController < ApplicationController
   def convert_params_to_int
     return false if params[:user].nil?
     params[:user][:role] = params[:user][:role].to_i
+  end
+
+  def check_admin_deletion
+    return unless User.find(params[:id]).admin?
+    if User.where(role: User.roles[:admin]).count == 1
+      redirect_to admin_users_path, notice: I18n.t('admin.controller.messages.admin_delete_error')
+    end
   end
 end

--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < ApplicationController
   before_action :require_admin_role
+  before_action :convert_params_to_int, only: %i(create update)
 
   def index
     @users = User.all
@@ -51,6 +52,7 @@ class Admin::UsersController < ApplicationController
     params.require(:user).permit(
       :name,
       :email,
+      :role,
       :password,
     )
   end
@@ -59,6 +61,12 @@ class Admin::UsersController < ApplicationController
     params.require(:user).permit(
       :name,
       :email,
+      :role,
     )
+  end
+
+  def convert_params_to_int
+    return false if params[:user].nil?
+    params[:user][:role] = params[:user][:role].to_i
   end
 end

--- a/training/app/controllers/application_controller.rb
+++ b/training/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include LoginHelper
 
+  def require_admin_role
+    redirect_to root_path, notice: I18n.t('application.controller.messages.role_error') unless admin_role?
+  end
+
   private def require_login
     redirect_to logins_new_path unless logged_in?
   end

--- a/training/app/helpers/login_helper.rb
+++ b/training/app/helpers/login_helper.rb
@@ -6,4 +6,8 @@ module LoginHelper
   def current_user
     User.find(session[:user_id])
   end
+
+  def admin_role?
+    current_user.admin?
+  end
 end

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -9,4 +9,7 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }, uniqueness: true
   validates :password, on: :create, presence: true, length: { in: 8..72 }, format: { with: VALID_PASSWORD_REGEX }
   validates :password, on: :update, presence: true, length: { in: 8..72 }, format: { with: VALID_PASSWORD_REGEX }, allow_blank: true
+
+  enum role: { normal: 0, admin: 1 }
+  validates :role, presence: true, inclusion: { in: User.roles.keys }
 end

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
       errors.add(:role, I18n.t('errors.messages.role.require_least_one'))
       return false
     end
+
     true
   end
 end

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -12,8 +12,10 @@ class User < ApplicationRecord
 
   enum role: { normal: 0, admin: 1 }
   validates :role, presence: true, inclusion: { in: User.roles.keys }
-  validate :change_role_valid?
+  validate :change_role_valid?, on: :update
 
+  # 管理ユーザーが1ユーザーのみの状態で編集画面から権限を変更すると
+  # 管理ユーザーが居ない状態に出来てしまう為、update時にバリデーションを行う
   private def change_role_valid?
     return true if User.admin.count > 1
     return true if self.admin?

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -12,4 +12,16 @@ class User < ApplicationRecord
 
   enum role: { normal: 0, admin: 1 }
   validates :role, presence: true, inclusion: { in: User.roles.keys }
+  validate :change_role_valid?
+
+  private def change_role_valid?
+    return true if User.admin.count > 1
+    return true if self.admin?
+
+    if User.admin.first.id == id
+      errors.add(:role, I18n.t('errors.messages.role.require_least_one'))
+      return false
+    end
+    true
+  end
 end

--- a/training/app/views/admin/users/_form.html.erb
+++ b/training/app/views/admin/users/_form.html.erb
@@ -27,6 +27,10 @@
   <% end %>
   <br/>
 
+  <%= f.label :role %>
+  <%= f.select :role, User.roles.map { |k, v| [I18n.t("users.model.role.#{k}"), v] }, selected: @user.role_before_type_cast %>
+  <br/>
+
   <% if new_page? %>
     <%= f.submit I18n.t('admin.view.partial.create'), data: { disable_with: I18n.t('admin.view.partial.creating') } %>
   <% else %>

--- a/training/app/views/admin/users/index.html.erb
+++ b/training/app/views/admin/users/index.html.erb
@@ -6,6 +6,7 @@
       <th><%= I18n.t('admin.view.index.name') %></th>
       <th><%= I18n.t('admin.view.index.email') %></th>
       <th><%= I18n.t('admin.view.index.task_count') %></th>
+      <th><%= I18n.t('admin.view.index.role') %></th>
       <th><%= I18n.t('admin.view.index.created_at') %></th>
       <th colspan="3" ></th>
     </tr>
@@ -17,6 +18,7 @@
         <td><%= user.name %></td>
         <td><%= user.email %></td>
         <td><%= user.tasks.count %></td>
+        <td><%= I18n.t("users.model.role.#{user.role}") %></td>
         <td><%= convert_date_format(user.created_at) %></td>
         <td><%= link_to I18n.t('admin.view.index.show_page'), admin_user_path(user.id) %></td>
         <td><%= link_to I18n.t('admin.view.index.edit_page'), edit_admin_user_path(user) %></td>

--- a/training/app/views/admin/users/show.html.erb
+++ b/training/app/views/admin/users/show.html.erb
@@ -7,6 +7,7 @@
 <p><%= I18n.t('admin.view.show.user_id') %> : <%= @user.id %></p>
 <p><%= I18n.t('admin.view.show.name') %> : <%= @user.name %></p>
 <p><%= I18n.t('admin.view.show.email') %> : <%= @user.email %></p>
+<p><%= I18n.t('admin.view.index.role') %> : <%= I18n.t("users.model.role.#{@user.role}") %></p>
 <p><%= I18n.t('admin.view.show.created_at') %> : <%= convert_date_format(@user.created_at) %></p>
 <p><%= I18n.t('admin.view.show.updated_at') %> : <%= convert_date_format(@user.updated_at) %></p>
 </div>

--- a/training/app/views/admin/users/show.html.erb
+++ b/training/app/views/admin/users/show.html.erb
@@ -7,7 +7,7 @@
 <p><%= I18n.t('admin.view.show.user_id') %> : <%= @user.id %></p>
 <p><%= I18n.t('admin.view.show.name') %> : <%= @user.name %></p>
 <p><%= I18n.t('admin.view.show.email') %> : <%= @user.email %></p>
-<p><%= I18n.t('admin.view.index.role') %> : <%= I18n.t("users.model.role.#{@user.role}") %></p>
+<p><%= I18n.t('admin.view.show.role') %> : <%= I18n.t("users.model.role.#{@user.role}") %></p>
 <p><%= I18n.t('admin.view.show.created_at') %> : <%= convert_date_format(@user.created_at) %></p>
 <p><%= I18n.t('admin.view.show.updated_at') %> : <%= convert_date_format(@user.updated_at) %></p>
 </div>

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -112,6 +112,7 @@ ja:
         created: 作成しました
         updated: 更新しました
         deleted: 削除しました
+        admin_delete_error: 管理ユーザーは少なくとも１ユーザー必要です
   application:
     view:
       logged_out: ログアウトする

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -108,6 +108,9 @@ ja:
   application:
     view:
       logged_out: ログアウトする
+    controller:
+      messages:
+        role_error: 管理画面を利用するには管理者権限が必要です
   attributes:
     name: 名前
     description: 説明

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -51,6 +51,11 @@ ja:
         created: 作成しました
         updated: 更新しました
         deleted: 削除しました
+  users:
+    model:
+      role:
+        normal: 通常ユーザー
+        admin: 管理ユーザー
   logins:
     view:
       new:
@@ -69,6 +74,7 @@ ja:
         title: ユーザー 一覧
         name: ユーザー名
         email: メールアドレス
+        role: ユーザー権限
         task_count: タスク数
         created_at: 作成日
         show_page: 詳細
@@ -86,6 +92,7 @@ ja:
         user_id: ユーザーID
         name: ユーザー名
         email: メールアドレス
+        role: ユーザー権限
         created_at: 作成日
         updated_at: 更新日  
         index_page: 一覧
@@ -121,6 +128,7 @@ ja:
     end_date: 終了期限
     email: メールアドレス
     password: パスワード
+    role: ユーザー権限
   activerecord:
     errors:
       messages:

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -266,6 +266,8 @@ ja:
       end_date:
         invalid: に入力された日付が正しくありません
         not_exist: に入力された日付は存在しません
+      role:
+        require_least_one: に指定する管理ユーザーは少なくとも１ユーザー必要です
     template:
       body: 次の項目を確認してください
       header:

--- a/training/db/migrate/20171222070048_add_column_to_user.rb
+++ b/training/db/migrate/20171222070048_add_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddColumnToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :role, :unsigned_tinyint, null: false, after: :password_digest
+  end
+end

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171214102346) do
+ActiveRecord::Schema.define(version: 20171222070048) do
 
   create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false, unsigned: true
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20171214102346) do
     t.string "name", null: false
     t.string "email", null: false
     t.string "password_digest", null: false
+    t.integer "role", limit: 1, null: false, unsigned: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/training/spec/controllers/admin/users_controller_spec.rb
+++ b/training/spec/controllers/admin/users_controller_spec.rb
@@ -43,9 +43,55 @@ RSpec.describe Admin::UsersController, type: :controller do
     end
   end
 
-  describe 'ログインしている場合' do
+  describe 'ログインしているが管理者権限がない場合' do
     before do
       set_user_session
+    end
+
+    subject { response }
+
+    #params を検証する前にログインを要求するのでダミーの値を指定する
+    let(:params) { { id: 'dummy' } }
+
+    describe 'GET #index' do
+      before { get :index }
+      it { is_expected.to require_admin_role }
+    end
+
+    describe 'GET #show' do
+      before { get :show, params: params }
+      it { is_expected.to require_admin_role }
+    end
+
+    describe 'GET #new' do
+      before { get :new }
+      it { is_expected.to require_admin_role }
+    end
+
+    describe 'GET #edit' do
+      before { get :edit, params: params }
+      it { is_expected.to require_admin_role }
+    end
+
+    describe 'POST #create' do
+      before { post :create, params: params }
+      it { is_expected.to require_admin_role }
+    end
+
+    describe 'POST #update' do
+      before { post :update, params: params }
+      it { is_expected.to require_admin_role }
+    end
+
+    describe 'DELETE #destroy' do
+      before { delete :destroy, params: params }
+      it { is_expected.to require_admin_role }
+    end
+  end
+
+  describe '管理者権限でログインしている場合' do
+    before do
+      set_admin_user_session
     end
 
     describe 'GET #index' do

--- a/training/spec/controllers/admin/users_controller_spec.rb
+++ b/training/spec/controllers/admin/users_controller_spec.rb
@@ -247,6 +247,29 @@ RSpec.describe Admin::UsersController, type: :controller do
           end
         end
       end
+
+      context '管理ユーザーの情報変更を行う場合' do
+        let(:params) { { user: FactoryBot.attributes_for(:user, role: role), id: get_user_session } }
+        let(:role) { User.roles[:normal] }
+
+        context '管理ユーザーが１名だけの場合' do
+          it 'ユーザー権限を変更できない' do
+            expect(User.find(get_user_session).admin?).to be true
+            patch :update, params: params
+            expect(User.find(get_user_session).admin?).not_to be false
+          end
+        end
+
+        context '管理ユーザーが１名以上の場合' do
+          let!(:user) { FactoryBot.create(:user, role: User.roles[:admin]) }
+
+          it 'ユーザー権限を変更できる' do
+            expect(User.find(get_user_session).admin?).to be true
+            patch :update, params: params
+            expect(User.find(get_user_session).admin?).to be false
+          end
+        end
+      end
     end
 
     describe 'DELETE #destroy' do

--- a/training/spec/factories/users.rb
+++ b/training/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
       "test#{n}@example.com"
     end
     password 'test1234'
+    role User.roles[:normal]
   end
 end

--- a/training/spec/features/admin_user_spec.rb
+++ b/training/spec/features/admin_user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 include Admin::UsersHelper
 
 RSpec.describe 'Admin::User', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
+  let!(:user) { FactoryBot.create(:user, role: User.roles[:admin]) }
 
   before do
     visit logins_new_path
@@ -37,7 +37,8 @@ RSpec.describe 'Admin::User', type: :feature do
       end
     end
 
-    describe '管理者がユーザーを削除する' do
+    # 削除テストにバグがありログインしている管理者ユーザーのアカウントを削除してしまってテストが落ちる　後で修正する
+    skip '管理者がユーザーを削除する' do
       context '削除をクリックしたとき' do
         let!(:user_2) { FactoryBot.create(:user) }
 
@@ -99,7 +100,8 @@ RSpec.describe 'Admin::User', type: :feature do
       expect(current_path).to eq edit_admin_user_path(user.id)
     end
 
-    context 'ユーザー情報を変更して更新をクリックしたとき' do
+    # 入力フォームがないのでUserの管理者権限が戻ってテストが落ちるのでフォーム実装までskip
+    skip 'ユーザー情報を変更して更新をクリックしたとき' do
       before do
         fill_in I18n.t('attributes.name'), with: 'hogefuga'
         fill_in I18n.t('attributes.email'), with: 'fuga@example.com'

--- a/training/spec/features/admin_user_spec.rb
+++ b/training/spec/features/admin_user_spec.rb
@@ -37,17 +37,17 @@ RSpec.describe 'Admin::User', type: :feature do
       end
     end
 
-    # 削除テストにバグがありログインしている管理者ユーザーのアカウントを削除してしまってテストが落ちる　後で修正する
-    skip '管理者がユーザーを削除する' do
+    context '管理者がユーザーを削除する' do
       context '削除をクリックしたとき' do
         let!(:user_2) { FactoryBot.create(:user) }
 
         it 'ユーザーが削除される' do
-          click_on I18n.t('admin.view.index.delete')
+          visit current_path
+          all('tbody tr')[1].click_on I18n.t('admin.view.index.delete')
           expect(current_path).to eq admin_users_path
           expect(page).to have_content I18n.t('admin.controller.messages.deleted')
-          expect(page).not_to have_content user.email
-          expect(page).to have_content user_2.email
+          expect(page).to have_content user.email
+          expect(page).not_to have_content user_2.email
         end
       end
     end
@@ -100,8 +100,7 @@ RSpec.describe 'Admin::User', type: :feature do
       expect(current_path).to eq edit_admin_user_path(user.id)
     end
 
-    # 入力フォームがないのでUserの管理者権限が戻ってテストが落ちるのでフォーム実装までskip
-    skip 'ユーザー情報を変更して更新をクリックしたとき' do
+    context 'ユーザー情報を変更して更新をクリックしたとき' do
       before do
         fill_in I18n.t('attributes.name'), with: 'hogefuga'
         fill_in I18n.t('attributes.email'), with: 'fuga@example.com'

--- a/training/spec/models/user_spec.rb
+++ b/training/spec/models/user_spec.rb
@@ -180,5 +180,30 @@ RSpec.describe User, type: :model do
         end       
       end
     end
+
+    describe 'role' do
+      let(:user) { FactoryBot.build(:user, role: role) }
+      subject { user.valid? }
+
+      context '入力が正しい場合' do
+        let(:role) { User.roles[:admin] }
+        it { is_expected.to be true }
+      end
+
+      context '空欄の場合' do
+        let(:role) { '' }
+        it { is_expected.to be false }
+      end
+
+      context '文字列の場合' do
+        let(:role) { 'hoge' }
+        it { expect{ subject }.to raise_error(ArgumentError) }
+      end
+
+      context 'enumに含まれない数値の場合' do
+        let(:role) { 123 }
+        it { expect{ subject }.to raise_error(ArgumentError) }
+      end
+    end
   end
 end

--- a/training/spec/support/login_macros.rb
+++ b/training/spec/support/login_macros.rb
@@ -3,6 +3,10 @@ module LoginMacros
     session[:user_id] = FactoryBot.create(:user).id
   end
 
+  def set_admin_user_session
+    session[:user_id] = FactoryBot.create(:user, role: User.roles[:admin]).id
+  end
+
   def get_user_session
     session[:user_id]
   end

--- a/training/spec/support/matchers/require_admin_role.rb
+++ b/training/spec/support/matchers/require_admin_role.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :require_admin_role do |expected|
+  match do |actual|
+    expect(actual).to redirect_to Rails.application.routes.url_helpers.root_path
+    expect(flash[:notice]).to eq I18n.t('application.controller.messages.role_error')
+  end
+
+  failure_message do |actual|
+    "管理者権限を要求していません"
+  end
+
+  failure_message_when_negated do |actual|
+    "管理者権限が要求されています"
+  end
+
+  description do |actual|
+    "管理者権限が要求される"
+  end
+end


### PR DESCRIPTION
### 対応課題
ステップ21 : ユーザにロールを追加しよう

### 実装内容
 - `ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう`

Userテーブルに新たに `role` カラムを追加し区別する様にしました。

----

 - `管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう`

管理ユーザーで無い場合はタスク一覧に遷移してメッセージを出力する様にしました。
![2017-12-25 20 10 34](https://user-images.githubusercontent.com/26861647/34338819-b2a3f27a-e9af-11e7-9139-27c5362b2147.png)

また、管理ユーザーのみログインできる機能についてはコントローラーテストで動作を担保しています

----

 - `ユーザ管理画面でロールを選択できるようにしましょう`

実装しました
![2017-12-25 20 12 06](https://user-images.githubusercontent.com/26861647/34338849-e81b8f76-e9af-11e7-8624-febbcfb1ec8b.png)

----

 - `管理ユーザが1人もいなくならないように削除の制御をしましょう`

管理ユーザーが１ユーザーのみの状態で対象ユーザーを削除しようとすると
メッセージを出して削除を行わないようにする処理を実装しました
![2017-12-25 20 13 43](https://user-images.githubusercontent.com/26861647/34338861-21acfdec-e9b0-11e7-8b23-67bd45caba7b.png)

----

### 補足

課題には設定がありませんでしたが、バグを発見したので修正しました。

削除については、課題で制御を行うように指定されて居ますが
ユーザー編集で権限を変更することで管理ユーザーが０の状況を作り出せるので
ユーザー編集時にも管理ユーザーの人数を確認する仕組みを実装しました

![2017-12-25 20 15 16](https://user-images.githubusercontent.com/26861647/34338873-5b6c528a-e9b0-11e7-8022-bfa9f311c7af.png)
