### PR TITLE
Kotaro step20 21

### DIFF
--- a/todo_manager/Gemfile
+++ b/todo_manager/Gemfile
@@ -62,6 +62,7 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15', '< 4.0'
+  gem 'poltergeist'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'

--- a/todo_manager/Gemfile.lock
+++ b/todo_manager/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    cliver (0.3.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -134,6 +135,10 @@ GEM
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    poltergeist (1.18.0)
+      capybara (>= 2.1, < 4)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -256,6 +261,7 @@ DEPENDENCIES
   kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2
+  poltergeist
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.0)

--- a/todo_manager/app/assets/javascripts/admin.coffee
+++ b/todo_manager/app/assets/javascripts/admin.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/todo_manager/app/assets/stylesheets/admin.scss
+++ b/todo_manager/app/assets/stylesheets/admin.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/todo_manager/app/controllers/admin_controller.rb
+++ b/todo_manager/app/controllers/admin_controller.rb
@@ -1,0 +1,97 @@
+class AdminController < ApplicationController
+  before_action :authenticate_user, :authorize_user
+
+  def index
+    @users = User.all.page(params[:page])
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(name: params[:name], password: params[:password], user_type: params[:user][:user_type])
+    if @user.save
+      flash[:notice] = I18n.t('flash.users.create')
+      redirect_to('/admin')
+    else
+      render 'new'
+    end
+  end
+
+  def show
+    @user = User.find_by(id: params[:id])
+  end
+
+  def edit
+    @user = User.find_by(id: params[:id])
+  end
+
+  def update
+    @user = User.find_by(id: params[:id])
+    @user.name = params[:name]
+    if @user.user_type == 'admin' && User.where(user_type: 'admin').count <= 1
+      @user.user_type = 'admin'
+    else
+      @user.user_type = params[:user][:user_type]
+    end
+    if !params[:password].nil?
+      @user.password = params[:password]
+    end
+
+    if @user.save
+      flash[:notice] = I18n.t('flash.users.update')
+      redirect_to("/admin/#{@user.id}/edit")
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @user = User.find_by(id: params[:id])
+
+    if @user.id != @current_user.id && @user.destroy
+      flash[:notice] = I18n.t('flash.users.destroy.success')
+      redirect_to('/admin')
+    else
+      flash.now[:notice] = I18n.t('flash.users.destroy.failure')
+      render 'show'
+    end
+  end
+
+  def todos
+    @user = User.find_by(id: params[:id])
+    @search = params[:search]
+    @status = Todo.status_ids[params[:status]].nil? ? nil : params[:status]
+    todos = Todo.where('title like ? and status_id like ? and user_id = ?', "%#{@search}%", @status.nil? ? '%' : Todo.status_ids[@status], @user.id)
+    @direction = %w(asc desc).include?(params[:direction]) ? params[:direction] : 'desc'
+    @sort = %w(created_at deadline priority_id).include?(params[:sort]) ? params[:sort] : 'created_at'
+    @todos = todos.page(params[:page]).order("#{@sort} #{@direction}")
+    render 'todos'
+  end
+
+  def new_todos
+    @user = User.find_by(id: params[:id])
+    @todo = Todo.new
+    @todo.deadline = Time.current.tomorrow.strftime('%Y-%m-%dT%H:%M')
+  end
+
+  def create_todos
+    @user = User.find_by(id: params[:id])
+    @todo = @user.todos.new(title: params[:title], content: params[:content], priority_id: params[:todo][:priority_id], deadline: params[:deadline])
+    if @todo.save
+      flash[:notice] = I18n.t('flash.todos.create')
+      redirect_to("/admin/#{params[:id]}/todos")
+    else
+      render 'new_todos'
+    end
+  end
+
+  def authorize_user
+    if @current_user.user_type != 'admin'
+      flash[:notice] = I18n.t('flash.users.authorization.failure')
+      redirect_to('/')
+    end
+  end
+
+end

--- a/todo_manager/app/controllers/todos_controller.rb
+++ b/todo_manager/app/controllers/todos_controller.rb
@@ -1,6 +1,6 @@
 class TodosController < ApplicationController
   before_action :authenticate_user
-  before_action :ensure_correct_user, {only: %i(detail edit update destroy)}
+  before_action :ensure_correct_user, { only: %i(detail edit update destroy) }
 
   def index
     @search = params[:search]
@@ -38,11 +38,11 @@ class TodosController < ApplicationController
   def update
     @todo = Todo.find_by(id: params[:id])
     @todo.assign_attributes({
-        title: params[:title],
-        content: params[:content],
-        priority_id: params[:todo][:priority_id],
-        status_id: params[:todo][:status_id],
-        deadline: params[:deadline]
+      title: params[:title],
+      content: params[:content],
+      priority_id: params[:todo][:priority_id],
+      status_id: params[:todo][:status_id],
+      deadline: params[:deadline]
     })
     if @todo.save
       flash[:notice] = I18n.t('flash.todos.update')
@@ -58,14 +58,14 @@ class TodosController < ApplicationController
       flash[:notice] = I18n.t('flash.todos.destroy.success')
       redirect_to('/')
     else
-      flash[:notice] = I18n.t('flash.todos.destroy.failure')
+      flash.now[:notice] = I18n.t('flash.todos.destroy.failure')
       render 'detail'
     end
   end
 
   def ensure_correct_user
     @todo = Todo.find_by(id: params[:id])
