### PR TITLE
スマホサイズで表示した場合の画面崩れ対応

### DIFF
--- a/todo_app/app/assets/stylesheets/_common.css.scss
+++ b/todo_app/app/assets/stylesheets/_common.css.scss
@@ -110,8 +110,9 @@ a.edit-button {
 }
 
 .form-wrapper{
+  margin: auto;
   padding: 50px 5px 5px 5px;
-  
+
   form{
     width: 100%;
   }


### PR DESCRIPTION
[ステップ17: デザインを当てよう](https://github.com/Fablic/training/tree/web_design_update1#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9717-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86)の対応です。

変更箇所が多いので、複数のPRに分けます。

# 内容

- スマホサイズにした時に登録・編集画面が左に寄ってしまう現象の修正です。
