### PR TITLE
【宮崎】ステップ19　ユーザへのロール追加

### DIFF
--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -53,7 +53,7 @@ module Admin
     end
 
     def check_admin
-      redirect_to root_path, alert: t('flash.user.not_admin') unless current_user.admin?
+      redirect_to root_path, alert: t('flash.user.not_admin') unless current_user&.admin?
     end
   end
 end

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -53,7 +53,7 @@ module Admin
     end
 
     def check_admin
-      redirect_to root_path, alert: t('flash.user.not_admin') if current_user.role == 'general'
+      redirect_to root_path, alert: t('flash.user.not_admin') unless current_user.admin?
     end
   end
 end

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   class UsersController < ApplicationController
     before_action :set_user, only: %i[show edit update destroy]
+    before_action :check_admin
 
     def index
       @users = User.all
@@ -49,6 +50,10 @@ module Admin
 
     def set_user
       @user = User.find(params[:id])
+    end
+
+    def check_admin
+      redirect_to root_path, alert: t('flash.user.not_admin') if current_user.role == 'general'
     end
   end
 end

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -39,7 +39,7 @@ module Admin
       @user.destroy!
       redirect_to admin_users_path, notice: t('flash.user.destroy_success')
     rescue StandardError
-      redirect_to admin_users_path, alert: t('flash.user.destroy_failure')
+      redirect_to admin_users_path, alert: t('errors.messages.least_one_admin')
     end
 
     private

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -39,7 +39,7 @@ module Admin
       @user.destroy!
       redirect_to admin_users_path, notice: t('flash.user.destroy_success')
     rescue StandardError
-      redirect_to admin_users_path, alert: t('errors.messages.least_one_admin')
+      redirect_to admin_users_path, alert: t('errors.messages.at_least_one_admin')
     end
 
     private

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -29,6 +29,7 @@ module Admin
     end
 
     def update
+      @user.current_user = current_user
       @user.update!(user_params)
       redirect_to admin_users_path, notice: t('flash.user.update_success')
     rescue StandardError

--- a/tasclear/app/controllers/admin/users_controller.rb
+++ b/tasclear/app/controllers/admin/users_controller.rb
@@ -45,7 +45,7 @@ module Admin
     private
 
     def user_params
-      params.require(:user).permit(:name, :email, :password)
+      params.require(:user).permit(:name, :email, :password, :role)
     end
 
     def set_user

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -8,4 +8,6 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
 
   has_secure_password
+
+  enum role: %i[general admin]
 end

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -17,13 +17,11 @@ class User < ApplicationRecord
   private
 
   def check_last_admin_when_destroy
-    return nil if general? || User.admin.count != 1
-    return_error
+    return_error if admin? && User.admin.count == 1
   end
 
   def check_last_admin_when_update
-    return nil if User.admin.count != 1
-    return_error
+    return_error if User.admin.count == 1
   end
 
   def return_error

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
 
   before_destroy :check_last_admin_when_destroy
   validate :check_last_admin_when_update, if: :general?, on: :update
+  attr_accessor :current_user
 
   private
 
@@ -21,7 +22,7 @@ class User < ApplicationRecord
   end
 
   def check_last_admin_when_update
-    return_error if User.admin.count == 1
+    return_error if self == current_user && User.admin.count == 1
   end
 
   def return_error

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -10,4 +10,24 @@ class User < ApplicationRecord
   has_secure_password
 
   enum role: %i[general admin]
+
+  before_destroy :check_last_admin_when_destroy
+  validate :check_last_admin_when_update, if: :general?, on: :update
+
+  private
+
+  def check_last_admin_when_destroy
+    return nil if general? || User.admin.count != 1
+    return_error
+  end
+
+  def check_last_admin_when_update
+    return nil if User.admin.count != 1
+    return_error
+  end
+
+  def return_error
+    errors.add :base, I18n.t('errors.messages.least_one_admin')
+    throw :abort
+  end
 end

--- a/tasclear/app/models/user.rb
+++ b/tasclear/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   end
 
   def return_error
-    errors.add :base, I18n.t('errors.messages.least_one_admin')
+    errors.add :base, I18n.t('errors.messages.at_least_one_admin')
     throw :abort
   end
 end