-    if @current_user.id != @todo.user_id
+    if @current_user.user_type != 'admin' && @current_user.id != @todo.user_id
       flash[:notice] = I18n.t('flash.users.authorization.failure')
       redirect_to('/')
     end

--- a/todo_manager/app/controllers/users_controller.rb
+++ b/todo_manager/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :forbid_login_user, {only: %i(login login_post)}
+  before_action :forbid_login_user, {only: %i(new create login login_post)}
 
   def login
   end
@@ -23,5 +23,17 @@ class UsersController < ApplicationController
   end
 
   def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(name: params[:name], password: params[:password])
+    if @user.save
+      session[:user_id] = @user.id
+      flash[:notice] = I18n.t('flash.users.signup')
+      redirect_to('/')
+    else
+      render('users/new')
+    end
   end
 end

--- a/todo_manager/app/controllers/users_controller.rb
+++ b/todo_manager/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :forbid_login_user, {only: %i(new create login login_post)}
+  before_action :forbid_login_user, { only: %i(new create login login_post) }
 
   def login
   end
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
       redirect_to('/')
     else
       @error_message = I18n.t('flash.users.login.failure')
-      render('users/login')
+      render 'login'
     end
   end
 
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
       flash[:notice] = I18n.t('flash.users.signup')
       redirect_to('/')
     else
-      render('users/new')
+      render 'new'
     end
   end
 end

--- a/todo_manager/app/helpers/admin_helper.rb
+++ b/todo_manager/app/helpers/admin_helper.rb
@@ -1,0 +1,2 @@
+module AdminHelper
+end

--- a/todo_manager/app/models/todo.rb
+++ b/todo_manager/app/models/todo.rb
@@ -1,5 +1,5 @@
 class Todo < ApplicationRecord
-  validates :title, {presence: true}
+  validates :title, { presence: true }
   enum status_id: { unstarted: 0, working: 1, completed: 2 }, priority_id: { low: 0, middle: 1, high: 2 }
   paginates_per 10
   belongs_to :user

--- a/todo_manager/app/models/user.rb
+++ b/todo_manager/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  validates :name, {presence: true, uniqueness: true}
+  validates :name, { presence: true, uniqueness: true }
+  enum user_type: { admin: 0, normal: 1 }
   has_secure_password
   has_many :todos, dependent: :destroy
 end

--- a/todo_manager/app/views/admin/edit.html.erb
+++ b/todo_manager/app/views/admin/edit.html.erb
@@ -1,0 +1,17 @@
+<h2><%= t('views.admin.edit.title') %></h2>
+<% @user.errors.full_messages.each do |message| %>
+  <%= message %>
+<% end %>
+<%= form_tag("/admin/#{@user.id}", method: :patch) do %>
+  <p><%= t('dictionary.name') %></p>
+  <input name="name" value="<%= @user.name %>">
+  <p><%= t('dictionary.role') %></p>
+  <% if @user.user_type == 'admin' && User.where(user_type: 'admin').count <= 1 %>
+    <%= t('role.admin') %>
+  <% else %>
+    <%= select :user, :user_type, [[t('role.admin'), 'admin'], [t('role.normal'), 'normal']], selected: @user.user_type %>
+  <% end %>
+  <p><%= t('dictionary.new_password') %></p>
+  <input type="password" name="password">
+  <br><input type="submit" value="<%= t('dictionary.update') %>">
+<% end %>

--- a/todo_manager/app/views/admin/index.html.erb
+++ b/todo_manager/app/views/admin/index.html.erb
@@ -1,0 +1,25 @@
+<h2><%= t('views.admin.index.title') %></h2>
+<%= link_to(t('dictionary.create'), '/admin/new') %>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th><%= t('dictionary.name') %></th>
+    <th><%= t('dictionary.role') %></th>
+    <th><%= t('dictionary.number_of_tasks') %></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @users.each do |user| %>
+    <tr>
+      <th><%= user.id %></th>
+      <th><%= link_to(user.name, "/admin/#{user.id}") %></th>
+      <th style="color:<%= 'red' if user.user_type == 'admin' %>">
+        <%= I18n.t("role.#{user.user_type}") %>
+      </th>
+      <th><%= link_to(user.todos.count, "/admin/#{user.id}/todos") %></th>
+    </tr>
+  <% end %>
+  </tbody>
+  <%= paginate @users %>
+</table>

--- a/todo_manager/app/views/admin/new.html.erb
+++ b/todo_manager/app/views/admin/new.html.erb
@@ -1,0 +1,15 @@
+<h2><%= t('views.admin.new.title') %></h2>
+
+<% @user.errors.full_messages.each do |message| %>
+  <%= message %>
+<% end %>
+
+<%= form_tag('/admin') do %>
+  <p><%= t('dictionary.name') %></p>
+  <input name="name" value="<%= @user.name %>">
+  <p><%= t('dictionary.password') %></p>
+  <input type="password" name="password">
+  <p><%= t('dictionary.role') %></p>
+  <%= select :user, :user_type, [[t('role.admin'), 'admin'], [t('role.normal'), 'normal']], selected: @user.user_type %>
+  <input type="submit" value="<%= t('dictionary.signup') %>">
+<% end %>

--- a/todo_manager/app/views/admin/new.html.erb
+++ b/todo_manager/app/views/admin/new.html.erb
@@ -11,5 +11,5 @@
   <input type="password" name="password">
   <p><%= t('dictionary.role') %></p>
   <%= select :user, :user_type, [[t('role.admin'), 'admin'], [t('role.normal'), 'normal']], selected: @user.user_type %>
