### PR TITLE
タスクにラベル機能を実装

### DIFF
--- a/training/app/controllers/labels_controller.rb
+++ b/training/app/controllers/labels_controller.rb
@@ -1,0 +1,48 @@
+class LabelsController < ApplicationController
+  before_action :set_label, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @labels = Label.all
+  end
+
+  def show
+  end
+
+  def new
+    @label = Label.new
+  end
+
+  def edit
+  end
+
+  def create
+    @label = Label.new(label_params)
+    if @label.save
+      redirect_to @label, notice: I18n.t('labels.controller.messages.created')
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @label.update(label_params)
+      redirect_to @label, notice: I18n.t('labels.controller.messages.updated')
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @label.destroy
+    redirect_to labels_url, notice: I18n.t('labels.controller.messages.deleted')
+  end
+
+  private
+    def set_label
+      @label = Label.find(params[:id])
+    end
+
+    def label_params
+      params.require(:label).permit(:name)
+    end
+end

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -6,6 +6,7 @@ class TasksController < ApplicationController
     @status = params[:status]
     @order = params[:order]
     @user = params[:user][:only_self_task] if params[:user].present?
+    @label_id = params[:label_id]
 
     @tasks = Task.search(params).page(params[:page])
   end

--- a/training/app/helpers/tasks_helper.rb
+++ b/training/app/helpers/tasks_helper.rb
@@ -1,0 +1,6 @@
+module TasksHelper
+  def label_name(label_id)
+    label = Label.find_by(id: label_id)
+    label.present? ? label.name : '-'
+  end
+end

--- a/training/app/models/label.rb
+++ b/training/app/models/label.rb
@@ -1,0 +1,3 @@
+class Label < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 255 }, uniqueness: true
+end

--- a/training/app/models/label.rb
+++ b/training/app/models/label.rb
@@ -1,3 +1,4 @@
 class Label < ApplicationRecord
+  has_many :tasks
   validates :name, presence: true, length: { maximum: 255 }, uniqueness: true
 end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -23,10 +23,10 @@ class Task < ApplicationRecord
                self.order(created_at: :desc)
              end
 
-    result = result.where('status = ?', params[:status]) if params[:status].present?
-    result = result.where('name = ?', params[:name]) if params[:name].present?
+    result = result.where(status: params[:status]) if params[:status].present?
+    result = result.where(name: params[:name]) if params[:name].present?
     if params[:user].present?
-      result = result.where('user_id = ?', params[:user][:only_self_task]) if params[:user][:only_self_task].present?
+      result = result.where(user_id: params[:user][:only_self_task]) if params[:user][:only_self_task].present?
     end
     result
   end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -25,6 +25,7 @@ class Task < ApplicationRecord
 
     result = result.where(status: params[:status]) if params[:status].present?
     result = result.where(name: params[:name]) if params[:name].present?
+    result = result.where(label_id: params[:label_id]) if params[:label_id].present?
     if params[:user].present?
       result = result.where(user_id: params[:user][:only_self_task]) if params[:user][:only_self_task].present?
     end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -1,5 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :user
+  belongs_to :label, optional: true
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :user_id, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/training/app/views/admin/users/show.html.erb
+++ b/training/app/views/admin/users/show.html.erb
@@ -23,6 +23,7 @@
       <th><%= I18n.t('tasks.view.index.status') %></th>
       <th><%= I18n.t('tasks.view.index.priority') %></th>
       <th><%= I18n.t('tasks.view.index.end_date') %></th>
+      <th><%= I18n.t('tasks.view.index.label_id') %></th>
     </tr>
   </thead>
   <tbody>
@@ -33,6 +34,7 @@
         <td><%= I18n.t("tasks.model.status.#{task.status}") %></td>
         <td><%= I18n.t("tasks.model.priority.#{task.priority}") %></td>
         <td><%= task.end_date %></td>
+        <td><%= label_name(task.label_id) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/training/app/views/labels/_form.html.erb
+++ b/training/app/views/labels/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_for(@label) do |f| %>
+
+  <% if @label.errors.any?%>
+    <div>
+      <ul>
+      <% @label.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <br/>
+
+  <% if request.path_info == new_label_path %>
+    <%= f.submit I18n.t('labels.view.partial.create'), data: { disable_with: I18n.t('labels.view.partial.creating')} %>
+  <% else %>
+    <%= f.submit I18n.t('labels.view.partial.update'), data: { disable_with: I18n.t('labels.view.partial.updating')} %>
+  <% end %>
+<% end %>

