### PR TITLE
【宮崎】ステップ18　ユーザ管理画面の実装

### DIFF
--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -1,52 +1,54 @@
 # frozen_string_literal: true
 
-class Admin::UsersController < ApplicationController
-  before_action :set_user, only: %i[show edit update destroy]
+module Admin
+  class UsersController < ApplicationController
+    before_action :set_user, only: %i[show edit update destroy]
 
-  def index
-    @users = User.all
-  end
-
-  def new
-    @user = User.new
-  end
-
-  def create
-    @user = User.new(user_params)
-    if @user.save
-      redirect_to admin_users_path, notice: t('flash.user.create_success')
-    else
-      render :new
+    def index
+      @users = User.all
     end
-  end
 
-  def edit
-  end
-
-  def show
-    @tasks = @user.tasks
-  end
-
-  def update
-    if @user.update(user_params)
-      redirect_to admin_users_path, notice: t('flash.user.update_success')
-    else
-      render :edit
+    def new
+      @user = User.new
     end
-  end
 
-  def destroy
-    @user.destroy
-    redirect_to admin_users_path, notice: t('flash.user.destroy_success')
-  end
+    def create
+      @user = User.new(user_params)
+      if @user.save
+        redirect_to admin_users_path, notice: t('flash.user.create_success')
+      else
+        render :new
+      end
+    end
 
-  private
+    def edit
+    end
 
-  def user_params
-    params.require(:user).permit(:name, :email, :password)
-  end
+    def show
+      @tasks = @user.tasks
+    end
 
-  def set_user
-    @user = User.find(params[:id])
+    def update
+      if @user.update(user_params)
+        redirect_to admin_users_path, notice: t('flash.user.update_success')
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @user.destroy
+      redirect_to admin_users_path, notice: t('flash.user.destroy_success')
+    end
+
+    private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :password)
+    end
+
+    def set_user
+      @user = User.find(params[:id])
+    end
   end
 end

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -14,11 +14,10 @@ module Admin
 
     def create
       @user = User.new(user_params)
-      if @user.save
-        redirect_to admin_users_path, notice: t('flash.user.create_success')
-      else
-        render :new
-      end
+      @user.save!
+      redirect_to admin_users_path, notice: t('flash.user.create_success')
+    rescue StandardError
+      render :new
     end
 
     def edit
@@ -29,11 +28,10 @@ module Admin
     end
 
     def update
-      if @user.update(user_params)
-        redirect_to admin_users_path, notice: t('flash.user.update_success')
-      else
-        render :edit
-      end
+      @user.update!(user_params)
+      redirect_to admin_users_path, notice: t('flash.user.update_success')
+    rescue StandardError
+      render :edit
     end
 
     def destroy

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -35,8 +35,10 @@ module Admin
     end
 
     def destroy
-      @user.destroy
+      @user.destroy!
       redirect_to admin_users_path, notice: t('flash.user.destroy_success')
+    rescue StandardError
+      redirect_to admin_users_path, alert: t('flash.user.destroy_failure')
     end
 
     private

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Admin::UsersController < ApplicationController
+  before_action :set_user, only: %i[show edit update destroy]
+
+  def index
+    @users = User.all
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_users_path, notice: t('flash.user.create_success')
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def show
+    @tasks = @user.tasks
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_users_path, notice: t('flash.user.update_success')
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @user.destroy
+    redirect_to admin_users_path, notice: t('flash.user.destroy_success')
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password)
+  end
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+end

--- a/tasclear/app/controllers/tasks_controller.rb
+++ b/tasclear/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
 
   def index
     if logged_in?
-      @tasks = Task.search_and_order(params, current_user).page(params[:page])
+      @tasks = Task.add_search_and_order_condition(current_user.tasks, params).page(params[:page])
     else
       redirect_to new_session_path
     end

--- a/tasclear/app/controllers/tasks_controller.rb
+++ b/tasclear/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
 
   def index
     if logged_in?
