### PR TITLE
タスク編集画面のテストコード追加

### DIFF
--- a/todo_app/spec/features/edit_task_page_spec.rb
+++ b/todo_app/spec/features/edit_task_page_spec.rb
@@ -70,7 +70,7 @@ describe 'タスク編集画面' , type: :feature do
               fill_in I18n.t('page.task.label.title'), with: ''
               fill_in I18n.t('page.task.label.description'), with: 'after task title description'
               fill_in_datetime_select(
-                  DateTime.strptime('2018/02/03 04:05:06', '%Y/%m/%d %H:%M:%S'),
+                  Time.new(2018, 2, 3, 4, 5, 6),
                   'task_deadline')
               select '進行中', from: 'task_status'
               select '高い', from: 'task_priority'

--- a/todo_app/spec/features/edit_task_page_spec.rb
+++ b/todo_app/spec/features/edit_task_page_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+require 'features/test_helpers'
+
+RSpec.configure do |config|
+  config.include TestHelpers
+end
+
+describe 'タスク編集画面' , type: :feature do
+  before do
+    @task = Task.new(title: 'before task title', description: 'before task description',
+                     deadline: '2017/01/01 01:01:01', status: 'not_start', priority: 'low')
+    @task.save
+    visit edit_task_path(@task)
+  end
+
+  describe 'アクセス' do
+    it '画面が表示されていること' do
+      expect(page).to have_css('#edit_task')
+    end
+  end
+
+  describe '登録されているタスク情報を表示する' do
+    it 'タスク名が表示されていること' do
+      expect(page.find_by_id('task_title').value).to eq @task.title
+    end
+
+    it '説明が表示されていること' do
+      expect(page.find_by_id('task_description').value).to eq @task.description
+    end
+
+    it '期日が表示されていること' do
+      expect(page.find_by_id('task_deadline_1i').value).to eq @task.deadline.strftime('%Y')
+      expect(page.find_by_id('task_deadline_2i').value).to eq @task.deadline.strftime('%-m')
+      expect(page.find_by_id('task_deadline_3i').value).to eq @task.deadline.strftime('%-d')
+      expect(page.find_by_id('task_deadline_4i').value).to eq @task.deadline.strftime('%H')
+      expect(page.find_by_id('task_deadline_5i').value).to eq @task.deadline.strftime('%M')
+    end
+
+    it 'ステータスが表示されていること' do
+      expect(page.find_by_id('task_status').value).to eq @task.status
+    end
+
+    it '優先度が表示されていること' do
+      expect(page.find_by_id('task_priority').value).to eq @task.priority
+    end
+  end
+
+  describe 'タスクを更新する' do
+    context '正常に更新できる場合' do
+      it '値を変更して更新できること' do
+        within('.edit_task') do
+          fill_in I18n.t('page.task.label.title'), with: 'after task title'
+          fill_in I18n.t('page.task.label.description'), with: 'after task title description'
+          fill_in_datetime_select(
+              DateTime.strptime('2018/02/03 04:05:06', '%Y/%m/%d %H:%M:%S'),
+              'task_deadline')
+          select '進行中', from: 'task_status'
+          select '高い', from: 'task_priority'
+        end
+        click_on I18n.t('helpers.submit.update')
+
+        expect(page).to have_css('#todo_app_task_list')
+        expect(page).to have_content I18n.t('success.update', it: Task.model_name.human)
+      end
+
+      context '更新に失敗する場合' do
+        context 'タスク名が空の場合' do
+          it 'エラーメッセージが表示されること' do
+            within('.edit_task') do
+              fill_in I18n.t('page.task.label.title'), with: ''
+              fill_in I18n.t('page.task.label.description'), with: 'after task title description'
+              fill_in_datetime_select(
+                  DateTime.strptime('2018/02/03 04:05:06', '%Y/%m/%d %H:%M:%S'),
+                  'task_deadline')
+              select '進行中', from: 'task_status'
+              select '高い', from: 'task_priority'
+            end
+            click_on I18n.t('helpers.submit.update')
+
+            expect(page).to have_css('#edit_task')
+            expect(page).to have_content('Titleを入力してください')
+          end
+        end
+      end
+
+      context '編集をやめたい場合' do
+        it 'キャンセルボタンクリックで一覧画面に戻れること' do
+          click_on I18n.t('helpers.submit.cancel')
+          expect(page).to have_css('#todo_app_task_list')
+        end
+      end
+    end
+  end
+end

--- a/todo_app/spec/features/edit_task_page_spec.rb
+++ b/todo_app/spec/features/edit_task_page_spec.rb
@@ -6,12 +6,12 @@ RSpec.configure do |config|
 end
 
 describe 'タスク編集画面' , type: :feature do