--- a/training/app/views/labels/edit.html.erb
+++ b/training/app/views/labels/edit.html.erb
@@ -1,0 +1,6 @@
+<h1><%= I18n.t('labels.view.edit.title') %></h1>
+
+<%= render 'form'%>
+
+<%= link_to I18n.t('labels.view.page.show_page'), @label %> |
+<%= link_to I18n.t('labels.view.page.index_page'), labels_path %>

--- a/training/app/views/labels/index.html.erb
+++ b/training/app/views/labels/index.html.erb
@@ -1,0 +1,25 @@
+<h1><%= I18n.t('labels.view.index.title') %></h1>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= I18n.t('attributes.name') %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @labels.each do |label| %>
+      <tr>
+        <td><%= label.name %></td>
+        <td><%= link_to I18n.t('labels.view.page.show_page'), label %></td>
+        <td><%= link_to I18n.t('labels.view.page.edit_page'), edit_label_path(label) %></td>
+        <td><%= link_to I18n.t('labels.view.page.delete'), label, method: :delete, data: { confirm: I18n.t('labels.view.index.delete_confirm') } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to I18n.t('labels.view.page.new_page'), new_label_path %>

--- a/training/app/views/labels/new.html.erb
+++ b/training/app/views/labels/new.html.erb
@@ -1,0 +1,5 @@
+<h1><%= I18n.t('labels.view.new.title') %></h1>
+
+<%= render 'form' %>
+
+<%= link_to I18n.t('labels.view.page.index_page'), labels_path %>

--- a/training/app/views/labels/show.html.erb
+++ b/training/app/views/labels/show.html.erb
@@ -1,0 +1,10 @@
+<h1><%= I18n.t('labels.view.show.title') %></h1>
+
+<div>
+  <h4><%= @label.name %></h4>
+  <p><%= I18n.t('labels.view.show.created_at') %> : <%= convert_date_format(@label.created_at) %></p>
+  <p><%= I18n.t('labels.view.show.updated_at') %> : <%= convert_date_format(@label.updated_at) %></p>
+</div>
+
+<%= link_to I18n.t('labels.view.page.edit_page'), edit_label_path(@label) %> |
+<%= link_to I18n.t('labels.view.page.index_page'), labels_path %>

--- a/training/app/views/tasks/_task_form.html.erb
+++ b/training/app/views/tasks/_task_form.html.erb
@@ -32,6 +32,10 @@
   <%= f.date_select :end_date %>
   <br/>
 
+  <%= f.label :label_id %>
+  <%= f.collection_select :label_id, Label.all, :id, :name, include_blank: true %>
+  <br/>
+
   <% if request.path_info == new_task_path %>
     <%= f.submit I18n.t('tasks.view.partial.create'), data: { disable_with: I18n.t('tasks.view.partial.creating')} %>
   <% else %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -14,7 +14,7 @@
     <%= label_tag :name, I18n.t('tasks.view.index.name') %>
     <%= text_field_tag :name, @name %>
     <br/>
-    <%= label_tag :label_id, 'ラベル' %>
+    <%= label_tag :label_id, I18n.t('tasks.view.index.label_id') %>
     <%= select_tag :label_id, options_for_select(Label.all.pluck(:name,:id) { |n, i| [n.name, i.id] }, selected: @label_id), include_blank: true %>
     <br/>
     <%= I18n.t('tasks.view.index.self_task') %>
@@ -44,6 +44,7 @@
     <p><%= I18n.t('tasks.view.index.status') %> : <%= I18n.t("tasks.model.status.#{task.status}") %></p>
     <p><%= I18n.t('tasks.view.index.priority') %> : <%= I18n.t("tasks.model.priority.#{task.priority}") %></p>
     <p><%= I18n.t('tasks.view.index.end_date') %> : <%= task.end_date %></p>
+    <p><%= I18n.t('tasks.view.index.label_id') %> : <%= label_name(task.label_id) %></p>
     <hr />
   <% end %>
   <%= paginate @tasks %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -14,6 +14,9 @@
     <%= label_tag :name, I18n.t('tasks.view.index.name') %>
     <%= text_field_tag :name, @name %>
     <br/>