-      @tasks = Task.search_and_order(params, current_user.id).page(params[:page])
+      @tasks = Task.search_and_order(params, current_user).page(params[:page])
     else
       redirect_to new_session_path
     end

--- a/tasclear/app/helpers/admin/users_helper.rb
+++ b/tasclear/app/helpers/admin/users_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Admin::UsersHelper
+  def tasks_amount(user)
+    user.tasks.count
+  end
+end

--- a/tasclear/app/models/task.rb
+++ b/tasclear/app/models/task.rb
@@ -15,10 +15,10 @@ class Task < ApplicationRecord
 
   belongs_to :user
 
-  def self.search_and_order(params, user_id)
+  def self.search_and_order(params, current_user)
     search_name = params[:search_name]
     search_status = params[:search_status]
-    tasks = self.where(user_id: user_id)
+    tasks = current_user.tasks
     tasks = tasks.where('name LIKE ?', "%#{search_name}%") if search_name.present?
     tasks = tasks.where(status: search_status) if search_status.present?
     if params.key?(:sort_category)

--- a/tasclear/app/models/task.rb
+++ b/tasclear/app/models/task.rb
@@ -15,10 +15,9 @@ class Task < ApplicationRecord
 
   belongs_to :user
 
-  def self.search_and_order(params, current_user)
+  def self.add_search_and_order_condition(tasks, params)
     search_name = params[:search_name]
     search_status = params[:search_status]
-    tasks = current_user.tasks
     tasks = tasks.where('name LIKE ?', "%#{search_name}%") if search_name.present?
     tasks = tasks.where(status: search_status) if search_status.present?
     if params.key?(:sort_category)

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { maximum: 255 }, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   validates :password, presence: true, length: { in: 6..30 }
 
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
 
   has_secure_password
 end

--- a/tasclear/app/views/admin/users/_form.html.erb
+++ b/tasclear/app/views/admin/users/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with(model: [:admin, @user], local: true) do |form| %>
+  <% if @user.errors.any? %>
+    <div>
+      <ul>
+        <% @user.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div class="form-group">
+    <%= form.label :name %>
+    <%= form.text_field :name, class:"form-control" %>
+  </div>
+  <div class="form-group">
+    <%= form.label :email %>
+    <%= form.email_field :email, class:"form-control" %>
+  </div>
+  <div class="form-group">
+    <%= form.label :password %>
+    <%= form.password_field :password, class:"form-control" %>
+  </div>
+  <%= form.submit class:"btn btn-primary" %>
+<% end %>

--- a/tasclear/app/views/admin/users/edit.html.erb
+++ b/tasclear/app/views/admin/users/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t('.title') %></h1>
+<%= render 'form' %>
+<%= link_to t('.back'), :back %>

--- a/tasclear/app/views/admin/users/index.html.erb
+++ b/tasclear/app/views/admin/users/index.html.erb
@@ -1,0 +1,24 @@
+<h1><%= t('.title') %></h1>
+<table class="table table-striped">
+  <tr class="table-primary">
+    <th><%= t('.name') %></th>
+    <th><%= t('.email') %></th>
+    <th><%= t('.amount') %></th>
+    <th></th>
+    <th></th>
+  </tr>
+  <% @users.each do |user| %>
+    <tr>
+      <td><%= user.name %></td>
+      <td><%= user.email %></td>
+      <td><%= link_to tasks_amount(user), admin_user_path(user.id) %></td>
+      <td><%= link_to edit_admin_user_path(user.id), class:"edit-btn" do %>
+        <i class="fa fa-edit"></i>
+      <% end %></td>
+      <td><%= link_to admin_user_path(user.id), class:'delete-btn', method: :delete, data: {confirm: t('.confirm')} do %>
+        <i class="fa fa-trash"></i>
+      <% end %></td>
+    </tr>
+  <% end %>
+</table>
+<%= link_to t('.new_user'), new_admin_user_path, class:"btn btn-primary" %>

