### PR TITLE
ステップ18: ユーザの管理画面を実装しよう

### DIFF
--- a/KTask/app/assets/stylesheets/users.scss
+++ b/KTask/app/assets/stylesheets/users.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Users controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/KTask/app/assets/stylesheets/users.scss
+++ b/KTask/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/KTask/app/controllers/admin/users_controller.rb
+++ b/KTask/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ module Admin
 
     def update
       @user.update!(user_params)
-      redirect_to admin_users_path, flash: {success: t('flash.user.update_success')}
+      redirect_to admin_users_path, flash: { success: t('flash.user.update_success') }
     rescue StandardError
       flash.now[:danger] = t('flash.user.update_failure')
       render :edit
@@ -47,10 +47,10 @@ module Admin
 
     def user_params
       params.require(:user).permit(:name, :email, :password)
-   end
+    end
 
     def set_user
       @user = User.find(params[:id])
-   end
+    end
   end
 end

--- a/KTask/app/controllers/admin/users_controller.rb
+++ b/KTask/app/controllers/admin/users_controller.rb
@@ -24,12 +24,21 @@ module Admin
     end
 
     def show
+      @tasks = @user.tasks
     end
 
     def update
+      @user.update!(user_params)
+      redirect_to admin_users_path, notice: t('flash.user.update_success')
+    rescue StandardError
+      render :edit
     end
 
     def destroy
+      @user.destroy!
+      redirect_to admin_users_path, notice: t('flash.user.delete_success')
+    rescue StandardError
+      redirect_to admin_users_path, alert: t('flash.user.delete_failure')
     end
 
     private

--- a/KTask/app/controllers/admin/users_controller.rb
+++ b/KTask/app/controllers/admin/users_controller.rb
@@ -50,7 +50,7 @@ module Admin
     end
 
     def set_user
-      @user = User.find(params[:id])
+      @user = User.find_by(params[:id])
     end
   end
 end

--- a/KTask/app/controllers/admin/users_controller.rb
+++ b/KTask/app/controllers/admin/users_controller.rb
@@ -16,8 +16,9 @@ module Admin
       @user = User.new(user_params)
       @user.save!
       redirect_to admin_users_path, flash: { success: t('flash.user.create_success') }
-    rescue StandardError
+    rescue StandardError => e
       flash.now[:danger] = t('flash.user.create_failure')
+      Rails.logger.error(e.message)
       render :new
     end
 
@@ -31,15 +32,17 @@ module Admin
     def update
       @user.update!(user_params)
       redirect_to admin_users_path, flash: { success: t('flash.user.update_success') }
-    rescue StandardError
+    rescue StandardError => e
       flash.now[:danger] = t('flash.user.update_failure')
+      Rails.logger.error(e.message)
       render :edit
     end
 
     def destroy
       @user.destroy!
       redirect_to admin_users_path, flash: { success: t('flash.user.delete_success') }
-    rescue StandardError
+    rescue StandardError => e
+      Rails.logger.error(e.message)
       redirect_to admin_users_path, flash: { danger: t('flash.user.delete_failure') }
     end
 

--- a/KTask/app/controllers/admin/users_controller.rb
+++ b/KTask/app/controllers/admin/users_controller.rb
@@ -50,7 +50,7 @@ module Admin
     end
 
     def set_user
-      @user = User.find_by(params[:id])
+      @user = User.find_by(id: params[:id])
     end
   end
 end

--- a/KTask/app/controllers/admin/users_controller.rb
+++ b/KTask/app/controllers/admin/users_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Admin
+  class UsersController < ApplicationController
+    before_action :set_user, only: %i[show edit update destroy]
+
+    def index
+      @users = User.all
+    end
+
+    def new
+      @user = User.new
+    end
+
+    def create
+      @user = User.new(user_params)
+      @user.save!
+      redirect_to admin_users_path, notice: t('flash.user.create_success')
+    rescue StandardError
+      render :new
+    end
+
+    def edit
+    end
+
+    def show
+    end
+
+    def update
+    end
+
+    def destroy
+    end
+
+    private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :password)
+   end
+
+    def set_user
+      @user = User.find(params[:id])
+   end
+  end
+end

--- a/KTask/app/controllers/admin/users_controller.rb
+++ b/KTask/app/controllers/admin/users_controller.rb
@@ -15,8 +15,9 @@ module Admin
     def create
       @user = User.new(user_params)
       @user.save!
-      redirect_to admin_users_path, notice: t('flash.user.create_success')
+      redirect_to admin_users_path, flash: { success: t('flash.user.create_success') }
     rescue StandardError
+      flash.now[:danger] = t('flash.user.create_failure')
       render :new
     end
 
@@ -29,16 +30,17 @@ module Admin
 
     def update
       @user.update!(user_params)
-      redirect_to admin_users_path, notice: t('flash.user.update_success')
+      redirect_to admin_users_path, flash: {success: t('flash.user.update_success')}
     rescue StandardError
+      flash.now[:danger] = t('flash.user.update_failure')
       render :edit
     end
 
     def destroy
       @user.destroy!
-      redirect_to admin_users_path, notice: t('flash.user.delete_success')
+      redirect_to admin_users_path, flash: { success: t('flash.user.delete_success') }
     rescue StandardError
-      redirect_to admin_users_path, alert: t('flash.user.delete_failure')
+      redirect_to admin_users_path, flash: { danger: t('flash.user.delete_failure') }
     end
 
     private