-  <input type="submit" value="<%= t('dictionary.signup') %>">
+  <input type="submit" value="<%= t('dictionary.create') %>">
 <% end %>

--- a/todo_manager/app/views/admin/new_todos.html.erb
+++ b/todo_manager/app/views/admin/new_todos.html.erb
@@ -1,0 +1,15 @@
+<h2><%= "#{@user.name}#{t('views.admin.new_todos.title')}" %></h2>
+<% @todo.errors.full_messages.each do |message| %>
+  <%= message %>
+<% end %>
+<%= form_tag("/admin/#{@user.id}/create") do %>
+  <p><%= t('dictionary.title') %></p>
+  <input name="title" value="<%= @todo.title %>">
+  <p><%= t('dictionary.content') %></p>
+  <textarea name="content"><%= @todo.content %></textarea>
+  <p><%= t('dictionary.priority') %></p>
+  <%= select :todo, :priority_id, [[t('priority.low'), 'low'], [t('priority.middle'), 'middle'], [t('priority.high'), 'high']], selected: @todo.priority_id %>
+  <p><%= t('dictionary.deadline') %></p>
+  <input type="datetime-local" name="deadline" min="<%= Time.current.strftime('%Y-%m-%dT%H:%M') %>" value="<%= @todo.deadline.strftime('%Y-%m-%dT%H:%M') if !@todo.deadline.nil? %>">
+  <input type="submit" value="<%= t('dictionary.create') %>">
+<% end %>

--- a/todo_manager/app/views/admin/show.html.erb
+++ b/todo_manager/app/views/admin/show.html.erb
@@ -1,0 +1,4 @@
+<h3><%= @user.name %></h3>
+<p><%= "#{t('dictionary.role')} #{t("role.#{@user.user_type}")}" %></p>
+<%= link_to(t('dictionary.edit'), "/admin/#{@user.id}/edit") %>
+<%= button_to(t('dictionary.destroy'), "/admin/#{@user.id}", method: :delete, data: { confirm: t('flash.confirmation.delete') }) %>

--- a/todo_manager/app/views/admin/todos.html.erb
+++ b/todo_manager/app/views/admin/todos.html.erb
@@ -1,0 +1,38 @@
+<h2><%= "#{@user.name}#{t('views.admin.todos.title')}" %></h2>
+<%= button_to(t('dictionary.all'), controller: :admin, action: :todos, sort: @sort, direction: @direction, search: '', status: '') %>
+<%= button_to(t('status.unstarted'), controller: :admin, action: :todos, sort: @sort, direction: @direction, search: @search, status: 'unstarted') %>
+<%= button_to(t('status.working'), controller: :admin, action: :todos, sort: @sort, direction: @direction, search: @search, status: 'working') %>
+<%= button_to(t('status.completed'), controller: :admin, action: :todos, sort: @sort, direction: @direction, search: @search, status: 'completed') %>
+<%= form_tag("/admin/#{params[:id]}/todos") do %>
+  <input type="search" name="search">
+  <input type="hidden" name="sort" value="<%= @sort %>">
+  <input type="hidden" name="direction" value="<%= @direction %>">
+  <input type="hidden" name="status" value="<%= @status %>">
+  <input type="submit" value="<%= t('dictionary.search') %>">
+<% end %>
+<%= link_to(t('dictionary.create'), './new') %>
+<table border="1">
+  <thead>
+  <tr>
+    <th><%= link_to(t('dictionary.priority'), controller: :admin, action: :todos, sort: 'priority_id', direction: @direction == 'desc' ? 'asc' : 'desc', search: @search, status: @status) %></th>
+    <th><%= t('dictionary.status') %></th>
+    <th><%= t('dictionary.title') %></th>
+    <th><%= t('dictionary.content') %></th>
+    <th><%= link_to(t('dictionary.deadline'), controller: :admin, action: :todos, sort: 'deadline', direction: @direction == 'desc' ? 'asc' : 'desc', search: @search, status: @status) %></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @todos.each do |todo| %>
+    <tr>
+      <th><%= t("priority.#{todo.priority_id}") %></th>
+      <th><%= t("status.#{todo.status_id}") %></th>
+      <th><%= link_to(todo.title, "/todos/#{todo.id}/detail") %></th>
+      <th><%= todo.content %></th>
+      <th style="color:<%= 'red' if !todo.deadline.nil? and todo.deadline < Time.current %>">
+        <%= l(todo.deadline, format: :long) if !todo.deadline.nil? %>
+      </th>
+    </tr>
+  <% end %>
+  </tbody>
+  <%= paginate @todos %>
+</table>

--- a/todo_manager/app/views/layouts/application.html.erb
+++ b/todo_manager/app/views/layouts/application.html.erb
@@ -19,6 +19,9 @@
       </li>
     <% else %>
       <li>
+        <%= link_to(t('dictionary.signup'), '/signup') %>
+      </li>
+      <li>
         <%= link_to(t('dictionary.login'), '/login') %>
       </li>
     <% end %>

--- a/todo_manager/app/views/layouts/application.html.erb
+++ b/todo_manager/app/views/layouts/application.html.erb
@@ -14,6 +14,11 @@
   <h1><%= link_to(t('title'), @current_user ? '/' : '/login') %></h1>
   <ul>
     <% if @current_user %>