--- a/tasclear/app/views/admin/users/index.html.erb
+++ b/tasclear/app/views/admin/users/index.html.erb
@@ -11,7 +11,7 @@
     <tr>
       <td><%= user.name %></td>
       <td><%= user.email %></td>
-      <td><%= link_to tasks_amount(user), admin_user_path(user.id) %></td>
+      <td class='amount'><%= link_to tasks_amount(user), admin_user_path(user.id), class:'amount-btn' %></td>
       <td><%= link_to edit_admin_user_path(user.id), class:"edit-btn" do %>
         <i class="fa fa-edit"></i>
       <% end %></td>

--- a/tasclear/app/views/admin/users/index.html.erb
+++ b/tasclear/app/views/admin/users/index.html.erb
@@ -9,8 +9,8 @@
   </tr>
   <% @users.each do |user| %>
     <tr>
-      <td><%= user.name %></td>
-      <td><%= user.email %></td>
+      <td class='name'><%= user.name %></td>
+      <td class='email'><%= user.email %></td>
       <td class='amount'><%= link_to tasks_amount(user), admin_user_path(user.id), class:'amount-btn' %></td>
       <td><%= link_to edit_admin_user_path(user.id), class:"edit-btn" do %>
         <i class="fa fa-edit"></i>

--- a/tasclear/app/views/admin/users/new.html.erb
+++ b/tasclear/app/views/admin/users/new.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t('.title') %></h1>
+<%= render 'form' %>
+<%= link_to t('.back'), :back %>

--- a/tasclear/app/views/admin/users/show.html.erb
+++ b/tasclear/app/views/admin/users/show.html.erb
@@ -1,0 +1,20 @@
+<h1><%= @user.name %><%= t('.title') %></h1>
+<table class="table table-striped">
+  <tr class="table-primary">
+    <th><%= t('.status') %></th>
+    <th><%= t('.priority') %></th>
+    <th><%= t('.deadline') %></th>
+    <th><%= t('.name') %></th>
+    <th></th>
+  </tr>
+  <% @tasks.each do |task| %>
+    <tr class="table-<%= border_color task.deadline if task.deadline.present? %>">
+      <td><span class="badge badge-<%= status_color task.status %>"><%= task.status_i18n %></span></td>
+      <td><span class="badge badge-<%= priority_color task.priority %>"><%= task.priority_i18n %></span></td>
+      <td><%= l(task.deadline, format: :short2) if task.deadline.present? %></td>
+      <td class='name'><%= task.name %></td>
+      <td><%= link_to t('.detail'), task_path(task.id) %></td>
+    </tr>
+  <% end %>
+</table>
+<%= link_to t('.back'), :back %>

--- a/tasclear/app/views/layouts/application.html.erb
+++ b/tasclear/app/views/layouts/application.html.erb
@@ -25,6 +25,9 @@
               <%= link_to t('.new_task'), new_task_path, class:'nav-link' if logged_in? %>
             </li>
             <li class="nav-item">
+              <%= link_to t('.users'), admin_users_path, class:'nav-link' %>
+            </li>
+            <li class="nav-item">
               <% if logged_in? %>
                 <%= link_to t('.logout'), session_path(current_user.id),method: :delete, class:'nav-link' %>
               <% else %>

--- a/tasclear/config/locales/ja.yml
+++ b/tasclear/config/locales/ja.yml
@@ -10,6 +10,10 @@ ja:
         deadline: '終了期限'
         status: 'ステータス'
         priority: '優先度'
+      user:
+        name: '名前'
+        email: 'メールアドレス'
+        password: 'パスワード'
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -22,6 +26,7 @@ ja:
       logout: 'ログアウト'
       title: '楽天スーパータスク'
       new_task: '新規タスク登録'
+      users: 'ユーザ一覧'
   tasks:
     index:
       title: 'タスク一覧'
@@ -52,6 +57,29 @@ ja:
       status: 'ステータス'
       priority: '優先度'
       back: '戻る'
