### PR TITLE
タイムゾーンの変更

### DIFF
--- a/todo_app/config/application.rb
+++ b/todo_app/config/application.rb
@@ -16,6 +16,10 @@ module TodoApp
     # -- all .rb files in that directory are automatically loaded.
     config.i18n.default_locale = :ja
 
+    # Timezone
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+
     config.generators do |g|
       g.test_framework :rspec,
                      fixtures: true,


### PR DESCRIPTION
[ステップ10: Railsのタイムゾーンを設定しましょう](https://github.com/Fablic/training/tree/timezone#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-rails%E3%81%AE%E3%82%BF%E3%82%A4%E3%83%A0%E3%82%BE%E3%83%BC%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)の対応です。

表示するタイムゾーンとデータベースに登録する時のタイムゾーンの2箇所を指定しました。
