### PR TITLE
ステップ13: ステータスを追加して、検索できるように

### DIFF
--- a/todoapp/Gemfile
+++ b/todoapp/Gemfile
@@ -38,6 +38,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 # i18n
 gem 'rails-i18n', '~> 5.1'
+gem 'enum_help'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/todoapp/Gemfile
+++ b/todoapp/Gemfile
@@ -40,6 +40,9 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'rails-i18n', '~> 5.1'
 gem 'enum_help'
 
+# search
+gem 'ransack'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/todoapp/Gemfile.lock
+++ b/todoapp/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
     concurrent-ruby (1.1.4)
     crass (1.0.4)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.8.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
@@ -225,6 +227,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  enum_help
   factory_bot_rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/todoapp/Gemfile.lock
+++ b/todoapp/Gemfile.lock
@@ -148,6 +148,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.2)
+    ransack (2.1.1)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -235,6 +240,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.2)
   rails-i18n (~> 5.1)
+  ransack
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/todoapp/app/controllers/tasks_controller.rb
+++ b/todoapp/app/controllers/tasks_controller.rb
@@ -2,14 +2,14 @@
 
 class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
-  helper_method :sort_column, :sort_direction
 
   def index
-    @tasks = if sort_params.to_hash.length.zero?
-               current_user.tasks.recent
-             else
-               current_user.tasks.order(sort_column + ' ' + sort_direction)
-             end
+    @search = if params[:q]
+                current_user.tasks.ransack(params[:q])
+              else
+                current_user.tasks.ransack(recent: true)
+              end
+    @search_tasks = @search.result
   end
 
   def show
@@ -51,18 +51,6 @@ class TasksController < ApplicationController
 
   def task_params
     params.require(:task).permit(:title, :description, :status, :end_at)
-  end
-
-  def sort_params
-    params.permit(:direction, :sort)
-  end
-
-  def sort_direction
-    %w[asc desc].include?(params[:direction]) ? params[:direction] : 'asc'
-  end
-
-  def sort_column
-    Task.column_names.include?(params[:sort]) ? params[:sort] : :id.to_s
   end
 
   def set_task

--- a/todoapp/app/controllers/tasks_controller.rb
+++ b/todoapp/app/controllers/tasks_controller.rb
@@ -25,8 +25,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    param = task_params.merge(status: Task::STATUS_NEW_TASK)
-    @task = current_user.tasks.new(param)
+    @task = current_user.tasks.new(task_params)
 
     if @task.save
       redirect_to @task,
@@ -51,7 +50,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :description, :end_at)
+    params.require(:task).permit(:title, :description, :status, :end_at)
   end
 
   def sort_params

--- a/todoapp/app/helpers/application_helper.rb
+++ b/todoapp/app/helpers/application_helper.rb
@@ -1,13 +1,2 @@
 module ApplicationHelper
-  # ソート用のClickableなリンクを作る
-  def sortable(column, title = nil)
-    title ||= column.titleize
-
-    direction = 'asc'
-    if column == sort_column && sort_direction == 'asc'
-      direction = 'desc'
-    end
-
-    link_to title, {:sort => column, :direction => direction}
-  end
 end

--- a/todoapp/app/models/task.rb
+++ b/todoapp/app/models/task.rb
@@ -2,7 +2,9 @@ class Task < ApplicationRecord
   validates :title,
             presence: true,
             length: { maximum: 64 }
-  validate :end_at_cannot_be_in_the_past
+  validates :status,
+            presence: true
+  validate :end_at_cannot_be_in_the_past, :status_out_of_range
 
   STATUS_NEW_TASK = 1
   STATUS_WORKING = 2
@@ -23,6 +25,14 @@ class Task < ApplicationRecord
     if end_at.present? && end_at <= Date.yesterday
       errors.add(:end_at,
                  I18n.t('errors.messages.end_at_cannot_be_in_the_past'))
+    end
+  end
+
+  def status_out_of_range
+    # statusが保存できるのは、定義したキーだけだよ
+    unless Task.statuses.keys.include?(status)
+      errors.add(:status,
+                 I18n.t('errors.messages.status_out_of_range'))
     end
   end
 

