### PR TITLE
[STEP13]ステータスを追加して、検索できるようにする

### DIFF
--- a/taskManager/app/controllers/application_controller.rb
+++ b/taskManager/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   rescue_from ActionController::RoutingError, with: :error_404
-  rescue_from Exception, with: :error_505
+#  rescue_from Exception, with: :error_505
 
   def error_404
     render template: 'errors/error_404', status: 404, layout: 'application', content_type: 'text/html'

--- a/taskManager/app/controllers/list_controller.rb
+++ b/taskManager/app/controllers/list_controller.rb
@@ -2,7 +2,7 @@ class ListController < ApplicationController
   before_action :all_labels, only: [:edit, :update, :new, :create]
 
   def index
-    @tasks = Task.includes(task_label: :label)
+    @tasks = Task.includes(task_label: :label).search(params)
   end
 
   def new

--- a/taskManager/app/models/task.rb
+++ b/taskManager/app/models/task.rb
@@ -30,4 +30,11 @@ class Task < ApplicationRecord
 
   # TODO: STEP12の課題で作ったもの
   default_scope -> { order(Arel.sql("deadline is null, deadline asc, created_at desc")) }
+
+  def self.search(params)
+    results = ::Task.all
+    results = results.where(status: params[:status]) if params[:status].present?
+    results = results.where("task_name like ?", "%" + params[:task_name]+ "%") if params[:task_name].present?
+    results
+  end
 end

--- a/taskManager/app/models/task.rb
+++ b/taskManager/app/models/task.rb
@@ -32,9 +32,21 @@ class Task < ApplicationRecord
   default_scope -> { order(Arel.sql("deadline is null, deadline asc, created_at desc")) }
 
   def self.search(params)
-    results = ::Task.all
+    results = Task.all
     results = results.where(status: params[:status]) if params[:status].present?
-    results = results.where("task_name like ?", "%" + params[:task_name]+ "%") if params[:task_name].present?
+
+    if params[:task_name].present?
+      search_word = replace_search_word(search_word: params[:task_name].dup)
+      results = results.where("task_name like ?", "%#{search_word}%")
+    end
     results
+  end
+
+  private
+
+  def self.replace_search_word(search_word:)
+    search_word.gsub!(/\%/, "\\%")
+    search_word.gsub!(/\_/, "\\_")
+    return search_word
   end
 end

--- a/taskManager/app/models/task.rb
+++ b/taskManager/app/models/task.rb
@@ -31,18 +31,7 @@ class Task < ApplicationRecord
   def self.search(params)
     results = Task.all
     results = results.where(status: params[:status]) if params[:status].present?
-    if params[:task_name].present?
-      search_word = replace_search_word(search_word: params[:task_name].dup)
-      results = results.where("task_name like ?", "%#{search_word}%")
-    end
+    results = results.where("task_name like ?", "%#{sanitize_sql_like(params[:task_name])}%") if params[:task_name].present?
     results
-  end
-
-  private
-
-  def self.replace_search_word(search_word: '')
-    search_word.gsub!(/\%/, "\\%")
-    search_word.gsub!(/\_/, "\\_")
-    return search_word
   end
 end

--- a/taskManager/app/views/list/index.html.erb
+++ b/taskManager/app/views/list/index.html.erb
@@ -6,6 +6,16 @@
   <%= content_tag(:div, value, class: "#{key}") %>
 <% end %>
 
+<p>検索</p>
+<%= form_tag(list_index_path, :method => 'get' ) do %>
+  <%= label_tag t "attributes.task.task_name" %>
+  <%= text_field_tag :task_name, value = params[:task_name] %>
+
+  <%= label_tag t "attributes.task.status" %>
+  <%= select_tag :status, options_for_select(Task.statuses.map { |k| [t("enum.task.status.#{k[0]}"), k[0]] }, :selected => params[:status] ), :include_blank => true %>
+  <%= submit_tag t("actions.search"), :status => nil %>
+<% end %>
+
 <table border="1">
   <tr>
     <th><%= t "attributes.task.task_name" %></th>

