### PR TITLE
Ito Step12

### DIFF
--- a/task_management/app/controllers/tasks_controller.rb
+++ b/task_management/app/controllers/tasks_controller.rb
@@ -21,7 +21,8 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to ({action: 'index'}), notice: I18n.t('flash.success_create')
     else
-      redirect_to ({action: 'new'}), alert: @task.errors.full_messages
+      flash.now[:alert] = I18n.t('flash.failure_create')
+      render :new
     end
   end
 
@@ -30,7 +31,8 @@ class TasksController < ApplicationController
     if @task.update_attributes(tasks_params)
       redirect_to ({action: 'show'}), id: params[:id], notice: I18n.t('flash.success_update')
     else
-        redirect_to ({action: 'edit'}), alert: @task.errors.full_messages
+      flash.now[:alert] = I18n.t('flash.failure_update')
+      render :edit
     end
   end
 

--- a/task_management/app/controllers/tasks_controller.rb
+++ b/task_management/app/controllers/tasks_controller.rb
@@ -21,7 +21,7 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to ({action: 'index'}), notice: I18n.t('flash.success_create')
     else
-      redirect_to ({action: 'new'}), alert: @task.errors.full_messages[0]
+      redirect_to ({action: 'new'}), alert: @task.errors.full_messages
     end
   end
 
@@ -30,7 +30,7 @@ class TasksController < ApplicationController
     if @task.update_attributes(tasks_params)
       redirect_to ({action: 'show'}), id: params[:id], notice: I18n.t('flash.success_update')
     else
-        redirect_to ({action: 'edit'}), alert: @task.errors.full_messages[0]
+        redirect_to ({action: 'edit'}), alert: @task.errors.full_messages
     end
   end
 

--- a/task_management/app/controllers/tasks_controller.rb
+++ b/task_management/app/controllers/tasks_controller.rb
@@ -21,11 +21,7 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to ({action: 'index'}), notice: I18n.t('flash.success_create')
     else
-      if @task.errors.details[:task_name][0][:error] == :blank
-        redirect_to ({action: 'new'}), alert: I18n.t('activerecord.format', attribute: I18n.t('activerecord.attributes.task.task_name'), message: I18n.t('activerecord.message.blank'))
-      else
-        redirect_to ({action: 'new'}), alert: I18n.t('activerecord.format', attribute: I18n.t('activerecord.attributes.task.task_name'), message: I18n.t('activerecord.message.too_long', count: @task.errors.details[:task_name][0][:count]))
-      end
+      redirect_to ({action: 'new'}), alert: @task.errors.full_messages[0]
     end
   end
 
@@ -34,13 +30,7 @@ class TasksController < ApplicationController
     if @task.update_attributes(tasks_params)
       redirect_to ({action: 'show'}), id: params[:id], notice: I18n.t('flash.success_update')
     else
-      p '================='
-      p @task.errors.full_messages
-      if @task.errors.details[:task_name][0][:error] == :blank
-        redirect_to ({action: 'edit'}), alert: I18n.t('activerecord.format', attribute: I18n.t('activerecord.attributes.task.task_name'), message: I18n.t('activerecord.message.blank'))
-      else
-        redirect_to ({action: 'edit'}), alert: I18n.t('activerecord.format', attribute: I18n.t('activerecord.attributes.task.task_name'), message: I18n.t('activerecord.message.too_long', count: @task.errors.details[:task_name][0][:count]))
-      end
+        redirect_to ({action: 'edit'}), alert: @task.errors.full_messages[0]
     end
   end
 

--- a/task_management/app/controllers/tasks_controller.rb
+++ b/task_management/app/controllers/tasks_controller.rb
@@ -21,7 +21,11 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to ({action: 'index'}), notice: I18n.t('flash.success_create')
     else