+  admin:
+    users:
+      index:
+        title: 'ユーザ一覧'
+        name: '名前'
+        email: 'メールアドレス'
+        amount: 'タスク数'
+        new_user: '新規ユーザ登録'
+        confirm: '本当に削除してもいいですか'
+      new:
+        title: '新規ユーザ登録'
+        back: '戻る'
+      edit:
+        title: 'ユーザ編集'
+        back: '戻る'
+      show:
+        title: 'さんのタスク一覧'
+        name: 'タスク名'
+        detail: '詳細'
+        deadline: '終了期限'
+        status: 'ステータス'
+        priority: '優先度'
+        back: '戻る'
   sessions:
     new:
       title: 'ログイン'
@@ -71,6 +99,10 @@ ja:
       create_success: 'タスクを作成しました'
       update_success: 'タスクを編集しました'
       destroy_success: 'タスクを削除しました'
+    user:
+      create_success: 'ユーザを作成しました'
+      update_success: 'ユーザを編集しました'
+      destroy_success: 'ユーザを削除しました'
     session:
       fail_login: 'ログインに失敗しました'
       logout_success: 'ログアウトしました'

--- a/tasclear/config/locales/ja.yml
+++ b/tasclear/config/locales/ja.yml
@@ -103,6 +103,7 @@ ja:
       create_success: 'ユーザを作成しました'
       update_success: 'ユーザを編集しました'
       destroy_success: 'ユーザを削除しました'
+      destroy_failure: 'ユーザの削除に失敗しました'
     session:
       fail_login: 'ログインに失敗しました'
       logout_success: 'ログアウトしました'

--- a/tasclear/config/routes.rb
+++ b/tasclear/config/routes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+  end
   root 'tasks#index'
   resources :tasks, except: %i[index]
   resources :sessions, only: %i[new create destroy]

--- a/tasclear/spec/features/admin_users_spec.rb
+++ b/tasclear/spec/features/admin_users_spec.rb
@@ -23,14 +23,14 @@ RSpec.feature 'AdminUsers', type: :feature do
     end
 
     scenario 'ユーザを編集する' do
-      expect do
-        find('.edit-btn').click
-        fill_in '名前', with: '変更後名前'
-        fill_in 'メールアドレス', with: 'changed@example.com'
-        fill_in 'パスワード', with: 'password2'
-        click_button '更新する'
-        expect(page).to have_content 'ユーザを編集しました'
-      end.to change { User.count }.by(0)
+      find('.edit-btn').click
+      fill_in '名前', with: '変更後名前'
+      fill_in 'メールアドレス', with: 'changed@example.com'
+      fill_in 'パスワード', with: 'password2'
+      click_button '更新する'
+      expect(page).to have_content 'ユーザを編集しました'
+      expect(page).to have_selector 'td.name', text: '変更後名前'
+      expect(page).to have_selector 'td.email', text: 'changed@example.com'
     end
 
     scenario 'ユーザを削除する' do

