### PR TITLE
【宮崎】ステップ16　ユーザモデルの追加

### DIFF
--- a/tasclear/Gemfile
+++ b/tasclear/Gemfile
@@ -37,6 +37,8 @@ group :development do
   gem 'spring-commands-rspec'
 
   gem 'fablicop', require: false
+
+  gem 'bullet'
 end
 
 group :test do

--- a/tasclear/Gemfile.lock
+++ b/tasclear/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
     builder (3.2.3)
+    bullet (5.7.5)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11.0)
     byebug (10.0.2)
     capybara (3.3.1)
       addressable
@@ -257,6 +260,7 @@ GEM
     uglifier (4.1.14)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
+    uniform_notifier (1.11.0)
     web-console (3.6.2)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -277,6 +281,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.1)
+  bullet
   byebug
   capybara
   coffee-rails (~> 4.2)

--- a/tasclear/app/models/task.rb
+++ b/tasclear/app/models/task.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
-  validates :name,
-    presence: true,
-    length: { maximum: 20 }
+  validates :name, presence: true, length: { maximum: 20 }
   validates :content, length: { maximum: 200 }
 
   enum status: %i[to_do doing done]

--- a/tasclear/app/models/task.rb
+++ b/tasclear/app/models/task.rb
@@ -15,6 +15,8 @@ class Task < ApplicationRecord
   # ページネーションの1ページ毎の表示数のデフォルトを変更
   paginates_per 10
 
+  belongs_to :user
+
   def self.search_and_order(params)
     search_name = params[:search_name]
     search_status = params[:search_status]

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+end

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -12,4 +12,6 @@ class User < ApplicationRecord
   validates :password_digest,
             presence: true,
             length: { in: 6..30 }
+
+  has_many :tasks
 end

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  validates :name,
-            presence: true,
-            length: { maximum: 30 }
-  validates :email,
-            presence: true,
-            uniqueness: true,
-            format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
-            length: { maximum: 255 }
-  validates :password_digest,
-            presence: true,
-            length: { in: 6..30 }
+  validates :name, presence: true, length: { maximum: 30 }
+  validates :email, presence: true, length: { maximum: 255 }, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :password_digest, presence: true, length: { in: 6..30 }
 
   has_many :tasks
 end

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -1,4 +1,15 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  validates :name,
+            presence: true,
+            length: { maximum: 30 }
+  validates :email,
+            presence: true,
+            uniqueness: true,
+            format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
+            length: { maximum: 255 }
+  validates :password_digest,
+            presence: true,
+            length: { in: 6..30 }
 end

--- a/tasclear/config/environments/development.rb
+++ b/tasclear/config/environments/development.rb
@@ -60,4 +60,14 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # bullet gemの設定
+  config.after_initialize do
+    Bullet.enable  = true
+    Bullet.alert   = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+    Bullet.add_footer   = true 
+  end
 end

--- a/tasclear/db/migrate/20180725041950_create_users.rb
+++ b/tasclear/db/migrate/20180725041950_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/tasclear/db/migrate/20180725062552_add_user_ref_to_tasks.rb
+++ b/tasclear/db/migrate/20180725062552_add_user_ref_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserRefToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+  end
+end

--- a/tasclear/db/schema.rb
+++ b/tasclear/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_20_065537) do
+ActiveRecord::Schema.define(version: 2018_07_25_062552) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -20,8 +20,10 @@ ActiveRecord::Schema.define(version: 2018_07_20_065537) do
     t.date "deadline"
     t.integer "status", default: 0, null: false
     t.integer "priority", default: 0, null: false
+    t.bigint "user_id"
     t.index ["priority"], name: "index_tasks_on_priority"
     t.index ["status"], name: "index_tasks_on_status"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/tasclear/db/schema.rb
+++ b/tasclear/db/schema.rb
@@ -24,4 +24,13 @@ ActiveRecord::Schema.define(version: 2018_07_20_065537) do
     t.index ["status"], name: "index_tasks_on_status"
   end
 
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "tasks", "users"
 end

--- a/tasclear/db/seeds.rb
+++ b/tasclear/db/seeds.rb
@@ -6,3 +6,4 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+User.create(name: 'Yusuke', email: 'yusuke@sample.com', password_digest: '12345678')

--- a/tasclear/spec/factories/users.rb
+++ b/tasclear/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name '楽太郎'
+    email 'raku@example.com'
+    password_digest 'password'
+  end
+end