+      <% if @current_user.user_type == 'admin' %>
+        <li>
+          <%= link_to(t('dictionary.management'), '/admin') %>
+        </li>
+      <% end %>
       <li>
         <%= link_to(t('dictionary.logout'), '/logout', { method: :post }) %>
       </li>

--- a/todo_manager/app/views/layouts/mailer.html.erb
+++ b/todo_manager/app/views/layouts/mailer.html.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <style>
-      /* Email styles need to be inline */
-    </style>
-  </head>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <style>
+    /* Email styles need to be inline */
+  </style>
+</head>
 
-  <body>
-    <%= yield %>
-  </body>
+<body>
+<%= yield %>
+</body>
 </html>

--- a/todo_manager/app/views/todos/edit.html.erb
+++ b/todo_manager/app/views/todos/edit.html.erb
@@ -13,6 +13,6 @@
   <%= select :todo, :status_id, [[t('status.unstarted'), 'unstarted'], [t('status.working'), 'working'], [t('status.completed'), 'completed']], selected: @todo.status_id %>
   <p><%= t('dictionary.deadline') %></p>
   <input type="datetime-local" name="deadline" value="<%= @todo.deadline.strftime('%Y-%m-%dT%H:%M') if !@todo.deadline.nil? %>">
+  <br>
   <input type="submit" value="<%= t('dictionary.update') %>">
 <% end %>
-<%= @status %>

--- a/todo_manager/app/views/todos/index.html.erb
+++ b/todo_manager/app/views/todos/index.html.erb
@@ -1,5 +1,5 @@
 <h2><%= t('views.todos.index.title') %></h2>
-<%= button_to(t('dictionary.all'), root_path(sort: @sort, direction: @direction, search: @search, status: '')) %>
+<%= button_to(t('dictionary.all'), root_path(sort: @sort, direction: @direction, search: '', status: '')) %>
 <%= button_to(t('status.unstarted'), root_path(sort: @sort, direction: @direction, search: @search, status: 'unstarted')) %>
 <%= button_to(t('status.working'), root_path(sort: @sort, direction: @direction, search: @search, status: 'working')) %>
 <%= button_to(t('status.completed'), root_path(sort: @sort, direction: @direction, search: @search, status: 'completed')) %>
@@ -13,13 +13,13 @@
 <%= link_to(t('dictionary.create'), '/todos/new') %>
 <table border="1">
   <thead>
-    <tr>
-      <th><%= link_to(t('dictionary.priority'), root_path(sort: 'priority_id', direction: @direction == 'desc' ? 'asc' : 'desc', search: @search, status: @status)) %></th>
-      <th><%= t('dictionary.status') %></th>
-      <th><%= t('dictionary.title') %></th>
-      <th><%= t('dictionary.content') %></th>
-      <th><%= link_to(t('dictionary.deadline'), root_path(sort: 'deadline', direction: @direction == 'desc' ? 'asc' : 'desc', search: @search, status: @status)) %></th>
-    </tr>
+  <tr>
+    <th><%= link_to(t('dictionary.priority'), root_path(sort: 'priority_id', direction: @direction == 'desc' ? 'asc' : 'desc', search: @search, status: @status)) %></th>
+    <th><%= t('dictionary.status') %></th>
+    <th><%= t('dictionary.title') %></th>
+    <th><%= t('dictionary.content') %></th>
+    <th><%= link_to(t('dictionary.deadline'), root_path(sort: 'deadline', direction: @direction == 'desc' ? 'asc' : 'desc', search: @search, status: @status)) %></th>
+  </tr>
   </thead>
   <tbody>
   <% @todos.each do |todo| %>

--- a/todo_manager/app/views/users/new.html.erb
+++ b/todo_manager/app/views/users/new.html.erb
@@ -1,2 +1,13 @@
-<h1>Users#new</h1>
-<p>Find me in app/views/users/new.html.erb</p>
+<h2><%= t('views.users.signup.title') %></h2>
+
+<% @user.errors.full_messages.each do |message| %>
+  <%= message %>
+<% end %>
+
+<%= form_tag('/users/create') do %>
+  <p><%= t('dictionary.name') %></p>
+  <input name="name" value="<%= @user.name %>">
+  <p><%= t('dictionary.password') %></p>
+  <input type="password" name="password">
+  <input type="submit" value="<%= t('dictionary.signup') %>">
+<% end %>

--- a/todo_manager/config/environments/production.rb
+++ b/todo_manager/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
@@ -54,7 +54,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -84,9 +84,9 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Do not dump schema after migrations.

--- a/todo_manager/config/environments/test.rb
+++ b/todo_manager/config/environments/test.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/todo_manager/config/locales/en.yml
+++ b/todo_manager/config/locales/en.yml
@@ -101,7 +101,7 @@ en:
       index:
         title: Todo List
       new:
-        title: Create Todo
+        title: New Todo
       edit:
         title: Edit Todo
 
@@ -120,6 +120,8 @@ en:
         title: Edit User
       todos:
         title: "'s Todo List"
+      new_todos:
+        title: "'s New Todo"
 
     pagination:
       first: '<<'

--- a/todo_manager/config/locales/en.yml
+++ b/todo_manager/config/locales/en.yml
@@ -46,9 +46,14 @@ en:
     priority: Priority
     name: Name
     password: Password
+    new_password: New Password
     login: Login
     logout: Logout
     signup: Signup
+    management: User Management
+    role: Role
+    show: Show
+    number_of_tasks: No. of tasks
 
   priority:
     low: Low
@@ -60,13 +65,17 @@ en:
     working: Working
     completed: Completed
 
