### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替え

### DIFF
--- a/todoapp/app/controllers/tasks_controller.rb
+++ b/todoapp/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = current_user.tasks
+    @tasks = current_user.tasks.recent
   end
 
   def show

--- a/todoapp/app/models/task.rb
+++ b/todoapp/app/models/task.rb
@@ -4,5 +4,5 @@ class Task < ApplicationRecord
   STATUS_COMPLETED = 3
 
   belongs_to :user
-
+  scope :recent, -> { order(created_at: :desc) }
 end

--- a/todoapp/db/migrate/20190124073139_add_index_tasks_created_at.rb
+++ b/todoapp/db/migrate/20190124073139_add_index_tasks_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksCreatedAt < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :created_at
+  end
+end

--- a/todoapp/db/schema.rb
+++ b/todoapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_21_021631) do
+ActiveRecord::Schema.define(version: 2019_01_24_073139) do
 
   create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", limit: 64, null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2019_01_21_021631) do
     t.datetime "end_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_tasks_on_created_at"
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
     t.index ["user_id"], name: "index_tasks_on_user_id"

--- a/todoapp/spec/features/tasks_spec.rb
+++ b/todoapp/spec/features/tasks_spec.rb
@@ -2,7 +2,24 @@ require 'rails_helper'
 
 describe 'タスク管理機能', type: :feature do
   let(:user_a) { FactoryBot.create(:user, name: 'ユーザーA') }
-  let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', user: user_a) }
+  let!(:task_a) {
+    FactoryBot.create(:task,
+                      title: '最初のタスク',
+                      user: user_a,
+                      created_at: '2010-10-10 00:10:00')
+  }
+  let!(:task_b) {
+    FactoryBot.create(:task,
+                      title: '2つ目のタスク',
+                      user: user_a,
+                      created_at: '2010-10-10 00:10:01')
+  }
+  let!(:task_c) {
+    FactoryBot.create(:task,
+                      title: '3つ目のタスク',
+                      user: user_a,
+                      created_at: '2010-10-10 00:10:02')
+  }
 
   shared_examples_for 'ユーザーAが作成したタスクが表示される' do
     it { expect(page).to have_content '最初のタスク' }
@@ -15,6 +32,16 @@ describe 'タスク管理機能', type: :feature do
       end
 
       it_behaves_like 'ユーザーAが作成したタスクが表示される'
+
+      example 'タスクは作成日付の降順で表示される' do
+        task_a_index = page.body.index('最初のタスク')
+        task_b_index = page.body.index('2つ目のタスク')
+        task_c_index = page.body.index('3つ目のタスク')
+
+        # indexが大きいとリストの後ろ側に表示されているとみなす
+        expect(task_c_index).to be < task_b_index
+        expect(task_b_index).to be < task_a_index
+      end
     end
   end
 

--- a/todoapp/spec/features/tasks_spec.rb
+++ b/todoapp/spec/features/tasks_spec.rb
@@ -1,39 +1,39 @@
 require 'rails_helper'
 
-describe 'タスク管理機能', type: :feature do
-  let(:user_a) { FactoryBot.create(:user, name: 'ユーザーA') }
+feature 'タスク管理機能', type: :feature do
+  let(:user_a) { create(:user, name: 'ユーザーA') }
   let!(:task_a) {
-    FactoryBot.create(:task,
-                      title: '最初のタスク',
-                      user: user_a,
-                      created_at: '2010-10-10 00:10:00')
+    create(:task,
+           title: '最初のタスク',
+           user: user_a,
+           created_at: '2010-10-10 00:10:00')
   }
   let!(:task_b) {
-    FactoryBot.create(:task,
-                      title: '2つ目のタスク',
-                      user: user_a,
-                      created_at: '2010-10-10 00:10:01')
+    create(:task,
+           title: '2つ目のタスク',
+           user: user_a,
+           created_at: '2010-10-10 00:10:01')
   }
   let!(:task_c) {
-    FactoryBot.create(:task,
-                      title: '3つ目のタスク',
-                      user: user_a,
-                      created_at: '2010-10-10 00:10:02')
+    create(:task,
+           title: '3つ目のタスク',
+           user: user_a,
+           created_at: '2010-10-10 00:10:02')
   }
 
   shared_examples_for 'ユーザーAが作成したタスクが表示される' do
-    it { expect(page).to have_content '最初のタスク' }
+    scenario { expect(page).to have_content '最初のタスク' }
   end
 
   describe '一覧表示機能' do
     context '一覧表示画面へ遷移した時' do
-      before do
+      background do
         visit tasks_path
       end
 
       it_behaves_like 'ユーザーAが作成したタスクが表示される'
 
-      example 'タスクは作成日付の降順で表示される' do
+      scenario 'タスクは作成日付の降順で表示される' do
         task_a_index = page.body.index('最初のタスク')
         task_b_index = page.body.index('2つ目のタスク')
         task_c_index = page.body.index('3つ目のタスク')
@@ -47,7 +47,7 @@ describe 'タスク管理機能', type: :feature do
 
   describe '詳細表示機能' do
     context '詳細表示画面へ遷移した時' do
-      before do
+      background do
         visit task_path(task_a)
       end
 
@@ -56,7 +56,7 @@ describe 'タスク管理機能', type: :feature do
   end
 
   describe '新規作成機能' do
-    before do
+    background do
       visit new_task_path
 
       # タスクのフォーム入力
@@ -74,7 +74,7 @@ describe 'タスク管理機能', type: :feature do
     end
 
     context '規作成画面で正しい情報を入力した時' do
-      example '登録後の画面で内容が正常に表示される' do
+      scenario '登録後の画面で内容が正常に表示される' do
         expect(page).to have_content 'たすくだよ'
         expect(page).to have_content 'たすくのせつめいだよ'
         expect(page).to have_content '2100/01/01 00:00:00'

--- a/todoapp/spec/rails_helper.rb
+++ b/todoapp/spec/rails_helper.rb
@@ -58,4 +58,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## やったこと
[ステップ10: タスク一覧を作成日時の順番で並び替えましょう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)
  * ソート用のINDEX追加
  * タスクの並び替え処理＆テスト追加

## その他
- [x] 依存 https://github.com/Fablic/training/pull/219