--- a/tasclear/spec/features/admin_users_spec.rb
+++ b/tasclear/spec/features/admin_users_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'AdminUsers', type: :feature do
+  scenario '新しいユーザを作成する' do
+    expect do
+      visit root_path
+      click_link 'ユーザ一覧'
+      click_link '新規ユーザ登録'
+      fill_in '名前', with: '太郎'
+      fill_in 'メールアドレス', with: 'taro@example.com'
+      fill_in 'パスワード', with: 'password'
+      click_button '登録する'
+      expect(page).to have_content 'ユーザを作成しました'
+    end.to change { User.count }.by(1)
+  end
+
+  feature '既存ユーザへの操作' do
+    background do
+      create(:user)
+      visit admin_users_path
+    end
+
+    scenario 'ユーザを編集する' do
+      expect do
+        find('.edit-btn').click
+        fill_in '名前', with: '変更後名前'
+        fill_in 'メールアドレス', with: 'changed@example.com'
+        fill_in 'パスワード', with: 'password2'
+        click_button '更新する'
+        expect(page).to have_content 'ユーザを編集しました'
+      end.to change { User.count }.by(0)
+    end
+
+    scenario 'ユーザを削除する' do
+      expect do
+        find('.delete-btn').click
+        expect(page).to have_content 'ユーザを削除しました'
+      end.to change { User.count }.by(-1)
+    end
+  end
+
+  feature 'ユーザが作成したタスク絡み' do
+    background do
+      create(:task)
+      visit admin_users_path
+    end
+
+    scenario 'ユーザを削除したら、そのユーザの抱えているタスクを削除する' do
+      expect do
+        find('.delete-btn').click
+      end.to change { Task.count }.by(-1)
+    end
+
+    scenario 'ユーザ一覧画面で、そのユーザが抱えているタスクの数を表示する' do
+      amounts = page.all('td.amount')
+      expect(amounts[0]).to have_content '1'
+    end
+
+    scenario 'ユーザが作成したタスクの一覧が見れる' do
+      find('.amount-btn').click
+      names = page.all('td.name')
+      expect(names.count).to eq 1
+    end
+  end
+end

--- a/tasclear/spec/features/projects_spec.rb
+++ b/tasclear/spec/features/projects_spec.rb
@@ -134,12 +134,11 @@ RSpec.feature 'Tasks', type: :feature do
       visit root_path
       names = page.all('td.name')
       # 10件目は表示されており、11件目は表示されていないことの確認
-      expect(names[9]).to have_content 'タスク10'
-      expect(names[10]).to be nil
+      expect(names.count).to eq 10
       click_link '次'
       names = page.all('td.name')
       # 2ページ目に11件目が表示されていることの確認
-      expect(names[0]).to have_content 'タスク11'
+      expect(names.count).to eq 1
     end
   end
 

--- a/tasclear/spec/models/task_spec.rb
+++ b/tasclear/spec/models/task_spec.rb
@@ -59,18 +59,18 @@ RSpec.describe Task, type: :model do
     let!(:task2) { create(:task, name: 'タスク２', status: 'doing') }
 
     it 'タスク名で検索できること' do
-      expect(Task.search_and_order({ search_name: 'タスク１' }, task1.user.id)).to include(task1)
-      expect(Task.search_and_order({ search_name: 'タスク１' }, task2.user.id)).not_to include(task2)
+      expect(Task.search_and_order({ search_name: 'タスク１' }, task1.user)).to include(task1)
+      expect(Task.search_and_order({ search_name: 'タスク１' }, task2.user)).not_to include(task2)
     end
 
     it 'ステータスで検索できること' do
-      expect(Task.search_and_order({ search_status: 'to_do' }, task1.user.id)).to include(task1)
-      expect(Task.search_and_order({ search_status: 'to_do' }, task2.user.id)).not_to include(task2)
+      expect(Task.search_and_order({ search_status: 'to_do' }, task1.user)).to include(task1)
+      expect(Task.search_and_order({ search_status: 'to_do' }, task2.user)).not_to include(task2)
     end
 
     it 'タスク名・ステータスの両方で検索できること' do
-      expect(Task.search_and_order({ search_name: 'タスク１', search_status: 'to_do' }, task1.user.id)).to include(task1)
-      expect(Task.search_and_order({ search_name: 'タスク１', search_status: 'to_do' }, task2.user.id)).not_to include(task2)
+      expect(Task.search_and_order({ search_name: 'タスク１', search_status: 'to_do' }, task1.user)).to include(task1)
+      expect(Task.search_and_order({ search_name: 'タスク１', search_status: 'to_do' }, task2.user)).not_to include(task2)
     end
   end
 end

--- a/tasclear/spec/models/task_spec.rb
+++ b/tasclear/spec/models/task_spec.rb
@@ -54,23 +54,23 @@ RSpec.describe Task, type: :model do
     end
   end
 