--- a/KTask/app/controllers/sessions_controller.rb
+++ b/KTask/app/controllers/sessions_controller.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class SessionsController < ApplicationController
   def new
   end
 
   def create
     user = User.find_by(email: params[:session][:email].downcase)
-    if user && user.authenticate(params[:session][:password])
+    if user&.authenticate(params[:session][:password])
       session[:user_id] = user.id
       redirect_to index_url, notice: t('flash.session.login_success')
     else
@@ -17,5 +19,4 @@ class SessionsController < ApplicationController
     session.delete(:user_id)
     render 'new'
   end
-
 end

--- a/KTask/app/controllers/sessions_controller.rb
+++ b/KTask/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user&.authenticate(params[:session][:password])
       session[:user_id] = user.id
-      redirect_to index_url, notice: t('flash.session.login_success')
+      redirect_to index_url, flash: { success: t('flash.session.login_success') }
     else
       flash.now[:danger] = t('flash.session.login_failed')
       render 'new'

--- a/KTask/app/controllers/tasks_controller.rb
+++ b/KTask/app/controllers/tasks_controller.rb
@@ -79,6 +79,6 @@ class TasksController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def task_params
-    params.require(:task).permit(:user_id, :title, :content, :status, :end_time)
+    params.require(:task).permit(:user_id, :title, :content, :status, :end_time, :priority)
   end
 end

--- a/KTask/app/controllers/users_controller.rb
+++ b/KTask/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def new
+  end
+end

--- a/KTask/app/controllers/users_controller.rb
+++ b/KTask/app/controllers/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UsersController < ApplicationController
   def index
     @users = User.all

--- a/KTask/app/controllers/users_controller.rb
+++ b/KTask/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
-  def new
+  def index
+    @users = User.all
   end
 end

--- a/KTask/app/controllers/users_controller.rb
+++ b/KTask/app/controllers/users_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+module Admin
 class UsersController < ApplicationController
   def index
     @users = User.all
   end
+end
 end

--- a/KTask/app/controllers/users_controller.rb
+++ b/KTask/app/controllers/users_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-module Admin
 class UsersController < ApplicationController
   def index
     @users = User.all
   end
-end
 end

--- a/KTask/app/helpers/admin/users_helper.rb
+++ b/KTask/app/helpers/admin/users_helper.rb
@@ -1,5 +1,5 @@
 module Admin::UsersHelper
-  def users_taskamount(user)
+  def users_tasks_amount(user)
     user.tasks.count
   end
 end

--- a/KTask/app/helpers/admin/users_helper.rb
+++ b/KTask/app/helpers/admin/users_helper.rb
@@ -1,0 +1,5 @@
+module Admin::UsersHelper
+  def users_taskamount(user)
+    user.tasks.count
+  end
+end

--- a/KTask/app/helpers/tasks_helper.rb
+++ b/KTask/app/helpers/tasks_helper.rb
@@ -7,4 +7,14 @@ module TasksHelper
     direction = (params[:sort] == column && params[:direction] == 'asc') ? 'desc' : 'asc'
     link_to title, sort: column, direction: direction
   end
+
+  def priority_color(priority)
+    if priority == 'high'
+      'danger'
+    elsif priority == 'middle'
+      'warning'
+    else
+      'success'
+    end
+  end
 end

--- a/KTask/app/helpers/tasks_helper.rb
+++ b/KTask/app/helpers/tasks_helper.rb
@@ -17,4 +17,14 @@ module TasksHelper
       'success'
     end
   end
+
+  def status_color(status)
+    if status == 'yet'
+      'primary'
+    elsif status == 'do'
+      'success'
+    else
+      'secondary'
+    end
+  end
 end

--- a/KTask/app/helpers/tasks_helper.rb
+++ b/KTask/app/helpers/tasks_helper.rb
@@ -9,22 +9,24 @@ module TasksHelper
   end
 
   def priority_color(priority)
-    if priority == 'high'
+    case priority
+    when 2 then
       'danger'
-    elsif priority == 'mid'
+    when 1 then
       'warning'
-    else
+    when 0 then
       'success'
     end
   end
 
   def status_color(status)
-    if status == 'yet'
-      'primary'
-    elsif status == 'do'
-      'success'
-    else
+    case status
+    when 2 then
       'secondary'
+    when 1 then
+      'success'
+    when 0 then
+      'primary'
     end
   end
 end

--- a/KTask/app/helpers/tasks_helper.rb
+++ b/KTask/app/helpers/tasks_helper.rb
@@ -11,7 +11,7 @@ module TasksHelper
   def priority_color(priority)
     if priority == 'high'
       'danger'
-    elsif priority == 'middle'
+    elsif priority == 'mid'
       'warning'
     else
       'success'

--- a/KTask/app/helpers/users_helper.rb
+++ b/KTask/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/KTask/app/helpers/users_helper.rb
+++ b/KTask/app/helpers/users_helper.rb
@@ -1,5 +1,2 @@
 module UsersHelper
-  def users_taskamount(user)
-    user.tasks.count
-  end
 end

--- a/KTask/app/helpers/users_helper.rb
+++ b/KTask/app/helpers/users_helper.rb
@@ -1,2 +1,5 @@
 module UsersHelper
+  def users_taskamount(user)
+    user.tasks.count
+  end
 end