-      redirect_to ({action: 'new'}), alert: I18n.t('flash.failure_create')
+      if @task.errors.details[:task_name][0][:error] == :blank
+        redirect_to ({action: 'new'}), alert: I18n.t('activerecord.format', attribute: I18n.t('activerecord.attributes.task.task_name'), message: I18n.t('activerecord.message.blank'))
+      else
+        redirect_to ({action: 'new'}), alert: I18n.t('activerecord.format', attribute: I18n.t('activerecord.attributes.task.task_name'), message: I18n.t('activerecord.message.too_long', count: @task.errors.details[:task_name][0][:count]))
+      end
     end
   end
 
@@ -30,7 +34,13 @@ class TasksController < ApplicationController
     if @task.update_attributes(tasks_params)
       redirect_to ({action: 'show'}), id: params[:id], notice: I18n.t('flash.success_update')
     else
-      redirect_to ({action: 'edit'}), alert: I18n.t('flash.failure_update')
+      p '================='
+      p @task.errors.full_messages
+      if @task.errors.details[:task_name][0][:error] == :blank
+        redirect_to ({action: 'edit'}), alert: I18n.t('activerecord.format', attribute: I18n.t('activerecord.attributes.task.task_name'), message: I18n.t('activerecord.message.blank'))
+      else
+        redirect_to ({action: 'edit'}), alert: I18n.t('activerecord.format', attribute: I18n.t('activerecord.attributes.task.task_name'), message: I18n.t('activerecord.message.too_long', count: @task.errors.details[:task_name][0][:count]))
+      end
     end
   end
 

--- a/task_management/app/models/task.rb
+++ b/task_management/app/models/task.rb
@@ -1,4 +1,4 @@
 class Task < ApplicationRecord
-  validates :task_name, length: { minimum: 1 }
+  validates :task_name, presence: true
   validates :task_name, length: { maximum: 255 }
 end

--- a/task_management/app/models/task.rb
+++ b/task_management/app/models/task.rb
@@ -1,2 +1,4 @@
 class Task < ApplicationRecord
+  validates :task_name, length: { minimum: 1 }
+  validates :task_name, length: { maximum: 255 }
 end

--- a/task_management/app/views/layouts/application.html.erb
+++ b/task_management/app/views/layouts/application.html.erb
@@ -11,7 +11,15 @@
 
   <body>
     <% flash.each do |key, value| %>
-      <%= value %>
+      <% if key == 'notice'%>
+        <%= value %>
+      <% elsif key == 'alert'%>
+        <ul>
+        <% value.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+        </ul>
+      <% end %>
     <% end %>
     <%= yield %>
   </body>

--- a/task_management/app/views/layouts/application.html.erb
+++ b/task_management/app/views/layouts/application.html.erb
@@ -11,15 +11,7 @@
 
   <body>
     <% flash.each do |key, value| %>
-      <% if key == 'notice'%>
-        <%= value %>
-      <% elsif key == 'alert'%>
-        <ul>
-        <% value.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-        </ul>
-      <% end %>
+      <%= content_tag(:div, value, class: "#{key}") %>
     <% end %>
     <%= yield %>
   </body>

--- a/task_management/app/views/tasks/_form.html.erb
+++ b/task_management/app/views/tasks/_form.html.erb
@@ -1,3 +1,7 @@
+<% task.errors.full_messages.each do |message| %>
+  <li><%= message %></li>
+<% end %>
+
 <%= form_with model: task, url: url, local: true do |form| %>
   <%= form.text_field :task_name %>
   <%= form.text_field :description %>

--- a/task_management/config/locales/ja.yml
+++ b/task_management/config/locales/ja.yml
@@ -20,3 +20,12 @@ ja:
     edit: 編集
     delete: 削除
     home: 一覧
+  activerecord:
+    format: "%{attribute}%{message}"
+    message:
+      blank: を入力してください。
+      too_long: は%{count}字以内で入力してください。
+    attributes:
+      task:
+        task_name: タスク名
+        description: 詳細

--- a/task_management/config/locales/ja.yml
+++ b/task_management/config/locales/ja.yml
@@ -21,11 +21,12 @@ ja:
     delete: 削除
     home: 一覧
   activerecord:
