### PR TITLE
タスク登録/編集画面のデザイン変更

### DIFF
--- a/todo_app/app/assets/stylesheets/_common.css.scss
+++ b/todo_app/app/assets/stylesheets/_common.css.scss
@@ -108,3 +108,11 @@ a.edit-button {
     }
   }
 }
+
+.form-wrapper{
+  padding: 50px 5px 5px 5px;
+  
+  form{
+    width: 100%;
+  }
+}

--- a/todo_app/app/views/layouts/application.html.erb
+++ b/todo_app/app/views/layouts/application.html.erb
@@ -11,8 +11,6 @@
 <body>
   <%= render "layouts/shared/header" %>
   <div class="container">
-    <div class="row">
-      <%= yield %>
-    </div>
+    <%= yield %>
   </div>
 </body>

--- a/todo_app/app/views/tasks/_form.html.erb
+++ b/todo_app/app/views/tasks/_form.html.erb
@@ -1,26 +1,35 @@
 <%= bootstrap_form_for(@task) do |t| %>
+  <div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-8 col-lg-8 task-edit-area">
+      <% if @task.errors.any? %>
+        <div id="error_explanation">
+          <h2><%= pluralize(@task.errors.count, "error") %> prohibited
+            this article from being saved:</h2>
+          <ul>
+            <% @task.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
 
-  <% if @task.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@task.errors.count, "error") %> prohibited
-        this article from being saved:</h2>
-      <ul>
-        <% @task.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
+      <%= t.text_field :title, label: I18n.t('page.task.labels.title') %>
+      <%= t.text_area :description, label: I18n.t('page.task.labels.description')  , rows: '10'%>
     </div>
-  <% end %>
 
-  <%= t.text_field :title, label: I18n.t('page.task.labels.title') %>
-  <%= t.text_area :description, label: I18n.t('page.task.labels.description')  %>
-  <%= t.datetime_select :deadline, label: I18n.t('page.task.labels.deadline')  %>
-  <%= t.select :status, status_pull_down,
-               { label: I18n.t('helpers.select.prompt_with_title', title: I18n.t('page.task.labels.status')) } %>
-  <%= t.select :priority,priority_pull_down,
-               { label: I18n.t('helpers.select.prompt_with_title', title: I18n.t('page.task.labels.priority')) } %>
+    <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 task-edit-area">
+      <%= t.datetime_select :deadline, label: I18n.t('page.task.labels.deadline')  %>
+      <%= t.select :status, status_pull_down,
+                   { label: I18n.t('helpers.select.prompt_with_title', title: I18n.t('page.task.labels.status')) } %>
+      <%= t.select :priority,priority_pull_down,
+                   { label: I18n.t('helpers.select.prompt_with_title', title: I18n.t('page.task.labels.priority')) } %>
+    </div>
+  </div>
 
-  <%= t.submit submit_btn_name, class: "btn btn-success" %>
-  <%= link_to I18n.t('helpers.submit.cancel'), tasks_path, {:class=>"btn btn-default"} %>
-
+  <div class="row">
+    <div class="col-12 submit-btn-wrapper">
+      <%= t.submit submit_btn_name, class: "btn btn-success" %>
+      <%= link_to I18n.t('helpers.submit.cancel'), tasks_path, {:class=>"btn btn-secondary"} %>
+    </div>
+  </div>
 <% end %>

--- a/todo_app/app/views/tasks/edit.html.erb
+++ b/todo_app/app/views/tasks/edit.html.erb
@@ -1,5 +1,3 @@
-<div id="edit_task">
-  <h1><%= I18n.t('page.task.titles.edit') %></h1>
-
+<div id="edit_task" class="row form-wrapper">
   <%= render 'form' %>
 </div>

--- a/todo_app/app/views/tasks/new.html.erb
+++ b/todo_app/app/views/tasks/new.html.erb
@@ -1,4 +1,3 @@
-<div id="add_task">
-  <h1><%= I18n.t('page.task.titles.new') %></h1>
+<div id="add_task" class="row form-wrapper">
   <%= render 'form' %>
 </div>


### PR DESCRIPTION
[ステップ17: デザインを当てよう](https://github.com/Fablic/training/tree/web_design_update1#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9717-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86)の対応です。

変更箇所が多いので、複数のPRに分けます。

# 内容

- タスク登録画面のデザイン変更
- タスク編集画面のデザイン変更