--- a/tasclear/spec/models/user_spec.rb
+++ b/tasclear/spec/models/user_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'バリデーション' do
+    it '名前、メールアドレス、パスワードがあれば有効な状態であること' do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+    it '名前が無ければ無効な状態であること' do
+      user = build(:user, name: '')
+      expect(user).to be_invalid
+    end
+    it '名前が30文字であれば有効な状態であること' do
+      user = build(:user, name: 'あ' * 30)
+      expect(user).to be_valid
+    end
+    it '名前が31文字であれば無効な状態であること' do
+      user = build(:user, name: 'あ' * 31)
+      expect(user).to be_invalid
+    end
+    it 'メールアドレスが無ければ無効な状態であること' do
+      user = build(:user, email: '')
+      expect(user).to be_invalid
+    end
+    it 'メールアドレスが重複していれば無効な状態であること' do
+      create(:user, email: 'aaa@example.com')
+      user = build(:user, email: 'aaa@example.com')
+      expect(user).to be_invalid
+    end
+    it 'メールアドレスが正しい形式で無ければ無効な状態であること' do
+      user = build(:user, email: 'aaa')
+      expect(user).to be_invalid
+    end
+    it 'メールアドレスが255文字であれば有効な状態であること' do
+      user = build(:user, email: 'a@a.' + 'a' * 251)
+      expect(user).to be_valid
+    end
+    it 'メールアドレスが266文字であれば無効な状態であること' do
+      user = build(:user, email: 'a@a.' + 'a' * 252)
+      expect(user).to be_invalid
+    end
+    it 'パスワードが無ければ無効な状態であること' do
+      user = build(:user, password_digest: '')
+      expect(user).to be_invalid
+    end
+    it 'パスワードが6文字であれば有効な状態であること' do
+      user = build(:user, password_digest: 'a' * 6)
+      expect(user).to be_valid
+    end
+    it 'パスワードが5文字であれば無効な状態であること' do
+      user = build(:user, password_digest: 'a' * 5)
+      expect(user).to be_invalid
+    end
+    it 'パスワードが30文字であれば有効な状態であること' do
+      user = build(:user, password_digest: 'a' * 30)
+      expect(user).to be_valid
+    end
+    it 'パスワードが31文字であれば無効な状態であること' do
+      user = build(:user, password_digest: 'a' * 31)
+      expect(user).to be_invalid
+    end
+  end
+end

--- a/tasclear/spec/models/user_spec.rb
+++ b/tasclear/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
     let(:name) { 'ほげ' }
     let(:email) { 'hoge@sample.com' }
     let(:password_digest) { 'password' }
-    subject(:user) { build(:user, name: name, email: email, password_digest: password_digest) }
+    subject { build(:user, name: name, email: email, password_digest: password_digest) }
 
     context '有効' do
       context '名前、メールアドレス、パスワードが指定される' do

--- a/tasclear/spec/models/user_spec.rb
+++ b/tasclear/spec/models/user_spec.rb
@@ -4,62 +4,85 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'バリデーション' do
-    it '名前、メールアドレス、パスワードがあれば有効な状態であること' do
-      user = build(:user)
-      expect(user).to be_valid
+    let(:name) { 'ほげ' }
+    let(:email) { 'hoge@sample.com' }
+    let(:password_digest) { 'password' }
+    let(:user) { build(:user, name: name, email: email, password_digest: password_digest) }
+    subject { user }
+
+    context '有効' do
+      context '名前、メールアドレス、パスワードが指定される' do
+        it { is_expected.to be_valid }
+      end
+
+      context '名前が30文字' do
+        let(:name) { 'あ' * 30 }
+        it { is_expected.to be_valid }
+      end
+
+      context 'メールアドレスが255文字' do
+        let(:email) { 'a@a.' + 'a' * 251 }
+        it { is_expected.to be_valid }
+      end
+
+      context 'パスワードが6文字' do
+        let(:password_digest) { 'a' * 6 }
+        it { is_expected.to be_valid }
+      end
+
+      context 'パスワードが30文字' do
+        let(:password_digest) { 'a' * 30 }
+        it { is_expected.to be_valid }
+      end
     end