-    format: "%{attribute}%{message}"
-    message:
-      blank: を入力してください。
-      too_long: は%{count}字以内で入力してください。
     attributes:
       task:
         task_name: タスク名
         description: 詳細
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      blank: を入力してください。
+      too_long: は%{count}字以内で入力してください。

--- a/task_management/spec/features/tasks_spec.rb
+++ b/task_management/spec/features/tasks_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature "Tasks", type: :feature do
       fill_in 'task_description', with: "#{@task.description}"
       click_button I18n.t('helpers.submit.create')
       
-      expect(current_url).to eq 'http://localhost:3000/tasks/new'
+      expect(current_url).to eq 'http://localhost:3000/tasks/create'
       expect(page).to have_content 'タスク名を入力してください。'
     end
     
@@ -121,7 +121,7 @@ RSpec.feature "Tasks", type: :feature do
       fill_in 'task_description', with: "#{@task.description}"
       click_button I18n.t('helpers.submit.create')
       
-      expect(current_url).to eq 'http://localhost:3000/tasks/new'
+      expect(current_url).to eq 'http://localhost:3000/tasks/create'
       expect(page).to have_content 'タスク名は255字以内で入力してください。'
     end
 

--- a/task_management/spec/features/tasks_spec.rb
+++ b/task_management/spec/features/tasks_spec.rb
@@ -6,103 +6,105 @@ RSpec.feature "Tasks", type: :feature do
     @task = create(:task)
   end
 
-  scenario '一覧画面からタスク登録画面に遷移' do
-    visit root_path
-    click_on I18n.t('button.new')
+  context '正常パターンのテスト' do
+    scenario '一覧画面からタスク登録画面に遷移' do
+      visit root_path
+      click_on I18n.t('button.new')
 
-    expect(current_url).to eq 'http://localhost:3000/tasks/new'
-    expect(page).to have_field 'task_task_name'
-    expect(page).to have_field 'task_description'
-    expect(page).to have_button I18n.t('helpers.submit.create')
-  end
-  
-  scenario 'タスクの登録' do
-    visit 'http://localhost:3000/tasks/new'
-    fill_in 'task_task_name', with: "#{@task.task_name}"
-    fill_in 'task_description', with: "#{@task.description}"
-    click_button I18n.t('helpers.submit.create')
-    
-    expect(current_url).to eq 'http://localhost:3000/'
-    expect(page).to have_content I18n.t('flash.success_create')
-    expect(page).to have_content I18n.t('view.task_name', :task => @task.task_name)
-  end
-  
-  scenario '一覧画面からタスク詳細画面への遷移' do
-    visit root_path
-    click_on I18n.t('view.task_name', :task => @task.task_name)
-    
-    expect(current_url).to eq "http://localhost:3000/tasks/show/#{@task.id}"
-    expect(page).not_to have_content I18n.t('flash.success_update')
-    expect(page).to have_content I18n.t('button.home')
-    expect(page).to have_content I18n.t('button.edit')
-    expect(page).to have_content I18n.t('button.delete')
-    expect(page).to have_content I18n.t('view.task_name', :task => @task.task_name)
-    expect(page).to have_content I18n.t('view.description', :task => @task.description)
-  end
-
-  scenario 'タスク詳細画面から一覧画面に遷移' do
-    visit "http://localhost:3000/tasks/show/#{@task.id}"
-    click_on I18n.t('button.home')
-
-    expect(current_url).to eq 'http://localhost:3000/'
-    expect(page).not_to have_content I18n.t('flash.success_create')
-    expect(page).not_to have_content I18n.t('flash.success_delete', :task => @task.task_name)
-    expect(page).to have_content I18n.t('button.new')
-    expect(page).to have_content I18n.t('view.task_name', :task => @task.task_name)
-  end
-
-  scenario '一覧画面でタスクを作成日の降順に表示' do
-    3.times do
-      Timecop.travel(Time.now + 1.day)
-      create(:task)
+      expect(current_url).to eq 'http://localhost:3000/tasks/new'
+      expect(page).to have_field 'task_task_name'
+      expect(page).to have_field 'task_description'
+      expect(page).to have_button I18n.t('helpers.submit.create')
     end