--- a/todoapp/app/models/task.rb
+++ b/todoapp/app/models/task.rb
@@ -25,4 +25,8 @@ class Task < ApplicationRecord
                  I18n.t('errors.messages.end_at_cannot_be_in_the_past'))
     end
   end
+
+  def self.ransackable_scopes(auth_object = nil)
+    %i[recent]
+  end
 end

--- a/todoapp/app/models/task.rb
+++ b/todoapp/app/models/task.rb
@@ -7,6 +7,11 @@ class Task < ApplicationRecord
   STATUS_NEW_TASK = 1
   STATUS_WORKING = 2
   STATUS_COMPLETED = 3
+  enum status: {
+    new_task: STATUS_NEW_TASK,
+    working: STATUS_WORKING,
+    completed: STATUS_COMPLETED
+  }
 
   belongs_to :user
   scope :recent, -> { order(created_at: :desc) }

--- a/todoapp/app/views/tasks/_form.html.erb
+++ b/todoapp/app/views/tasks/_form.html.erb
@@ -11,6 +11,9 @@
   <%= f.label :description %>
   <%= f.text_field :description %>
 
+  <%= f.label :status %>
+  <%= f.select :status, Task.statuses_i18n.invert %>
+
   <%= f.label :end_at %>
   <%= f.date_field :end_at, min: Time.now.to_date, max: Time.now.to_date + (365 * 100) %>
 

--- a/todoapp/app/views/tasks/index.html.erb
+++ b/todoapp/app/views/tasks/index.html.erb
@@ -3,7 +3,7 @@
 <%= link_to t('tasks.new.title'), controller: 'tasks', action: 'new' %>
 
 <%= search_form_for @search, url: tasks_path, enforce_utf8: false do |f| %>
-  <dt><%= f.text_field :title_cont, placeholder: '検索するテキストを入力...' %></dt>
+  <dt><%= f.text_field :title_cont, placeholder: '検索するタイトルを入力...' %></dt>
   <dt><%= f.select :status_eq, Task.statuses.map{|k, v| [Task.statuses_i18n[k], v]} %></dt>
   <dd><%= f.submit %></dd>
 <% end %>

--- a/todoapp/app/views/tasks/index.html.erb
+++ b/todoapp/app/views/tasks/index.html.erb
@@ -17,7 +17,7 @@
     <tr>
       <td><%= link_to task.id, task_path(task.id) %></td>
       <td><%= task.title %></td>
-      <td><%= task.status %></td>
+      <td><%= task.status_i18n %></td>
       <td><%= l(task.end_at) unless task.end_at.nil? %></td>
       <td><%= l(task.created_at) %></td>
       <td><%= l(task.updated_at) %></td>

--- a/todoapp/app/views/tasks/index.html.erb
+++ b/todoapp/app/views/tasks/index.html.erb
@@ -2,18 +2,24 @@
 
 <%= link_to t('tasks.new.title'), controller: 'tasks', action: 'new' %>
 
+<%= search_form_for @search, url: tasks_path, enforce_utf8: false do |f| %>
+  <dt><%= f.text_field :title_cont, placeholder: '検索するテキストを入力...' %></dt>
+  <dt><%= f.select :status_eq, Task.statuses.map{|k, v| [Task.statuses_i18n[k], v]} %></dt>
+  <dd><%= f.submit %></dd>
+<% end %>
+
 <table>
   <tr>
     <th><%= Task.human_attribute_name(:id) %></th>
     <th><%= Task.human_attribute_name(:title) %></th>
     <th><%= Task.human_attribute_name(:status) %></th>
-    <th><%= sortable :end_at.to_s, Task.human_attribute_name(:end_at) %></th>
+    <th><%= sort_link(@search, :end_at, Task.human_attribute_name(:end_at), default_order: :desc) %></th>
     <th><%= Task.human_attribute_name(:created_at) %></th>
     <th><%= Task.human_attribute_name(:updated_at) %></th>
     <th></th>
     <th></th>
   </tr>
-  <% @tasks.each do |task| %>
+  <% @search_tasks.each do |task| %>
     <tr>
       <td><%= link_to task.id, task_path(task.id) %></td>
       <td><%= task.title %></td>

