### PR TITLE
Ito Step21

### DIFF
--- a/task_management/app/models/user.rb
+++ b/task_management/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  enum admin: {general: false, admin: true}
   has_many :tasks, dependent: :delete_all
   validates :user_name, presence: true, length: {maximum: 255}
   validates :password, presence: true, on: :create

--- a/task_management/app/views/admin/users/_form.html.erb
+++ b/task_management/app/views/admin/users/_form.html.erb
@@ -10,6 +10,7 @@
     <%= I18n.t('activerecord.attributes.user.user_name') %>：<%= form.text_field :user_name, class: 'm-2' %><br>
     <%= I18n.t('activerecord.attributes.user.mail_address') %>：<%= form.text_field :mail_address, class: 'm-2' %><br>
     <%= I18n.t('activerecord.attributes.user.password') %>：<%= form.password_field :password, class: 'm-2' %><br>
+    <%= I18n.t('activerecord.attributes.user.role') %>：<%= form.select :admin, User.admins.keys.map{|k| [I18n.t("role.#{k}"), k]}, class: 'm-2' %><br>
     <%= form.submit %>
   <% end %>
 </div>

--- a/task_management/app/views/admin/users/show.html.erb
+++ b/task_management/app/views/admin/users/show.html.erb
@@ -11,6 +11,9 @@
         <li>
           <%= I18n.t('view.user.mail_address', user: @user.mail_address) %>
         </li>