-    Timecop.return
-    visit root_path
-
-    tasks_list = all('ul li')
-    tasks = Task.select('task_name').order('created_at DESC')
-    task_names = []
-    tasks.each do |t|
-      task_names << 'タスク：' + t.task_name
-    end
-    tasks_list.each_with_index do |t, i|
-      expect(t.text).to eq task_names[i]
-    end
-  end
-
-  scenario 'タスク詳細画面からタスク編集画面に遷移' do
-    visit "http://localhost:3000/tasks/show/#{@task.id}"
-    click_on I18n.t('button.edit')  
     
-    expect(current_url).to eq "http://localhost:3000/tasks/edit/#{@task.id}" 
-    expect(page).to have_field 'task_task_name', with: @task.task_name
-    expect(page).to have_field 'task_description', with: @task.description
-    expect(page).to have_button I18n.t('helpers.submit.update')
-  end
-
-  scenario 'タスクの編集' do
-    visit "http://localhost:3000/tasks/edit/#{@task.id}"
-    fill_in 'task_task_name', with: "#{@task.task_name}(edited)"
-    fill_in 'task_description', with: "#{@task.description}(edited)"
-    click_button I18n.t('helpers.submit.update')
-
-    expect(current_url).to eq "http://localhost:3000/tasks/show/#{@task.id}"
-    expect(page).to have_content I18n.t('flash.success_update')
-    expect(page).to have_content I18n.t('view.task_name', :task => @task.task_name)
-    expect(page).to have_content I18n.t('view.description', :task => @task.description)
-  end
-
-  scenario 'タスクの削除' do
-    visit "http://localhost:3000/tasks/show/#{@task.id}"
-    click_on I18n.t('button.delete')
+    scenario 'タスクの登録' do
+      visit 'http://localhost:3000/tasks/new'
+      fill_in 'task_task_name', with: "#{@task.task_name}"
+      fill_in 'task_description', with: "#{@task.description}"
+      click_button I18n.t('helpers.submit.create')
+      
+      expect(current_url).to eq 'http://localhost:3000/'
+      expect(page).to have_content I18n.t('flash.success_create')
+      expect(page).to have_content I18n.t('view.task_name', :task => @task.task_name)
+    end
     
