### PR TITLE
「ギュ」ステップ12: 終了期限を追加整列する

### DIFF
--- a/KTask/app/controllers/tasks_controller.rb
+++ b/KTask/app/controllers/tasks_controller.rb
@@ -6,10 +6,10 @@ class TasksController < ApplicationController
   # GET /tasks
   # GET /tasks.json
   def index
-    @sort_column = params[:sort]
-    @sort_direction = params[:direction].to_s
-    @tasks = if !@sort_column.nil?
-               Task.order(@sort_column + ' ' + @sort_direction, created_at: :desc)
+    @sort = params[:sort]
+    @direction = params[:direction]
+    @tasks = if @sort.present?
+               Task.order(@sort + ' ' + @direction)
              else
                Task.order(created_at: :desc)
              end

--- a/KTask/app/controllers/tasks_controller.rb
+++ b/KTask/app/controllers/tasks_controller.rb
@@ -5,8 +5,18 @@ class TasksController < ApplicationController
 
   # GET /tasks
   # GET /tasks.json
+  helper_method :sort_column, :sort_direction
   def index
-    @tasks = Task.order(created_at: :desc)
+    @tasks = Task.order(sort_column + ' ' + sort_direction)
+  end
+
+  private
+  def sort_column
+    params[:sort] || 'created_at'
+  end
+
+  def sort_direction
+    params[:direction] || 'desc'
   end
 
   # GET /tasks/1

--- a/KTask/app/controllers/tasks_controller.rb
+++ b/KTask/app/controllers/tasks_controller.rb
@@ -7,7 +7,7 @@ class TasksController < ApplicationController
   # GET /tasks.json
   helper_method :sort_column, :sort_direction
   def index
-    @tasks = Task.order(sort_column + ' ' + sort_direction)
+    @tasks = Task.order("#{sort_column} #{sort_direction}")
   end
 
   # GET /tasks/1

--- a/KTask/app/controllers/tasks_controller.rb
+++ b/KTask/app/controllers/tasks_controller.rb
@@ -8,11 +8,9 @@ class TasksController < ApplicationController
   def index
     @sort = params[:sort]
     @direction = params[:direction]
-    @tasks = if @sort.present?
-               Task.order(@sort + ' ' + @direction)
-             else
-               Task.order(created_at: :desc)
-             end
+    @sort = 'created_at' if @sort.nil?
+    @direction = 'desc' if @direction.nil?
+    @tasks = Task.order("#{@sort} #{@direction}")
   end
 
   # GET /tasks/1

--- a/KTask/app/controllers/tasks_controller.rb
+++ b/KTask/app/controllers/tasks_controller.rb
@@ -10,15 +10,6 @@ class TasksController < ApplicationController
     @tasks = Task.order(sort_column + ' ' + sort_direction)
   end
 
-  private
-  def sort_column
-    params[:sort] || 'created_at'
-  end
-
-  def sort_direction
-    params[:direction] || 'desc'
-  end
-
   # GET /tasks/1
   # GET /tasks/1.json
   def show
@@ -83,5 +74,13 @@ class TasksController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def task_params
     params.require(:task).permit(:user_id, :title, :content, :status, :end_time)
+  end
+  
+  def sort_column
+    params[:sort] || 'created_at'
+  end
+
+  def sort_direction
+    params[:direction] || 'desc'
   end
 end

--- a/KTask/app/controllers/tasks_controller.rb
+++ b/KTask/app/controllers/tasks_controller.rb
@@ -5,9 +5,14 @@ class TasksController < ApplicationController
 
   # GET /tasks
   # GET /tasks.json
-  helper_method :sort_column, :sort_direction
   def index
-    @tasks = Task.order("#{sort_column} #{sort_direction}")
+    @sort_column = params[:sort]
+    @sort_direction = params[:direction].to_s
+    @tasks = if !@sort_column.nil?
+               Task.order(@sort_column + ' ' + @sort_direction, created_at: :desc)
+             else
+               Task.order(created_at: :desc)
+             end
   end
 
   # GET /tasks/1
@@ -74,13 +79,5 @@ class TasksController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def task_params
     params.require(:task).permit(:user_id, :title, :content, :status, :end_time)
-  end
-  
-  def sort_column
-    params[:sort] || 'created_at'
-  end
-
-  def sort_direction
-    params[:direction] || 'desc'
   end
 end

--- a/KTask/app/helpers/application_helper.rb
+++ b/KTask/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def sort(column, title = nil)
+  def toggle_sort(column, title = nil)
     title ||= t('.' + column)
     # ソートの状態を比較する
     direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'

--- a/KTask/app/helpers/application_helper.rb
+++ b/KTask/app/helpers/application_helper.rb
@@ -1,10 +1,4 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def toggle_sort(column, title = nil)
-    title ||= t('.' + column)
-    # ソートの状態を比較する
-    direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
-    link_to title, sort: column, direction: direction
-  end
 end

