### PR TITLE
「ギュ」ステップ13: ステータスを追加して、検索機能の追加

### DIFF
--- a/KTask/app/controllers/tasks_controller.rb
+++ b/KTask/app/controllers/tasks_controller.rb
@@ -6,11 +6,7 @@ class TasksController < ApplicationController
   # GET /tasks
   # GET /tasks.json
   def index
-    @sort = params[:sort]
-    @direction = params[:direction]
-    @sort = 'created_at' if @sort.nil?
-    @direction = 'desc' if @direction.nil?
-    @tasks = Task.order("#{@sort} #{@direction}")
+    @tasks = Task.search_and_order(params)
   end
 
   # GET /tasks/1

--- a/KTask/app/models/task.rb
+++ b/KTask/app/models/task.rb
@@ -5,4 +5,17 @@ class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 20 }
   validates :content, presence: true, length: { maximum: 255 }
   validates :status, presence: true
+
+  def self.search_and_order(params)
+    sort = params[:sort]
+    sort = 'created_at' if sort.nil?
+    direction = params[:direction]
+    direction = 'desc' if direction.nil?
+    search_title = params[:search_title]
+    search_status = params[:search_status]
+    tasks = Task.all
+    tasks = tasks.where('title LIKE ?', "%#{search_title}%") if search_title.present?
+    tasks = tasks.where(status: search_status) if search_status.present?
+    tasks.order("#{sort} #{direction}")
+  end
 end

--- a/KTask/app/models/task.rb
+++ b/KTask/app/models/task.rb
@@ -7,13 +7,11 @@ class Task < ApplicationRecord
   validates :status, presence: true
 
   def self.search_and_order(params)
-    sort = params[:sort]
-    sort = 'created_at' if sort.nil?
-    direction = params[:direction]
-    direction = 'desc' if direction.nil?
+    sort = params[:sort] || 'created_at'
+    direction = params[:direction] || 'desc'
     search_title = params[:search_title]
     search_status = params[:search_status]
-    tasks = Task.all
+    tasks = self
     tasks = tasks.where('title LIKE ?', "%#{search_title}%") if search_title.present?
     tasks = tasks.where(status: search_status) if search_status.present?
     tasks.order("#{sort} #{direction}")

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -2,6 +2,14 @@
 
 <h1><%= t('.page_title') %></h1>
 
+<div>
+<%= form_tag(root_path, method: 'get') do %>
+  <%= label_tag :search_title, t('.search_title') %><%= text_field_tag :search_title, params[:search_title] %>
+  <%= label_tag :search_status, t('.search_status') %><%= select_tag :search_status, options_for_select(Task.statuses.map { |k, v| [t("tasks.status.#{k}"), k] }), :prompt => '状態' %>
+  <%= submit_tag t('.search_submit') %>
+<% end %>
+</div>
+
 <table>
   <thead>
     <tr>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -5,7 +5,7 @@
 <div>
 <%= form_tag(root_path, method: 'get') do %>
   <%= label_tag :search_title, t('.search_title') %><%= text_field_tag :search_title, params[:search_title] %>
-  <%= label_tag :search_status, t('.search_status') %><%= select_tag :search_status, options_for_select(Task.statuses.map { |k, v| [t("tasks.status.#{k}"), k] }), :prompt => '状態' %>
+  <%= label_tag :search_status, t('.search_status') %><%= select_tag :search_status, options_for_select(Task.statuses.map { |k, v| [t("tasks.status.#{k}"), k] }, :selected => params[:search_status]), include_blank: true %>
   <%= submit_tag t('.search_submit') %>
 <% end %>
 </div>

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -43,6 +43,9 @@ ja:
       back: '戻る'
       new_task: '新規タスク登録'
       delete_message: '削除しますか？'
+      search_title: 'スケジュール名'
+      search_status: '状態'
+      search_submit: '検索'
     show:
       page_title: 'タスク詳細'
       title: 'スケジュール名'

--- a/KTask/db/migrate/20181003025720_add_index_status_to_task.rb
+++ b/KTask/db/migrate/20181003025720_add_index_status_to_task.rb
@@ -1,0 +1,5 @@
+class AddIndexStatusToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/KTask/db/schema.rb
+++ b/KTask/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_26_055133) do
+ActiveRecord::Schema.define(version: 2018_10_03_025720) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2018_09_26_055133) do
     t.datetime "end_time", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/KTask/spec/factories/tasks.rb
+++ b/KTask/spec/factories/tasks.rb
@@ -2,10 +2,9 @@
 
 FactoryBot.define do
   factory :task do
