### PR TITLE
ステップ5: データベースの接続設定（周辺設定）をしましょう

### DIFF
--- a/todo_app/Gemfile
+++ b/todo_app/Gemfile
@@ -3,8 +3,8 @@ ruby "2.3.1"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.8'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use mysql2 as the database for Active Record
+gem 'mysql2'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/todo_app/Gemfile.lock
+++ b/todo_app/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
+    mysql2 (0.4.6)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     rack (1.6.9)
@@ -131,7 +132,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -156,11 +156,11 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
+  mysql2
   rails (= 4.2.8)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
-  sqlite3
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/todo_app/config/database.yml
+++ b/todo_app/config/database.yml
@@ -1,8 +1,10 @@
 default: &default
   adapter: mysql2
+  # 今回はDockerを使用しているのでlocalhostではなく127.0.0.1で接続
   host: 127.0.0.1
   username: root
   password:
+  # 🍣 を入力したいのです
   encoding: utf8mb4
   pool: 5
   timeout: 5000

--- a/todo_app/config/database.yml
+++ b/todo_app/config/database.yml
@@ -1,25 +1,19 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: mysql2
+  host: 127.0.0.1
+  username: root
+  password:
+  encoding: utf8mb4
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: todo_app
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3
+  database: todo_app_test

--- a/todo_app/docs/README.md
+++ b/todo_app/docs/README.md
@@ -58,6 +58,12 @@
 
 ## Spec
 
+### ローカル開発用DB
+
+```
+docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD="yes" -p "3306:3306" mysql:5.6
+```
+
 ### データモデル
 
 まずはTasksをCRUDしてみます。


### PR DESCRIPTION
## 概要

[ステップ5: データベースの接続設定（周辺設定）をしましょう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%975-%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9%E3%81%AE%E6%8E%A5%E7%B6%9A%E8%A8%AD%E5%AE%9A%E5%91%A8%E8%BE%BA%E8%A8%AD%E5%AE%9A%E3%82%92%E3%81%97%E3%81%BE%E3%81%97%E3%82%87%E3%81%86) の対応です。

## 内容

* DBをSQLiteからMySQLに変更
* DockerでMySQLを立ち上げて `rake db:create` を実行