--- a/KTask/app/helpers/application_helper.rb
+++ b/KTask/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def sort(column, title = nil)
+    title ||= t('.' + column)
+    # ソートの状態を比較する
+    direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
+    link_to title, sort: column, direction: direction
+  end
 end

--- a/KTask/app/helpers/tasks_helper.rb
+++ b/KTask/app/helpers/tasks_helper.rb
@@ -4,11 +4,7 @@ module TasksHelper
   def toggled_sort_link(column, title = nil)
     title ||= t('.' + column)
     # ソートの状態を比較する
-    direction = if params[:direction] == 'asc'
-                  'desc'
-                else
-                  'asc'
-                end
+    direction = (params[:sort] == column && params[:direction] == 'asc') ? 'desc' : 'asc'
     link_to title, sort: column, direction: direction
   end
 end

--- a/KTask/app/helpers/tasks_helper.rb
+++ b/KTask/app/helpers/tasks_helper.rb
@@ -4,10 +4,11 @@ module TasksHelper
   def toggled_sort_link(column, title = nil)
     title ||= t('.' + column)
     # ソートの状態を比較する
-    if params[:direction] == 'asc'
-      link_to title, sort: column, direction: 'desc'
-    else
-      link_to title, sort: column, direction: 'asc'
-    end
+    direction = if params[:direction] == 'asc'
+                  'desc'
+                else
+                  'asc'
+                end
+    link_to title, sort: column, direction: direction
   end
 end

--- a/KTask/app/helpers/tasks_helper.rb
+++ b/KTask/app/helpers/tasks_helper.rb
@@ -1,4 +1,13 @@
 # frozen_string_literal: true
 
 module TasksHelper
+  def toggled_sort_link(column, title = nil)
+    title ||= t('.' + column)
+    # ソートの状態を比較する
+    if params[:direction] == 'asc'
+      link_to title, sort: column, direction: 'desc'
+    else
+      link_to title, sort: column, direction: 'asc'
+    end
+  end
 end

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -8,7 +8,7 @@
       <th><%= t('.title') %></th>
       <th><%= t('.content') %></th>
       <th><%= t('.status') %></th>
-      <th><%= t('.end_time') %></th>
+      <th><%= sort ('end_time') %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -8,7 +8,7 @@
       <th><%= t('.title') %></th>
       <th><%= t('.content') %></th>
       <th><%= t('.status') %></th>
-      <th><%= sort ('end_time') %></th>
+      <th><%= toggle_sort ('end_time') %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -8,7 +8,7 @@
       <th><%= t('.title') %></th>
       <th><%= t('.content') %></th>
       <th><%= t('.status') %></th>
-      <th><%= toggle_sort ('end_time') %></th>
+      <th><%= toggled_sort_link('end_time') %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/KTask/spec/features/tasks_spec.rb
+++ b/KTask/spec/features/tasks_spec.rb
@@ -63,4 +63,14 @@ RSpec.feature 'Tasks', type: :feature do
     expect(titles[0]).to have_content('task2')
     expect(titles[1]).to have_content('task1')
   end
+
+  scenario '一覧画面で終了期限で整列されていること' do
+    FactoryBot.create(:task, id: 0, title: 'task1', end_time: '2018-9-29 12:10:10')
+    FactoryBot.create(:task, id: 1, title: 'task2', end_time: '2018-9-30 12:10:10')
+    visit root_path
+    titles = page.all('td.title')
+    click_link '終了時間'
+    expect(titles[0]).to have_content 'task1'
+    expect(titles[1]).to have_content 'task2'
+  end
 end

--- a/KTask/spec/features/tasks_spec.rb
+++ b/KTask/spec/features/tasks_spec.rb
@@ -68,9 +68,13 @@ RSpec.feature 'Tasks', type: :feature do
     FactoryBot.create(:task, id: 0, title: 'task1', end_time: '2018-9-29 12:10:10')
     FactoryBot.create(:task, id: 1, title: 'task2', end_time: '2018-9-30 12:10:10')
     visit root_path
-    titles = page.all('td.title')
+    asc_titles = page.all('td.title')
     click_link '終了時間'
-    expect(titles[0]).to have_content 'task1'
-    expect(titles[1]).to have_content 'task2'
+    expect(asc_titles[0]).to have_content 'task1'
+    expect(asc_titles[1]).to have_content 'task2'
+    click_link '終了時間'
+    desc_titles = page.all('td.title')
+    expect(desc_titles[0]).to have_content 'task2'
+    expect(desc_titles[1]).to have_content 'task1'
   end
 end


### PR DESCRIPTION
# ステップ12: 終了期限を追加しよう
- タスクに対して、終了期限を登録できるようにしてみましょう
- 一覧画面で、終了期限でソートできるようにしましょう
- specを拡充しましょう
- PRしてレビューをしてもらったら、リリースしてみましょう
(終了期限カラムの追加は、最初の作成時にスカフォールドを使用してカラムの追加は無いです)
# 行ったこと
- 一覧画面で終了期限の整列機能を追加
- 整列ためのヘルパー追加
  - ヘルパーの `sort` メソッドで整列具現
- 終了期限整列のFeature spec作成