### PR TITLE
【宮崎】ステップ11　終了期限の項目、終了期限でのソート機能追加

### DIFF
--- a/tasclear/app/controllers/tasks_controller.rb
+++ b/tasclear/app/controllers/tasks_controller.rb
@@ -4,7 +4,13 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.order(created_at: :desc)
+    if params[:sort] == '1'
+      direction = session[:direction] == 'asc' ? 'desc' : 'asc'
+      @tasks = Task.order(deadline: "#{direction}", created_at: :desc)
+      session[:direction] = direction
+    else
+      @tasks = Task.order(created_at: :desc)
+    end
   end
 
   def new
@@ -37,13 +43,6 @@ class TasksController < ApplicationController
   def destroy
     @task.destroy
     redirect_to root_path, notice: t('flash.task.destroy_success')
-  end
-
-  def sort_deadline
-    direction = session[:direction] == 'asc' ? 'desc' : 'asc'
-    @tasks = Task.order(deadline: "#{direction}", created_at: :desc)
-    session[:direction] = direction
-    render :index
   end
 
   private

--- a/tasclear/app/controllers/tasks_controller.rb
+++ b/tasclear/app/controllers/tasks_controller.rb
@@ -42,7 +42,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :content)
+    params.require(:task).permit(:name, :content, :deadline)
   end
 
   def set_task

--- a/tasclear/app/controllers/tasks_controller.rb
+++ b/tasclear/app/controllers/tasks_controller.rb
@@ -39,6 +39,13 @@ class TasksController < ApplicationController
     redirect_to root_path, notice: t('flash.task.destroy_success')
   end
 
+  def sort_deadline
+    direction = session[:direction] == 'asc' ? 'desc' : 'asc'
+    @tasks = Task.order(deadline: "#{direction}", created_at: :desc)
+    session[:direction] = direction
+    render :index
+  end
+
   private
 
   def task_params

--- a/tasclear/app/controllers/tasks_controller.rb
+++ b/tasclear/app/controllers/tasks_controller.rb
@@ -4,13 +4,11 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    if params[:sort] == '1'
-      direction = session[:direction] == 'asc' ? 'desc' : 'asc'
-      @tasks = Task.order(deadline: "#{direction}", created_at: :desc)
-      session[:direction] = direction
-    else
-      @tasks = Task.order(created_at: :desc)
-    end
+    @tasks = if params.key?(:sort)
+               Task.order(deadline: params[:sort].to_sym, created_at: :desc)
+             else
+               Task.order(created_at: :desc)
+             end
   end
 
   def new

--- a/tasclear/app/helpers/tasks_helper.rb
+++ b/tasclear/app/helpers/tasks_helper.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 module TasksHelper
+  def link_sort(label_name)
+    if params[:sort] == 'asc'
+      link_to label_name, root_path(sort: 'desc')
+    else
+      link_to label_name, root_path(sort: 'asc')
+    end
+  end
 end

--- a/tasclear/app/views/tasks/_form.html.erb
+++ b/tasclear/app/views/tasks/_form.html.erb
@@ -16,5 +16,9 @@
     <%= form.label :content %>
     <%= form.text_field :content %>
   </div>
+  <div class="task_deadline">
+    <%= form.label :deadline %>
+    <%= form.date_field :deadline %>
+  </div>
   <%= form.submit %>
 <% end %>

--- a/tasclear/app/views/tasks/index.html.erb
+++ b/tasclear/app/views/tasks/index.html.erb
@@ -1,7 +1,7 @@
 <h1><%= t('.title') %></h1>
 <table>
   <tr>
-    <th><%= t('.deadline') %></th>
+    <th><%= link_to t('.deadline'), sort_path %></th>
     <th><%= t('.name') %></th>
     <th><%= t('.content') %></th>
   </tr>

--- a/tasclear/app/views/tasks/index.html.erb
+++ b/tasclear/app/views/tasks/index.html.erb
@@ -12,7 +12,7 @@
       <td><%= task.content %></td>
       <td><%= link_to t('.detail'), task_path(task.id) %></td>
       <td><%= link_to t('.edit'), edit_task_path(task.id) %></td>
