### PR TITLE
タスクのバリデーション追加

### DIFF
--- a/todo_app/app/models/task.rb
+++ b/todo_app/app/models/task.rb
@@ -1,9 +1,17 @@
 class Task < ApplicationRecord
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :description, length: { maximum: 255 }
   validates :deadline, presence: true
   validates :status, presence: true
   validates :priority, presence: true
+  validate :valid_datetime?
 
   enum status: Hash[%i[not_start progress done].map { |sym| [sym, sym.to_s] }].freeze
   enum priority: Hash[%i[low normal high quickly right_now].map { |sym| [sym, sym.to_s] }].freeze
+
+  private
+
+  def valid_datetime?
+    errors.add(:deadline, I18n.t('errors.messages.invalid')) unless !! DateTime.parse(deadline) rescue false
+  end
 end

--- a/todo_app/app/models/task.rb
+++ b/todo_app/app/models/task.rb
@@ -15,6 +15,6 @@ class Task < ApplicationRecord
   end
 
   def valid_datetime?
-    !! DateTime.parse(deadline.to_s) rescue false
+    DateTime.parse(deadline.to_s).present? rescue false
   end
 end

--- a/todo_app/app/models/task.rb
+++ b/todo_app/app/models/task.rb
@@ -1,21 +1,24 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
   validates :description, length: { maximum: 255 }
-  validates :deadline, presence: true
   validates :status, presence: true
   validates :priority, presence: true
-  validate :valid_datetime?
+  validate :validate_datetime
 
   enum status: Hash[%i[not_start progress done].map { |sym| [sym, sym.to_s] }].freeze
   enum priority: Hash[%i[low normal high quickly right_now].map { |sym| [sym, sym.to_s] }].freeze
 
   private
 
-  def valid_datetime?
-    errors.add(:deadline, I18n.t('errors.messages.invalid')) unless can_parse_datetime
+  def validate_datetime
+    errors.add(:deadline, I18n.t('errors.messages.invalid_datetime')) unless valid_datetime?
   end
 
-  def can_parse_datetime
-    !! DateTime.parse(deadline.to_s) rescue false
+  def valid_datetime?
+    if deadline.present?
+      !! DateTime.parse(deadline.to_s) rescue false
+    else
+      false
+    end
   end
 end

--- a/todo_app/app/models/task.rb
+++ b/todo_app/app/models/task.rb
@@ -12,6 +12,10 @@ class Task < ApplicationRecord
   private
 
   def valid_datetime?
-    errors.add(:deadline, I18n.t('errors.messages.invalid')) unless !! DateTime.parse(deadline) rescue false
+    errors.add(:deadline, I18n.t('errors.messages.invalid')) unless can_parse_datetime
+  end
+
+  def can_parse_datetime
+    !! DateTime.parse(deadline.to_s) rescue false
   end
 end

--- a/todo_app/app/models/task.rb
+++ b/todo_app/app/models/task.rb
@@ -15,10 +15,6 @@ class Task < ApplicationRecord
   end
 
   def valid_datetime?
-    if deadline.present?
-      !! DateTime.parse(deadline.to_s) rescue false
-    else
-      false
-    end
+    !! DateTime.parse(deadline.to_s) rescue false
   end
 end

--- a/todo_app/config/locales/ja.yml
+++ b/todo_app/config/locales/ja.yml
@@ -148,6 +148,7 @@ ja:
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
       other_than: は%{count}以外の値にしてください
+      invalid_datetime: は有効な日付時刻を入力してください
     template:
       body: 次の項目を確認してください
       header:

--- a/todo_app/spec/models/task_spec.rb
+++ b/todo_app/spec/models/task_spec.rb
@@ -9,12 +9,12 @@ describe Task, type: :model do
       end
 
       it 'タイトルが50文字以下であれば有効な状態であること' do
-        task = build(:task, title:  (1..50).to_a.map { |i| 'a' }.join)
+        task = build(:task, title:  'a' * 50)
         expect(task).to be_valid
       end
 
       it '説明が255文字以下であれば有効な状態であること' do
-        task = build(:task, description:  (1..255).to_a.map { |i| 'a' }.join)
+        task = build(:task, description:  'a' * 255)
         expect(task).to be_valid
       end
     end
@@ -26,12 +26,12 @@ describe Task, type: :model do
       end
 
       it 'タイトルが51文字以上の場合、無効な状態であること' do
-        task = build(:task, title:  (1..51).to_a.map { |i| 'a' }.join)
+        task = build(:task, title:  'a' * 51)
         expect(task).to be_invalid
       end
 
       it '説明が256文字以上の場合、無効な状態であること' do
-        task = build(:task, description:  (1..256).to_a.map { |i| 'a' }.join)
+        task = build(:task, description:  'a' * 256)
         expect(task).to be_invalid
       end
 