-    expect(current_url).to eq 'http://localhost:3000/'
-    expect(page).to have_content I18n.t('flash.success_delete', :task => @task.task_name)
-    visit current_path
-    expect(page).not_to have_content I18n.t('view.task_name', :task => @task.task_name)
+    scenario '一覧画面からタスク詳細画面への遷移' do
+      visit root_path
+      click_on I18n.t('view.task_name', :task => @task.task_name)
+      
+      expect(current_url).to eq "http://localhost:3000/tasks/show/#{@task.id}"
+      expect(page).not_to have_content I18n.t('flash.success_update')
+      expect(page).to have_content I18n.t('button.home')
+      expect(page).to have_content I18n.t('button.edit')
+      expect(page).to have_content I18n.t('button.delete')
+      expect(page).to have_content I18n.t('view.task_name', :task => @task.task_name)
+      expect(page).to have_content I18n.t('view.description', :task => @task.description)
+    end
+
+    scenario 'タスク詳細画面から一覧画面に遷移' do
+      visit "http://localhost:3000/tasks/show/#{@task.id}"
+      click_on I18n.t('button.home')
+
+      expect(current_url).to eq 'http://localhost:3000/'
+      expect(page).not_to have_content I18n.t('flash.success_create')
+      expect(page).not_to have_content I18n.t('flash.success_delete', :task => @task.task_name)
+      expect(page).to have_content I18n.t('button.new')
+      expect(page).to have_content I18n.t('view.task_name', :task => @task.task_name)
+    end
+
+    scenario '一覧画面でタスクを作成日の降順に表示' do
+      3.times do
+        Timecop.travel(Time.now + 1.day)
+        create(:task)
+      end
+      Timecop.return
+      visit root_path
+
+      tasks_list = all('ul li')
+      tasks = Task.select('task_name').order('created_at DESC')
+      task_names = []
+      tasks.each do |t|
+        task_names << 'タスク：' + t.task_name
+      end
+      tasks_list.each_with_index do |t, i|
+        expect(t.text).to eq task_names[i]
+      end
+    end
+
+    scenario 'タスク詳細画面からタスク編集画面に遷移' do
+      visit "http://localhost:3000/tasks/show/#{@task.id}"
+      click_on I18n.t('button.edit')  
+      
+      expect(current_url).to eq "http://localhost:3000/tasks/edit/#{@task.id}" 
+      expect(page).to have_field 'task_task_name', with: @task.task_name
+      expect(page).to have_field 'task_description', with: @task.description
+      expect(page).to have_button I18n.t('helpers.submit.update')
+    end
+
+    scenario 'タスクの編集' do
+      visit "http://localhost:3000/tasks/edit/#{@task.id}"
+      fill_in 'task_task_name', with: "#{@task.task_name}(edited)"
+      fill_in 'task_description', with: "#{@task.description}(edited)"
+      click_button I18n.t('helpers.submit.update')
+
+      expect(current_url).to eq "http://localhost:3000/tasks/show/#{@task.id}"
+      expect(page).to have_content I18n.t('flash.success_update')
+      expect(page).to have_content I18n.t('view.task_name', :task => @task.task_name)
+      expect(page).to have_content I18n.t('view.description', :task => @task.description)
+    end
+
+    scenario 'タスクの削除' do
+      visit "http://localhost:3000/tasks/show/#{@task.id}"
+      click_on I18n.t('button.delete')
+      
+      expect(current_url).to eq 'http://localhost:3000/'
+      expect(page).to have_content I18n.t('flash.success_delete', :task => @task.task_name)
+      visit current_path
+      expect(page).not_to have_content I18n.t('view.task_name', :task => @task.task_name)
+    end
   end
 
-  feature '登録・更新の失敗' do
+  context '登録・更新の失敗' do
     scenario '0文字のタスクを登録' do
       visit 'http://localhost:3000/tasks/new'
       fill_in 'task_task_name', with: ''

--- a/task_management/spec/features/tasks_spec.rb
+++ b/task_management/spec/features/tasks_spec.rb
@@ -97,4 +97,53 @@ RSpec.feature "Tasks", type: :feature do
     visit current_path
     expect(page).not_to have_content I18n.t('view.task_name', :task => @task.task_name)
   end
+
+  feature '登録・更新の失敗' do
+    background do
+      @str = ''
+      while @str.length < 256 do
+        @str << 'a'
+      end
+    end
+
+    scenario '0文字のタスクを登録' do
+      visit 'http://localhost:3000/tasks/new'
+      fill_in 'task_task_name', with: ''
+      fill_in 'task_description', with: "#{@task.description}"
+      click_button I18n.t('helpers.submit.create')
+      
+      expect(current_url).to eq 'http://localhost:3000/tasks/new'
+      expect(page).to have_content I18n.t('flash.failure_create')
+    end
+
+    scenario '256文字のタスクを登録' do
+      visit 'http://localhost:3000/tasks/new'
+      fill_in 'task_task_name', with: @str
+      fill_in 'task_description', with: "#{@task.description}"
+      click_button I18n.t('helpers.submit.create')
+      
+      expect(current_url).to eq 'http://localhost:3000/tasks/new'
+      expect(page).to have_content I18n.t('flash.failure_create')
+    end
+
+    scenario '0文字のタスクに更新' do
+      visit "http://localhost:3000/tasks/edit/#{@task.id}"
+      fill_in 'task_task_name', with: ''
+      fill_in 'task_description', with: "#{@task.description}(edited)"
+      click_button I18n.t('helpers.submit.update')
+
+      expect(current_url).to eq "http://localhost:3000/tasks/edit/#{@task.id}"
+      expect(page).to have_content I18n.t('flash.failure_update')
+    end
+
+    scenario '256文字のタスクに更新' do
+      visit "http://localhost:3000/tasks/edit/#{@task.id}"
+      fill_in 'task_task_name', with: @str
+      fill_in 'task_description', with: "#{@task.description}(edited)"
+      click_button I18n.t('helpers.submit.update')
+
+      expect(current_url).to eq "http://localhost:3000/tasks/edit/#{@task.id}"
+      expect(page).to have_content I18n.t('flash.failure_update')
+    end
+  end
 end

