### PR TITLE
タスク一覧画面のデザイン変更

### DIFF
--- a/todo_app/app/views/kaminari/_paginator.html.erb
+++ b/todo_app/app/views/kaminari/_paginator.html.erb
@@ -1,6 +1,6 @@
 <%= paginator.render do %>
   <nav>
-    <ul class="pagination">
+    <ul class="pagination justify-content-center">
       <%= first_page_tag unless current_page.first? %>
       <%= prev_page_tag unless current_page.first? %>
       <% each_page do |page| %>


### PR DESCRIPTION
[ステップ17: デザインを当てよう](https://github.com/Fablic/training/tree/web_design_update1#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9717-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86)の対応です。

変更箇所が多いので、複数のPRに分けます。

# 内容

- ページングボタンが左寄りだったので、中央寄せに変更しました。