### PR TITLE
ステップ10:タスク一覧を作成日時の順番で並び替え

### DIFF
--- a/task_app/app/controllers/tasks_controller.rb
+++ b/task_app/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :find_task, only: %i[edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def new

--- a/task_app/app/views/tasks/index.html.erb
+++ b/task_app/app/views/tasks/index.html.erb
@@ -5,12 +5,14 @@
   <tr>
     <th><%= Task.human_attribute_name(:name) %></th>
     <th><%= Task.human_attribute_name(:description) %></th>
+    <th><%= Task.human_attribute_name(:created_at) %></th>
     <th>アクション</th>
   </tr>
   <% @tasks.each do |task| %>
     <tr>
       <td><%= task.name %></td>
       <td><%= simple_format(task.description) %></td>
+      <td><%= I18n.l(task.created_at, format: :long) %></td>
       <td>
         <%= link_to I18n.t('actions.edit'), edit_task_path(task) %>
         <%= link_to I18n.t('actions.destroy'), task_path(task), method: :delete,

--- a/task_app/spec/features/tasks_spec.rb
+++ b/task_app/spec/features/tasks_spec.rb
@@ -13,6 +13,25 @@ feature 'タスク管理機能', type: :feature do
     end
   end
 
+  feature 'タスクの並び順' do
+    let!(:tasks) {
+      [
+        FactoryBot.create(:task, name: 'タスク1', description: 'タスク1の説明', created_at: Time.zone.now),
+        FactoryBot.create(:task, name: 'タスク2', description: 'タスク2の説明', created_at: Time.zone.now - 1.day),
+        FactoryBot.create(:task, name: 'タスク3', description: 'タスク3の説明', created_at: Time.zone.now - 2.days),
+      ]
+    }
+
+    scenario 'タスクが登録日時の降順で並んでいる' do
+      visit root_path
+
+      page.all('.task-list tbody tr').each_with_index do |element, i|
+        next if i <= 0
+        expect(element.text).to have_content tasks[i - 1].name
+      end
+    end
+  end
+
   feature '登録機能' do
     before do
       visit root_path

--- a/task_app/spec/features/tasks_spec.rb
+++ b/task_app/spec/features/tasks_spec.rb
@@ -17,12 +17,12 @@ feature 'タスク管理機能', type: :feature do
     let!(:tasks) {
       [
         FactoryBot.create(:task, name: 'タスク1', description: 'タスク1の説明', created_at: Time.zone.now),
-        FactoryBot.create(:task, name: 'タスク2', description: 'タスク2の説明', created_at: Time.zone.now - 1.day),
-        FactoryBot.create(:task, name: 'タスク3', description: 'タスク3の説明', created_at: Time.zone.now - 2.days),
+        FactoryBot.create(:task, name: 'タスク2', description: 'タスク2の説明', created_at: 1.day.ago),
+        FactoryBot.create(:task, name: 'タスク3', description: 'タスク3の説明', created_at: 2.days.ago),
       ]
     }
 
-    scenario 'タスクが登録日時の降順で並んでいる' do
+    scenario 'タスクが登録日時の降順で並ぶ' do
       visit root_path
 
       page.all('.task-list tbody tr').each_with_index do |element, i|


### PR DESCRIPTION
以下の修正を行いました。
お手数ですが、ご確認をお願いします。

> ### ステップ10: タスク一覧を作成日時の順番で並び替えましょう
> - 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
> - 並び替えがうまく行っていることをfeature specで書いてみましょう

### 確認したこと
- 一覧画面でタスクが作成日時の降順で並ぶこと
- rubocopとrspecテストが通ること