-  before do
-    @task = Task.new(title: 'before task title', description: 'before task description',
-                     deadline: '2017/01/01 01:01:01', status: 'not_start', priority: 'low')
-    @task.save
-    visit edit_task_path(@task)
+  let(:task) do
+    create(:task, title: 'before task title', description: 'before task description',
+           deadline: '2017/01/01 01:01:01', status: 'not_start', priority: 'low')
   end
+
+  before { visit edit_task_path(task) }
 
   describe 'アクセス' do
     it '画面が表示されていること' do
@@ -21,27 +21,27 @@ describe 'タスク編集画面' , type: :feature do
 
   describe '登録されているタスク情報を表示する' do
     it 'タスク名が表示されていること' do
-      expect(page.find_by_id('task_title').value).to eq @task.title
+      expect(page.find_by_id('task_title').value).to eq task.title
     end
 
     it '説明が表示されていること' do
-      expect(page.find_by_id('task_description').value).to eq @task.description
+      expect(page.find_by_id('task_description').value).to eq task.description
     end
 
     it '期日が表示されていること' do
-      expect(page.find_by_id('task_deadline_1i').value).to eq @task.deadline.strftime('%Y')
-      expect(page.find_by_id('task_deadline_2i').value).to eq @task.deadline.strftime('%-m')
-      expect(page.find_by_id('task_deadline_3i').value).to eq @task.deadline.strftime('%-d')
-      expect(page.find_by_id('task_deadline_4i').value).to eq @task.deadline.strftime('%H')
-      expect(page.find_by_id('task_deadline_5i').value).to eq @task.deadline.strftime('%M')
+      expect(page.find_by_id('task_deadline_1i').value).to eq task.deadline.strftime('%Y')
+      expect(page.find_by_id('task_deadline_2i').value).to eq task.deadline.strftime('%-m')
+      expect(page.find_by_id('task_deadline_3i').value).to eq task.deadline.strftime('%-d')
+      expect(page.find_by_id('task_deadline_4i').value).to eq task.deadline.strftime('%H')
+      expect(page.find_by_id('task_deadline_5i').value).to eq task.deadline.strftime('%M')
     end
 
     it 'ステータスが表示されていること' do
-      expect(page.find_by_id('task_status').value).to eq @task.status
+      expect(page.find_by_id('task_status').value).to eq task.status
     end
 
     it '優先度が表示されていること' do
-      expect(page.find_by_id('task_priority').value).to eq @task.priority
+      expect(page.find_by_id('task_priority').value).to eq task.priority
     end
   end
 

--- a/todo_app/spec/features/edit_task_page_spec.rb
+++ b/todo_app/spec/features/edit_task_page_spec.rb
@@ -52,7 +52,7 @@ describe 'タスク編集画面' , type: :feature do
           fill_in I18n.t('page.task.label.title'), with: 'after task title'
           fill_in I18n.t('page.task.label.description'), with: 'after task title description'
           fill_in_datetime_select(
-              DateTime.strptime('2018/02/03 04:05:06', '%Y/%m/%d %H:%M:%S'),
+              Time.new(2018, 2, 3, 4, 5, 6),
               'task_deadline')
           select '進行中', from: 'task_status'
           select '高い', from: 'task_priority'

--- a/todo_app/spec/features/edit_task_page_spec.rb
+++ b/todo_app/spec/features/edit_task_page_spec.rb
@@ -8,7 +8,7 @@ end
 describe 'タスク編集画面' , type: :feature do
   let(:task) do
     create(:task, title: 'before task title', description: 'before task description',
-           deadline: '2017/01/01 01:01:01', status: 'not_start', priority: 'low')
+           deadline: Time.new(2017, 1, 1, 1, 1, 1), status: 'not_start', priority: 'low')
   end
 
   before { visit edit_task_path(task) }


### PR DESCRIPTION
[ステップ8: テスト（feature spec）を書こう](https://github.com/everyleaf/el-training)の**タスク編集画面**のレビューをお願いします 。

# 内容

- タスク編集画面のテストコード追加
  - 初期表示
  - 登録処理
    - 正常の場合
    - バリデーションに引っかかる場合

タスク登録画面のテストコードで外だししたmoduleを利用するため、 https://github.com/Fablic/training/pull/34 で行なっているため、コミットをマージしています。

テストの実行結果は以下の通りです。

```
タスク編集画面
  アクセス
    画面が表示されていること
  登録されているタスク情報を表示する
    タスク名が表示されていること
    説明が表示されていること
    期日が表示されていること
    ステータスが表示されていること
    優先度が表示されていること
  タスクを更新する
    正常に更新できる場合
      値を変更して更新できること
      更新に失敗する場合
        タスク名が空の場合
          エラーメッセージが表示されること
      編集をやめたい場合
        キャンセルボタンクリックで一覧画面に戻れること

Finished in 8.88 seconds (files took 2.03 seconds to load)
9 examples, 0 failures
```