--- a/taskManager/config/locales/ja.yml
+++ b/taskManager/config/locales/ja.yml
@@ -96,6 +96,7 @@ ja:
     edit: 編集
     new: 新規登録
     back: 戻る
+    search: 検索
   enum:
     task:
       status:

--- a/taskManager/spec/controllers/list_controller_spec.rb
+++ b/taskManager/spec/controllers/list_controller_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe ListController, type: :controller do
       expect(response).to have_http_status "200"
     end
     # TODO: まだ実装してない
-    it "認証済みのユーザでアクセスできる"
-    it "未認証のユーザでアクセスするとログイン画面にリダイレクトされること"
-    it "全体的に値の範囲テストを指定ない"
+    pending "認証済みのユーザでアクセスできる"
+    pending "未認証のユーザでアクセスするとログイン画面にリダイレクトされること"
+    pending "全体的に値の範囲テストを指定ない"
     it "タスク名の検索ができる" do
       get :index, params: { task_name: "task" }
       expect(response).to have_http_status "200"

--- a/taskManager/spec/controllers/list_controller_spec.rb
+++ b/taskManager/spec/controllers/list_controller_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe ListController, type: :controller do
   # TODO user_idを1固定にしているので、セッション管理するようになったら変更すること
   let(:user1) { FactoryBot.create(:user, id: 1) }
   let(:user2) { FactoryBot.create(:user) }
-  let!(:task1) { FactoryBot.create(:task, user_id: user1.id) }
-  let!(:task2) { FactoryBot.create(:task, user_id: user1.id) }
-  let!(:task3) { FactoryBot.create(:task, user_id: user2.id) }
+  let!(:task1) { FactoryBot.create(:task, user_id: user1.id, status: :waiting) }
+  let!(:task2) { FactoryBot.create(:task, user_id: user1.id, status: :waiting) }
+  let!(:task3) { FactoryBot.create(:task, user_id: user2.id, status: :completed) }
 
   describe "タスク一覧画面" do
     it "正常にレスポンス(200)を返すこと" do
@@ -17,6 +17,14 @@ RSpec.describe ListController, type: :controller do
     it "認証済みのユーザでアクセスできる"
     it "未認証のユーザでアクセスするとログイン画面にリダイレクトされること"
     it "全体的に値の範囲テストを指定ない"
+    it "タスク名の検索ができる" do
+      get :index, params: { task_name: "task" }
+      expect(response).to have_http_status "200"
+    end
+    it "ステータスの検索ができる" do
+      get :index, params: { status: :waiting }
+      expect(response).to have_http_status "200"
+    end
   end
 
   describe "タスク登録画面" do

--- a/taskManager/spec/factories/tasks.rb
+++ b/taskManager/spec/factories/tasks.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :task do
     sequence(:task_name) { |n| "taskname#{n}" }
     sequence(:description) { |n| "description#{n}" }
-    deadline nil
-    priority :low
-    status :waiting
+    deadline { rand(1..1000).days.from_now }
+    sequence(:priority) { Task.priorities.keys.sample }
+    sequence(:status) { Task.statuses.keys.sample }
     association :user
-    created_at Time.now
+    sequence(:created_at) { |n| Time.now + ((n - 1) * 1000).days }
     updated_at Time.now
   end
 end

--- a/taskManager/spec/features/lists_spec.rb
+++ b/taskManager/spec/features/lists_spec.rb
@@ -7,8 +7,8 @@ RSpec.feature "Lists", type: :feature do
   let!(:task) { FactoryBot.create_list(:task, 10) }
   let!(:expect_result) {
     task.sort do |a, b|
-      a[:created_at] <=> b[:created_at]
-    end.reverse
+      b[:created_at] <=> a[:created_at]
+    end
   }
 
   feature "タスクの追加" do