--- a/task_management/spec/features/tasks_spec.rb
+++ b/task_management/spec/features/tasks_spec.rb
@@ -59,9 +59,13 @@ RSpec.feature "Tasks", type: :feature do
     Timecop.return
     visit root_path
 
-    tasks = all('ul li')
-    task_names = ['タスク：task_name8', 'タスク：task_name7', 'タスク：task_name6', 'タスク：task_name5']
-    tasks.each_with_index do |t, i|
+    tasks_list = all('ul li')
+    tasks = Task.select('task_name').order('created_at DESC')
+    task_names = []
+    tasks.each do |t|
+      task_names << 'タスク：' + t.task_name
+    end
+    tasks_list.each_with_index do |t, i|
       expect(t.text).to eq task_names[i]
     end
   end
@@ -99,13 +103,6 @@ RSpec.feature "Tasks", type: :feature do
   end
 
   feature '登録・更新の失敗' do
-    background do
-      @str = ''
-      while @str.length < 256 do
-        @str << 'a'
-      end
-    end
-
     scenario '0文字のタスクを登録' do
       visit 'http://localhost:3000/tasks/new'
       fill_in 'task_task_name', with: ''
@@ -113,17 +110,17 @@ RSpec.feature "Tasks", type: :feature do
       click_button I18n.t('helpers.submit.create')
       
       expect(current_url).to eq 'http://localhost:3000/tasks/new'
-      expect(page).to have_content I18n.t('flash.failure_create')
+      expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.task_name.blank')
     end
 
     scenario '256文字のタスクを登録' do
       visit 'http://localhost:3000/tasks/new'
-      fill_in 'task_task_name', with: @str
+      fill_in 'task_task_name', with: 'a'*256
       fill_in 'task_description', with: "#{@task.description}"
       click_button I18n.t('helpers.submit.create')
       
       expect(current_url).to eq 'http://localhost:3000/tasks/new'
-      expect(page).to have_content I18n.t('flash.failure_create')
+      expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.task_name.too_long')
     end
 
     scenario '0文字のタスクに更新' do
@@ -133,17 +130,17 @@ RSpec.feature "Tasks", type: :feature do
       click_button I18n.t('helpers.submit.update')
 
       expect(current_url).to eq "http://localhost:3000/tasks/edit/#{@task.id}"
-      expect(page).to have_content I18n.t('flash.failure_update')
+      expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.task_name.blank')
     end
 
     scenario '256文字のタスクに更新' do
       visit "http://localhost:3000/tasks/edit/#{@task.id}"
-      fill_in 'task_task_name', with: @str
+      fill_in 'task_task_name', with: 'a'*256
       fill_in 'task_description', with: "#{@task.description}(edited)"
       click_button I18n.t('helpers.submit.update')
 
       expect(current_url).to eq "http://localhost:3000/tasks/edit/#{@task.id}"
-      expect(page).to have_content I18n.t('flash.failure_update')
+      expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.task_name.too_long')
     end
   end
 end

--- a/task_management/spec/features/tasks_spec.rb
+++ b/task_management/spec/features/tasks_spec.rb
@@ -110,9 +110,9 @@ RSpec.feature "Tasks", type: :feature do
       click_button I18n.t('helpers.submit.create')
       
       expect(current_url).to eq 'http://localhost:3000/tasks/new'