--- a/tasclear/app/views/admin/users/_form.html.erb
+++ b/tasclear/app/views/admin/users/_form.html.erb
@@ -9,6 +9,10 @@
     </div>
   <% end %>
   <div class="form-group">
+    <%= form.label :role %>
+    <%= form.select :role, User.roles_i18n.invert, {}, {class:"form-control"} %>
+  </div>
+  <div class="form-group">
     <%= form.label :name %>
     <%= form.text_field :name, class:"form-control" %>
   </div>

--- a/tasclear/app/views/admin/users/index.html.erb
+++ b/tasclear/app/views/admin/users/index.html.erb
@@ -1,6 +1,7 @@
 <h1><%= t('.title') %></h1>
 <table class="table table-striped">
   <tr class="table-primary">
+    <th><%= t('.role') %></th>
     <th><%= t('.name') %></th>
     <th><%= t('.email') %></th>
     <th><%= t('.amount') %></th>
@@ -9,6 +10,7 @@
   </tr>
   <% @users.each do |user| %>
     <tr>
+      <td><%= user.role_i18n %></span></td>
       <td class='name'><%= user.name %></td>
       <td class='email'><%= user.email %></td>
       <td class='amount'><%= link_to tasks_amount(user), admin_user_path(user.id), class:'amount-btn' %></td>

--- a/tasclear/app/views/layouts/application.html.erb
+++ b/tasclear/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
               <%= link_to t('.new_task'), new_task_path, class:'nav-link' if logged_in? %>
             </li>
             <li class="nav-item">
-              <%= link_to t('.users'), admin_users_path, class:'nav-link' %>
+              <%= link_to t('.users'), admin_users_path, class:'nav-link' if current_user && current_user.admin? %>
             </li>
             <li class="nav-item">
               <% if logged_in? %>

--- a/tasclear/app/views/layouts/application.html.erb
+++ b/tasclear/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
               <%= link_to t('.new_task'), new_task_path, class:'nav-link' if logged_in? %>
             </li>
             <li class="nav-item">
-              <%= link_to t('.users'), admin_users_path, class:'nav-link' if current_user && current_user.admin? %>
+              <%= link_to t('.users'), admin_users_path, class:'nav-link' if current_user&.admin? %>
             </li>
             <li class="nav-item">
               <% if logged_in? %>

--- a/tasclear/config/locales/ja.yml
+++ b/tasclear/config/locales/ja.yml
@@ -249,6 +249,7 @@ ja:
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
       other_than: は%{count}以外の値にしてください
+      least_one_admin: 少なくとも1人の管理ユーザが必要です
     template:
       body: 次の項目を確認してください
       header:

--- a/tasclear/config/locales/ja.yml
+++ b/tasclear/config/locales/ja.yml
@@ -11,6 +11,7 @@ ja:
         status: 'ステータス'
         priority: '優先度'
       user:
+        role: 'ユーザ種類'
         name: '名前'
         email: 'メールアドレス'
         password: 'パスワード'
@@ -61,6 +62,7 @@ ja:
     users:
       index:
         title: 'ユーザ一覧'
+        role: 'ユーザ種類'
         name: '名前'
         email: 'メールアドレス'
         amount: 'タスク数'
@@ -94,6 +96,10 @@ ja:
         low: '低'
         middle: '中'
         high: '高'
+    user:
+      role:
+        general: '一般ユーザ'
+        admin: '管理ユーザ'
   flash:
     task:
       create_success: 'タスクを作成しました'

--- a/tasclear/config/locales/ja.yml
+++ b/tasclear/config/locales/ja.yml
@@ -104,6 +104,7 @@ ja:
       update_success: 'ユーザを編集しました'
       destroy_success: 'ユーザを削除しました'
       destroy_failure: 'ユーザの削除に失敗しました'
+      not_admin: '権限がありません'
     session:
       fail_login: 'ログインに失敗しました'
       logout_success: 'ログアウトしました'

--- a/tasclear/config/locales/ja.yml
+++ b/tasclear/config/locales/ja.yml
@@ -249,7 +249,7 @@ ja:
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
       other_than: は%{count}以外の値にしてください