-      <td><%= link_to t('.delete'), task_path(task.id), method: :delete, data: {confirm: t(',confirm')} %></td>
+      <td><%= link_to t('.delete'), task_path(task.id), method: :delete, data: {confirm: t('.confirm')} %></td>
     </tr>
   <% end %>
 </table>

--- a/tasclear/app/views/tasks/index.html.erb
+++ b/tasclear/app/views/tasks/index.html.erb
@@ -1,11 +1,13 @@
 <h1><%= t('.title') %></h1>
 <table>
   <tr>
+    <th><%= t('.deadline') %></th>
     <th><%= t('.name') %></th>
     <th><%= t('.content') %></th>
   </tr>
   <% @tasks.each do |task| %>
     <tr>
+      <td><%= task.deadline %></td>
       <td class='name'><%= task.name %></td>
       <td><%= task.content %></td>
       <td><%= link_to t('.detail'), task_path(task.id) %></td>

--- a/tasclear/app/views/tasks/index.html.erb
+++ b/tasclear/app/views/tasks/index.html.erb
@@ -1,7 +1,7 @@
 <h1><%= link_to t('.title'), root_path %></h1>
 <table>
   <tr>
-    <th><%= link_to t('.deadline'), root_path(sort: '1') %></th>
+    <th><%= link_sort t('.deadline') %></th>
     <th><%= t('.name') %></th>
     <th><%= t('.content') %></th>
   </tr>

--- a/tasclear/app/views/tasks/index.html.erb
+++ b/tasclear/app/views/tasks/index.html.erb
@@ -1,7 +1,7 @@
-<h1><%= t('.title') %></h1>
+<h1><%= link_to t('.title'), root_path %></h1>
 <table>
   <tr>
-    <th><%= link_to t('.deadline'), sort_path %></th>
+    <th><%= link_to t('.deadline'), root_path(sort: '1') %></th>
     <th><%= t('.name') %></th>
     <th><%= t('.content') %></th>
   </tr>

--- a/tasclear/app/views/tasks/show.html.erb
+++ b/tasclear/app/views/tasks/show.html.erb
@@ -1,4 +1,5 @@
 <h1><%= t('.title') %></h1>
 <p><%= t('.name') %>：<%= @task.name %></p>
 <p><%= t('.content') %>：<%= @task.content %></p>
+<p><%= t('.deadline') %>：<%= @task.deadline %></p>
 <%= link_to t('.back'), :back %>

--- a/tasclear/config/locales/ja.yml
+++ b/tasclear/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
       task:
         name: 'タスク名'
         content: '内容'
+        deadline: '終了期限'
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -19,6 +20,7 @@ ja:
       name: 'タスク名'
       content: '内容'
       detail: '詳細'
+      deadline: '終了期限'
       edit: '編集'
       delete: '削除'
       confirm: '本当に削除してもいいですか'
@@ -33,6 +35,7 @@ ja:
       title: 'タスク詳細'
       name: 'タスク名'
       content: '内容'
+      deadline: '終了期限'
       back: '戻る'
   flash:
     task:

--- a/tasclear/config/routes.rb
+++ b/tasclear/config/routes.rb
@@ -3,4 +3,5 @@
 Rails.application.routes.draw do
   root 'tasks#index'
   resources :tasks, except: %i[index]
+  get 'sort', to: 'tasks#sort_deadline'
 end

--- a/tasclear/config/routes.rb
+++ b/tasclear/config/routes.rb
@@ -3,5 +3,4 @@
 Rails.application.routes.draw do
   root 'tasks#index'
   resources :tasks, except: %i[index]
-  get 'sort', to: 'tasks#sort_deadline'
 end

--- a/tasclear/db/migrate/20180717060620_add_column_to_task.rb
+++ b/tasclear/db/migrate/20180717060620_add_column_to_task.rb
@@ -1,0 +1,5 @@
+class AddColumnToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :deadline, :date
+  end
+end

--- a/tasclear/db/schema.rb
+++ b/tasclear/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_10_022549) do
+ActiveRecord::Schema.define(version: 2018_07_17_060620) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "deadline"
   end
 
 end

--- a/tasclear/spec/factories/tasks.rb
+++ b/tasclear/spec/factories/tasks.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :task do
     name '家事'
     content '掃除、洗濯'