--- a/todo_app/spec/models/task_spec.rb
+++ b/todo_app/spec/models/task_spec.rb
@@ -41,14 +41,13 @@ describe Task, type: :model do
       it '期日がなければ無効な状態であること' do
         task = build(:task, deadline: nil)
         expect(task).to be_invalid
-        expect(task.errors[:deadline][0]).to eq I18n.t('errors.messages.empty')
+        expect(task.errors[:deadline][0]).to eq I18n.t('errors.messages.invalid_datetime')
       end
 
       it '期日のフォーマットが不正な場合、無効な状態であること' do
         task = build(:task, deadline: 'Invalid datetime format')
         expect(task).to be_invalid
-        expect(task.errors[:deadline][0]).to eq I18n.t('errors.messages.empty')
-        expect(task.errors[:deadline][1]).to eq I18n.t('errors.messages.invalid')
+        expect(task.errors[:deadline][0]).to eq I18n.t('errors.messages.invalid_datetime')
       end
 
       it 'ステータスがなければ無効な状態であること' do

--- a/todo_app/spec/models/task_spec.rb
+++ b/todo_app/spec/models/task_spec.rb
@@ -7,6 +7,16 @@ describe Task, type: :model do
         task = build(:task)
         expect(task).to be_valid
       end
+
+      it 'タイトルが50文字以下であれば有効な状態であること' do
+        task = build(:task, title:  (1..50).to_a.map { |i| 'a' }.join)
+        expect(task).to be_valid
+      end
+
+      it '説明が255文字以下であれば有効な状態であること' do
+        task = build(:task, description:  (1..255).to_a.map { |i| 'a' }.join)
+        expect(task).to be_valid
+      end
     end
 
     context '無効な場合' do
@@ -15,11 +25,25 @@ describe Task, type: :model do
         expect(task).to be_invalid
       end
 
+      it 'タイトルが51文字以上の場合、無効な状態であること' do
+        task = build(:task, title:  (1..51).to_a.map { |i| 'a' }.join)
+        expect(task).to be_invalid
+      end
+
+      it '説明が256文字以上の場合、無効な状態であること' do
+        task = build(:task, description:  (1..256).to_a.map { |i| 'a' }.join)
+        expect(task).to be_invalid
+      end
+
       it '期日がなければ無効な状態であること' do
         task = build(:task, deadline: nil)
         expect(task).to be_invalid
       end
 
+      it '期日のフォーマットが不正な場合、無効な状態であること' do
+        task = build(:task, deadline: 'invalid datetime format')
+        expect(task).to be_invalid
+      end
       it 'ステータスがなければ無効な状態であること' do
         task = build(:task, status: nil)
         expect(task).to be_invalid

--- a/todo_app/spec/models/task_spec.rb
+++ b/todo_app/spec/models/task_spec.rb
@@ -23,35 +23,44 @@ describe Task, type: :model do
       it 'タイトルがなければ無効な状態であること' do
         task = build(:task, title: nil)
         expect(task).to be_invalid
+        expect(task.errors[:title][0]).to eq I18n.t('errors.messages.empty')
       end
 
       it 'タイトルが51文字以上の場合、無効な状態であること' do
         task = build(:task, title:  'a' * 51)
         expect(task).to be_invalid
+        expect(task.errors[:title][0]).to eq I18n.t('errors.messages.too_long', count: 50)
       end
 
       it '説明が256文字以上の場合、無効な状態であること' do
         task = build(:task, description:  'a' * 256)
         expect(task).to be_invalid
+        expect(task.errors[:description][0]).to eq I18n.t('errors.messages.too_long', count: 255)
       end
 
       it '期日がなければ無効な状態であること' do
         task = build(:task, deadline: nil)
         expect(task).to be_invalid
+        expect(task.errors[:deadline][0]).to eq I18n.t('errors.messages.empty')
       end
 
       it '期日のフォーマットが不正な場合、無効な状態であること' do
-        task = build(:task, deadline: 'invalid datetime format')
+        task = build(:task, deadline: 'Invalid datetime format')
         expect(task).to be_invalid
+        expect(task.errors[:deadline][0]).to eq I18n.t('errors.messages.empty')
+        expect(task.errors[:deadline][1]).to eq I18n.t('errors.messages.invalid')
       end
+
       it 'ステータスがなければ無効な状態であること' do
         task = build(:task, status: nil)
         expect(task).to be_invalid
+        expect(task.errors[:status][0]).to eq I18n.t('errors.messages.empty')
       end
 
       it '優先度がなければ無効な状態であること' do
         task = build(:task, priority: nil)
         expect(task).to be_invalid
+        expect(task.errors[:priority][0]).to eq I18n.t('errors.messages.empty')
       end
     end
 


### PR DESCRIPTION
[ステップ12: バリデーションを設定してみよう](https://github.com/Fablic/training/tree/add_validation_to_task#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)の対応です。

# 内容

- タスク名、説明に最大文字数を追加
- 期日にDateTimeのフォーマット検証を追加
- テストコードを追加
