### PR TITLE
Ito Step10

### DIFF
--- a/task_management/config/application.rb
+++ b/task_management/config/application.rb
@@ -17,5 +17,7 @@ module TaskManagement
     # the framework and any gems in your application.
 
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
Railsのタイムゾーンを東京に変更しました。
`config.active_record.default_timezone = :local`でDBに保存される際の時刻がJSTに変わっていたので、ローカル上のMySQLの設定は特に変更していません。
(先ほど反映されなかったのはrailsサーバの再起動を忘れていたためでした。)

レビューをお願い致します。