-      least_one_admin: 少なくとも1人の管理ユーザが必要です
+      at_least_one_admin: 少なくとも1人の管理ユーザが必要です
     template:
       body: 次の項目を確認してください
       header:

--- a/tasclear/db/migrate/20180731044857_add_column_to_user.rb
+++ b/tasclear/db/migrate/20180731044857_add_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddColumnToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer, default: 0, null: false
+  end
+end

--- a/tasclear/db/schema.rb
+++ b/tasclear/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_25_062552) do
+ActiveRecord::Schema.define(version: 2018_07_31_044857) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2018_07_25_062552) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role", default: 0, null: false
   end
 
   add_foreign_key "tasks", "users"

--- a/tasclear/spec/features/admin_users_spec.rb
+++ b/tasclear/spec/features/admin_users_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'AdminUsers', type: :feature do
       end
     end
 
-    feature '管理ユーザを作成' do
+    feature '別の管理ユーザが存在するケース' do
       background do
         create(:user, role: 'admin')
         visit admin_users_path
@@ -92,7 +92,7 @@ RSpec.feature 'AdminUsers', type: :feature do
       end
     end
 
-    feature '2名以上のユーザ作成' do
+    feature '2名以上の一般ユーザを使用するケース' do
       background do
         @user1 = create(:user)
         create(:task, name: 'ユーザ1のタスク', user_id: @user1.id)

--- a/tasclear/spec/features/admin_users_spec.rb
+++ b/tasclear/spec/features/admin_users_spec.rb
@@ -3,23 +3,25 @@
 require 'rails_helper'
 
 RSpec.feature 'AdminUsers', type: :feature do
-  scenario '新しいユーザを作成する' do
-    expect do
-      visit root_path
-      click_link 'ユーザ一覧'
-      click_link '新規ユーザ登録'
-      fill_in '名前', with: '太郎'
-      fill_in 'メールアドレス', with: 'taro@example.com'
-      fill_in 'パスワード', with: 'password'
-      click_button '登録する'
-      expect(page).to have_content 'ユーザを作成しました'
-    end.to change { User.count }.by(1)
-  end
-
-  feature '既存ユーザへの操作' do
+  feature '管理ユーザーで操作' do
     background do
-      create(:user)
-      visit admin_users_path
+      user = create(:user, role: 'admin')
+      visit root_path
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: user.password
+      click_button 'ログイン'
+      click_link 'ユーザ一覧'
+    end
+
+    scenario '新しいユーザを作成する' do
+      expect do
+        click_link '新規ユーザ登録'
+        fill_in '名前', with: '太郎'
+        fill_in 'メールアドレス', with: 'taro@example.com'
+        fill_in 'パスワード', with: 'password'
+        click_button '登録する'
+        expect(page).to have_content 'ユーザを作成しました'
+      end.to change { User.count }.by(1)
     end
 
     scenario 'ユーザを編集する' do
@@ -33,35 +35,73 @@ RSpec.feature 'AdminUsers', type: :feature do
       expect(page).to have_selector 'td.email', text: 'changed@example.com'
     end
 
-    scenario 'ユーザを削除する' do
+    scenario '管理ユーザが1人もいなくなってしまう場合はユーザの削除ができない' do
       expect do
         find('.delete-btn').click