-    it '名前が無ければ無効な状態であること' do
-      user = build(:user, name: '')
-      expect(user).to be_invalid
-    end
-    it '名前が30文字であれば有効な状態であること' do
-      user = build(:user, name: 'あ' * 30)
-      expect(user).to be_valid
-    end
-    it '名前が31文字であれば無効な状態であること' do
-      user = build(:user, name: 'あ' * 31)
-      expect(user).to be_invalid
-    end
-    it 'メールアドレスが無ければ無効な状態であること' do
-      user = build(:user, email: '')
-      expect(user).to be_invalid
-    end
-    it 'メールアドレスが重複していれば無効な状態であること' do
-      create(:user, email: 'aaa@example.com')
-      user = build(:user, email: 'aaa@example.com')
-      expect(user).to be_invalid
-    end
-    it 'メールアドレスが正しい形式で無ければ無効な状態であること' do
-      user = build(:user, email: 'aaa')
-      expect(user).to be_invalid
-    end
-    it 'メールアドレスが255文字であれば有効な状態であること' do
-      user = build(:user, email: 'a@a.' + 'a' * 251)
-      expect(user).to be_valid
-    end
-    it 'メールアドレスが266文字であれば無効な状態であること' do
-      user = build(:user, email: 'a@a.' + 'a' * 252)
-      expect(user).to be_invalid
-    end
-    it 'パスワードが無ければ無効な状態であること' do
-      user = build(:user, password_digest: '')
-      expect(user).to be_invalid
-    end
-    it 'パスワードが6文字であれば有効な状態であること' do
-      user = build(:user, password_digest: 'a' * 6)
-      expect(user).to be_valid
-    end
-    it 'パスワードが5文字であれば無効な状態であること' do
-      user = build(:user, password_digest: 'a' * 5)
-      expect(user).to be_invalid
-    end
-    it 'パスワードが30文字であれば有効な状態であること' do
-      user = build(:user, password_digest: 'a' * 30)
-      expect(user).to be_valid
-    end
-    it 'パスワードが31文字であれば無効な状態であること' do
-      user = build(:user, password_digest: 'a' * 31)
-      expect(user).to be_invalid
+
+    context '無効' do
+      context '名前が指定されない' do
+        let(:name) { '' }
+        it { is_expected.to be_invalid }
+      end
+
+      context '名前が31文字' do
+        let(:name) { 'あ' * 31 }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'メールアドレスが指定されない' do
+        let(:email) { '' }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'メールアドレスが重複' do
+        before do
+          create(:user, email: email)
+        end
+        it { is_expected.to be_invalid }
+      end
+
+      context 'メールアドレスが正しい形式ではない' do
+        let(:email) { 'hogehoge' }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'メールアドレスが256文字' do
+        let(:email) { 'a@a.' + 'a' * 252 }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'パスワードが指定されない' do
+        let(:password_digest) { '' }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'パスワードが5文字' do
+        let(:password_digest) { 'a' * 5 }
+        it { is_expected.to be_invalid }
+      end
+
+      context 'パスワードが31文字' do
+        let(:password_digest) { 'a' * 31 }
+        it { is_expected.to be_invalid }
+      end
     end
   end
 end

--- a/tasclear/spec/models/user_spec.rb
+++ b/tasclear/spec/models/user_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe User, type: :model do
     let(:name) { 'ほげ' }
     let(:email) { 'hoge@sample.com' }
     let(:password_digest) { 'password' }
-    let(:user) { build(:user, name: name, email: email, password_digest: password_digest) }
-    subject { user }
+    subject(:user) { build(:user, name: name, email: email, password_digest: password_digest) }
 
     context '有効' do
       context '名前、メールアドレス、パスワードが指定される' do


### PR DESCRIPTION
# ステップ16: 複数人で利用できるようにしよう（ユーザの導入）
- ユーザモデルを作成してみましょう
- 最初のユーザをseedで作成してみましょう
- ユーザとタスクが紐づくようにしましょう
  - 関連に対してインデックスを貼りましょう
  - N+1問題を回避するための仕組みを取り入れましょう
# 行ったこと
- ユーザモデルの追加
- ユーザモデルのバリデーション追加
- モデルスペック追加
- 最初のユーザをseedで作成するためにシードファイルを作成
- ユーザとモデルの関連付け
- N+1問題を回避するために仕組みとして、bullet gemを導入
# 備考
- ユーザモデルは追加したものの、ログイン・ログアウト機能は未実装（ステップ17で実装予定）のため、以下の影響があります
  - タスクのモデルスペック、フィーチャスペックが通らなくなっている（タスクモデルのバリデーションでユーザidを必須としているため、タスクの新規登録・更新ができない）