--- a/KTask/app/models/task.rb
+++ b/KTask/app/models/task.rb
@@ -2,9 +2,11 @@
 
 class Task < ApplicationRecord
   enum status: %i[yet do done]
+  enum priority: %i[low mid high]
   validates :title, presence: true, length: { maximum: 20 }
   validates :content, presence: true, length: { maximum: 255 }
   validates :status, presence: true
+  validates :priority, presence: true
 
   belongs_to :user
 

--- a/KTask/app/models/user.rb
+++ b/KTask/app/models/user.rb
@@ -5,6 +5,6 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }, length: { maximum: 50 }
   validates :password, presence: true, length: { maximum: 12 }
 
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
   has_secure_password
 end

--- a/KTask/app/views/admin/users/_form.html.erb
+++ b/KTask/app/views/admin/users/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with(model: [:admin, @user], local: true) do |form| %>
+
+  <% if @user.errors.any? %>
+    <div id="error_explanation">
+      <h2>次を確認してください</h2>
+      <ul>
+      <% @user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+
+  <div class="form-group">
+    <%= form.label :name %>
+    <%= form.text_field :name, class:'form-control', style:'width:30%;' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :email %>
+    <%= form.text_field :email, class:'form-control', style:'width:40%;' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :password %>
+    <%= form.password_field :password, class:'form-control', style:'width:40%;' %>
+  </div>
+
+  <div class="form-group">
+    <%= form.submit :class => 'btn btn-primary' %>
+  </div>
+<% end %>
+

--- a/KTask/app/views/admin/users/edit.html.erb
+++ b/KTask/app/views/admin/users/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t('.title') %><h1>
+<%= render 'form' %>
+<%= link_to t('.back'), :back, class: 'btn btn-secondary' %>

--- a/KTask/app/views/admin/users/index.html.erb
+++ b/KTask/app/views/admin/users/index.html.erb
@@ -16,7 +16,7 @@
       <tr>
         <td class='table-active title'><%= user.name %></td>
         <td class='table-active'><%= user.email %></td>
-        <td class='table-active'><%= users_taskamount(user) %></td>
+        <td class='table-active'><%= link_to users_taskamount(user), admin_user_path(user.id) %></td>
         <td><%= link_to t('.edit'), edit_admin_user_path(user.id), class:'btn btn-outline-secondary' %></td>
         <td><%= link_to t('.delete'), admin_user_path(user.id), method: :delete, data: { confirm: t('.delete_message') }, class:'btn btn-outline-danger' %></td>
 

--- a/KTask/app/views/admin/users/index.html.erb
+++ b/KTask/app/views/admin/users/index.html.erb
@@ -1,0 +1,25 @@
+<h1><%= t('.title') %></h1>
+
+<table class='table', style='width: 100%;'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'><%= t('.user_name') %></th>
+      <th scope='col'><%= t('.user_mail') %></th>
+      <th scope='col'><%= t('.total_user_tasks') %></th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td class='table-active title'><%= user.name %></td>
+        <td class='table-active'><%= user.email %></td>
+        <td class='table-active'><%= users_taskamount(user) %></td>
+        <td class='table-active'></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to t('.new_user'), new_admin_user_path, class:'btn btn-success' %>

--- a/KTask/app/views/admin/users/index.html.erb
+++ b/KTask/app/views/admin/users/index.html.erb
@@ -7,6 +7,7 @@
       <th scope='col'><%= t('.user_mail') %></th>
       <th scope='col'><%= t('.total_user_tasks') %></th>
       <th></th>
+      <ht></th>
     </tr>
   </thead>
 
@@ -16,6 +17,9 @@
         <td class='table-active title'><%= user.name %></td>
         <td class='table-active'><%= user.email %></td>
         <td class='table-active'><%= users_taskamount(user) %></td>
+        <td><%= link_to t('.edit'), edit_admin_user_path(user.id), class:'btn btn-outline-secondary' %></td>
+        <td><%= link_to t('.delete'), admin_user_path(user.id), method: :delete, data: { confirm: t('.delete_message') }, class:'btn btn-outline-danger' %></td>
+
         <td class='table-active'></td>
       </tr>
     <% end %>

--- a/KTask/app/views/admin/users/index.html.erb
+++ b/KTask/app/views/admin/users/index.html.erb
@@ -16,7 +16,7 @@
       <tr>
         <td class='table-active name'><%= user.name %></td>
         <td class='table-active email'><%= user.email %></td>
-        <td class='table-active amount'><%= link_to users_taskamount(user), admin_user_path(user.id) %></td>
+        <td class='table-active amount'><%= link_to users_tasks_amount(user), admin_user_path(user.id) %></td>
         <td><%= link_to t('.edit'), edit_admin_user_path(user.id), class:'btn btn-outline-secondary' %></td>
         <td><%= link_to t('.delete'), admin_user_path(user.id), method: :delete, data: { confirm: t('.delete_message') }, class:'btn btn-outline-danger' %></td>
         <td class='table-active'></td>

--- a/KTask/app/views/admin/users/index.html.erb
+++ b/KTask/app/views/admin/users/index.html.erb
@@ -14,12 +14,11 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
-        <td class='table-active title'><%= user.name %></td>
-        <td class='table-active'><%= user.email %></td>
-        <td class='table-active'><%= link_to users_taskamount(user), admin_user_path(user.id) %></td>
+        <td class='table-active name'><%= user.name %></td>
+        <td class='table-active email'><%= user.email %></td>
+        <td class='table-active amount'><%= link_to users_taskamount(user), admin_user_path(user.id) %></td>
         <td><%= link_to t('.edit'), edit_admin_user_path(user.id), class:'btn btn-outline-secondary' %></td>
         <td><%= link_to t('.delete'), admin_user_path(user.id), method: :delete, data: { confirm: t('.delete_message') }, class:'btn btn-outline-danger' %></td>