@@ -109,8 +109,8 @@ RSpec.feature "Lists", type: :feature do
     end
   end
   feature "タスク名検索" do
-    let!(:task2) { FactoryBot.create(:task, user_id: user.id, status: :completed, task_name: "タスク1") }
-    let!(:task3) { FactoryBot.create(:task, user_id: user.id, status: :waiting, task_name: "タスク2") }
+    let!(:task2) { FactoryBot.create(:task, user_id: user.id, status: :completed, task_name: "タスク2") }
+    let!(:task3) { FactoryBot.create(:task, user_id: user.id, status: :waiting, task_name: "タスク3") }
     let!(:expect_result) {
       task.select{ |i| i[:task_name] =~ /タスク/ }.sort do |a, b|
         a[:created_at] <=> b[:created_at]

--- a/taskManager/spec/models/task_spec.rb
+++ b/taskManager/spec/models/task_spec.rb
@@ -77,38 +77,59 @@ RSpec.describe Task, type: :model do
   end
   # TODO: 検索機能が現状ないので後で実装する
   context "検索関連テスト(１項目)" do
+    let(:user) { user = FactoryBot.create(:user) }
+    let!(:task1) {
+      FactoryBot.create(:task, task_name: 'task1', user_id: user.id, status: :waiting, created_at: '2018-05-20 14:00:00')
+    }
+    let!(:task2) {
+      FactoryBot.create(:task, task_name: 'task2', user_id: user.id, status: :waiting, created_at: '2018-05-21 15:00:00')
+    }
+    let!(:task3) {
+      FactoryBot.create(:task, task_name: 'task3', user_id: user.id, status: :waiting, created_at: '2018-05-20 14:02:00')
+    }
+    let!(:task4) {
+      FactoryBot.create(:task, task_name: 'task4', user_id: user.id, status: :waiting, deadline: "2018-05-20 14:00:00", created_at: "2018-05-04 10:11:10")
+    }
+    let!(:task5) {
+      FactoryBot.create(:task, task_name: 'task5', user_id: user.id, status: :completed ,deadline: nil, created_at: "2018-04-01 10:00:00")
+    }
+    let!(:task6) {
+      FactoryBot.create(:task, task_name: 'task6', user_id: user.id, status: :waiting, deadline: "2018-05-19 14:00:00", created_at: "2018-05-10 10:03:04")
+    }
+    let!(:task7) {
+      FactoryBot.create(:task, task_name: 'task7', user_id: user.id, status: :working, deadline: nil, created_at: "2018-10-21 15:00:00")
+    }
+    let!(:task8) {
+      FactoryBot.create(:task, task_name: 'task8', user_id: user.id, status: :working, deadline: "2018-04-10 10:11:21", created_at: "2018-05-21 15:00:00")
+    }
+    let!(:task9) {
+      FactoryBot.create(:task, task_name: 'task9', user_id: user.id, status: :completed, deadline: nil, created_at: "2018-05-20 14:02:00")
+    }
     it "全件検索ができる"
-    it "タスク名検索ができる"
+    it "タスク名検索ができる" do
+      params = { task_name: "task1" }
+      expect(Task.search(params)).to eq [task1]
+    end
     it "説明検索ができる"
     it "期限で検索ができる"
     it "優先度で検索ができる"
-    it "ステータスで検索ができる"
+    it "ステータスで検索ができる" do
+      params = { status: :working }
+      expect(Task.search(params)).to eq [task8, task7]
+    end
     it "1つのラベルで検索ができる"
     it "複数件のラベルで検索ができる"
-    it "登録日時の降順で検索できること(STEP10)の課題" do
-      user = FactoryBot.create(:user)
-
-      # order by created_at descの場合(task2 -> task3 -> task1の順番になるはず)
-      task1 = FactoryBot.create(:task, user_id: user.id, created_at: "2018-05-20 14:00:00")
-      task2 = FactoryBot.create(:task, user_id: user.id, created_at: "2018-05-21 15:00:00")
-      task3 = FactoryBot.create(:task, user_id: user.id, created_at: "2018-05-20 14:02:00")
-
-      expect(Task.all).to eq [task2, task3, task1]
-    end
     it "期限の昇順 + 登録日時で検索できること(STEP12)の課題" do
-      user = FactoryBot.create(:user)
-      task1 = FactoryBot.create(:task, user_id: user.id, deadline: "2018-05-20 14:00:00", created_at: "2018-05-04 10:11:10")
-      task2 = FactoryBot.create(:task, user_id: user.id, deadline: nil, created_at: "2018-04-01 10:00:00")
-      task3 = FactoryBot.create(:task, user_id: user.id, deadline: "2018-05-19 14:00:00", created_at: "2018-05-10 10:03:04")
-      task4 = FactoryBot.create(:task, user_id: user.id, deadline: nil, created_at: "2018-10-21 15:00:00")
-      task5 = FactoryBot.create(:task, user_id: user.id, deadline: "2018-04-10 10:11:21", created_at: "2018-05-21 15:00:00")
-      task6 = FactoryBot.create(:task, user_id: user.id, deadline: nil, created_at: "2018-05-20 14:02:00")
-
-      expect(Task.all).to eq [task5, task3, task1, task4, task6, task2]
+      expect(Task.all).to eq [
+        task8, task6, task4, task7, task2, task3, task9, task1, task5
+      ]
     end
-  end
-  context "検索関連テスト(複数項目)" do
-    it "タスク名とステータスで検索ができる"
+    it "タスク名とステータスで検索ができる" do
+      task10 = FactoryBot.create(:task, task_name: "テスト10", user_id: user.id, status: :working, deadline: "2018-04-10 10:11:21", created_at: "2018-05-21 15:00:00")
+      task11 = FactoryBot.create(:task, task_name: "テスト11", user_id: user.id, status: :working, deadline: nil, created_at: "2018-05-20 14:02:00")
+      params = { status: :working, task_name: "テスト" }
+      expect(Task.search(params)).to eq [task10, task11]
+    end
     it "説明と期限で検索ができる"
     it "優先度とラベルで検索ができる"
   end

--- a/taskManager/spec/models/task_spec.rb
+++ b/taskManager/spec/models/task_spec.rb
@@ -105,55 +105,31 @@ RSpec.describe Task, type: :model do
   end
 
   describe 'タスク検索テスト' do
-    let(:user) { user = FactoryBot.create(:user) }
-    let!(:task1) {
-      FactoryBot.create(:task, task_name: 'task1', user_id: user.id, status: :waiting, created_at: '2018-05-20 14:00:00')
-    }
-    let!(:task2) {
-      FactoryBot.create(:task, task_name: 'task2', user_id: user.id, status: :waiting, created_at: '2018-05-21 15:00:00')
-    }
-    let!(:task3) {
-      FactoryBot.create(:task, task_name: 'task3', user_id: user.id, status: :waiting, created_at: '2018-05-20 14:02:00')
-    }
-    let!(:task4) {
-      FactoryBot.create(:task, task_name: 'task4', user_id: user.id, status: :waiting, deadline: "2018-05-20 14:00:00", created_at: "2018-05-04 10:11:10")
-    }
-    let!(:task5) {
-      FactoryBot.create(:task, task_name: 'task5', user_id: user.id, status: :completed ,deadline: nil, created_at: "2018-04-01 10:00:00")
-    }
-    let!(:task6) {
-      FactoryBot.create(:task, task_name: 'task6', user_id: user.id, status: :waiting, deadline: "2018-05-19 14:00:00", created_at: "2018-05-10 10:03:04")
-    }
-    let!(:task7) {
-      FactoryBot.create(:task, task_name: 'task7', user_id: user.id, status: :working, deadline: nil, created_at: "2018-10-21 15:00:00")
-    }
-    let!(:task8) {
-      FactoryBot.create(:task, task_name: 'task8', user_id: user.id, status: :working, deadline: "2018-04-10 10:11:21", created_at: "2018-05-21 15:00:00")
-    }
-    let!(:task9) {
-      FactoryBot.create(:task, task_name: 'task9', user_id: user.id, status: :completed, deadline: nil, created_at: "2018-05-20 14:02:00")
-    }
-    context "検索関連テスト(１項目)"
-    context "全件検索ができる"
+    let!(:user) {FactoryBot.create(:user) }
+    let!(:task) { FactoryBot.create_list(:task, 10) }
+    pending "検索関連テスト(１項目)"
+    pending "全件検索ができる"
     context "タスク名で検索" do
-      let(:params) do
-        { task_name: "task1" }
-      end
+      let(:params) do { task_name: "あああ" } end
+      let!(:task1) { FactoryBot.create(:task, task_name: "あああ") }
       it "タスク名検索ができる" do
         expect(Task.search(params)).to eq [task1]
       end
     end
-    context "説明検索ができる"
-    context "期限で検索ができる"
-    context "優先度で検索ができる"
+    pending "説明検索ができる"
+    pending "期限で検索ができる"
+    pending "優先度で検索ができる"
     context "ステータス検索" do
       let(:params) do { status: :working } end
       it "ステータスで検索ができる" do
-        expect(Task.search(params)).to eq [task7, task8]
+        expect_result = task.select{ |i| i[:status] == "working" }.sort do |a, b|
+          a[:created_at] <=> b[:created_at]
+        end
+        expect(expect_result).to eq Task.search(params)
       end
     end
-    context "1つのラベルで検索ができる"
-    context "複数件のラベルで検索ができる"
+    pending "1つのラベルで検索ができる"
+    pending "複数件のラベルで検索ができる"
     context "タスク名とステータスで検索" do
       let!(:task10) { FactoryBot.create(:task, task_name: "テスト10", user_id: user.id, status: :working, deadline: "2018-04-10 10:11:21", created_at: "2018-05-21 15:00:00") }
       let!(:task11) { FactoryBot.create(:task, task_name: "テスト11", user_id: user.id, status: :working, deadline: nil, created_at: "2018-05-20 14:02:00") }
@@ -162,17 +138,15 @@ RSpec.describe Task, type: :model do
         expect(Task.search(params)).to eq [task10, task11]
       end
     end
-    context "説明と期限で検索ができる"
-    context "優先度とラベルで検索ができる"
-    context "検索関連テスト(１項目)"
-    context "説明検索ができる"
-    context "優先度で検索ができる"
-    context "ステータスで検索ができる"
-    context "1つのラベルで検索ができる"
-    context "複数件のラベルで検索ができる"
-    context "検索関連テスト(複数項目)"
-    context "タスク名とステータスで検索ができる"
-    context "説明と期限で検索ができる"
-    context "優先度とラベルで検索ができる"
+    pending "説明と期限で検索ができる"
+    pending "優先度とラベルで検索ができる"
+    pending "検索関連テスト(１項目)"
+    pending "説明検索ができる"
+    pending "優先度で検索ができる"
+    pending "1つのラベルで検索ができる"
+    pending "複数件のラベルで検索ができる"
+    pending "検索関連テスト(複数項目)"
+    pending "説明と期限で検索ができる"
+    pending "優先度とラベルで検索ができる"
   end
 end


### PR DESCRIPTION
下記の作業を実施しました。

### ステップ13: ステータスを追加して、検索できるようにしよう
- [X] ステータス（未着手・着手中・完了）を追加してみよう
  - [X] 【オプション要件】初学者ではない場合はstateを管理するGemを導入しても構いません
- [X] 一覧画面でタイトルとステータスで検索ができるようにしよう
  - [X] 【オプション要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構いません
- [X] 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
  - [X] 以降のステップでも必要に応じて確認する癖をつけましょう
- [ ] 検索インデックスを貼りましょう
- [X] 検索に対してmodel specを追加してみよう（feature specも拡充しておきましょう）