--- a/todoapp/app/views/tasks/show.html.erb
+++ b/todoapp/app/views/tasks/show.html.erb
@@ -17,6 +17,10 @@
       <td><%= @task.description %></td>
     </tr>
     <tr>
+      <th><%= Task.human_attribute_name(:status) %></th>
+      <td><%= @task.status_i18n %></td>
+    </tr>
+    <tr>
       <th><%= Task.human_attribute_name(:end_at) %></th>
       <td><%= l(@task.end_at) unless @task.end_at.nil? %></td>
     </tr>

--- a/todoapp/config/locales/models/ja.yml
+++ b/todoapp/config/locales/models/ja.yml
@@ -18,3 +18,9 @@ ja:
         end_at: 完了期限
         created_at: 登録日時
         updated_at: 更新日時
+  enums:
+    task:
+      status:
+        new_task: 未対応
+        working: 着手中
+        completed: 完了

--- a/todoapp/config/locales/views/ja.yml
+++ b/todoapp/config/locales/views/ja.yml
@@ -19,6 +19,7 @@ ja:
   errors:
     messages:
       end_at_cannot_be_in_the_past: 'は過去の日付を使用できません'
+      status_out_of_range: 'に対象外のステータスが指定されています'
   date:
     formats:
       default: "%Y/%m/%d"

--- a/todoapp/spec/features/tasks_spec.rb
+++ b/todoapp/spec/features/tasks_spec.rb
@@ -48,7 +48,10 @@ feature 'タスク管理機能', type: :feature do
     end
     context '終了期限を昇順でソートした時' do
       background do
-        visit tasks_path(sort: 'end_at', direction: 'asc')
+        visit tasks_path
+        click_link '完了期限'
+        # 昇順にするためには2度押す
+        click_link '完了期限'
       end
 
       scenario 'タスクは作成日付の降順で表示される' do
@@ -63,7 +66,8 @@ feature 'タスク管理機能', type: :feature do
     end
     context '終了期限を降順でソートした時' do
       background do
-        visit tasks_path(sort: 'end_at', direction: 'desc')
+        visit tasks_path
+        click_link '完了期限'
       end
 
       scenario 'タスクは作成日付の降順で表示される' do

--- a/todoapp/spec/features/tasks_spec.rb
+++ b/todoapp/spec/features/tasks_spec.rb
@@ -6,6 +6,7 @@ feature 'タスク管理機能', type: :feature do
     create(:task,
            title: '最初のタスク',
            user: user_a,
+           status: 'working',
            end_at: '2100-10-10 00:10:00',
            created_at: '2010-10-10 00:10:00')
   }
@@ -13,6 +14,7 @@ feature 'タスク管理機能', type: :feature do
     create(:task,
            title: '2つ目のタスク',
            user: user_a,
+           status: 'completed',
            end_at: '2100-10-10 00:10:01',
            created_at: '2010-10-10 00:10:01')
   }
@@ -20,6 +22,7 @@ feature 'タスク管理機能', type: :feature do
     create(:task,
            title: '3つ目のタスク',
            user: user_a,
+           status: 'working',
            end_at: nil,
            created_at: '2010-10-10 00:10:02')
   }
@@ -46,6 +49,7 @@ feature 'タスク管理機能', type: :feature do
         expect(task_b_index).to be < task_a_index
       end
     end
+
     context '終了期限を昇順でソートした時' do
       background do
         visit tasks_path
@@ -64,6 +68,7 @@ feature 'タスク管理機能', type: :feature do
         expect(task_a_index).to be < task_b_index
       end
     end
+
     context '終了期限を降順でソートした時' do
       background do
         visit tasks_path
@@ -77,6 +82,91 @@ feature 'タスク管理機能', type: :feature do
 
         # indexが大きいとリストの後ろ側に表示されているとみなす
         expect(task_b_index).to be < task_a_index