-
         <td class='table-active'></td>
       </tr>
     <% end %>

--- a/KTask/app/views/admin/users/index.html.erb
+++ b/KTask/app/views/admin/users/index.html.erb
@@ -26,4 +26,7 @@
   </tbody>
 </table>
 
+<p>
 <%= link_to t('.new_user'), new_admin_user_path, class:'btn btn-success' %>
+<%= link_to t('.back'), :back, class: 'btn btn-secondary' %>
+</p>

--- a/KTask/app/views/admin/users/new.html.erb
+++ b/KTask/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('.title') %></h1>
+
+<%= render 'form' %>
+
+<%= link_to t('.back'), :back, class:'btn btn-secondary' %>

--- a/KTask/app/views/admin/users/show.html.erb
+++ b/KTask/app/views/admin/users/show.html.erb
@@ -16,8 +16,8 @@
       <tr>
         <td class='table-active title'><%= task.title %></td>
         <td class='table-active'><%= task.content %></td>
-        <td class='table-active'><span class="badge badge-<%= priority_color task.priority %>"><%= task.human_attribute_enum(:priority) %></span></td>
-        <td class='table-active'><span class="badge badge-pill badge-<%= status_color task.status %>"><%= task.human_attribute_enum(:status) %></span></td>
+        <td class='table-active'><span class="badge badge-<%= priority_color task.class.priorities[task.priority] %>"><%= task.human_attribute_enum(:priority) %></span></td>
+        <td class='table-active'><span class="badge badge-pill badge-<%= status_color task.class.statuses[task.status] %>"><%= task.human_attribute_enum(:status) %></span></td>
         <td class='table-active'><%= task.end_time %></td>
         <td><%= link_to t('.detail'), task, class:'btn btn-outline-info' %></td>
         <td><%= link_to t('.edit'), edit_task_path(task), class:'btn btn-outline-secondary' %></td>

--- a/KTask/app/views/admin/users/show.html.erb
+++ b/KTask/app/views/admin/users/show.html.erb
@@ -1,0 +1,29 @@
+<h1><%= @user.name %><%= t('.title') %></h1>
+<table class='table'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'><%= t('.task_name') %></th>
+      <th scope='col'><%= t('.content') %></th>
+      <th scope='col'><%= t('.priority') %></th>
+      <th scope='col'><%= t('.status') %></th>
+      <th scope='col'><%= toggled_sort_link('end_time') %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td class='table-active title'><%= task.title %></td>
+        <td class='table-active'><%= task.content %></td>
+        <td class='table-active'><span class="badge badge-<%= priority_color task.priority %>"><%= task.human_attribute_enum(:priority) %></span></td>
+        <td class='table-active'><span class="badge badge-pill badge-<%= status_color task.status %>"><%= task.human_attribute_enum(:status) %></span></td>
+        <td class='table-active'><%= task.end_time %></td>
+        <td><%= link_to t('.detail'), task, class:'btn btn-outline-info' %></td>
+        <td><%= link_to t('.edit'), edit_task_path(task), class:'btn btn-outline-secondary' %></td>
+        <td><%= link_to t('.delete'), task, method: :delete, data: { confirm: t('.delete_message') }, class:'btn btn-outline-danger' %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+

--- a/KTask/app/views/layouts/application.html.erb
+++ b/KTask/app/views/layouts/application.html.erb
@@ -10,6 +10,12 @@
   </head>
 
   <body>
+    <% if notice %>
+      <p class="alert alert-success alert-dismissible"><%= notice %></p>
+    <% end %>
+    <% if alert %>
+      <p class="alert alert-danger alert-dismissible"><%= alert %></p>
+    <% end %>
     <div class="container">
       <%= yield %>
     </div>

--- a/KTask/app/views/layouts/application.html.erb
+++ b/KTask/app/views/layouts/application.html.erb
@@ -10,14 +10,23 @@
   </head>
 
   <body>
+    <div class="container">
     <% if notice %>
       <p class="alert alert-success alert-dismissible"><%= notice %></p>
     <% end %>
     <% if alert %>
       <p class="alert alert-danger alert-dismissible"><%= alert %></p>
     <% end %>
-    <div class="container">
-      <%= yield %>
+
+    <% if logged_in? %>
+      <div style='text-align:right'>
+        <%= link_to t('.user_info'), admin_users_path, class:'btn btn-outline-danger' %>
+        <%= link_to t('.logout'), session_path(current_user.id), method: :delete, class:'btn btn-outline-info' %>
+      <% end %>
+      </div>
+      <div class="container">
+        <%= yield %>
+      </div>
     </div>
   </body>
 </html>

--- a/KTask/app/views/layouts/application.html.erb
+++ b/KTask/app/views/layouts/application.html.erb
@@ -11,11 +11,8 @@
 
   <body>
     <div class="container">
-    <% if notice %>
-      <p class="alert alert-success alert-dismissible"><%= notice %></p>
-    <% end %>
-    <% if alert %>
-      <p class="alert alert-danger alert-dismissible"><%= alert %></p>
+    <% flash.each do |message_type, message| %>
+      <div class="alert alert-<%= message_type %>"><%= message %></div>
     <% end %>
 
     <% if logged_in? %>

