### PR TITLE
Modified order to descending order of created time

### DIFF
--- a/tms/app/controllers/tasks_controller.rb
+++ b/tms/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   # GET /tasks
   # GET /tasks.json
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order('created_at DESC')
   end
 
   # GET /tasks/1
@@ -28,7 +28,7 @@ class TasksController < ApplicationController
 
     respond_to do |format|
       if @task.save
-        format.html { redirect_to @task, notice: t("flash.task.create") }
+        format.html { redirect_to @task, notice: t('flash.task.create') }
         format.json { render :show, status: :created, location: @task }
       else
         format.html { render :new }
@@ -42,7 +42,7 @@ class TasksController < ApplicationController
   def update
     respond_to do |format|
       if @task.update(task_params)
-        format.html { redirect_to @task, notice: t("flash.task.update") }
+        format.html { redirect_to @task, notice: t('flash.task.update') }
         format.json { render :show, status: :ok, location: @task }
       else
         format.html { render :edit }
@@ -56,7 +56,7 @@ class TasksController < ApplicationController
   def destroy
     @task.destroy
     respond_to do |format|
-      format.html { redirect_to tasks_url, notice: t("flash.task.destroy") }
+      format.html { redirect_to tasks_url, notice: t('flash.task.destroy') }
       format.json { head :no_content }
     end
   end

--- a/tms/app/views/tasks/index.html.erb
+++ b/tms/app/views/tasks/index.html.erb
@@ -11,6 +11,7 @@
       <th><%= t('page.task.thead.priority') %></th>
       <th><%= t('page.task.thead.status') %></th>
       <th><%= t('page.task.thead.user') %></th>
+      <th><%= t('page.task.thead.created_at') %></th>
       <th colspan='3'></th>
     </tr>
   </thead>
@@ -24,6 +25,7 @@
         <td><%= priority_name(task.priority) %></td>
         <td><%= status_name(task.status) %></td>
         <td><%= task.user_id %></td>
+        <td><%= task.created_at %></td>
         <td><%= link_to t('page.task.link.detail'), task %></td>
         <td><%= link_to t('page.task.link.edit'), edit_task_path(task) %></td>
         <td><%= link_to t('page.task.link.delete'), task, method: :delete, data: { confirm: t('dialog') } %></td>

--- a/tms/app/views/tasks/show.html.erb
+++ b/tms/app/views/tasks/show.html.erb
@@ -32,5 +32,10 @@
   <%= @task.user_id %>
 </p>
 
+<p>
+<strong><%= t('page.task.thead.created_at') %>:</strong>
+  <%= @task.created_at %>
+</p>
+
 <%= link_to t('page.task.link.edit'), edit_task_path(@task) %> |
 <%= link_to t('page.task.link.back'), tasks_path %>

--- a/tms/spec/factories/tasks.rb
+++ b/tms/spec/factories/tasks.rb
@@ -1,10 +1,11 @@
 FactoryBot.define do
   factory :task do
-    title "Setup DEV ENV"
+    title "Test Task 1"
     description "Setup development environment on localhost"
     due_date "2018-04-17"
-    priority 0    
-    status 0    
+    priority 0
+    status 0
     user_id 1
+    created_at Time.now
   end
 end

--- a/tms/spec/features/tasks_spec.rb
+++ b/tms/spec/features/tasks_spec.rb
@@ -1,19 +1,34 @@
 require 'rails_helper'
 
 RSpec.feature "Tasks", type: :feature do
-  scenario "user create a new task" do
-    visit root_path
-    expect {
-      click_link I18n.t("page.task.link.new")
-      fill_in I18n.t('page.task.thead.title'), with: "Setup DEV ENV"
-      fill_in I18n.t('page.task.thead.description'), with: "Setup development environment on localhost."
-      fill_in I18n.t('page.task.thead.user'), with: 1
-      fill_in I18n.t('page.task.thead.priority'), with: 0
-      fill_in I18n.t('page.task.thead.status'), with: 0
-      fill_in I18n.t('page.task.thead.due_date'), with: "2018-04-17"
-      click_button I18n.t("helpers.submit.create")
+  describe "Tasks list" do
+    let!(:task) { FactoryBot.create(:task) }
 
-      expect(page).to have_content I18n.t("flash.task.create")
-    }.to change(Task, :count).by(1)
+    context "When user visit tasks list" do
+      let!(:new_task) { FactoryBot.create(:task, title: 'Test Task 2', created_at: Time.now.since(1.days)) }
+
+      it "User can see tasks in descending order of created time" do
+        visit root_path
+        expect(new_task.created_at.time > task.created_at.time).to be true
+      end
+    end
+
+    context "When user click 'タスク登録' button" do
+      it "User can create a new task" do
+        visit root_path
+        expect {
+          click_link I18n.t("page.task.link.new")
+          fill_in I18n.t('page.task.thead.title'), with: "Setup DEV ENV"
+          fill_in I18n.t('page.task.thead.description'), with: "Setup development environment on localhost."
+          fill_in I18n.t('page.task.thead.user'), with: 1
+          fill_in I18n.t('page.task.thead.priority'), with: 0
+          fill_in I18n.t('page.task.thead.status'), with: 0
+          fill_in I18n.t('page.task.thead.due_date'), with: "2018-04-17"
+          click_button I18n.t("helpers.submit.create")
+
+          expect(page).to have_content I18n.t("flash.task.create")
+        }.to change(Task, :count).by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Target Step

[ステップ11: タスク一覧を作成日時の順番で並び替えましょう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)

Revised Part
- Modified order to descending order of created time at tasks list
- Adapted feature spec of task