-        expect(page).to have_content 'ユーザを削除しました'
-      end.to change { User.count }.by(-1)
+        expect(page).to have_content '少なくとも1人の管理ユーザが必要です'
+      end.to change { User.count }.by(0)
+    end
+
+    scenario '管理ユーザが1人もいなくなってしまうようなユーザ種別の編集はできない' do
+      find('.edit-btn').click
+      select '一般ユーザ', from: 'ユーザ種類'
+      fill_in 'パスワード', with: 'password'
+      click_button '更新する'
+      expect(page).to have_content '少なくとも1人の管理ユーザが必要です'
+    end
+
+    feature '既存ユーザへの操作' do
+      background do
+        create(:user)
+        visit admin_users_path
+      end
+
+      scenario '管理ユーザが0人にならない場合はユーザが削除できる' do
+        expect do
+          all('.delete-btn')[1].click
+          expect(page).to have_content 'ユーザを削除しました'
+        end.to change { User.count }.by(-1)
+      end
+    end
+
+    feature 'ユーザが作成したタスク絡み' do
+      background do
+        create(:task)
+        visit admin_users_path
+      end
+
+      scenario 'ユーザを削除したら、そのユーザの抱えているタスクを削除する' do
+        expect do
+          all('.delete-btn')[1].click
+        end.to change { Task.count }.by(-1)
+      end
+
+      scenario 'ユーザ一覧画面で、そのユーザが抱えているタスクの数を表示する' do
+        amounts = page.all('td.amount')
+        expect(amounts[1]).to have_content '1'
+      end
+
+      scenario 'ユーザが作成したタスクの一覧が見れる' do
+        all('.amount-btn')[1].click
+        names = page.all('td.name')
+        expect(names.count).to eq 1
+      end
     end
   end
 
-  feature 'ユーザが作成したタスク絡み' do
+  feature '一般ユーザーで操作' do
     background do
-      create(:task)
+      user = create(:user, role: 'general')
+      visit root_path
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: user.password
+      click_button 'ログイン'
+    end
+
+    scenario '一般ユーザではユーザ一覧画面にアクセスできない' do
       visit admin_users_path
-    end
-
-    scenario 'ユーザを削除したら、そのユーザの抱えているタスクを削除する' do
-      expect do
-        find('.delete-btn').click
-      end.to change { Task.count }.by(-1)
-    end
-
-    scenario 'ユーザ一覧画面で、そのユーザが抱えているタスクの数を表示する' do
-      amounts = page.all('td.amount')
-      expect(amounts[0]).to have_content '1'
-    end
-
-    scenario 'ユーザが作成したタスクの一覧が見れる' do
-      find('.amount-btn').click
-      names = page.all('td.name')
-      expect(names.count).to eq 1
+      expect(page).to have_content '権限がありません'
+      expect(page).to have_current_path '/'
     end
   end
 end

--- a/tasclear/spec/features/admin_users_spec.rb
+++ b/tasclear/spec/features/admin_users_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'AdminUsers', type: :feature do
       expect(page).to have_content '少なくとも1人の管理ユーザが必要です'
     end
 
-    feature '既存ユーザへの操作' do
+    feature '別ユーザへの操作' do
       background do
         create(:user)
         visit admin_users_path
@@ -75,6 +75,20 @@ RSpec.feature 'AdminUsers', type: :feature do
         expect do
           all('.delete-btn')[1].click
         end.to change { Task.where(user_id: @user1.id).count }.by(-1)
+      end
+    end
+
+    feature '管理ユーザを作成' do
+      background do
+        create(:user, role: 'admin')
+        visit admin_users_path
+      end
+
+      scenario '自分自身を削除できる' do
+        expect do
+          all('.delete-btn')[0].click
+          expect(page).to have_current_path '/sessions/new'
+        end.to change { User.count }.by(-1)
       end
     end
 

--- a/tasclear/spec/features/admin_users_spec.rb
+++ b/tasclear/spec/features/admin_users_spec.rb
@@ -24,17 +24,6 @@ RSpec.feature 'AdminUsers', type: :feature do
       end.to change { User.count }.by(1)
     end
 
-    scenario 'ユーザを編集する' do
-      find('.edit-btn').click
-      fill_in '名前', with: '変更後名前'
-      fill_in 'メールアドレス', with: 'changed@example.com'
-      fill_in 'パスワード', with: 'password2'
-      click_button '更新する'
-      expect(page).to have_content 'ユーザを編集しました'
-      expect(page).to have_selector 'td.name', text: '変更後名前'
-      expect(page).to have_selector 'td.email', text: 'changed@example.com'
-    end
-
     scenario '管理ユーザが1人もいなくなってしまう場合はユーザの削除ができない' do
       expect do
         find('.delete-btn').click
@@ -56,11 +45,15 @@ RSpec.feature 'AdminUsers', type: :feature do
         visit admin_users_path
       end
 
