### PR TITLE
rubocop（マージしない）

### DIFF
--- a/todo_app/spec/features/task_page_spec.rb
+++ b/todo_app/spec/features/task_page_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'タスク一覧画面', type: :feature do
@@ -37,7 +39,7 @@ describe 'タスク一覧画面', type: :feature do
 
   context '複数のタスクが登録されている場合', type: :feature do
     before do
-      (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", created_at: "2018/1/1 0:0:#{i}" )}
+      (1..10).to_a.each { |i| create(:task, title: "Rspec test #{i}", created_at: "2018/1/1 0:0:#{i}") }
     end
 
     context '初期表示の場合' do
@@ -50,7 +52,7 @@ describe 'タスク一覧画面', type: :feature do
         visit '/'
         all('table#task_table tbody tr').reverse_each.with_index do |td, idx|
           # 作成時に登録順でインクリメントしているので、idでソートされていると名前も昇順になっている
-          expect(td).to have_selector('a', text: "Rspec test #{idx+1}")
+          expect(td).to have_selector('a', text: "Rspec test #{idx + 1}")
         end
       end
     end
@@ -59,7 +61,7 @@ describe 'タスク一覧画面', type: :feature do
   describe '画面の表示内容を変更する' do
     describe 'ソート順を変更する' do
       before do
-        (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", deadline: "2018/2/#{11 - i} 01:01:01", created_at: "2018/1/1 0:0:#{i}" )}
+        (1..10).to_a.each { |i| create(:task, title: "Rspec test #{i}", deadline: "2018/2/#{11 - i} 01:01:01", created_at: "2018/1/1 0:0:#{i}") }
 
         visit '/'
         within('.card-text') do
@@ -69,11 +71,11 @@ describe 'タスク一覧画面', type: :feature do
       end
 
       context '新着順でソートしたい場合' do
-        let (:sort) {'created_at'}
+        let (:sort) { 'created_at' }
 
         it 'created_atの降順で表示されていること' do
           all('table#task_table tbody tr').each.with_index do |td, idx|
-            expect(td).to have_content("2018/01/01 00:00:#{format('%02d',10 - idx)}")
+            expect(td).to have_content("2018/01/01 00:00:#{format('%02d', 10 - idx)}")
           end
 
           expect(page.find_by_id('sort').value).to eq 'created_at'
@@ -81,11 +83,11 @@ describe 'タスク一覧画面', type: :feature do
       end
 
       context '期日が近い順でソートしたい場合' do
-        let (:sort) {'deadline'}
+        let (:sort) { 'deadline' }
 
         it 'deadlineの降順で表示されていること' do
           all('table#task_table tbody tr').each.with_index do |td, idx|
-            expect(td).to have_content("2018/02/#{format('%02d',10 - idx)} 01:01:01")
+            expect(td).to have_content("2018/02/#{format('%02d', 10 - idx)} 01:01:01")
           end
 
           expect(page.find_by_id('sort').value).to eq 'deadline'
@@ -124,7 +126,7 @@ describe 'タスク一覧画面', type: :feature do
   end
 
   context 'タスクの削除したい場合', type: :feature do
-    before { create(:task, title: 'Rspec test 1' ) }
+    before { create(:task, title: 'Rspec test 1') }
 
     context '確認ダイアログでキャンセルボタンを押した場合' do
       it '対象行は削除されないこと' do


### PR DESCRIPTION
確認したらCloseしちゃって下さい！

```sh
$ rubocop -a spec/features/task_page_spec.rb
```

した結果です、ご参考までに。

```
Inspecting 1 file
W

Offenses:

spec/features/task_page_spec.rb:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
require 'rails_helper'
^
spec/features/task_page_spec.rb:3:1: C: Metrics/BlockLength: Block has too many lines. [121/25]
describe 'タスク一覧画面', type: :feature do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/task_page_spec.rb:40:25: C: Layout/SpaceInsideBlockBraces: Space between { and | missing.
      (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", created_at: "2018/1/1 0:0:#{i}" )}
                        ^^
spec/features/task_page_spec.rb:40:81: C: Metrics/LineLength: Line is too long. [103/80]
      (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", created_at: "2018/1/1 0:0:#{i}" )}
                                                                                ^^^^^^^^^^^^^^^^^^^^^^^
spec/features/task_page_spec.rb:40:101: C: Layout/SpaceInsideParens: Space inside parentheses detected.
      (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", created_at: "2018/1/1 0:0:#{i}" )}
                                                                                                    ^
spec/features/task_page_spec.rb:40:103: C: Layout/SpaceInsideBlockBraces: Space missing inside }.
      (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", created_at: "2018/1/1 0:0:#{i}" )}
                                                                                                      ^
spec/features/task_page_spec.rb:52:13: C: Style/AsciiComments: Use only ascii symbols in comments.
          # 作成時に登録順でインクリメントしているので、idでソートされていると名前も昇順になっている
            ^^^^^^^^^^^^^^^^^^^^^^
spec/features/task_page_spec.rb:53:67: C: Layout/SpaceAroundOperators: Surrounding space missing for operator +.
          expect(td).to have_selector('a', text: "Rspec test #{idx+1}")
                                                                  ^
spec/features/task_page_spec.rb:59:3: C: Metrics/BlockLength: Block has too many lines. [28/25]
  describe '画面の表示内容を変更する' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/task_page_spec.rb:60:5: C: Metrics/BlockLength: Block has too many lines. [26/25]
    describe 'ソート順を変更する' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^
spec/features/task_page_spec.rb:62:27: C: Layout/SpaceInsideBlockBraces: Space between { and | missing.
        (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", deadline: "2018/2/#{11 - i} 01:01:01", created_at: "2018/1/1 0:0:#{i}" )}
                          ^^
spec/features/task_page_spec.rb:62:81: C: Metrics/LineLength: Line is too long. [144/80]
        (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", deadline: "2018/2/#{11 - i} 01:01:01", created_at: "2018/1/1 0:0:#{i}" )}
                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/features/task_page_spec.rb:62:142: C: Layout/SpaceInsideParens: Space inside parentheses detected.
        (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", deadline: "2018/2/#{11 - i} 01:01:01", created_at: "2018/1/1 0:0:#{i}" )}
                                                                                                                                             ^
spec/features/task_page_spec.rb:62:144: C: Layout/SpaceInsideBlockBraces: Space missing inside }.
        (1..10).to_a.each {|i| create(:task, title: "Rspec test #{i}", deadline: "2018/2/#{11 - i} 01:01:01", created_at: "2018/1/1 0:0:#{i}" )}
                                                                                                                                               ^
spec/features/task_page_spec.rb:72:12: W: Lint/ParenthesesAsGroupedExpression: (...) interpreted as grouped expression.
        let (:sort) {'created_at'}
           ^
spec/features/task_page_spec.rb:72:22: C: Layout/SpaceInsideBlockBraces: Space missing inside {.
        let (:sort) {'created_at'}
                     ^
spec/features/task_page_spec.rb:72:34: C: Layout/SpaceInsideBlockBraces: Space missing inside }.
        let (:sort) {'created_at'}
                                 ^
spec/features/task_page_spec.rb:76:73: C: Layout/SpaceAfterComma: Space missing after comma.
            expect(td).to have_content("2018/01/01 00:00:#{format('%02d',10 - idx)}")
                                                                        ^
spec/features/task_page_spec.rb:76:81: C: Metrics/LineLength: Line is too long. [85/80]
            expect(td).to have_content("2018/01/01 00:00:#{format('%02d',10 - idx)}")
                                                                                ^^^^^
spec/features/task_page_spec.rb:84:12: W: Lint/ParenthesesAsGroupedExpression: (...) interpreted as grouped expression.
        let (:sort) {'deadline'}
           ^
spec/features/task_page_spec.rb:84:22: C: Layout/SpaceInsideBlockBraces: Space missing inside {.
        let (:sort) {'deadline'}
                     ^
spec/features/task_page_spec.rb:84:32: C: Layout/SpaceInsideBlockBraces: Space missing inside }.
        let (:sort) {'deadline'}
                               ^
spec/features/task_page_spec.rb:88:64: C: Layout/SpaceAfterComma: Space missing after comma.
            expect(td).to have_content("2018/02/#{format('%02d',10 - idx)} 01:01:01")
                                                               ^
spec/features/task_page_spec.rb:88:81: C: Metrics/LineLength: Line is too long. [85/80]
            expect(td).to have_content("2018/02/#{format('%02d',10 - idx)} 01:01:01")
                                                                                ^^^^^
spec/features/task_page_spec.rb:127:49: C: Layout/SpaceInsideParens: Space inside parentheses detected.
    before { create(:task, title: 'Rspec test 1' ) }
                                                ^

1 file inspected, 25 offenses detected
```