+    <%= label_tag :label_id, 'ラベル' %>
+    <%= select_tag :label_id, options_for_select(Label.all.pluck(:name,:id) { |n, i| [n.name, i.id] }, selected: @label_id), include_blank: true %>
+    <br/>
     <%= I18n.t('tasks.view.index.self_task') %>
     <%= check_box 'user', 'only_self_task', { checked: @user.to_i == current_user.id }, current_user.id, '' %>
 

--- a/training/app/views/tasks/show.html.erb
+++ b/training/app/views/tasks/show.html.erb
@@ -7,6 +7,7 @@
   <p><%= I18n.t('tasks.view.show.status') %> : <%= I18n.t("tasks.model.status.#{@task.status}") %></p>
   <p><%= I18n.t('tasks.view.show.priority') %> : <%= I18n.t("tasks.model.priority.#{@task.priority}") %></p>
   <p><%= I18n.t('tasks.view.show.end_date') %> : <%= @task.end_date %></p>
+  <p><%= I18n.t('tasks.view.show.label_id') %> : <%= label_name(@task.label_id) %></p>
 </div>
 <div>
   <%= link_to(I18n.t('tasks.view.show.index_page'), tasks_path) %> / <%= link_to(I18n.t('tasks.view.show.edit_page'), edit_task_path(@task)) %> / 

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -52,6 +52,7 @@ ja:
         status: ステータス
         priority: 優先順位
         end_date: 終了期限
+        label_id: ラベル
         self_task: 自分のタスクのみ表示
       new:
         title: タスク作成
@@ -68,6 +69,7 @@ ja:
         end_date: 終了期限
         index_page: 一覧
         edit_page: 編集
+        label_id: ラベル
         delete: 削除
         delete_confirm: 削除しますか？
       partial:

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -159,7 +159,7 @@ ja:
     user_id: ユーザー番号
     priority: 優先順位
     status: ステータス
-    label_id: ラベル番号
+    label_id: ラベル
     end_date: 終了期限
     email: メールアドレス
     password: パスワード

--- a/training/config/locales/ja.yml
+++ b/training/config/locales/ja.yml
@@ -1,5 +1,34 @@
 ---
 ja:
+  labels:
+    view:
+      index:
+        title: ラベル一覧
+        delete_confirm: 削除しますか？
+      show:
+        title: ラベル詳細
+        created_at: ラベル作成日
+        updated_at: ラベル更新日
+      edit:
+        title: ラベル編集
+      new:
+        title: ラベル作成
+      partial:
+        create: 作成
+        creating: 作成中
+        update: 更新
+        updating: 更新中
+      page:
+        show_page: 詳細
+        index_page: 一覧
+        edit_page: 編集
+        delete: 削除
+        new_page: ラベル作成
+    controller:
+      messages:
+        created: ラベルを作成しました
+        updated: ラベルを更新しました
+        deleted: ラベルを削除しました
   tasks:
     model:
       status:

--- a/training/config/routes.rb
+++ b/training/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :labels
   root to: 'tasks#index'
   resources :tasks
   namespace :admin do

--- a/training/db/migrate/20171225112748_create_labels.rb
+++ b/training/db/migrate/20171225112748_create_labels.rb
@@ -1,0 +1,10 @@
+class CreateLabels < ActiveRecord::Migration[5.1]
+  def change
+    create_table :labels do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :labels, :name, unique: true
+  end
+end

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171222070048) do
+ActiveRecord::Schema.define(version: 20171225112748) do
+
+  create_table "labels", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_labels_on_name", unique: true
+  end
 
   create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false, unsigned: true

--- a/training/spec/controllers/labels_controller_spec.rb
+++ b/training/spec/controllers/labels_controller_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe LabelsController, type: :controller do
       let(:params) { { label: FactoryBot.attributes_for(:label, name: name), id: label.id } }
 
       context 'データが正しい場合' do
-        let(:name) {'hoge'}
+        let(:name) { 'hoge' }
 
         it 'ラベルが更新される' do
           expect(Label.find(label.id)).to eq label
@@ -158,7 +158,7 @@ RSpec.describe LabelsController, type: :controller do
       end
 
       context 'データが不正な場合' do