-      scenario '管理ユーザが0人にならない場合はユーザが削除できる' do
-        expect do
-          all('.delete-btn')[1].click
-          expect(page).to have_content 'ユーザを削除しました'
-        end.to change { User.count }.by(-1)
+      scenario 'ユーザを編集する' do
+        all('.edit-btn')[1].click
+        fill_in '名前', with: '変更後名前'
+        fill_in 'メールアドレス', with: 'changed@example.com'
+        fill_in 'パスワード', with: 'password2'
+        click_button '更新する'
+        expect(page).to have_content 'ユーザを編集しました'
+        expect(page).to have_selector 'td.name', text: '変更後名前'
+        expect(page).to have_selector 'td.email', text: 'changed@example.com'
       end
     end
 
@@ -82,6 +75,13 @@ RSpec.feature 'AdminUsers', type: :feature do
       background do
         create(:user, role: 'admin')
         visit admin_users_path
+      end
+
+      scenario '管理ユーザが0人にならない場合はユーザが削除できる' do
+        expect do
+          all('.delete-btn')[1].click
+          expect(page).to have_content 'ユーザを削除しました'
+        end.to change { User.count }.by(-1)
       end
 
       scenario '自分自身を削除できる' do

--- a/tasclear/spec/features/admin_users_spec.rb
+++ b/tasclear/spec/features/admin_users_spec.rb
@@ -66,15 +66,17 @@ RSpec.feature 'AdminUsers', type: :feature do
 
     feature 'ユーザが作成したタスク絡み' do
       background do
-        create(:task)
+        @user1 = create(:user)
+        create(:task, user_id: @user1.id)
         visit admin_users_path
       end
 
       scenario 'ユーザを削除したら、そのユーザの抱えているタスクを削除する' do
         expect do
           all('.delete-btn')[1].click
-        end.to change { Task.count }.by(-1)
+        end.to change { Task.where(user_id: @user1.id).count }.by(-1)
       end
+    end
 
       scenario 'ユーザ一覧画面で、そのユーザが抱えているタスクの数を表示する' do
         amounts = page.all('td.amount')

--- a/tasclear/spec/features/admin_users_spec.rb
+++ b/tasclear/spec/features/admin_users_spec.rb
@@ -78,15 +78,32 @@ RSpec.feature 'AdminUsers', type: :feature do
       end
     end
 
+    feature '2名以上のユーザ作成' do
+      background do
+        @user1 = create(:user)
+        create(:task, name: 'ユーザ1のタスク', user_id: @user1.id)
+        @user2 = create(:user)
+        create(:task, name: 'ユーザ2のタスク1', user_id: @user2.id)
+        create(:task, name: 'ユーザ2のタスク2', user_id: @user2.id)
+        visit admin_users_path
+      end
+
       scenario 'ユーザ一覧画面で、そのユーザが抱えているタスクの数を表示する' do
         amounts = page.all('td.amount')
         expect(amounts[1]).to have_content '1'
+        expect(amounts[2]).to have_content '2'
       end
 
       scenario 'ユーザが作成したタスクの一覧が見れる' do
         all('.amount-btn')[1].click
-        names = page.all('td.name')
-        expect(names.count).to eq 1
+        expect(page).to have_content 'ユーザ1のタスク'
+        expect(page).not_to have_content 'ユーザ2のタスク1'
+        expect(page).not_to have_content 'ユーザ2のタスク2'
+        visit admin_users_path
+        all('.amount-btn')[2].click
+        expect(page).not_to have_content 'ユーザ1のタスク'
+        expect(page).to have_content 'ユーザ2のタスク1'
+        expect(page).to have_content 'ユーザ2のタスク2'
       end
     end
   end


### PR DESCRIPTION
# ステップ19: ユーザにロールを追加しよう
- ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
- 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
- ユーザ管理画面でロールを選択できるようにしましょう
- 管理ユーザが1人もいなくならないように削除の制御をしましょう
- ※ Gemの使用・不使用は自由です
# 行ったこと
- ユーザ種別のカラム追加（enum型）
- 管理ユーザだけがユーザ管理画面にアクセスできるように制御
- ユーザ管理画面でユーザ種別を選択・一覧表示できる機能追加
- 管理ユーザが0人にならないように削除・更新の制御
- 実装した機能に関するフィーチャスペックの追加