+  role:
+    admin: Admin
+    normal: User
+
   flash:
     todos:
       create: New todo has been created.
       update: Todo has been updated.
       destroy:
-        success: Todo has been deleted.
-        failure: Failed to delete todo.
+        success: The todo has been deleted.
+        failure: Failed to delete the todo.
 
     users:
       signup: You have signed up successfully.
@@ -78,6 +87,14 @@ en:
       logout: You have logged out successfully.
       authorization:
         failure: You don't have permission.
+      create: The user has been created.
+      destroy:
+        success: The user has been deleted.
+        failure: Failed to delete the user.
+      update: The user information has been updated.
+
+    confirmation:
+      delete: Are you sure to delete it?
 
   views:
     todos:
@@ -93,6 +110,16 @@ en:
         title: Log in
       signup:
         title: Sign up
+
+    admin:
+      index:
+        title: User List
+      new:
+        title: Create User
+      edit:
+        title: Edit User
+      todos:
+        title: "'s Todo List"
 
     pagination:
       first: '<<'

--- a/todo_manager/config/locales/en.yml
+++ b/todo_manager/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
     password: Password
     login: Login
     logout: Logout
+    signup: Signup
 
   priority:
     low: Low
@@ -68,6 +69,7 @@ en:
         failure: Failed to delete todo.
 
     users:
+      signup: You have signed up successfully.
       login:
         success: You have logged in successfully.
         failure: Your name or password is wrong.
@@ -88,7 +90,9 @@ en:
 
     users:
       login:
-        title: Login
+        title: Log in
+      signup:
+        title: Sign up
 
     pagination:
       first: '<<'

--- a/todo_manager/config/locales/ja.yml
+++ b/todo_manager/config/locales/ja.yml
@@ -15,9 +15,14 @@ ja:
     priority: 優先度
     name: 名前
     password: パスワード
+    new_password: 新しいパスワード
     login: ログイン
     logout: ログアウト
     signup: 登録
+    management: ユーザ管理
+    role: 役割
+    show: 表示
+    number_of_tasks: タスク数
 
   priority:
     low: 低
@@ -28,6 +33,10 @@ ja:
     unstarted: 未着手
     working: 着手中
     completed: 完了
+
+  role:
+    admin: 管理者
+    normal: 利用者
 
   flash:
     todos:
@@ -47,6 +56,14 @@ ja:
       logout: ログアウトしました。
       authorization:
         failure: 権限がありません。
+      create: ユーザを作成しました。
+      destroy:
+        success: ユーザを削除しました。
+        failure: ユーザの削除に失敗しました。
+      update: ユーザ情報を更新しました。
+
+    confirmation:
+      delete: 本当に削除してもよろしいですか？
 
   views:
     todos:
@@ -62,6 +79,16 @@ ja:
         title: ログイン
       signup:
         title: 新規登録
+
+    admin:
+      index:
+        title: ユーザ一覧
+      new:
+        title: ユーザ作成
+      edit:
+        title: ユーザ編集
+      todos:
+        title: のタスク一覧
 
     pagination:
       first: '<<'

--- a/todo_manager/config/locales/ja.yml
+++ b/todo_manager/config/locales/ja.yml
@@ -17,6 +17,7 @@ ja:
     password: パスワード
     login: ログイン
     logout: ログアウト
+    signup: 登録
 
   priority:
     low: 低
@@ -37,6 +38,7 @@ ja:
         failure: タスクの削除に失敗しました。
 
     users:
+      signup: ユーザ登録が完了しました。
       login:
         success: ログインしました。
         failure: 名前またはパスワードが間違っています。
@@ -58,6 +60,8 @@ ja:
     users:
       login:
         title: ログイン
+      signup:
+        title: 新規登録
 
     pagination:
       first: '<<'
@@ -67,6 +71,19 @@ ja:
       truncate: ...
 
   activerecord:
+    models:
+      todo: タスク
+      user: ユーザ
+
+    attributes:
+      todo:
+        title: タスク名
+        content: 内容
+
+      user:
+        name: 名前
+        password: パスワード
+
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -173,7 +190,7 @@ ja:
       second: 秒
       year: 年
   errors:
-    format: "%{attribute} %{message}"
+    format: "%{attribute}%{message}"
     messages:
       accepted: を受諾してください
       blank: を入力してください

--- a/todo_manager/config/locales/ja.yml
+++ b/todo_manager/config/locales/ja.yml
@@ -89,6 +89,8 @@ ja:
         title: ユーザ編集
       todos:
         title: のタスク一覧
+      new_todos:
+        title: のタスク作成
 
     pagination:
       first: '<<'

--- a/todo_manager/config/routes.rb
+++ b/todo_manager/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get 'login', to: 'users#login'
   post 'logout', to: 'users#logout'
   get 'signup', to: 'users#new'
+  post 'users/create', to: 'users#create'
 
   root 'todos#index'
   post '/', to: 'todos#index'

--- a/todo_manager/config/routes.rb
+++ b/todo_manager/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
+  resources :admin
+  get 'admin/:id/todos', to: 'admin#todos'
+  post 'admin/:id/todos', to: 'admin#todos'
+
   post 'login', to: 'users#login_post'
   get 'login', to: 'users#login'
   post 'logout', to: 'users#logout'
   get 'signup', to: 'users#new'
-  post 'users/create', to: 'users#create'
+  post 'users/create'
 
   root 'todos#index'
   post '/', to: 'todos#index'