-    id {0}
-    title {'This is a Robot'}
-    content {'Test Object'}
-    status {0}
-    end_time {'2018-09-27 00:16:35'}
+    title { 'This is a Robot' }
+    content { 'Test Object' }
+    status { 'do' }
+    end_time { '2018-09-27' }
   end
 end

--- a/KTask/spec/features/tasks_spec.rb
+++ b/KTask/spec/features/tasks_spec.rb
@@ -77,4 +77,14 @@ RSpec.feature 'Tasks', type: :feature do
     expect(desc_titles[0]).to have_content 'task2'
     expect(desc_titles[1]).to have_content 'task1'
   end
+  scenario '一覧画面でタイトル名と状態で検索' do
+    create(:task, title: 'task1', status: 'do')
+    create(:task, title: 'task2', status: 'done')
+    visit root_path
+    fill_in I18n.t('tasks.index.search_title'), with: 'task1'
+    select I18n.t('tasks.status.do'), from: I18n.t('tasks.index.search_status')
+    click_button I18n.t('tasks.index.search_submit')
+    expect(page).to have_content('task1')
+    expect(page).not_to have_content('task2')
+  end
 end

--- a/KTask/spec/features/tasks_spec.rb
+++ b/KTask/spec/features/tasks_spec.rb
@@ -48,25 +48,17 @@ RSpec.feature 'Tasks', type: :feature do
   end
 
   scenario 'タスクの作成日順並べ替えテスト' do
+    create(:task, id: 0, title: 'task1', created_at: '2018-9-29')
+    create(:task, id: 1, title: 'task2', created_at: '2018-9-30')
     visit root_path
-    click_link '新規タスク登録'
-    fill_in 'スケジュール', with: 'task1'
-    fill_in '内容', with: 'task1'
-    click_button '登録する'
-    click_link '戻る'
-    click_link '新規タスク登録'
-    fill_in 'スケジュール', with: 'task2'
-    fill_in '内容', with: 'task2'
-    click_button '登録する'
-    click_link '戻る'
     titles = page.all('td.title')
-    expect(titles[0]).to have_content('task2')
-    expect(titles[1]).to have_content('task1')
+    expect(titles[0]).to have_content 'task2'
+    expect(titles[1]).to have_content 'task1'
   end
 
   scenario '一覧画面で終了期限で整列されていること' do
-    FactoryBot.create(:task, id: 0, title: 'task1', end_time: '2018-9-29 12:10:10')
-    FactoryBot.create(:task, id: 1, title: 'task2', end_time: '2018-9-30 12:10:10')
+    create(:task, id: 0, title: 'task1', end_time: '2018-9-29 12:10:10')
+    create(:task, id: 1, title: 'task2', end_time: '2018-9-30 12:10:10')
     visit root_path
     asc_titles = page.all('td.title')
     click_link '終了時間'

--- a/KTask/spec/features/tasks_spec.rb
+++ b/KTask/spec/features/tasks_spec.rb
@@ -48,8 +48,8 @@ RSpec.feature 'Tasks', type: :feature do
   end
 
   scenario 'タスクの作成日順並べ替えテスト' do
-    create(:task, id: 0, title: 'task1', created_at: '2018-9-29')
-    create(:task, id: 1, title: 'task2', created_at: '2018-9-30')
+    create(:task, title: 'task1', created_at: '2018-9-29')
+    create(:task, title: 'task2', created_at: '2018-9-30')
     visit root_path
     titles = page.all('td.title')
     expect(titles[0]).to have_content 'task2'
@@ -57,8 +57,8 @@ RSpec.feature 'Tasks', type: :feature do
   end
 
   scenario '一覧画面で終了期限で整列されていること' do
-    create(:task, id: 0, title: 'task1', end_time: '2018-9-29 12:10:10')
-    create(:task, id: 1, title: 'task2', end_time: '2018-9-30 12:10:10')
+    create(:task, title: 'task1', end_time: '2018-9-29 12:10:10')
+    create(:task, title: 'task2', end_time: '2018-9-30 12:10:10')
     visit root_path
     asc_titles = page.all('td.title')
     click_link '終了時間'

--- a/KTask/spec/models/task_spec.rb
+++ b/KTask/spec/models/task_spec.rb
@@ -5,37 +5,44 @@ require 'rails_helper'
 RSpec.describe Task, type: :model do
   context 'パラメータが正しい場合' do
     it 'タスクの有効' do
-      task = create(:task)
+      task = build(:task)
       expect(task).to be_valid
     end
   end
+
   context 'パラメータが正しくない場合' do
     it 'タスクのタイトルが入れていない' do