--- a/KTask/app/views/sessions/new.html.erb
+++ b/KTask/app/views/sessions/new.html.erb
@@ -1,9 +1,5 @@
 <h1 class='display-4', style='text-align:center'>KTask</h1>
 
-<% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %>"><%= message %></div>
-<% end %>
-
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_for(:session, url: login_path) do |f| %>

--- a/KTask/app/views/sessions/new.html.erb
+++ b/KTask/app/views/sessions/new.html.erb
@@ -16,7 +16,10 @@
         <%= f.password_field :password, class: 'form-control' %>
       </div>
 
+      <p>
       <%= f.submit t('.submit'), class: "btn btn-primary" %>
+      <%= link_to t('.new_user'), new_admin_user_path, class:'btn btn-success' %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/KTask/app/views/tasks/_form.html.erb
+++ b/KTask/app/views/tasks/_form.html.erb
@@ -23,6 +23,11 @@
   </div>
 
   <div class="form-group">
+    <%= form.label :priority %>
+    <%= form.select :priority, Task.priorities.map{|k, _|  [Task.human_attribute_enum_value(:priority, k), k]}.to_h, {}, class:'form-control', style:'width:40%;' %>
+  </div>
+
+  <div class="form-group">
     <%= form.label :status %>
     <%= form.select :status, Task.statuses.map{|k, _|  [Task.human_attribute_enum_value(:status, k), k]}.to_h, {}, class:'form-control', style:'width:40%;' %>
   </div>

--- a/KTask/app/views/tasks/_task.json.jbuilder
+++ b/KTask/app/views/tasks/_task.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! task, :id, :user_id, :title, :content, :status, :end_time, :created_at, :updated_at
+json.extract! task, :id, :user_id, :title, :content, :status, :end_time, :created_at, :updated_at, :priority
 json.url task_url(task, format: :json)

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -1,12 +1,4 @@
-<% if notice != nil %>
-  <p id="notice", class='alert alert-success'><%= notice %></p>
-<% end %>
-
 <h1 class='display-4'><%= current_user.name.upcase + '`s'  %><%= t('.page_title') %></h1>
-<p style='text-align:right'>
-<%= link_to t('.userinfo'), admin_users_path, class:'btn btn-outline-danger' %>
-<%= link_to t('.logout'), logout_path, method: :delete, class:'btn btn-outline-info' %>
-</p>
 
 <div>
 <%= form_tag(index_path, method: 'get') do %>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class='display-4'><%= current_user.name.upcase + '`s'  %><%= t('.page_title') %></h1>
 <p style='text-align:right'>
-<%= link_to t('.userinfo'), admin_path, class:'btn btn-outline-danger' %>
+<%= link_to t('.userinfo'), admin_users_path, class:'btn btn-outline-danger' %>
 <%= link_to t('.logout'), logout_path, method: :delete, class:'btn btn-outline-info' %>
 </p>
 

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <div>
-<%= form_tag(root_path, method: 'get') do %>
+<%= form_tag(index_path, method: 'get') do %>
   <%= label_tag :search_title, t('.search_title'), class: 'col-sm-2 col-form-label col-form-label-lg' %>
 <br>
   <%= text_field_tag :search_title, params[:search_title] %>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -38,7 +38,7 @@
       <tr>
         <td class='table-active title'><%= task.title %></td>
         <td class='table-active'><%= task.content %></td>
-        <td class='table-active'><%= task.human_attribute_enum(:priority) %></td>
+        <td class='table-active'><span class="badge badge-<%= priority_color task.priority %>"><%= task.human_attribute_enum(:priority) %></span></td>
         <td class='table-active'><%= task.human_attribute_enum(:status) %></td>
         <td class='table-active'><%= task.end_time %></td>
         <td><%= link_to t('.detail'), task, class:'btn btn-outline-info' %></td>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -30,8 +30,8 @@
       <tr>
         <td class='table-active title'><%= task.title %></td>
         <td class='table-active'><%= task.content %></td>
-        <td class='table-active'><span class="badge badge-<%= priority_color task.priority %>"><%= task.human_attribute_enum(:priority) %></span></td>
-        <td class='table-active'><span class="badge badge-pill badge-<%= status_color task.status %>"><%= task.human_attribute_enum(:status) %></span></td>
+        <td class='table-active'><span class="badge badge-<%= priority_color task.class.priorities[task.priority] %>"><%= task.human_attribute_enum(:priority) %></span></td>
+        <td class='table-active'><span class="badge badge-pill badge-<%= status_color task.class.statuses[task.status] %>"><%= task.human_attribute_enum(:status) %></span></td>
         <td class='table-active'><%= task.end_time %></td>
         <td><%= link_to t('.detail'), task, class:'btn btn-outline-info' %></td>
         <td><%= link_to t('.edit'), edit_task_path(task), class:'btn btn-outline-secondary' %></td>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -39,7 +39,7 @@
         <td class='table-active title'><%= task.title %></td>
         <td class='table-active'><%= task.content %></td>
         <td class='table-active'><span class="badge badge-<%= priority_color task.priority %>"><%= task.human_attribute_enum(:priority) %></span></td>