+    deadline '2018-07-31'
   end
 end

--- a/tasclear/spec/features/projects_spec.rb
+++ b/tasclear/spec/features/projects_spec.rb
@@ -57,4 +57,24 @@ RSpec.feature 'Tasts', type: :feature do
     expect(names[0]).to have_content 'タスク２'
     expect(names[1]).to have_content 'タスク１'
   end
+  scenario 'タスク一覧画面で終了時間でソートできること' do
+    create(:task, name: '終了期限先', deadline: '2018-7-18')
+    sleep(1)
+    create(:task, name: '終了期限後', deadline: '2018-7-25')
+    # 「終了期限後」を後に作成したので上に表示されている
+    visit root_path
+    names = page.all('td.name')
+    expect(names[0]).to have_content '終了期限後'
+    expect(names[1]).to have_content '終了期限先'
+    # 終了期限をクリックすると終了期限が早い順にソートされ、「終了期限先」が上に表示される
+    click_link I18n.t('tasks.index.deadline')
+    names = page.all('td.name')
+    expect(names[0]).to have_content '終了期限先'
+    expect(names[1]).to have_content '終了期限後'
+    # もう一度終了期限をクリックすると反対に終了期限が遅い順にソートされ、「終了期限後」が上に表示される
+    click_link I18n.t('tasks.index.deadline')
+    names = page.all('td.name')
+    expect(names[0]).to have_content '終了期限後'
+    expect(names[1]).to have_content '終了期限先'
+  end
 end

--- a/tasclear/spec/features/projects_spec.rb
+++ b/tasclear/spec/features/projects_spec.rb
@@ -43,24 +43,16 @@ RSpec.feature 'Tasts', type: :feature do
     end.to change { Task.count }.by(-1)
   end
   scenario 'タスク一覧が作成日時の降順で並んでいること' do
+    create(:task, name: 'タスク１', created_at: '2018-7-16 08:10:10')
+    create(:task, name: 'タスク２', created_at: '2018-7-16 09:10:15')
     visit root_path
-    click_link I18n.t('tasks.index.new_task')
-    fill_in I18n.t('activerecord.attributes.task.name'), with: 'タスク１'
-    fill_in I18n.t('activerecord.attributes.task.content'), with: 'RSpecについて'
-    click_button I18n.t('helpers.submit.create')
-    sleep(1)
-    click_link I18n.t('tasks.index.new_task')
-    fill_in I18n.t('activerecord.attributes.task.name'), with: 'タスク２'
-    fill_in I18n.t('activerecord.attributes.task.content'), with: '筋トレ'
-    click_button I18n.t('helpers.submit.create')
     names = page.all('td.name')
     expect(names[0]).to have_content 'タスク２'
     expect(names[1]).to have_content 'タスク１'
   end
   scenario 'タスク一覧画面で終了時間でソートできること' do
-    create(:task, name: '終了期限先', deadline: '2018-7-18')
-    sleep(1)
-    create(:task, name: '終了期限後', deadline: '2018-7-25')
+    create(:task, name: '終了期限先', deadline: '2018-7-18', created_at: '2018-7-16 08:10:10')
+    create(:task, name: '終了期限後', deadline: '2018-7-25', created_at: '2018-7-16 09:10:15')
     # 「終了期限後」を後に作成したので上に表示されている
     visit root_path
     names = page.all('td.name')


### PR DESCRIPTION
# ステップ11: 終了期限を追加しよう
- タスクに対して、終了期限を登録できるようにしてみましょう
- 一覧画面で、終了期限でソートできるようにしましょう
- specを拡充しましょう
- PRしてレビューをしてもらったら、リリースしてみましょう
# 行ったこと
- タスクモデルに終了期限カラム（`deadline`）追加
- 終了期限の項目をCRUDに追加
- タスク一覧画面で終了期限でソートできる機能を追加
  - タスクコントローラに新たに `sort_deadline` アクションを追加して実装しました
  - リンクを一度押すと終了期限の昇順となり、以降リンクを押す度に昇順と降順が変わる仕様としています
- 終了時間のソートに関するフィーチャスペックのシナリオを１つ追加