### PR TITLE
データベースの設定を変更

### DIFF
--- a/todo_app/config/database.yml
+++ b/todo_app/config/database.yml
@@ -1,54 +1,21 @@
-# MySQL. Versions 5.1.10 and up are supported.
-#
-# Install the MySQL driver
-#   gem install mysql2
-#
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem 'mysql2'
-#
-# And be sure to use new-style password hashing:
-#   http://dev.mysql.com/doc/refman/5.7/en/old-client.html
-#
 default: &default
   adapter: mysql2
   encoding: utf8
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password:
+  pool: 5
+  username: todo_app
+  password: admin001
   socket: /tmp/mysql.sock
 
 development:
   <<: *default
   database: todo_app_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: todo_app_test
 
-# As with config/secrets.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
-production:
-  <<: *default
-  database: todo_app_production
-  username: todo_app
-  password: <%= ENV['TODO_APP_DATABASE_PASSWORD'] %>
+#production:
+#  <<: *default
+#  database: todo_app_production
+#  username: todo_app
+#  password: admin001


### PR DESCRIPTION
trainingの[ステップ5: データベースの接続設定（周辺設定）をしましょう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%975-%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9%E3%81%AE%E6%8E%A5%E7%B6%9A%E8%A8%AD%E5%AE%9A%E5%91%A8%E8%BE%BA%E8%A8%AD%E5%AE%9A%E3%82%92%E3%81%97%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)の対応です。

もともとrailsのアプリ作成時に`-d mysql`を指定していたため、`Gemfile`の変更はありません。

アプリ用にDBユーザーを作成しているため、以下のコマンドを実行する必要があります。
`rails db:create`の動作確認は完了しています。

```
$ mysql -u root
[mysql> CREATE USER 'todo_app'@localhost IDENTIFIED BY 'admin001';
[mysql> grant create on *.* to 'todo_app'@'localhost';
```

`database.yml`の記載方法に間違いがないかご確認をお願いします。