-        <td class='table-active'><%= task.human_attribute_enum(:status) %></td>
+        <td class='table-active'><span class="badge badge-pill badge-<%= status_color task.status %>"><%= task.human_attribute_enum(:status) %></span></td>
         <td class='table-active'><%= task.end_time %></td>
         <td><%= link_to t('.detail'), task, class:'btn btn-outline-info' %></td>
         <td><%= link_to t('.edit'), edit_task_path(task), class:'btn btn-outline-secondary' %></td>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -21,11 +21,12 @@
 <% end %>
 </div>
 
-<table class='table', style='width: 100%;'>
+<table class='table'>
   <thead class='thead-dark'>
     <tr>
       <th scope='col'><%= t('.title') %></th>
       <th scope='col'><%= t('.content') %></th>
+      <th scope='col'><%= t('.priority') %></th>
       <th scope='col'><%= t('.status') %></th>
       <th scope='col'><%= toggled_sort_link('end_time') %></th>
       <th colspan="3"></th>
@@ -37,6 +38,7 @@
       <tr>
         <td class='table-active title'><%= task.title %></td>
         <td class='table-active'><%= task.content %></td>
+        <td class='table-active'><%= task.human_attribute_enum(:priority) %></td>
         <td class='table-active'><%= task.human_attribute_enum(:status) %></td>
         <td class='table-active'><%= task.end_time %></td>
         <td><%= link_to t('.detail'), task, class:'btn btn-outline-info' %></td>

--- a/KTask/app/views/tasks/index.html.erb
+++ b/KTask/app/views/tasks/index.html.erb
@@ -3,7 +3,10 @@
 <% end %>
 
 <h1 class='display-4'><%= @login_user.name.upcase + '`s'  %><%= t('.page_title') %></h1>
-<p style='text-align:right'><%= link_to t('.logout'), logout_path, method: :delete, class:'btn btn-outline-info' %></p>
+<p style='text-align:right'>
+<%= link_to t('.userinfo'), admin_path, class:'btn btn-outline-danger' %>
+<%= link_to t('.logout'), logout_path, method: :delete, class:'btn btn-outline-info' %>
+</p>
 
 <div>
 <%= form_tag(root_path, method: 'get') do %>

--- a/KTask/app/views/tasks/show.html.erb
+++ b/KTask/app/views/tasks/show.html.erb
@@ -18,6 +18,11 @@
 </p>
 
 <p>
+  <div class="form-group h4"><%= t('.priority') %> </div>
+  <%= @task.human_attribute_enum(:priority) %>
+</p>
+
+<p>
   <div class="form-group h4"><%= t('.status') %> </div>
   <%= @task.human_attribute_enum(:status) %>
 </p>

--- a/KTask/app/views/users/index.html.erb
+++ b/KTask/app/views/users/index.html.erb
@@ -1,0 +1,25 @@
+<h1><%= t('.title') %></h1>
+
+<table class='table', style='width: 100%;'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'><%= t('.user_name') %></th>
+      <th scope='col'><%= t('.user_mail') %></th>
+      <th scope='col'><%= t('.total_user_tasks') %></th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td class='table-active title'><%= user.name %></td>
+        <td class='table-active'><%= user.email %></td>
+        <td class='table-active'><%= users_taskamount(user) %></td>
+        <td class='table-active'></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to t('.new_user'), new_task_path, class:'btn btn-success' %>

--- a/KTask/app/views/users/new.html.erb
+++ b/KTask/app/views/users/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#new</h1>
+<p>Find me in app/views/users/new.html.erb</p>

--- a/KTask/app/views/users/new.html.erb
+++ b/KTask/app/views/users/new.html.erb
@@ -1,2 +1,29 @@
 <h1>Users#new</h1>
-<p>Find me in app/views/users/new.html.erb</p>
+
+<table class='table', style='width: 100%;'>
+  <thead class='thead-dark'>
+    <tr>
+      <th scope='col'><%= t('.title') %></th>
+      <th scope='col'><%= t('.content') %></th>
+      <th scope='col'><%= t('.status') %></th>
+      <th scope='col'><%= toggled_sort_link('end_time') %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td class='table-active title'><%= task.title %></td>
+        <td class='table-active'><%= task.content %></td>
+        <td class='table-active'><%= task.human_attribute_enum(:status) %></td>
+        <td class='table-active'><%= task.end_time %></td>
+        <td><%= link_to t('.detail'), task, class:'btn btn-outline-info' %></td>
+        <td><%= link_to t('.edit'), edit_task_path(task), class:'btn btn-outline-secondary' %></td>
+        <td><%= link_to t('.delete'), task, method: :delete, data: { confirm: t('.delete_message') }, class:'btn btn-outline-danger' %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to t('.new_user'), new_task_path, class:'btn btn-success' %>

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -38,6 +38,10 @@ ja:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
 
+  layouts:
+    application:
+      logout: 'ログアウト'
+      user_info: 'ユーザ一覧'
   tasks:
     status:
       yet: '未着手'

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -49,6 +49,7 @@ ja:
       search_status: '状態'
       search_submit: '検索'
       logout: 'ログアウト'
+      userinfo: 'ユーザ一覧'
     show:
       page_title: 'タスク詳細'
       title: 'スケジュール名'

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -17,6 +17,10 @@ ja:
         low: '下'
         mid: '中'
         high: '上'
+      user:
+        name: '名前'
+        email: 'メールアドレス'
+        password: 'パスワード'
     enum:
       task:
         status:
@@ -73,12 +77,18 @@ ja:
     new:
       page_title: 'タスク登録'
       back: '戻る'
-  users:
-    index:
-      title: 'ユーザ 一覧'
-      user_name: 'ユーザ名'
-      user_mail: 'メール アドレス'
-      total_user_tasks: 'タスク数'
+
+  admin:
+    users:
+      index:
+        title: 'ユーザ 一覧'
+        user_name: '名前'
+        user_mail: 'メールアドレス'
+        total_user_tasks: 'タスク数'
+        new_user: 'ユーザ登録'
+      new:
+        title: 'ユーザ登録'
+        back: '戻る'
 
   sessions:
     new:

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -92,6 +92,7 @@ ja:
         new_user: 'ユーザ登録'
         edit: '更新'
         delete: '削除'
+        delete_message: 'このユーザを削除しますか'
       new:
         title: 'ユーザ登録'
         back: '戻る'

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -73,6 +73,12 @@ ja:
     new:
       page_title: 'タスク登録'
       back: '戻る'
+  users:
+    index:
+      title: 'ユーザ 一覧'
+      user_name: 'ユーザ名'
+      user_mail: 'メール アドレス'
+      total_user_tasks: 'タスク数'
 
   sessions:
     new:

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -93,6 +93,7 @@ ja:
         edit: '更新'
         delete: '削除'
         delete_message: 'このユーザを削除しますか'
+        back: '戻る'
       new:
         title: 'ユーザ登録'
         back: '戻る'

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -13,12 +13,20 @@ ja:
         yet: '未着手'
         do: '着手'
         done: '完了'
+      task/priority:
+        low: '下'
+        mid: '中'
+        high: '上'
     enum:
       task:
         status:
           yet: '未着手'
           do: '着手'
           done: '完了'
+        priority:
+          low: '下'
+          mid: '中'
+          high: '上'
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -30,13 +38,14 @@ ja:
     status:
       yet: '未着手'
       do: '着手'
-      done: '完了' 
+      done: '完了'
     form:
-      back: '戻る' 
+      back: '戻る'
     index:
       page_title: 'スケジュール リスト'
       title: 'スケジュール'
       content: '内容'
+      priority: '友禅順位'
       status: '状態'
       end_time: '終了時間'
       detail: '詳細'

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -133,7 +133,9 @@ ja:
       logout_success: 'ログアウトしました'
     user:
       create_success: 'ユーザを登録しました'
+      create_failure: 'ユーザ登録を失敗しました、確認してください'
       update_success: 'ユーザを更新しました'
+      update_failure: 'ユーザ更新に失敗しました、確認してください'
       delete_success: 'ユーザを削除しました'
       delete_failure: 'ユーザ削除エーラ'
 

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -86,8 +86,13 @@ ja:
         user_mail: 'メールアドレス'
         total_user_tasks: 'タスク数'
         new_user: 'ユーザ登録'
+        edit: '更新'
+        delete: '削除'
       new:
         title: 'ユーザ登録'
+        back: '戻る'
+      edit:
+        title: 'ユーザ更新'
         back: '戻る'
 
   sessions:
@@ -109,6 +114,11 @@ ja:
       login_failed: 'ログイン失敗しました確認してください'
       login_success: 'ログイン成功しました'
       logout_success: 'ログアウトしました'
+    user:
+      create_success: 'ユーザを登録しました'
+      update_success: 'ユーザを更新しました'
+      delete_success: 'ユーザを削除しました'
+      delete_failure: 'ユーザ削除エーラ'
 
   date:
     abbr_day_names:

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -114,6 +114,7 @@ ja:
   sessions:
     new:
       submit: 'ログイン'
+      new_user: 'ユーザ登録'
 
   views:
     pagination:

--- a/KTask/config/locales/ja.yml
+++ b/KTask/config/locales/ja.yml
@@ -100,6 +100,16 @@ ja:
       edit:
         title: 'ユーザ更新'
         back: '戻る'
+      show:
+        title: 'タスクリスト'
+        task_name: 'タスク名'
+        content: '内容'
+        priority: '友禅順位'
+        status: '状態'
+        end_time: '終了時間'
+        detail: '詳細'
+        edit: '修正'
+        delete: '削除'
 
   sessions:
     new:

--- a/KTask/config/routes.rb
+++ b/KTask/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get 'admin' => 'users#new'
   get    'login'   => 'sessions#new'
   post   'login'   => 'sessions#create'
   delete 'logout'  => 'sessions#destroy'

--- a/KTask/config/routes.rb
+++ b/KTask/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   delete 'logout'  => 'sessions#destroy'
   get 'index' => 'tasks#index'
   resources :tasks
-
+  resources :sessions, only: %i[new create destroy]
   root 'sessions#new'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/KTask/config/routes.rb
+++ b/KTask/config/routes.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'admin' => 'users#index'
+  namespace :admin do
+    resources :users
+  end
   get    'login'   => 'sessions#new'
   post   'login'   => 'sessions#create'
   delete 'logout'  => 'sessions#destroy'

--- a/KTask/config/routes.rb
+++ b/KTask/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'admin' => 'users#new'
+  get 'admin' => 'users#index'
   get    'login'   => 'sessions#new'
   post   'login'   => 'sessions#create'
   delete 'logout'  => 'sessions#destroy'