+        <li>
+          <%= I18n.t('view.user.role', user: I18n.t("role.#{@user.admin}")) %>
+        </li>
       </ul>
       <%= link_to(I18n.t('button.edit'), edit_admin_user_path, class: 'btn btn-secondary m-2') %>
       <%= link_to(I18n.t('button.delete'), admin_user_path(id: @user.id), method: 'delete', class: 'btn btn-danger m-2',

--- a/task_management/app/views/layouts/application.html.erb
+++ b/task_management/app/views/layouts/application.html.erb
@@ -19,7 +19,10 @@
                 <%= current_user.user_name %>
               </button>
               <div class='dropdown-menu dropdown-menu-right' aria-labelledby="navbarDropdownMenuLink">
-                <%= link_to 'log out', logout_path, method: 'delete' %>
+                <% if current_user.admin? %>
+                  <%= link_to I18n.t('view.nav.admin'), admin_users_path, class: 'dropdown-item'%>
+                <% end %>
+                <%= link_to I18n.t('view.nav.log_out'), logout_path, method: 'delete', class: 'dropdown-item' %>
               </div>
             </li>
           </ul>

--- a/task_management/config/locales/ja.yml
+++ b/task_management/config/locales/ja.yml
@@ -28,6 +28,8 @@ ja:
     success_delete_user: ユーザ：%{user}を削除しました
     failure_delete_user: ユーザ：%{user}の削除に失敗しました
     failure_delete_loggined_user: ログイン中のユーザは削除できません
+    require_admin: 管理者以外はアクセスできません
+    failure_change_current_user_role: ログイン中のユーザはロールを変更できません
   view:
     task_name: タスク：%{task}
     description: 詳細：%{task}
@@ -40,10 +42,14 @@ ja:
     user:
       user_name: ユーザ名：%{user}
       mail_address: メールアドレス：%{user}
+      role: ロール：%{user}
     task_quantity: タスク数：%{quantity}
     admin:
       old_password: 変更前のパスワード
       new_password: 変更後のパスワード
+    nav:
+      admin: 管理画面
+      log_out: ログアウト
   views:
     pagination:
       first: 最初
@@ -68,6 +74,7 @@ ja:
         user_name: ユーザ名
         mail_address: メールアドレス
         password: パスワード
+        role: ロール
   errors:
     format: "%{attribute}%{message}"
     messages:
@@ -101,3 +108,6 @@ ja:
     password: パスワード
   confirm-modal:
     confirm: 本当に%{user}を削除しますか？
+  role:
+    general: 一般ユーザ
+    admin: 管理ユーザ

--- a/task_management/db/seeds.rb
+++ b/task_management/db/seeds.rb
@@ -5,4 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-User.create(user_name: 'user1', mail_address: 'user1@example.com', password: 'password', admin: 0)
+User.create(user_name: 'user1', mail_address: 'user1@example.com', password: 'password', admin: 'general')
+User.create(user_name: 'admin', mail_address: 'admin@example.com', password: 'admin', admin: 'admin')

--- a/task_management/spec/factories/user.rb
+++ b/task_management/spec/factories/user.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     sequence(:user_name) { |n| "user#{n}"}
     sequence(:mail_address) { |n| "user#{n}@example.com"}
     sequence(:password) { |n| "password#{n}"}
-    admin false
+    admin 'admin'
   end
 end

--- a/task_management/spec/features/admins_spec.rb
+++ b/task_management/spec/features/admins_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Admins", type: :feature do
     background do
       login(@user.mail_address, @user.password)
     end
-    context '管理画面にアクセスする' do
+    context '管理ユーザが管理画面にアクセスする' do
       given!(:task) {create(:task, user_id: @user.id)}
       scenario '管理画面を表示する' do
         visit admin_users_path
@@ -17,6 +17,18 @@ RSpec.feature "Admins", type: :feature do
         expect(page).to have_content I18n.t('button.new')
         expect(page).to have_content I18n.t('view.user.user_name', :user => @user.user_name)
         expect(page).to have_content I18n.t('view.task_quantity', :quantity => 1)
+      end
+    end
+
+    context '一般ユーザが管理画面にアクセスする' do
+      given(:general_user){create(:user, admin: 'general')}
+      scenario 'タスク一覧画面に遷移してエラーメッセージが表示される' do
+        logout
+        login(general_user.mail_address, general_user.password)
+        visit admin_users_path
+
+        expect(current_path).to eq root_path
+        expect(page).to have_content '管理者以外はアクセスできません'
       end
     end
 
@@ -43,6 +55,7 @@ RSpec.feature "Admins", type: :feature do
         expect(page).to have_content 'ユーザ情報'
         expect(page).to have_content I18n.t('view.user.user_name', user: @user.user_name)
         expect(page).to have_content I18n.t('view.user.mail_address', user: @user.mail_address)
+        expect(page).to have_content I18n.t('view.user.role', user: I18n.t("role.#{@user.admin}"))
         expect(page).to have_content I18n.t('button.edit')
         expect(page).to have_content I18n.t('button.delete')
         expect(page).to have_content 'タスク'
@@ -75,6 +88,7 @@ RSpec.feature "Admins", type: :feature do
         fill_in 'user_user_name', with: 'new_account'
         fill_in 'user_mail_address', with: 'new@example.com'
         fill_in 'user_password', with: 'new_password'
+        select I18n.t('role.admin'), from: 'user_admin'
         click_button I18n.t('helpers.submit.create')
 
         expect(current_path).to eq admin_users_path
@@ -102,8 +116,9 @@ RSpec.feature "Admins", type: :feature do
   end
 
   feature 'ユーザの更新' do
+    given(:logined_user) {create(:user, user_name: 'logined_user')}
     background do
-      login(@user.mail_address, @user.password)
+      login(logined_user.mail_address, logined_user.password)
     end
 
     context '全てのフォームに正常な値を入力した場合' do
@@ -112,12 +127,14 @@ RSpec.feature "Admins", type: :feature do
         fill_in 'user_user_name', with: 'changed_name'
         fill_in 'user_mail_address', with: 'changed@example.com'
         fill_in 'user_password', with: 'changed_password'
+        select I18n.t('role.general'), from: 'user_admin'
         click_button I18n.t('helpers.submit.update')
 
         expect(current_path).to eq admin_user_path(id: @user.id)
         expect(page).to have_content 'アカウント情報を更新しました'
         expect(page).to have_content 'ユーザ名：changed_name'
         expect(page).to have_content 'メールアドレス：changed@example.com'
+        expect(page).to have_content 'ロール：一般ユーザ'
       end
     end
 
@@ -162,6 +179,17 @@ RSpec.feature "Admins", type: :feature do
         expect(page).to have_content 'メールアドレスを入力してください'
       end
     end
+
+    context 'ログイン中のユーザのロールを変更する場合' do
+      scenario '変更に失敗してエラーメッセージが表示される' do
+        visit edit_admin_user_path(id: logined_user.id)
+        select I18n.t('role.general'), from: 'user_admin'
+        click_button I18n.t('helpers.submit.update')
+
+        expect(current_path).to eq edit_admin_user_path(id: logined_user.id)
+        expect(page).to have_content 'ログイン中のユーザはロールを変更できません'
+      end
+    end
   end
 
   feature 'ユーザの削除', js: true do
@@ -199,6 +227,27 @@ RSpec.feature "Admins", type: :feature do
 
         expect(current_path).to eq admin_user_path(id: logined_user.id)
         expect(page).to have_content 'ログイン中のユーザは削除できません'
+      end
+    end
+  end
+
+  feature 'ロール' do
+    given(:admin_user){create(:user)}
+    given(:general_user){create(:user, admin: 'general')}
+
+    context '管理ユーザがログインした場合' do
+      scenario 'ナビゲーションバーに管理画面へのリンクが表示される' do
+        login(admin_user.mail_address, admin_user.password)
+
+        expect(page).to have_content I18n.t('view.nav.admin')
+      end
+    end
+
+    context '一般ユーザがログインした場合' do
+      scenario 'ナビゲーションバーに管理画面へのリンクが表示されない' do
+        login(general_user.mail_address, general_user.password)
+
+        expect(page).not_to have_content I18n.t('view.nav.admin')
       end
     end
   end

--- a/task_management/spec/features/sessions_spec.rb
+++ b/task_management/spec/features/sessions_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature "Sessions", type: :feature do
 
   feature '認可' do
     given(:task) {create(:task, task_name: 'a', user_id: @user.id)}
-    given(:user2) {create(:user, user_name: 'b', mail_address: 'b@example.com', password: 'b', admin: false)}
+    given(:user2) {create(:user, user_name: 'b', mail_address: 'b@example.com', password: 'b')}
     
     context '一覧画面' do
       given!(:task2) {create(:task, task_name: 'b', user_id: user2.id)}

--- a/task_management/spec/features/tasks_spec.rb
+++ b/task_management/spec/features/tasks_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "Tasks", type: :feature do
   background do
-    @user = create(:user)
+    @user = create(:user, admin: 'general')
     @task = create(:task, user_id: @user.id)
   end
 

--- a/task_management/spec/models/user_spec.rb
+++ b/task_management/spec/models/user_spec.rb
@@ -121,6 +121,29 @@ RSpec.describe User, type: :model do
         end
       end
     end
+    
+    describe 'ロール' do
+      context 'adminの場合' do
+        let(:user){FactoryBot.build(:user, admin: 'general')}
+        it 'バリデーションエラーが発生しない' do
+          expect(user.validate).to be_truthy
+        end
+      end
+
+      context 'generalの場合' do
+        let(:user){FactoryBot.build(:user, admin: 'general')}
+        it 'バリデーションエラーが発生しない' do
+          expect(user.validate).to be_truthy
+        end
+      end
+
+      context 'admin, general以外の場合' do
+        let(:user){FactoryBot.build(:user)}
+        it '引数エラーが発生する' do
+          expect{(FactoryBot.build(:user, admin: 'a'))}.to raise_error(ArgumentError)
+        end
+      end
+    end
   end
 
   describe 'Relation' do

--- a/task_management/spec/support/login_macros.rb
+++ b/task_management/spec/support/login_macros.rb
@@ -7,6 +7,6 @@ module LoginMacros
   end
 
   def logout
-    click_on 'log out'
+    click_on I18n.t('view.nav.log_out')
   end
 end

--- a/task_management/spec/support/prepare_tasks_macros.rb
+++ b/task_management/spec/support/prepare_tasks_macros.rb
@@ -1,7 +1,7 @@
 module PrepareTasksMacros
   def prepare_ordered_tasks(order)
     ordered_tasks = Task.all.order(order)
-    tasks = ["#{@user.user_name}\nlog out"]
+    tasks = ["#{@user.user_name}\nログアウト"]
     ordered_tasks.each do |t|
       tasks << '期限：' + t.due_date.to_s
       tasks << '状態：' + I18n.t("status.#{t.status}")


### PR DESCRIPTION
ユーザにロールを追加しました。

以下の要件を満たす方法として、ログイン中のユーザは自身のロールを変更できないようにしました。
> 管理ユーザが1人もいなくならないように削除の制御をしましょう

また、今回のステップの要件以外に、以下の点を変更しました。
- adminのtrue/falseをenumでわかりやすくした
- ユーザの詳細画面に、そのユーザのロールを表示

ご確認お願いいたします。