-      expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.task_name.blank')
+      expect(page).to have_content 'タスク名を入力してください。'
     end
-
+    
     scenario '256文字のタスクを登録' do
       visit 'http://localhost:3000/tasks/new'
       fill_in 'task_task_name', with: 'a'*256
@@ -120,7 +120,7 @@ RSpec.feature "Tasks", type: :feature do
       click_button I18n.t('helpers.submit.create')
       
       expect(current_url).to eq 'http://localhost:3000/tasks/new'
-      expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.task_name.too_long')
+      expect(page).to have_content 'タスク名は255字以内で入力してください。'
     end
 
     scenario '0文字のタスクに更新' do
@@ -130,7 +130,7 @@ RSpec.feature "Tasks", type: :feature do
       click_button I18n.t('helpers.submit.update')
 
       expect(current_url).to eq "http://localhost:3000/tasks/edit/#{@task.id}"
-      expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.task_name.blank')
+      expect(page).to have_content 'タスク名を入力してください。'
     end
 
     scenario '256文字のタスクに更新' do
@@ -140,7 +140,7 @@ RSpec.feature "Tasks", type: :feature do
       click_button I18n.t('helpers.submit.update')
 
       expect(current_url).to eq "http://localhost:3000/tasks/edit/#{@task.id}"
-      expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.task_name.too_long')
+      expect(page).to have_content 'タスク名は255字以内で入力してください。'
     end
   end
 end

--- a/task_management/spec/models/task_spec.rb
+++ b/task_management/spec/models/task_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe '#validation' do
-    context 'タスク名がnilの場合' do
-      let(:task) {Task.new(task_name: nil)}
+    context 'タスク名が0文字の場合' do
+      let(:task) {Task.new(task_name: '')}
       it 'バリデーションエラーが発生する' do
         expect(task.validate).to be_falsy
         expect(task.errors).to have_key(:task_name)

--- a/task_management/spec/models/task_spec.rb
+++ b/task_management/spec/models/task_spec.rb
@@ -1,45 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  context '正常なタスク' do
-    let(:task) {Task.new(task_name: 'task')}
-    it '新規作成' do
-      expect(task.validate).to be_truthy
+  describe '#validation' do
+    context 'タスク名がnilの場合' do
+      let(:task) {Task.new(task_name: nil)}
+      it 'バリデーションエラーが発生する' do
+        expect(task.validate).to be_falsy
+        expect(task.errors).to have_key(:task_name)
+        expect(task.errors.full_messages).to eq ['タスク名を入力してください。']
+      end
     end
 
-    it '更新' do
-      expect(task.validate).to be_truthy
-    end
-  end
-
-  context '空白のタスク' do
-    let(:task) {Task.new(task_name: nil)}
-    it '新規作成' do
-      expect(task.validate).to be_falsy
-      expect(task.errors).to have_key(:task_name)
-      expect(task.errors.full_messages).to eq ['タスク名を入力してください。']
+    context 'タスク名が1文字の場合' do
+      let(:task) {Task.new(task_name: 'a')}
+      it 'バリデーションエラーが発生しない' do
+        expect(task.validate).to be_truthy
+      end
     end
 
-    it '更新' do
-      expect(task.validate).to be_falsy
-      expect(task.errors).to have_key(:task_name)
-      expect(task.errors.full_messages).to eq ['タスク名を入力してください。']
-    end
-  end
-
-  context '256文字以上のタスク' do
-    let(:task) {Task.new(task_name: 'a'*256)}
-    it '新規作成' do
-      expect(task.validate).to be_falsy
-      expect(task.errors).to have_key(:task_name)
-      expect(task.errors.full_messages).to eq ['タスク名は255字以内で入力してください。']
+    context 'タスク名が255文字の場合' do
+      let(:task) {Task.new(task_name: 'a'*255)}
+      it 'バリデーションエラーが発生しない' do
+        expect(task.validate).to be_truthy
+      end
     end
 