--- a/todo_manager/config/routes.rb
+++ b/todo_manager/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   resources :admin
   get 'admin/:id/todos', to: 'admin#todos'
   post 'admin/:id/todos', to: 'admin#todos'
+  get 'admin/:id/new', to: 'admin#new_todos'
+  post 'admin/:id/create', to: 'admin#create_todos'
 
   post 'login', to: 'users#login_post'
   get 'login', to: 'users#login'

--- a/todo_manager/spec/controllers/users_controller_spec.rb
+++ b/todo_manager/spec/controllers/users_controller_spec.rb
@@ -15,5 +15,4 @@ RSpec.describe UsersController, type: :controller do
       expect(response).to have_http_status(200)
     end
   end
-
 end

--- a/todo_manager/spec/helpers/admin_helper_spec.rb
+++ b/todo_manager/spec/helpers/admin_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AdminHelper. For example:
+#
+# describe AdminHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe AdminHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/todo_manager/spec/rails_helper.rb
+++ b/todo_manager/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'capybara/poltergeist'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -57,4 +58,9 @@ RSpec.configure do |config|
 
   config.include Capybara::DSL
   config.include FactoryBot::Syntax::Methods
+
+  Capybara.register_driver :poltergeist do |app|
+    Capybara::Poltergeist::Driver.new(app, js_errors: false, inspector: true)
+  end
+  Capybara.javascript_driver = :poltergeist
 end

--- a/todo_manager/spec/requests/todos_spec.rb
+++ b/todo_manager/spec/requests/todos_spec.rb
@@ -185,32 +185,32 @@ RSpec.describe 'Todos', type: :request do
       end
 
       describe 'sort todos by deadline' do
+        let!(:todo2) { create(:todo, title: 'hoge', user_id: user.id, status_id: 1, deadline: 2.days.since) }
+        let!(:todo3) { create(:todo, title: 'hoge', user_id: user.id, status_id: 1, deadline: 3.days.since) }
         before do
-          create(:todo, title: 'hoge', user_id: user.id, status_id: 1, deadline: 2.days.since)
-          create(:todo, title: 'hoge', user_id: user.id, status_id: 1, deadline: 3.days.since)
           click_link I18n.t('dictionary.deadline')
         end
         context 'in asc' do
           it 'should be ordered' do
             trs = page.all('tbody tr')
-            expect(trs[0]).to have_content(I18n.l(1.day.since, format: :long))
-            expect(trs[1]).to have_content(I18n.l(2.days.since, format: :long))
-            expect(trs[2]).to have_content(I18n.l(3.days.since, format: :long))
+            expect(trs[0]).to have_content(I18n.l(todo.deadline, format: :long))
+            expect(trs[1]).to have_content(I18n.l(todo2.deadline, format: :long))
+            expect(trs[2]).to have_content(I18n.l(todo3.deadline, format: :long))
           end
 
           it 'should be refined by status_id' do
             click_button(I18n.t('status.working'))
             trs = page.all('tbody tr')
-            expect(trs[0]).to have_content(I18n.l(2.days.since, format: :long))
-            expect(trs[1]).to have_content(I18n.l(3.days.since, format: :long))
+            expect(trs[0]).to have_content(I18n.l(todo2.deadline, format: :long))
+            expect(trs[1]).to have_content(I18n.l(todo3.deadline, format: :long))
           end
 
           it 'should be refined by title' do
             fill_in 'search', with: 'hoge'
             click_button(I18n.t('dictionary.search'))
             trs = page.all('tbody tr')
-            expect(trs[0]).to have_content(I18n.l(2.days.since, format: :long))
-            expect(trs[1]).to have_content(I18n.l(3.days.since, format: :long))
+            expect(trs[0]).to have_content(I18n.l(todo2.deadline, format: :long))
+            expect(trs[1]).to have_content(I18n.l(todo3.deadline, format: :long))
           end
         end
 
@@ -219,17 +219,17 @@ RSpec.describe 'Todos', type: :request do
 
           it 'should be ordered' do
             trs = page.all('tbody tr')
-            expect(trs[0]).to have_content(I18n.l(3.days.since, format: :long))
-            expect(trs[1]).to have_content(I18n.l(2.days.since, format: :long))
-            expect(trs[2]).to have_content(I18n.l(1.day.since, format: :long))
+            expect(trs[0]).to have_content(I18n.l(todo3.deadline, format: :long))
+            expect(trs[1]).to have_content(I18n.l(todo2.deadline, format: :long))
+            expect(trs[2]).to have_content(I18n.l(todo.deadline, format: :long))
           end
 
           it 'should be refined by status_id' do
             click_button(I18n.t('status.working'))
             trs = page.all('tbody tr')
             expect(trs).to all(have_content(I18n.t('status.working')))
-            expect(trs[0]).to have_content(I18n.l(3.days.since, format: :long))
-            expect(trs[1]).to have_content(I18n.l(2.days.since, format: :long))
+            expect(trs[0]).to have_content(I18n.l(todo3.deadline, format: :long))
+            expect(trs[1]).to have_content(I18n.l(todo2.deadline, format: :long))
           end
 
           it 'should be refined by title' do
@@ -237,8 +237,8 @@ RSpec.describe 'Todos', type: :request do
             click_button(I18n.t('dictionary.search'))
             trs = page.all('tbody tr')
             expect(trs).to all(have_content('hoge'))