-  describe '#search_and_order' do
+  describe '#add_search_and_order_condition' do
     let!(:task1) { create(:task, name: 'タスク１', status: 'to_do') }
     let!(:task2) { create(:task, name: 'タスク２', status: 'doing') }
 
     it 'タスク名で検索できること' do
-      expect(Task.search_and_order({ search_name: 'タスク１' }, task1.user)).to include(task1)
-      expect(Task.search_and_order({ search_name: 'タスク１' }, task2.user)).not_to include(task2)
+      expect(Task.add_search_and_order_condition(task1.user.tasks, { search_name: 'タスク１' })).to include(task1)
+      expect(Task.add_search_and_order_condition(task2.user.tasks, { search_name: 'タスク１' })).not_to include(task2)
     end
 
     it 'ステータスで検索できること' do
-      expect(Task.search_and_order({ search_status: 'to_do' }, task1.user)).to include(task1)
-      expect(Task.search_and_order({ search_status: 'to_do' }, task2.user)).not_to include(task2)
+      expect(Task.add_search_and_order_condition(task1.user.tasks, { search_status: 'to_do' })).to include(task1)
+      expect(Task.add_search_and_order_condition(task2.user.tasks, { search_status: 'to_do' })).not_to include(task2)
     end
 
     it 'タスク名・ステータスの両方で検索できること' do
-      expect(Task.search_and_order({ search_name: 'タスク１', search_status: 'to_do' }, task1.user)).to include(task1)
-      expect(Task.search_and_order({ search_name: 'タスク１', search_status: 'to_do' }, task2.user)).not_to include(task2)
+      expect(Task.add_search_and_order_condition(task1.user.tasks, { search_name: 'タスク１', search_status: 'to_do' })).to include(task1)
+      expect(Task.add_search_and_order_condition(task2.user.tasks, { search_name: 'タスク１', search_status: 'to_do' })).not_to include(task2)
     end
   end
 end

--- a/tasclear/spec/models/task_spec.rb
+++ b/tasclear/spec/models/task_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Task, type: :model do
     let(:content) { 'ほげほげ' }
     let(:status) { 'doing' }
     let(:priority) { 'low' }
-    subject { build(:task, name: name, content: content, status: status, priority: priority) }
+    let(:user) { create(:user) }
+    subject { build(:task, name: name, content: content, status: status, priority: priority, user_id: user.id) }
 
     context '有効' do
       context 'タスク名、内容、ステータス、パスワードが指定される' do


### PR DESCRIPTION
# ステップ18: ユーザの管理画面を実装しよう
- 画面上に管理メニューを追加しましょう
- 管理画面にはかならず /admin というURLを先頭につけるようにしましょう
  - routes.rb に追加する前に、あらかじめURLやルーティング名（ *_path となる名前）を想定して設計してみましょう
- ユーザ一覧・作成・更新・削除を実装しましょう
- ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう
- ユーザが作成したタスクの一覧が見られるようにしてみましょう
# 行ったこと
- ルーティングへnamespace追加
- ユーザのCRUD機能実装
- ユーザ削除後にそのユーザに紐付くタスクを削除する機能実装
- ユーザ一覧画面にそのユーザの持つタスク数を表示する機能実装
- ユーザが作成したタスクの一覧画面を追加
- ユーザ管理画面へのリンクをグローバルナビゲーションに追加
- ユーザ管理画面の日本語化
- ユーザ管理機能のフィーチャスペック追加
# 画面
## ユーザ一覧画面
![screen shot 2018-07-30 at 6 41 39 pm](https://user-images.githubusercontent.com/34002043/43390115-637bfa7a-9428-11e8-8926-19288cb0c8b9.png)
## ユーザ毎のタスク一覧
![screen shot 2018-07-30 at 6 41 49 pm](https://user-images.githubusercontent.com/34002043/43390142-73b5a224-9428-11e8-8228-d981b6898b70.png)