+        expect(task_a_index).to be < task_c_index
+      end
+    end
+
+    context 'タイトルとステータスで検索した時' do
+      background do
+        visit tasks_path
+
+        fill_in :q_title_cont, with: 'つ目のタスク'
+        select '着手中', from: :q_status_eq
+
+        click_button '検索'
+      end
+
+      scenario '絞り込まれたやつだけ表示される' do
+        task_a_index = page.body.index('最初のタスク')
+        task_b_index = page.body.index('2つ目のタスク')
+        task_c_index = page.body.index('3つ目のタスク')
+
+        expect(task_a_index).to be nil
+        expect(task_b_index).to be nil
+        expect(task_c_index).not_to be nil
+      end
+    end
+
+    context 'ステータスで検索した時' do
+      background do
+        visit tasks_path
+
+        select '完了', from: :q_status_eq
+
+        click_button '検索'
+      end
+
+      scenario '絞り込まれたやつだけ表示される' do
+        task_a_index = page.body.index('最初のタスク')
+        task_b_index = page.body.index('2つ目のタスク')
+        task_c_index = page.body.index('3つ目のタスク')
+
+        expect(task_a_index).to be nil
+        expect(task_b_index).not_to be nil
+        expect(task_c_index).to be nil
+      end
+    end
+
+    context '検索＆終了期限を昇順でソートした時' do
+      background do
+        visit tasks_path
+
+        select '着手中', from: :q_status_eq
+
+        click_button '検索'
+
+        click_link '完了期限'
+        # 昇順にするためには2度押す
+        click_link '完了期限'
+      end
+
+      scenario '絞り込まれた状態でソートされる' do
+        task_a_index = page.body.index('最初のタスク')
+        task_b_index = page.body.index('2つ目のタスク')
+        task_c_index = page.body.index('3つ目のタスク')
+
+        expect(task_b_index).to be nil
+        expect(task_c_index).to be < task_a_index
+      end
+    end
+
+    context '検索＆終了期限を降順でソートした時' do
+      background do
+        visit tasks_path
+
+        select '着手中', from: :q_status_eq
+
+        click_button '検索'
+
+        click_link '完了期限'
+      end
+
+      scenario '絞り込まれた状態でソートされる' do
+        task_a_index = page.body.index('最初のタスク')
+        task_b_index = page.body.index('2つ目のタスク')
+        task_c_index = page.body.index('3つ目のタスク')
+
+        expect(task_b_index).to be nil
         expect(task_a_index).to be < task_c_index
       end
     end

--- a/todoapp/spec/models/task_spec.rb
+++ b/todoapp/spec/models/task_spec.rb
@@ -4,7 +4,7 @@ describe Task, type: :model do
   let(:user_a) { build(:user, name: 'ユーザーA') }
 
   describe 'titleのバリデーションチェック' do
-    context '何も入力されてないとき' do
+    context '何も入力されてない時' do
       example 'エラーになる' do
         task = build(:task, user: user_a, title: '')
         expect(task).to be_invalid
@@ -26,6 +26,28 @@ describe Task, type: :model do
       example 'エラーになる' do
         task = build(:task, user: user_a, title: 'a' * 65)
         expect(task).to be_invalid
+      end
+    end
+  end
+
+  describe 'statusのバリデーションチェック' do
+    context '何も入力されてない時' do
+      example 'エラーになる' do
+        task = build(:task, user: user_a, status: '')
+        expect(task).to be_invalid
+      end
+    end
+    context '適当な文字が入力された時' do
+      example 'エラーになる' do
+        expect {
+          build(:task, user: user_a, status: 'aaa')
+        }.to raise_error(ArgumentError)
+      end
+    end
+    context 'ちゃんとしたやーつが入力された時' do
+      example '登録可能' do
+        task = build(:task, user: user_a, status: 'completed')
+        expect(task).to be_valid
       end
     end
   end


### PR DESCRIPTION
## やったこと
[ステップ13: ステータスを追加して、検索できるようにしよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)
  * Gem追加
    * ransack: 検索、ソート用（これを導入したので、既存のソート処理は削除しています）
    * enum_help: enumの多言語化対応
    * statusまわり
      * もともとカラムは作っていた＆インデックスは貼っていたのでマイグレーションはなし
      * taskモデルにstatusのバリデーションを追加