-            expect(trs[0]).to have_content(I18n.l(3.days.since, format: :long))
-            expect(trs[1]).to have_content(I18n.l(2.days.since, format: :long))
+            expect(trs[0]).to have_content(I18n.l(todo3.deadline, format: :long))
+            expect(trs[1]).to have_content(I18n.l(todo2.deadline, format: :long))
           end
         end
       end

--- a/todo_manager/spec/requests/todos_spec.rb
+++ b/todo_manager/spec/requests/todos_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'Todos', type: :request do
         before do
           create(:todo, title: 'hoge', user_id: user.id, status_id: 1, deadline: 2.days.since)
           create(:todo, title: 'hoge', user_id: user.id, status_id: 1, deadline: 3.days.since)
-          click_on I18n.t('dictionary.deadline')
+          click_link I18n.t('dictionary.deadline')
         end
         context 'in asc' do
           it 'should be ordered' do
@@ -135,7 +135,7 @@ RSpec.describe 'Todos', type: :request do
           end
 
           it 'should be refined by status_id' do
-            click_on(I18n.t('status.working'))
+            click_button(I18n.t('status.working'))
             trs = page.all('tbody tr')
             expect(trs[0]).to have_content(I18n.l(2.days.since, format: :long))
             expect(trs[1]).to have_content(I18n.l(3.days.since, format: :long))
@@ -143,7 +143,7 @@ RSpec.describe 'Todos', type: :request do
 
           it 'should be refined by title' do
             fill_in 'search', with: 'hoge'
-            click_on(I18n.t('dictionary.search'))
+            click_button(I18n.t('dictionary.search'))
             trs = page.all('tbody tr')
             expect(trs[0]).to have_content(I18n.l(2.days.since, format: :long))
             expect(trs[1]).to have_content(I18n.l(3.days.since, format: :long))
@@ -151,7 +151,7 @@ RSpec.describe 'Todos', type: :request do
         end
 
         context 'in desc' do
-          before { click_on I18n.t('dictionary.deadline') }
+          before { click_link I18n.t('dictionary.deadline') }
 
           it 'should be ordered' do
             trs = page.all('tbody tr')
@@ -161,7 +161,7 @@ RSpec.describe 'Todos', type: :request do
           end
 
           it 'should be refined by status_id' do
-            click_on(I18n.t('status.working'))
+            click_button(I18n.t('status.working'))
             trs = page.all('tbody tr')
             expect(trs).to all(have_content(I18n.t('status.working')))
             expect(trs[0]).to have_content(I18n.l(3.days.since, format: :long))
@@ -170,7 +170,7 @@ RSpec.describe 'Todos', type: :request do
 
           it 'should be refined by title' do
             fill_in 'search', with: 'hoge'
-            click_on(I18n.t('dictionary.search'))
+            click_button(I18n.t('dictionary.search'))
             trs = page.all('tbody tr')
             expect(trs).to all(have_content('hoge'))
             expect(trs[0]).to have_content(I18n.l(3.days.since, format: :long))
@@ -183,7 +183,7 @@ RSpec.describe 'Todos', type: :request do
         before do
           create(:todo, title: 'hoge', user_id: user.id, priority_id: 0, status_id: 1)
           create(:todo, title: 'hoge', user_id: user.id, priority_id: 2, status_id: 1)
-          click_on I18n.t('dictionary.priority')
+          click_link I18n.t('dictionary.priority')
         end
         context 'in asc' do
           it 'should be ordered' do
@@ -194,7 +194,7 @@ RSpec.describe 'Todos', type: :request do
           end
 
           it 'should be refined by status_id' do
-            click_on(I18n.t('status.working'))
+            click_button(I18n.t('status.working'))
             trs = page.all('tbody tr')
             expect(trs).to all(have_content(I18n.t('status.working')))
             expect(trs[0]).to have_content(I18n.t('priority.low'))
@@ -358,7 +358,7 @@ RSpec.describe 'Todos', type: :request do
             end
 
             it 'should show an error message' do
-              is_expected.to have_content("Title #{I18n.t('errors.messages.blank')}")
+              is_expected.to have_content(I18n.t('errors.format', attribute: Todo.human_attribute_name(:title), message: I18n.t('errors.messages.blank')))
             end
 
             it 'should keep the value' do
@@ -447,7 +447,7 @@ RSpec.describe 'Todos', type: :request do
                     end
 
                     it 'should show an error message' do
-                      is_expected.to have_content("Title #{I18n.t('errors.messages.blank')}")
+                      is_expected.to have_content(I18n.t('errors.format', attribute: Todo.human_attribute_name(:title), message: I18n.t('errors.messages.blank')))
                     end
 
                     it 'should keep the edited value' do

--- a/todo_manager/spec/requests/todos_spec.rb
+++ b/todo_manager/spec/requests/todos_spec.rb
@@ -25,53 +25,117 @@ RSpec.describe 'Todos', type: :request do
         is_expected.to have_content(I18n.t('flash.users.login.must'))
       end
 
-      it 'should have a header and the login link' do
-        is_expected.to have_link(I18n.t('title'), href: '/login')
-      end
-
       it 'should be login page' do
         expect(current_path).to eq '/login'
       end
 
-      context 'name is wrong' do
-        before do
-          fill_in 'name', with: 'aaaa'
-          fill_in 'password', with: user.password
-          click_button I18n.t('dictionary.login')
+      it 'should have a header and the login link and the signup link' do
+        is_expected.to have_link(I18n.t('title'), href: '/login')
+        is_expected.to have_link(I18n.t('dictionary.signup'), href: '/signup')
+        is_expected.to have_link(I18n.t('dictionary.login'), href: '/login')
+      end
+
+      describe 'signup' do
+        before { click_link I18n.t('dictionary.signup') }
+
+        it 'should be signup page' do
+          expect(current_path).to eq '/signup'
         end
 