-        let(:name) {''}
+        let(:name) { '' }
 
         it 'ラベルは更新されない' do
           expect(Label.find(label.id)).to eq label
@@ -175,7 +175,7 @@ RSpec.describe LabelsController, type: :controller do
 
     describe 'DELETE #destroy' do
       let(:label) { FactoryBot.create(:label) }
-      let(:params) { {id: label.id} }
+      let(:params) { { id: label.id } }
 
       it 'ラベルを削除する' do
         expect(Label.find(label.id)).to eq label

--- a/training/spec/controllers/labels_controller_spec.rb
+++ b/training/spec/controllers/labels_controller_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe LabelsController, type: :controller do
       end
 
       context 'データが重複する場合' do
-        let!(:label) { FactoryBot.create(:label) }
-        let(:params) { { label: FactoryBot.attributes_for(:label) } }
+        let!(:label) { FactoryBot.create(:label, name: 'hoge') }
+        let(:params) { { label: FactoryBot.attributes_for(:label, name: 'hoge') } }
 
         it 'ラベルは作成されない' do
           expect{

--- a/training/spec/controllers/labels_controller_spec.rb
+++ b/training/spec/controllers/labels_controller_spec.rb
@@ -1,0 +1,188 @@
+require 'rails_helper'
+
+RSpec.describe LabelsController, type: :controller do
+  describe 'ログインしていない場合' do
+    subject { response }
+
+    #params を検証する前にログインを要求するのでダミーの値を指定する
+    let(:params) { { id: 'dummy' } }
+
+    describe 'GET #index' do
+      before { get :index }
+      it { is_expected.to require_login }
+    end
+
+    describe 'GET #show' do
+      before { get :show, params: params }
+      it { is_expected.to require_login }
+    end
+
+    describe 'GET #new' do
+      before { get :new }
+      it { is_expected.to require_login }
+    end
+
+    describe 'GET #edit' do
+      before { get :edit, params: params }
+      it { is_expected.to require_login }
+    end
+
+    describe 'POST #create' do
+      before { post :create, params: params }
+      it { is_expected.to require_login }
+    end
+
+    describe 'POST #update' do
+      before { post :update, params: params }
+      it { is_expected.to require_login }
+    end
+
+    describe 'DELETE #destroy' do
+
+      before { delete :destroy, params: params }
+      it { is_expected.to require_login }
+    end
+  end
+
+  describe 'ログインしている場合' do
+    before do
+      set_user_session
+    end
+
+    describe 'GET #index' do
+      let!(:label) { FactoryBot.create(:label) }
+
+      it '@labels にラベル情報を持っている' do
+        get :index
+        expect(assigns(:labels)[0]).to eq label
+      end
+
+      it 'index テンプレートを表示する' do
+        get :index
+        expect(response).to render_template :index
+      end
+    end
+
+    describe 'GET #show' do
+      let(:label) { FactoryBot.create(:label) }
+      let(:params) { { id: label.id } }
+
+      it '@label にラベル情報を持っている' do
+        get :show, params: params
+        expect(assigns(:label)).to eq label
+      end
+
+      it 'show テンプレートを表示する' do
+        get :show, params: params
+        expect(response).to render_template :show
+      end
+    end
+
+    describe 'GET #edit' do
+      let(:label) { FactoryBot.create(:label) }
+      let(:params) { { id: label.id } }
+
+      it '@label にラベル情報を持っている' do
+        get :edit, params: params
+        expect(assigns(:label)).to eq label
+      end
+
+      it 'edit テンプレートを表示する' do
+        get :edit, params: params
+        expect(response).to render_template :edit
+      end
+    end
+
+    describe 'GET #new' do
+      it 'new テンプレートを表示する' do
+        get :new
+        expect(response).to render_template :new
+      end
+    end
+
+    describe 'POST #create' do
+      context 'データが正しい場合' do
+        let(:params) { { label: FactoryBot.attributes_for(:label) } }
+
+        it 'ラベルが新たに作成される' do
+          expect{
+            post :create, params: params
+          }.to change(Label, :count).by(1)
+        end
+      end
+
+      context 'データが不正な場合' do
+        let(:params) { { label: FactoryBot.attributes_for(:label, name: '') } }
+
+        it 'ラベルは作成されない' do
+          expect{
+            post :create, params: params
+          }.not_to change(Label, :count)
+        end
+
+        it 'newテンプレートを表示する' do
+          get :create, params: params
+          expect(response).to render_template :new
+        end
+      end
+
+      context 'データが重複する場合' do
+        let!(:label) { FactoryBot.create(:label) }
+        let(:params) { { label: FactoryBot.attributes_for(:label) } }
+
+        it 'ラベルは作成されない' do
+          expect{
+            post :create, params: params
+          }.not_to change(Label, :count)
+        end
+
+        it 'newテンプレートを表示する' do
+          get :create, params: params
+          expect(response).to render_template :new
+        end
+      end
+    end
+
+    describe 'POST #update' do
+      let(:label) { FactoryBot.create(:label) }
+      let(:params) { { label: FactoryBot.attributes_for(:label, name: name), id: label.id } }
+
+      context 'データが正しい場合' do
+        let(:name) {'hoge'}
+
+        it 'ラベルが更新される' do
+          expect(Label.find(label.id)).to eq label
+          patch :update, params: params
+          expect(Label.find(label.id).name).to eq name
+        end
+      end
+
+      context 'データが不正な場合' do
+        let(:name) {''}
+
+        it 'ラベルは更新されない' do
+          expect(Label.find(label.id)).to eq label
+          patch :update, params: params
+          expect(Label.find(label.id).name).not_to eq name
+        end
+
+        it 'editテンプレートを表示する' do
+          put :update, params: params
+          expect(response).to render_template :edit
+        end
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      let(:label) { FactoryBot.create(:label) }
+      let(:params) { {id: label.id} }
+
+      it 'ラベルを削除する' do
+        expect(Label.find(label.id)).to eq label
+        delete :destroy, params: params
+        expect{ Label.find(label.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end
+

--- a/training/spec/factories/labels.rb
+++ b/training/spec/factories/labels.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :label do
-    name 'test_label'
+    sequence :name do |n|
+      "test_label_#{n}"
+    end
   end
 end

--- a/training/spec/factories/labels.rb
+++ b/training/spec/factories/labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :label do
+    name 'test_label'
+  end
+end

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     description 'description'
     priority 0
     status Task.statuses[:not_started]
-    label_id 0 # ラベル機能実装時に修正する
+    label
     end_date Time.zone.today
   end
 end

--- a/training/spec/features/task_spec.rb
+++ b/training/spec/features/task_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe 'Task', type: :feature do
     end
 
     context '検索機能でタスクを絞り込む' do
+      let!(:label) { FactoryBot.create(:label) }
       let!(:task_saerch_1) { FactoryBot.create(:task, name: 'hoge', status: 0, priority: 1, end_date: '2010-01-01', user_id: user.id) }
-      let!(:task_saerch_2) { FactoryBot.create(:task, name: 'fuga', status: 1, priority: 2, end_date: '2010-01-02') }
+      let!(:task_saerch_2) { FactoryBot.create(:task, name: 'fuga', status: 1, priority: 2, end_date: '2010-01-02', label_id: label.id) }
 
       context 'ステータス　着手中　で検索したとき' do
         it '対象のタスクのみが表示される' do
@@ -51,6 +52,16 @@ RSpec.describe 'Task', type: :feature do
           fill_in 'タスク名', with: 'hoge'
           click_button '検索する'
           expect(all('h4')[0]).to have_content task_saerch_1.name
+          expect(all('h4')[1]).to be nil
+        end
+      end
+
+      context 'ラベル名で検索したとき' do
+        it '対象のタスクのみが表示される' do
+          visit current_path
+          select label.name, from: 'label_id'
+          click_button '検索する'
+          expect(all('h4')[0]).to have_content task_saerch_2.name
           expect(all('h4')[1]).to be nil
         end
       end
@@ -134,6 +145,25 @@ RSpec.describe 'Task', type: :feature do
       it '詳細ページに遷移する' do
         expect(current_path).to eq task_path(task.id)
         expect(page).to have_content update_name
+      end
+
+      it '更新しました　とメッセージが表示される' do
+        expect(page).to have_content I18n.t('tasks.controller.messages.updated')
+      end
+    end
+
+    context 'ラベル情報を追加する' do
+      let!(:label) { FactoryBot.create(:label) }
+
+      before do
+        visit current_path
+        select label.name, from: 'task_label_id'
+        click_on I18n.t('tasks.view.partial.update')
+      end
+
+      it '詳細ページに遷移する' do
+        expect(current_path).to eq task_path(task.id)
+        expect(page).to have_content label.name
       end
 
       it '更新しました　とメッセージが表示される' do

--- a/training/spec/models/label_spec.rb
+++ b/training/spec/models/label_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  describe 'validation' do
+    describe 'name' do
+      let!(:label) { FactoryBot.build(:label, name: name) }
+      subject { label.valid? }
+
+      context '入力が正しい場合' do
+        let(:name) { 'test' }
+        it { is_expected.to be true }
+      end
+
+      context '空欄の場合' do
+        let(:name) { '' }
+        it { is_expected.to be false }
+      end
+
+      context '重複した場合' do
+        before { FactoryBot.create(:label, name: name) }
+
+        let(:name) { 'hoge' }
+        it { is_expected.to be false }
+      end
+
+      context '文字列の長さ' do
+        context '254以下の場合' do
+          let(:name) { 'a' * 254 }
+          it { is_expected.to be true }
+        end
+
+        context '255の場合' do
+          let(:name) { 'a' * 255 }
+          it { is_expected.to be true }
+        end
+
+        context '256以上の場合' do
+          let(:name) { 'a' * 256 }
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end

--- a/training/spec/models/tasks_spec.rb
+++ b/training/spec/models/tasks_spec.rb
@@ -247,6 +247,35 @@ RSpec.describe Task, type: :model do
         end
       end
 
+      context 'ラベル検索' do
+        let!(:label) { FactoryBot.create(:label) }
+        let!(:task_0) { FactoryBot.create(:task, label_id: label.id) }
+        let!(:task_1) { FactoryBot.create(:task) }
+
+        context '指定しない場合' do
+          let(:params) { {} }
+          it '全てのタスクが出力される' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to eq task_1
+          end
+        end
+
+        context 'ラベルを指定した場合' do
+          let(:params) { { label_id: label.id } }
+          it '対象のタスクが絞り込まれる' do
+            expect(subject[0]).to eq task_0
+            expect(subject[1]).to be nil
+          end
+        end
+
+        context '存在しないラベルを指定した場合' do
+          let(:params) { { label_id: 0 } }
+          it '何も出力されない' do
+            expect(subject[0]).to be_nil
+          end
+        end
+      end
+
       context '作成ユーザー絞り込み検索' do
         let!(:user) { FactoryBot.create(:user) }
         let!(:task_0) { FactoryBot.create(:task) }


### PR DESCRIPTION
### 対応課題
ステップ22 : タスクにラベルをつけられるようにしよう

### 実装内容

 - `タスクに複数のラベルをつけられるようにしてみましょう`

課題では複数のラベルと書かれて居ますが、仕様設計時に確認した際に`1タスク 1ラベル` という事で
決めてテーブル設計などを進めてしまったので`1タスク 1ラベル` で実装を行いました。

(ラベル一覧画面)
![2017-12-26 18 28 35](https://user-images.githubusercontent.com/26861647/34353339-d4d84376-ea6a-11e7-8119-3ad4b493f540.png)

----

(ラベル作成画面)
編集画面も同様のレイアウトです
![2017-12-26 18 28 53](https://user-images.githubusercontent.com/26861647/34353349-e69e242c-ea6a-11e7-8d7f-7d51d73de9a5.png)

----

(タスク作成画面)
新たにラベルの設定項目が追加されました
![2017-12-26 18 32 26](https://user-images.githubusercontent.com/26861647/34353406-2fe8ec70-ea6b-11e7-9db2-635e44449dbe.png)

----

(タスク詳細画面)
新たにラベルの表示項目が追加されました
一覧画面にも同様にラベルが表示されるようになっています

![2017-12-26 18 33 16](https://user-images.githubusercontent.com/26861647/34353427-56400ba6-ea6b-11e7-9bff-dca0b0917f1c.png)

----

 - `つけたラベルで検索できるようにしてみましょう`

検索項目にラベルの項目を追加して検索機能を実装しました。
![2017-12-26 18 30 06](https://user-images.githubusercontent.com/26861647/34353432-5d9c5030-ea6b-11e7-919d-1aeda1291ffd.png)


### 補足
