### PR TITLE
タスク詳細画面のデザイン変更

### DIFF
--- a/todo_app/app/views/tasks/show.html.erb
+++ b/todo_app/app/views/tasks/show.html.erb
@@ -1,30 +1,35 @@
-<div id="show_task">
-  <h1><%= I18n.t('page.task.titles.show') %></h1>
+<div id="show_task" class="row form-wrapper">
+  <div class="row">
+    <div class="col-xs-8 col-sm-8 col-md-8 col-lg-8 task-edit-area">
+      <div class="form-group">
+        <label class="control-label required" for="task_title"><%= I18n.t('page.task.labels.title') %></label>
+        <input class="form-control" readonly type="text" value="<%= @task.title%>" id="task_title" />
+      </div>
+      <div class="form-group">
+        <label class="control-label" for="task_description"><%= I18n.t('page.task.labels.description') %></label>
+        <textarea rows="10" readonly class="form-control" id="task_description"><%= @task.description %></textarea>
+      </div>
+    </div>
 
-  <table class="table">
-    <tbody>
-      <tr>
-        <td><%= I18n.t('page.task.labels.title') %></td>
-        <td><%= @task.title%> </td>
-      </tr>
-      <tr>
-        <td><%= I18n.t('page.task.labels.description') %></td>
-        <td><%= @task.description %></td>
-      </tr>
-      <tr>
-        <td><%= I18n.t('page.task.labels.deadline') %></td>
-        <td><%= @task.deadline %></td>
-      </tr>
-      <tr>
-        <td><%= I18n.t('page.task.labels.status') %></td>
-        <td><%= status_value @task.status%></td>
-      </tr>
-      <tr>
-        <td><%= I18n.t('page.task.labels.priority') %></td>
-        <td><%= priority_value @task.priority%></td>
-      </tr>
-    </tbody>
-  </table>
-
-  <%= link_to I18n.t('helpers.submit.back'), tasks_path, {:class=>"btn btn-default"} %>
+    <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4 task-edit-area">
+      <div class="form-group">
+        <label class="control-label required" for="task_deadline"><%= I18n.t('page.task.labels.deadline') %></label>
+        <input class="form-control" readonly type="text" value="<%= @task.deadline.to_s %>" id="task_deadline" />
+      </div>
+      <div class="form-group">
+        <label class="control-label required" for="task_status"><%= I18n.t('page.task.labels.status') %></label>
+        <input class="form-control" readonly type="text" value="<%= status_value @task.status%>" id="task_status" />
+      </div>
+      <div class="form-group">
+        <label class="control-label required" for="task_priority"><%= I18n.t('page.task.labels.priority') %></label>
+        <input class="form-control" readonly type="text" value="<%= priority_value @task.priority%>" id="task_priority" />
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 submit-btn-wrapper">
+      <%= link_to I18n.t('helpers.submit.edit'), edit_task_path(@task), class: "btn btn-success" %>
+      <%= link_to I18n.t('helpers.submit.back'), tasks_path, {:class=>"btn btn-secondary"} %>
+    </div>
+  </div>
 </div>

--- a/todo_app/spec/features/show_task_page_spec.rb
+++ b/todo_app/spec/features/show_task_page_spec.rb
@@ -16,33 +16,23 @@ describe 'タスク詳細画面', type: :feature do
 
   describe 'タスクの登録内容の表示確認' do
     it 'タスク名が表示されていること' do
-      tr = find(:css, 'table tbody').all('tr')[0]
-      expect(tr).to have_content(I18n.t('page.task.labels.title'))
-      expect(tr).to have_content('Rspec test 1')
+      expect(find('#task_title').value).to eq 'Rspec test 1'
     end
 
     it '内容が表示されていること' do
-      tr = find(:css, 'table tbody').all('tr')[1]
-      expect(tr).to have_content(I18n.t('page.task.labels.description'))
-      expect(tr).to have_content('This is a sample description')
+      expect(find('#task_description').value).to eq 'This is a sample description'
     end
 
     it '期日が表示されていること' do
-      tr = find(:css, 'table tbody').all('tr')[2]
-      expect(tr).to have_content(I18n.t('page.task.labels.deadline'))
-      expect(tr).to have_content('2018/03/01 00:00:00')
+      expect(find('#task_deadline').value).to eq '2018/03/01 00:00:00'
     end
 
     it 'ステータスが表示されていること' do
-      tr = find(:css, 'table tbody').all('tr')[3]
-      expect(tr).to have_content(I18n.t('page.task.labels.status'))
-      expect(tr).to have_content(Task.human_attribute_name('statuses.progress'))
+      expect(find('#task_status').value).to eq Task.human_attribute_name('statuses.progress')
     end
 
     it '優先度が表示されていること' do
-      tr = find(:css, 'table tbody').all('tr')[4]
-      expect(tr).to have_content(I18n.t('page.task.labels.priority'))
-      expect(tr).to have_content(Task.human_attribute_name('priorities.high'))
+      expect(find('#task_priority').value).to eq Task.human_attribute_name('priorities.high')
     end
   end
 


### PR DESCRIPTION
[ステップ17: デザインを当てよう](https://github.com/Fablic/training/tree/web_design_update1#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9717-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86)の対応です。

変更箇所が多いので、複数のPRに分けます。

# 内容

- タスク詳細画面のデザイン変更
- HTMLの変更に伴うテストの変更