-      task = create(:task, title: nil)
+      task = build(:task, title: nil)
       expect(task).not_to be_valid
     end
+
     it 'タイトル文字の制限を超える' do
-      task = create(:task, title: 'あ' * 21)
+      task = build(:task, title: 'あ' * 21)
       expect(task).not_to be_valid
     end
+
     it 'タスクの内容が入れていない' do
-      task = create(:task, content: nil)
+      task = build(:task, content: nil)
       expect(task).not_to be_valid
     end
   end
+
   context '検索機能テスト' do
     before do
       @task1 = create(:task, id: 1, title: 'task1', status: 'yet')
       @task2 = create(:task, id: 2, title: 'task2', status: 'do')
     end
+
     it 'タスクの名で検索' do
       expect(Task.search_and_order({ search_title: 'task1' })).to include(@task1)
       expect(Task.search_and_order({ search_title: 'task1' })).not_to include(@task2)
     end
+
     it 'タスクの状態で検索' do
       expect(Task.search_and_order({ search_status: 'yet' })).to include(@task1)
       expect(Task.search_and_order({ search_status: 'yet' })).not_to include(@task2)
     end
+
     it 'タスク名と状態で検索' do
       expect(Task.search_and_order({ search_title: 'task1', search_status: 'yet' })).to include(@task1)
       expect(Task.search_and_order({ search_title: 'task1', search_status: 'yet' })).not_to include(@task2)

--- a/KTask/spec/models/task_spec.rb
+++ b/KTask/spec/models/task_spec.rb
@@ -5,22 +5,40 @@ require 'rails_helper'
 RSpec.describe Task, type: :model do
   context 'パラメータが正しい場合' do
     it 'タスクの有効' do
-      task = FactoryBot.create(:task)
+      task = create(:task)
       expect(task).to be_valid
     end
   end
   context 'パラメータが正しくない場合' do
     it 'タスクのタイトルが入れていない' do
-      task = FactoryBot.create(:task, title: nil)
+      task = create(:task, title: nil)
       expect(task).not_to be_valid
     end
     it 'タイトル文字の制限を超える' do
-      task = FactoryBot.create(:task, title: 'あ' * 21)
+      task = create(:task, title: 'あ' * 21)
       expect(task).not_to be_valid
     end
     it 'タスクの内容が入れていない' do
-      task = FactoryBot.create(:task, content: nil)
+      task = create(:task, content: nil)
       expect(task).not_to be_valid
+    end
+  end
+  context '検索機能テスト' do
+    before do
+      @task1 = create(:task, id: 1, title: 'task1', status: 'yet')
+      @task2 = create(:task, id: 2, title: 'task2', status: 'do')
+    end
+    it 'タスクの名で検索' do
+      expect(Task.search_and_order({ search_title: 'task1' })).to include(@task1)
+      expect(Task.search_and_order({ search_title: 'task1' })).not_to include(@task2)
+    end
+    it 'タスクの状態で検索' do
+      expect(Task.search_and_order({ search_status: 'yet' })).to include(@task1)
+      expect(Task.search_and_order({ search_status: 'yet' })).not_to include(@task2)
+    end
+    it 'タスク名と状態で検索' do
+      expect(Task.search_and_order({ search_title: 'task1', search_status: 'yet' })).to include(@task1)
+      expect(Task.search_and_order({ search_title: 'task1', search_status: 'yet' })).not_to include(@task2)
     end
   end
 end

--- a/KTask/spec/rails_helper.rb
+++ b/KTask/spec/rails_helper.rb
@@ -37,10 +37,9 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
+  
+  config.include FactoryBot::Syntax::Methods
+  
   config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours to your tests
@@ -62,4 +61,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  
 end


### PR DESCRIPTION
# ステップ13: ステータスを追加して、検索できるようにしよう
- ステータス（未着手・着手中・完了）を追加してみよう
  - 【オプション要件】初学者ではない場合はstateを管理するGemを導入しても構いません
- 一覧画面でタイトルとステータスで検索ができるようにしよう
  - 【オプション要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構いません
- 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
  - 以降のステップでも必要に応じて確認する癖をつけましょう
- 検索インデックスを貼りましょう
- 検索に対してmodel specを追加してみよう（feature specも拡充しておきましょう）
# 行ったこと
- タスクに状態（未着手・着手中・完了）を導入
  - (ステップ９で作成しました)👌
- 一覧画面で、タスクの名と状態で検索フォームを生成
- タスクモデルにインデックス追加
- 検索機能のモデル＆フィーチャスペック作成
- FactoryBotの修正