-    it '更新' do
-      expect(task.validate).to be_falsy
-      expect(task.errors).to have_key(:task_name)
-      expect(task.errors.full_messages).to eq ['タスク名は255字以内で入力してください。']
+    context 'タスク名が256文字の場合' do
+      let(:task) {Task.new(task_name: 'a'*256)}
+      it 'バリデーションエラーが発生する' do
+        expect(task.validate).to be_falsy
+        expect(task.errors).to have_key(:task_name)
+        expect(task.errors.full_messages).to eq ['タスク名は255字以内で入力してください。']
+      end
     end
   end
-
 end

--- a/task_management/spec/models/task_spec.rb
+++ b/task_management/spec/models/task_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  context '正常なタスク' do
+    let(:task) {Task.new(task_name: 'task')}
+    it '新規作成' do
+      expect(task.validate).to be_truthy
+    end
+
+    it '更新' do
+      expect(task.validate).to be_truthy
+    end
+  end
+
+  context '空白のタスク' do
+    let(:task) {Task.new(task_name: nil)}
+    it '新規作成' do
+      expect(task.validate).to be_falsy
+      expect(task.errors).to have_key(:task_name)
+      expect(task.errors[:task_name]).to eq ['タスク名を入力してください。']
+    end
+
+    it '更新' do
+      expect(task.validate).to be_falsy
+      expect(task.errors).to have_key(:task_name)
+      expect(task.errors[:task_name]).to eq ['タスク名を入力してください。']
+    end
+  end
+
+  context '256文字以上のタスク' do
+    let(:task) {Task.new(task_name: 'a'*256)}
+    it '新規作成' do
+      expect(task.validate).to be_falsy
+      expect(task.errors).to have_key(:task_name)
+      expect(task.errors[:task_name]).to eq ['タスク名は255字以内で入力してください。']
+    end
+
+    it '更新' do
+      expect(task.validate).to be_falsy
+      expect(task.errors).to have_key(:task_name)
+      expect(task.errors[:task_name]).to eq ['タスク名は255字以内で入力してください。']
+    end
+  end
+
+end

--- a/task_management/spec/models/task_spec.rb
+++ b/task_management/spec/models/task_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Task, type: :model do
     it '新規作成' do
       expect(task.validate).to be_falsy
       expect(task.errors).to have_key(:task_name)
-      expect(task.errors[:task_name]).to eq ['タスク名を入力してください。']
+      expect(task.errors.full_messages).to eq ['タスク名を入力してください。']
     end
 
     it '更新' do
       expect(task.validate).to be_falsy
       expect(task.errors).to have_key(:task_name)
-      expect(task.errors[:task_name]).to eq ['タスク名を入力してください。']
+      expect(task.errors.full_messages).to eq ['タスク名を入力してください。']
     end
   end
 
@@ -32,13 +32,13 @@ RSpec.describe Task, type: :model do
     it '新規作成' do
       expect(task.validate).to be_falsy
       expect(task.errors).to have_key(:task_name)
-      expect(task.errors[:task_name]).to eq ['タスク名は255字以内で入力してください。']
+      expect(task.errors.full_messages).to eq ['タスク名は255字以内で入力してください。']
     end
 
     it '更新' do
       expect(task.validate).to be_falsy
       expect(task.errors).to have_key(:task_name)
-      expect(task.errors[:task_name]).to eq ['タスク名は255字以内で入力してください。']
+      expect(task.errors.full_messages).to eq ['タスク名は255字以内で入力してください。']
     end
   end
 


### PR DESCRIPTION
タスク名に対してバリデーションを作成しました。
手順書ではDBの制約を含めたマイグレーションを作成すると書かれていますが、Step6のマイグレーションで既に設定されていたため、今回はモデルのバリデーション追加とテストケースの追加のみ行いました。

現在development環境でタスクの編集を行うと、ログに"Can't verify CSRF token authenticity."というメッセージが表示されてflashメッセージが表示されないためWIPにしています。