### PR TITLE
create spec for testing validation of todo model

### DIFF
--- a/todo_manager/spec/models/todo_spec.rb
+++ b/todo_manager/spec/models/todo_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Todo, type: :model do
+  describe 'validation' do
+    describe 'title' do
+      context 'is nil' do
+        it "can't be created" do
+          expect{ create(:todo, title: '') }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+      context 'is not nil' do
+        it 'can be created' do
+          expect{ create(:todo) }.not_to raise_error
+        end
+      end
+    end
+  end
+    
+end

--- a/todo_manager/spec/models/todo_spec.rb
+++ b/todo_manager/spec/models/todo_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe Todo, type: :model do
     describe 'title' do
       context 'is nil' do
         it "can't be created" do
-          expect{ create(:todo, title: '') }.to raise_error(ActiveRecord::RecordInvalid)
+          expect{ Todo.create!(title: '') }.to raise_error(ActiveRecord::RecordInvalid)
         end
       end
+
       context 'is not nil' do
         it 'can be created' do
-          expect{ create(:todo) }.not_to raise_error
+          expect{ Todo.create!(title: 'hoge') }.not_to raise_error
         end
       end
     end
   end
-    
 end


### PR DESCRIPTION
validationの設定、DBの制約の設定、validation errorのメッセージ表示などは既に実装していたので、modelのvalidationに対するテストだけ追加しました。