### PR TITLE
【宮崎】ステップ９　タスク一覧の並び替え

### DIFF
--- a/tasclear/app/controllers/tasks_controller.rb
+++ b/tasclear/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.order(created_at: :desc)
   end
 
   def new

--- a/tasclear/app/views/tasks/index.html.erb
+++ b/tasclear/app/views/tasks/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @tasks.each do |task| %>
     <tr>
-      <td><%= task.name %></td>
+      <td class='name'><%= task.name %></td>
       <td><%= task.content %></td>
       <td><%= link_to t('.detail'), task_path(task.id) %></td>
       <td><%= link_to t('.edit'), edit_task_path(task.id) %></td>

--- a/tasclear/spec/features/projects_spec.rb
+++ b/tasclear/spec/features/projects_spec.rb
@@ -53,6 +53,8 @@ RSpec.feature 'Tasts', type: :feature do
     fill_in I18n.t('activerecord.attributes.task.name'), with: 'タスク２'
     fill_in I18n.t('activerecord.attributes.task.content'), with: '筋トレ'
     click_button I18n.t('helpers.submit.create')
-    expect(page.text).to match(/タスク２.*タスク１/)
+    names = page.all('td.name')
+    expect(names[0]).to have_content 'タスク２'
+    expect(names[1]).to have_content 'タスク１'
   end
 end

--- a/tasclear/spec/features/projects_spec.rb
+++ b/tasclear/spec/features/projects_spec.rb
@@ -42,4 +42,17 @@ RSpec.feature 'Tasts', type: :feature do
       expect(page).to have_content I18n.t('flash.task.destroy_success')
     end.to change { Task.count }.by(-1)
   end
+  scenario 'タスク一覧が作成日時の降順で並んでいること' do
+    visit root_path
+    click_link I18n.t('tasks.index.new_task')
+    fill_in I18n.t('activerecord.attributes.task.name'), with: 'タスク１'
+    fill_in I18n.t('activerecord.attributes.task.content'), with: 'RSpecについて'
+    click_button I18n.t('helpers.submit.create')
+    sleep(1)
+    click_link I18n.t('tasks.index.new_task')
+    fill_in I18n.t('activerecord.attributes.task.name'), with: 'タスク２'
+    fill_in I18n.t('activerecord.attributes.task.content'), with: '筋トレ'
+    click_button I18n.t('helpers.submit.create')
+    expect(page.text).to match(/タスク２.*タスク１/)
+  end
 end


### PR DESCRIPTION
# ステップ９の内容
## ステップ9: タスク一覧を作成日時の順番で並び替えましょう
- 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
- 並び替えがうまく行っていることをfeature specで書いてみましょう
## 行ったこと
- タスクコントローラのindexアクションにorderメソッドを追加
- フィーチャスペックのテストケース追加
  - 2つデータを作成して、後で作成した方が上に表示されていることを確認しています
  - 2つ連続でデータを作成すると同じ時間に作成されたことになり、作成時間によるソートが効かなかったので、sleepメソッドで1秒間隔を開けてデータを作成するようにしています