--- a/KTask/db/migrate/20181019001554_add_column_priority.rb
+++ b/KTask/db/migrate/20181019001554_add_column_priority.rb
@@ -1,5 +1,5 @@
 class AddColumnPriority < ActiveRecord::Migration[5.2]
   def change
-    add_column :tasks, :priority, :string, before: :end_time, null: false, limit: 30
+    add_column :tasks, :priority, :integer, before: :end_time, null: false
   end
 end

--- a/KTask/db/migrate/20181019001554_add_column_priority.rb
+++ b/KTask/db/migrate/20181019001554_add_column_priority.rb
@@ -1,0 +1,5 @@
+class AddColumnPriority < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :priority, :string, before: :end_time, null: false, limit: 30
+  end
+end

--- a/KTask/db/schema.rb
+++ b/KTask/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_11_010912) do
+ActiveRecord::Schema.define(version: 2018_10_19_001554) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", limit: 20, null: false
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2018_10_11_010912) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "priority", limit: 30, null: false
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end

--- a/KTask/db/schema.rb
+++ b/KTask/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2018_10_19_001554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.string "priority", limit: 30, null: false
+    t.integer "priority", null: false
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end

--- a/KTask/spec/factories/tasks.rb
+++ b/KTask/spec/factories/tasks.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     priority { 'high' }
     status { 'do' }
     end_time { '2018-09-27' }
+    association :user
   end
 end

--- a/KTask/spec/factories/tasks.rb
+++ b/KTask/spec/factories/tasks.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :task do
     sequence(:title) { |n| "task#{n}" }
     content { 'Test Object' }
+    priority { 'high' }
     status { 'do' }
     end_time { '2018-09-27' }
   end

--- a/KTask/spec/features/admin_users_spec.rb
+++ b/KTask/spec/features/admin_users_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.feature 'AdminUsers', type: :feature do
+  scenario '新しいユーザを作成する' do
+    expect do
+      visit root_path
+      click_link 'ユーザ登録'
+      fill_in '名前', with: 'Test user'
+      fill_in 'メールアドレス', with: 'taro@example.com'
+      fill_in 'パスワード', with: 'password'
+      click_button '登録する'
+      expect(page).to have_content 'ユーザを登録しました'
+    end.to change { User.count }.by(1)
+  end
+
+  feature '既存ユーザへの操作' do
+    background do
+      create(:user)
+      visit admin_users_path
+    end
+
+    scenario 'ユーザを更新する' do
+      click_link I18n.t('admin.users.index.edit')
+      fill_in '名前', with: 'after Test user'
+      fill_in 'メールアドレス', with: 'changed@example.com'
+      fill_in 'パスワード', with: 'password2'
+      click_button '更新する'
+      expect(page).to have_content I18n.t('flash.user.update_success')
+      expect(page).to have_selector 'td.name', text: 'after Test user'
+      expect(page).to have_selector 'td.email', text: 'changed@example.com'
+    end
+
+    scenario 'ユーザを削除する' do
+      expect do
+        click_link I18n.t('admin.users.index.delete')
+        expect(page).to have_content 'ユーザを削除しました'
+      end.to change { User.count }.by(-1)
+    end
+  end
+
+  feature 'ユーザが作成したタスク絡み' do
+    background do
+      create(:task)
+      visit admin_users_path
+    end
+    scenario 'ユーザを削除した時、そのユーザのタスクを削除する' do
+      expect do
+        click_link I18n.t('admin.users.index.delete')
+      end.to change { Task.count }.by(-1)
+    end
+    scenario 'ユーザ一覧画面で、そのユーザが作成したタスクの数を表示する' do
+      amounts = page.all('td.amount')
+      expect(amounts[0]).to have_content '1'
+    end
+    scenario 'ユーザが作成したタスクの一覧が見れる' do
+      find('.amount').click
+      names = page.all('td.name')
+      expect(names.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
# ステップ18: ユーザの管理画面を実装しよう
- 画面上に管理メニューを追加しましょう
- 管理画面にはかならず `/admin` というURLを先頭につけるようにしましょう
  - `routes.rb` に追加する前に、あらかじめURLやルーティング名（ `*_path` となる名前）を想定して設計してみましょう
- ユーザ一覧・作成・更新・削除を実装しましょう
- ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう
- ユーザが作成したタスクの一覧が見られるようにしてみましょう
# 行ったこと
- ユーザ管理画面の追加
- タスクの友禅順位追加(研修の要件ですが忘れて、、このステップで実装🙇‍♂️)
- ルーティングへ admin namespace追加
- ユーザのCRUD実装(作成は管理者ざない場合もできるように実装、管理者のロール追加はステップ１９で)
- ユーザが作成したタスクのリスト画面追加(この部分もステップ１９では管理者機能で変更)
- ユーザを削除した時タスクも消すようにdependent追加
- ユーザ一覧・ログアウトボタンをlayoutに追加
- フラッシュメッセージ出力layoutに追加
- adminフィーチャスペック作成
![image](https://user-images.githubusercontent.com/17827803/47475534-c34a1780-d856-11e8-92d9-89640a00722a.png)
![image](https://user-images.githubusercontent.com/17827803/47475538-ccd37f80-d856-11e8-9a38-e9b3161715b7.png)
![image](https://user-images.githubusercontent.com/17827803/47475545-d361f700-d856-11e8-922e-cb094b2ce0e5.png)
![image](https://user-images.githubusercontent.com/17827803/47478033-f2ff1c80-d862-11e8-86a6-ca4d3d87e353.png)
