### PR TITLE
タスク一覧画面のソート順変更

### DIFF
--- a/todo_app/app/controllers/tasks_controller.rb
+++ b/todo_app/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order('created_at DESC, id DESC')
   end
 
   def new

--- a/todo_app/app/controllers/tasks_controller.rb
+++ b/todo_app/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
 
   def index
-    @tasks = Task.all.order('created_at DESC, id DESC')
+    @tasks = Task.all.order(created_at: :desc, id: :desc)
   end
 
   def new

--- a/todo_app/spec/features/task_page_spec.rb
+++ b/todo_app/spec/features/task_page_spec.rb
@@ -37,7 +37,7 @@ describe 'タスク一覧画面', type: :feature do
 
   context '複数のタスクが登録されている場合', type: :feature do
     before do
-      (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}" )}
+      (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", created_at: "2018/1/1 0:0:#{i}" )}
     end
 
     it '複数行がテーブルに表示されていること' do
@@ -45,11 +45,23 @@ describe 'タスク一覧画面', type: :feature do
       expect(page).to have_css('table#task_table tbody tr', count: 10)
     end
 
-    it 'id順で降順ソートされていること' do
-      visit '/'
-      all('table#task_table tbody tr').reverse_each.with_index do |td, idx|
-        # 作成時に登録順でインクリメントしているので、idでソートされていると名前も昇順になっている
-        expect(td).to have_selector('a', text: "Rspec test #{idx+1}")
+    context '作成日が異なる場合' do
+      it '作成日の降順で表がソートされていること' do
+        visit '/'
+        all('table#task_table tbody tr').reverse_each.with_index do |td, idx|
+          # 作成時に登録順でインクリメントしているので、idでソートされていると名前も昇順になっている
+          expect(td).to have_selector('a', text: "Rspec test #{idx+1}")
+        end
+      end
+    end
+
+    context '作成日が同一場合' do
+      it 'idの降順で表がソートされていること' do
+        Task.update_all(created_at:  '2018/1/1 0:0:0')
+        visit '/'
+        all('table#task_table tbody tr').reverse_each.with_index do |td, idx|
+          expect(td).to have_selector('a', text: "Rspec test #{idx+1}")
+        end
       end
     end
   end

--- a/todo_app/spec/features/task_page_spec.rb
+++ b/todo_app/spec/features/task_page_spec.rb
@@ -45,9 +45,9 @@ describe 'タスク一覧画面', type: :feature do
       expect(page).to have_css('table#task_table tbody tr', count: 10)
     end
 
-    it 'id順で昇順ソートされていること' do
+    it 'id順で降順ソートされていること' do
       visit '/'
-      all('table#task_table tbody tr').each.with_index do |td, idx|
+      all('table#task_table tbody tr').reverse_each.with_index do |td, idx|
         # 作成時に登録順でインクリメントしているので、idでソートされていると名前も昇順になっている
         expect(td).to have_selector('a', text: "Rspec test #{idx+1}")
       end

--- a/todo_app/spec/features/task_page_spec.rb
+++ b/todo_app/spec/features/task_page_spec.rb
@@ -45,8 +45,8 @@ describe 'タスク一覧画面', type: :feature do
       expect(page).to have_css('table#task_table tbody tr', count: 10)
     end
 
-    context '作成日が異なる場合' do
-      it '作成日の降順で表がソートされていること' do
+    context 'created_atが異なる場合' do
+      it 'created_atの降順で表がソートされていること' do
         visit '/'
         all('table#task_table tbody tr').reverse_each.with_index do |td, idx|
           # 作成時に登録順でインクリメントしているので、idでソートされていると名前も昇順になっている
@@ -55,7 +55,7 @@ describe 'タスク一覧画面', type: :feature do
       end
     end
 
-    context '作成日が同一場合' do
+    context 'created_atが同一場合' do
       it 'idの降順で表がソートされていること' do
         Task.update_all(created_at:  '2018/1/1 0:0:0')
         visit '/'


### PR DESCRIPTION
[ステップ11: タスク一覧を作成日時の順番で並び替えましょう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)の対応です。

# 内容
- タスクのソート順を作成日の降順に変更する
  - DBのカラムがdatetimeなので、同一秒に登録された場合のソート順を制御するため、作成日/idの二つの降順でソートする
- ソート順変更のテストコード修正