-        it "can't be logged in" do
-          is_expected.to have_content(I18n.t('flash.users.login.failure'))
-          expect(current_path).to eq '/login'
+        context 'same name already exists' do
+          before do
+            fill_in 'name', with: user.name
+            fill_in 'password', with: 'hoge'
+            click_button I18n.t('dictionary.signup')
+          end
+
+          it "can't be created and show error messages" do
+            expect(current_path).to eq '/users/create'
+            is_expected.to have_content(I18n.t('errors.format', attribute: User.human_attribute_name(:name), message: I18n.t('errors.messages.taken')))
+          end
+        end
+
+        context 'name is nil' do
+          before do
+            fill_in 'password', with: 'hoge'
+            click_button I18n.t('dictionary.signup')
+          end
+
+          it "can't be created and show error messages" do
+            expect(current_path).to eq '/users/create'
+            is_expected.to have_content(I18n.t('errors.format', attribute: User.human_attribute_name(:name), message: I18n.t('errors.messages.empty')))
+          end
+        end
+
+        context 'password is nil' do
+          before do
+            fill_in 'name', with: 'name'
+            click_button I18n.t('dictionary.signup')
+          end
+
+          it "can't be created and show error messages" do
+            expect(current_path).to eq '/users/create'
+            is_expected.to have_content(I18n.t('errors.format', attribute: User.human_attribute_name(:password), message: I18n.t('errors.messages.empty')))
+          end
+        end
+
+        context 'unique name' do
+          before do
+            fill_in 'name', with: 'unique'
+            fill_in 'password', with: 'password'
+            click_button I18n.t('dictionary.signup')
+          end
+
+          it 'can be created' do
+            expect(current_path).to eq '/'
+            is_expected.to have_content(I18n.t('flash.users.signup'))
+          end
+
+          it_behaves_like 'have a header'
         end
       end
 
-      context 'password is wrong' do
-        before do
-          fill_in 'name', with: user.name
-          fill_in 'password', with: 'aaaa'
-          click_button I18n.t('dictionary.login')
+      describe 'login' do
+        context 'name is wrong' do
+          before do
+            fill_in 'name', with: 'aaaa'
+            fill_in 'password', with: user.password
+            click_button I18n.t('dictionary.login')
+          end
+
+          it "can't be logged in" do
+            is_expected.to have_content(I18n.t('flash.users.login.failure'))
+            expect(current_path).to eq '/login'
+          end
         end
 
-        it "can't be logged in" do
-          is_expected.to have_content(I18n.t('flash.users.login.failure'))
-          expect(current_path).to eq '/login'
-        end
-      end
+        context 'password is wrong' do
+          before do
+            fill_in 'name', with: user.name
+            fill_in 'password', with: 'aaaa'
+            click_button I18n.t('dictionary.login')
+          end
 
-      context 'name and password are true' do
-        before do
-          fill_in 'name', with: user.name
-          fill_in 'password', with: user.password
-          click_button I18n.t('dictionary.login')
-        end
-
-        it 'can be logged in' do
-          is_expected.to have_content(I18n.t('flash.users.login.success'))
-          expect(current_path).to eq '/'
+          it "can't be logged in" do
+            is_expected.to have_content(I18n.t('flash.users.login.failure'))
+            expect(current_path).to eq '/login'
+          end
         end
 
-        it_behaves_like 'have a header'
+        context 'name and password are true' do
+          before do
+            fill_in 'name', with: user.name
+            fill_in 'password', with: user.password
+            click_button I18n.t('dictionary.login')
+          end
+
+          it 'can be logged in' do
+            is_expected.to have_content(I18n.t('flash.users.login.success'))
+            expect(current_path).to eq '/'
+          end
+
+          it_behaves_like 'have a header'
+        end
       end
     end
 

--- a/todo_manager/spec/spec_helper.rb
+++ b/todo_manager/spec/spec_helper.rb
@@ -47,8 +47,8 @@ RSpec.configure do |config|
   config.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
   end
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
 =begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing

--- a/todo_manager/spec/views/admin/edit.html.erb_spec.rb
+++ b/todo_manager/spec/views/admin/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "admin/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/todo_manager/spec/views/admin/index.html.erb_spec.rb
+++ b/todo_manager/spec/views/admin/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "admin/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/todo_manager/spec/views/admin/new.html.erb_spec.rb
+++ b/todo_manager/spec/views/admin/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "admin/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/todo_manager/spec/views/admin/show.html.erb_spec.rb
+++ b/todo_manager/spec/views/admin/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "admin/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
画面上に管理メニューを追加しました
管理画面にはかならず /admin というURLを先頭につけるようにしました
routes.rb に追加する前に、あらかじめURLやルーティング名（ *_path となる名前）を想定して設計しました
ユーザ一覧・作成・更新・削除を実装しました
ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしました
ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしました
ユーザが作成したタスクの一覧が見られるようにしました
ユーザに管理ユーザと一般ユーザを区別するようにしました
管理ユーザだけがユーザ管理画面にアクセスできるようにしました
ユーザ管理画面でロールを選択できるようにしました
管理ユーザが1人もいなくならないように削除と更新の制御をしました