### PR TITLE
ステップ13: ステータスを追加して、検索機能を実装

### DIFF
--- a/task_app/app/controllers/tasks_controller.rb
+++ b/task_app/app/controllers/tasks_controller.rb
@@ -4,9 +4,7 @@ class TasksController < ApplicationController
   before_action :find_task, only: %i[edit update destroy]
 
   def index
-    params[:sort_column]    ||= 'created_at'
-    params[:sort_direction] ||= 'desc'
-    @tasks = Task.all.order(params[:sort_column] + ' ' + params[:sort_direction])
+    @tasks = Task.search(params).order("#{params[:sort_column] || 'created_at'} #{params[:sort_direction] || 'desc'}")
   end
 
   def new

--- a/task_app/app/controllers/tasks_controller.rb
+++ b/task_app/app/controllers/tasks_controller.rb
@@ -45,7 +45,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :description, :due_date, :priority)
+    params.require(:task).permit(:name, :description, :due_date, :priority, :status)
   end
 
   def find_task

--- a/task_app/app/helpers/tasks_helper.rb
+++ b/task_app/app/helpers/tasks_helper.rb
@@ -2,7 +2,16 @@
 
 module TasksHelper
   def sort_link(column_name)
-    output = link_to('▲', sort_column: column_name, sort_direction: :asc)
-    output << link_to('▼', sort_column: column_name, sort_direction: :desc)
+    output = link_to_unless_current('▲', root_path(take_search_params(column_name, :asc)))
+    output << link_to_unless_current('▼', root_path(take_search_params(column_name, :desc)))
+  end
+
+  def take_search_params(sort_column, direction)
+    {
+      sort_column:    sort_column,
+      sort_direction: direction,
+      name:           params[:name],
+      status:         params[:status],
+    }
   end
 end

--- a/task_app/app/models/task.rb
+++ b/task_app/app/models/task.rb
@@ -2,10 +2,12 @@
 
 class Task < ApplicationRecord
   enum priority: %i[low middle high].freeze
+  enum status: %i[to_do in_progress done].freeze
 
   validates :name,        presence: true, length: { maximum: 30 }
   validates :description, presence: true, length: { maximum: 800 }
   validates :priority,    presence: true
+  validates :status,      presence: true
   validate :validate_due_date
 
   private

--- a/task_app/app/models/task.rb
+++ b/task_app/app/models/task.rb
@@ -10,6 +10,13 @@ class Task < ApplicationRecord
   validates :status,      presence: true
   validate :validate_due_date
 
+  def self.search(params)
+    output = self
+    output = output.where('name LIKE ?', "%#{params[:name]}%") if params[:name].present?
+    output = output.where(status: params[:status]) if params[:status].present?
+    output
+  end
+
   private
 
   def validate_due_date

--- a/task_app/app/views/tasks/_form.html.erb
+++ b/task_app/app/views/tasks/_form.html.erb
@@ -28,6 +28,11 @@
   </div>
 
   <div>
+    <%= form.label :status %>
+    <%= form.select :status, Task.statuses.map { |key, value| [I18n.t("enums.task.status.#{key}"), key] } %>
+  </div>
+
+  <div>
     <%= form.submit '送信' %>
   </div>
 <% end %>

--- a/task_app/app/views/tasks/index.html.erb
+++ b/task_app/app/views/tasks/index.html.erb
@@ -6,8 +6,9 @@
     <th><%= Task.human_attribute_name(:id) %></th>
     <th><%= Task.human_attribute_name(:name) %></th>
     <th><%= Task.human_attribute_name(:description) %></th>
-    <th><%= Task.human_attribute_name(:due_date) %><%= sort_link(:due_date) %></th>
+    <th><%= Task.human_attribute_name(:status) %></th>
     <th><%= Task.human_attribute_name(:priority) %><%= sort_link(:priority) %></th>
+    <th><%= Task.human_attribute_name(:due_date) %><%= sort_link(:due_date) %></th>
     <th><%= Task.human_attribute_name(:created_at) %><%= sort_link(:created_at) %></th>
     <th>アクション</th>
   </tr>
@@ -16,8 +17,9 @@
       <td><%= task.id %></td>
       <td><%= task.name %></td>
       <td><%= simple_format(task.description) %></td>
-      <td><%= I18n.l(task.due_date, format: :short) %></td>
+      <td><%= I18n.t("enums.task.status.#{task.status}") %></td>
       <td><%= I18n.t("enums.task.priority.#{task.priority}") %></td>
+      <td><%= I18n.l(task.due_date, format: :short) %></td>
       <td><%= I18n.l(task.created_at, format: :long) %></td>
       <td>
         <%= link_to I18n.t('actions.edit'), edit_task_path(task) %>

--- a/task_app/app/views/tasks/index.html.erb
+++ b/task_app/app/views/tasks/index.html.erb
@@ -1,6 +1,13 @@
 <h1><%= I18n.t('actions_with_model.index', model_name: Task.model_name.human) %></h1>
-<%= link_to I18n.t('actions_with_model.new', model_name: Task.model_name.human), new_task_path %>
 
+<%= form_with url: root_path, method: 'get', local: true do |form| %>
+  <%= form.text_field :name, placeholder: 'タスク名を入力', value: params[:name] %>
+  <%= form.select :status, Task.statuses.map { |key, value| [I18n.t("enums.task.status.#{key}"), key] }, selected: params[:status], include_blank: '指定しない' %>
+  <%= form.submit '検索' %>
+<% end %>
+<br>
+
+<%= link_to I18n.t('actions_with_model.new', model_name: Task.model_name.human), new_task_path %>
 <table class="task-list" border="1" cellpadding="3">
   <tr>
     <th><%= Task.human_attribute_name(:id) %></th>

--- a/task_app/config/locales/ja.yml
+++ b/task_app/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
         description: 説明
         due_date: 期限
         priority: 優先度
+        status: ステータス
         created_at: 登録日時
         updated_at: 更新日時
     errors:
@@ -24,6 +25,10 @@ ja:
         low: 低
         middle: 中
         high: 高
+      status:
+        to_do: 未着手
+        in_progress: 着手中
+        done: 完了
   actions:
     index: '一覧'
     new: '登録'

--- a/task_app/config/routes.rb
+++ b/task_app/config/routes.rb
@@ -2,8 +2,5 @@
 
 Rails.application.routes.draw do
   root to: 'tasks#index'
-
-  controller :tasks do
-    resources :tasks, except: %i[index show]
-  end
+  resources :tasks, except: %i[index show]
 end

--- a/task_app/db/migrate/20190130063058_add_status_to_task.rb
+++ b/task_app/db/migrate/20190130063058_add_status_to_task.rb
@@ -1,0 +1,5 @@
+class AddStatusToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :status, :integer, after: :priority, limit: 1, null: false
+  end
+end

--- a/task_app/db/migrate/20190130063257_add_index_to_task.rb
+++ b/task_app/db/migrate/20190130063257_add_index_to_task.rb
@@ -1,0 +1,6 @@
+class AddIndexToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :name
+    add_index :tasks, :status
+  end
+end

--- a/task_app/db/schema.rb
+++ b/task_app/db/schema.rb
@@ -10,15 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_28_012514) do
+ActiveRecord::Schema.define(version: 2019_01_30_063257) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
     t.date "due_date", null: false
     t.integer "priority", limit: 1, null: false
+    t.integer "status", limit: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tasks_on_name"
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/task_app/spec/factories/tasks.rb
+++ b/task_app/spec/factories/tasks.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     description { 'トイレ,風呂' }
     due_date { '20190225' }
     priority { Task.priorities[:middle] }
+    status { Task.statuses[:in_progress] }
   end
 end

--- a/task_app/spec/features/tasks_spec.rb
+++ b/task_app/spec/features/tasks_spec.rb
@@ -3,28 +3,6 @@
 require 'rails_helper'
 
 feature 'タスク管理機能', type: :feature do
-  shared_examples_for 'validationエラーが表示される' do
-    context '空欄のまま送信したとき' do
-      let(:task_name) { '' }
-      let(:task_description) { '' }
-
-      scenario '入力を促すエラーメッセージが表示される' do
-        expect(page).to have_selector '#error_explanation', text: 'タスク名を入力してください'
-        expect(page).to have_selector '#error_explanation', text: '説明を入力してください'
-      end
-    end
-
-    context '制限を超えた文字数を入力したとき' do
-      let(:task_name) { 'a' * 31 }
-      let(:task_description) { 'a' * 801 }
-
-      scenario '文字数に関するエラーメッセージが表示される' do
-        expect(page).to have_selector '#error_explanation', text: '30文字以内'
-        expect(page).to have_selector '#error_explanation', text: '800文字以内'
-      end
-    end
-  end
-
   feature '一覧機能' do
     let!(:first_task) { FactoryBot.create(:task) }
 
@@ -34,6 +12,7 @@ feature 'タスク管理機能', type: :feature do
       expect(page).to have_content '掃除'
       expect(page).to have_content '02/25'
       expect(page).to have_content '中'
+      expect(page).to have_content '着手中'
       expect(Task.count).to eq 1
     end
   end
@@ -41,9 +20,30 @@ feature 'タスク管理機能', type: :feature do
   feature 'ソート機能' do
     let!(:tasks) {
       [
-        FactoryBot.create(:task, name: 'タスク1', description: 'タスク1の説明', due_date: '20190203', priority: Task.priorities[:middle], created_at: Time.zone.now),
-        FactoryBot.create(:task, name: 'タスク2', description: 'タスク2の説明', due_date: '20190209', priority: Task.priorities[:high],   created_at: 1.day.ago),
-        FactoryBot.create(:task, name: 'タスク3', description: 'タスク3の説明', due_date: '20190206', priority: Task.priorities[:low],    created_at: 2.days.ago),
+        FactoryBot.create(
+          :task,
+          name:       'タスク1',
+          due_date:   '20190203',
+          priority:   Task.priorities[:middle],
+          status:     Task.statuses[:in_progress],
+          created_at: Time.zone.now,
+        ),
+        FactoryBot.create(
+          :task,
+          name:       'タスク2',
+          due_date:   '20190209',
+          priority:   Task.priorities[:high],
+          status:     Task.statuses[:done],
+          created_at: 1.day.ago,
+        ),
+        FactoryBot.create(
+          :task,
+          name:       'タスク3',
+          due_date:   '20190206',
+          priority:   Task.priorities[:low],
+          status:     Task.statuses[:to_do],
+          created_at: 2.days.ago,
+        ),
       ]
     }
 
@@ -66,8 +66,8 @@ feature 'タスク管理機能', type: :feature do
     end
 
     context '列「登録日時」の「▲/▼」をクリックした時' do
-      it_behaves_like '任意の順でソートされる', { xpath: '/html/body/table/tbody/tr[1]/th[6]/a[1]', order: [2, 1, 0] }
-      it_behaves_like '任意の順でソートされる', { xpath: '/html/body/table/tbody/tr[1]/th[6]/a[2]', order: [0, 1, 2] }
+      it_behaves_like '任意の順でソートされる', { xpath: '/html/body/table/tbody/tr[1]/th[7]/a[1]', order: [2, 1, 0] }
+      it_behaves_like '任意の順でソートされる', { xpath: '/html/body/table/tbody/tr[1]/th[7]/a[2]', order: [0, 1, 2] }
     end
 
     context '列「優先度」の「▲/▼」をクリックした時' do
@@ -76,64 +76,230 @@ feature 'タスク管理機能', type: :feature do
     end
 
     context '列「期限」の「▲/▼」をクリックした時' do
-      it_behaves_like '任意の順でソートされる', { xpath: '/html/body/table/tbody/tr[1]/th[4]/a[1]', order: [0, 2, 1] }
-      it_behaves_like '任意の順でソートされる', { xpath: '/html/body/table/tbody/tr[1]/th[4]/a[2]', order: [1, 2, 0] }
+      it_behaves_like '任意の順でソートされる', { xpath: '/html/body/table/tbody/tr[1]/th[6]/a[1]', order: [0, 2, 1] }
+      it_behaves_like '任意の順でソートされる', { xpath: '/html/body/table/tbody/tr[1]/th[6]/a[2]', order: [1, 2, 0] }
     end
   end
 
-  feature '登録機能' do
+  feature '検索機能' do
+    let!(:tasks) {
+      [
+        FactoryBot.create(
+          :task,
+          name:       'タスク1',
+          due_date:   '20190203',
+          priority:   Task.priorities[:middle],
+          status:     Task.statuses[:in_progress],
+          created_at: Time.zone.now,
+        ),
+        FactoryBot.create(
+          :task,
+          name:       'タスク2',
+          due_date:   '20190209',
+          priority:   Task.priorities[:high],
+          status:     Task.statuses[:to_do],
+          created_at: 1.day.ago,
+        ),
+        FactoryBot.create(
+          :task,
+          name:       'task3',
+          due_date:   '20190206',
+          priority:   Task.priorities[:low],
+          status:     Task.statuses[:in_progress],
+          created_at: 2.days.ago,
+        ),
+        FactoryBot.create(
+          :task,
+          name:       'ラスク4',
+          due_date:   '20190212',
+          priority:   Task.priorities[:low],
+          status:     Task.statuses[:in_progress],
+          created_at: 3.days.ago,
+        ),
+      ]
+    }
+
     before do
       visit root_path
-      click_on('タスク登録')
-      fill_in 'タスク名', with: task_name
-      fill_in '説明', with: task_description
-      fill_in '期限', with: '20190213'
-      select '高', from: 'task_priority'
-      click_on('送信')
+      fill_in 'name', with: task_name
+      select status, from: 'status'
+      click_on('検索')
     end
 
-    context '名前と説明を入力したとき' do
-      let(:task_name) { '最初のタスク' }
-      let(:task_description) { '最初のタスクの説明' }
+    context '「タスク」で名前検索したとき' do
+      let(:task_name) { 'タスク' }
+      let(:status) { '指定しない' }
 
-      scenario '正常に登録される' do
-        expect(page).to have_selector '.alert-success', text: '最初のタスク'
-        expect(page).to have_content '02/13'
-        expect(page).to have_content '高'
-        expect(Task.count).to eq 1
+      scenario '検索結果は2件' do
+        expect(page.all('tr').size).to eq 3
+        expect(page).to have_content('タスク1', count: 1)
+        expect(page).to have_content('タスク2', count: 1)
+        expect(find_field('name').value).to eq 'タスク'
       end
     end
 
-    it_behaves_like 'validationエラーが表示される'
+    context '「hoge」で名前検索したとき' do
+      let(:task_name) { 'hoge' }
+      let(:status) { '指定しない' }
+
+      scenario '検索結果は0件' do
+        expect(page.all('tr').size).to eq 1
+        expect(find_field('name').value).to eq 'hoge'
+      end
+    end
+
+    context '「着手中」でステータス検索したとき' do
+      let(:task_name) { '' }
+      let(:status) { '着手中' }
+
+      scenario '検索結果は3件' do
+        expect(page.all('tr').size).to eq 4
+        expect(page).to have_content('タスク1', count: 1)
+        expect(page).to have_content('task3', count: 1)
+        expect(page).to have_content('ラスク4', count: 1)
+        expect(page).to have_select('status', selected: '着手中')
+      end
+    end
+
+    context '「指定しない」でステータス検索したとき' do
+      let(:task_name) { '' }
+      let(:status) { '指定しない' }
+
+      scenario '検索結果は4件' do
+        expect(page.all('tr').size).to eq 5
+        expect(page).to have_select('status', selected: '指定しない')
+      end
+    end
+
+    context '名前&ステータス検索したとき' do
+      let(:task_name) { 'スク' }
+      let(:status) { '着手中' }
+
+      scenario '検索結果は2件' do
+        expect(page.all('tr').size).to eq 3
+        expect(page).to have_content('タスク1', count: 1)
+        expect(page).to have_content('ラスク4', count: 1)
+        expect(find_field('name').value).to eq 'スク'
+        expect(page).to have_select('status', selected: '着手中')
+      end
+    end
+
+    context '検索後、期限で降順ソートしたとき' do
+      let(:task_name) { 'スク' }
+      let(:status) { '着手中' }
+
+      before do
+        page.find(:xpath, '/html/body/table/tbody/tr[1]/th[6]/a[2]').click
+        sleep 1
+      end
+
+      scenario '検索結果2件が期限で降順ソートされる' do
+        expect(page.all('tr').size).to eq 3
+        expect(page.all('tr')[1].text).to have_content 'ラスク4'
+        expect(page.all('tr')[2].text).to have_content 'タスク1'
+        expect(find_field('name').value).to eq 'スク'
+        expect(page).to have_select('status', selected: '着手中')
+      end
+    end
+
+    context '検索後、優先度で昇順ソートしたとき' do
+      let(:task_name) { 'スク' }
+      let(:status) { '着手中' }
+
+      before do
+        page.find(:xpath, '/html/body/table/tbody/tr[1]/th[5]/a[1]').click
+        sleep 1
+      end
+
+      scenario '検索結果2件が優先度で昇順ソートされる' do
+        expect(page.all('tr').size).to eq 3
+        expect(page.all('tr')[1].text).to have_content 'ラスク4'
+        expect(page.all('tr')[2].text).to have_content 'タスク1'
+        expect(find_field('name').value).to eq 'スク'
+        expect(page).to have_select('status', selected: '着手中')
+      end
+    end
   end
 
-  feature '編集機能' do
-    let!(:first_task) { FactoryBot.create(:task) }
+  feature '登録・編集機能' do
+    shared_examples_for 'validationエラーが表示される' do
+      context '空欄のまま送信したとき' do
+        let(:task_name) { '' }
+        let(:task_description) { '' }
 
-    before do
-      visit root_path
-      click_on('編集')
-      fill_in 'タスク名', with: task_name
-      fill_in '説明', with: task_description
-      fill_in '期限', with: '20190213'
-      select '高', from: 'task_priority'
-      click_on('送信')
-    end
+        scenario '入力を促すエラーメッセージが表示される' do
+          expect(page).to have_selector '#error_explanation', text: 'タスク名を入力してください'
+          expect(page).to have_selector '#error_explanation', text: '説明を入力してください'
+        end
+      end
 
-    context '名前と説明を入力したとき' do
-      let(:task_name) { '掃除' }
-      let(:task_description) { 'トイレ,風呂,キッチン' }
+      context '制限を超えた文字数を入力したとき' do
+        let(:task_name) { 'a' * 31 }
+        let(:task_description) { 'a' * 801 }
 
-      scenario '正常に更新される' do
-        expect(page).to have_selector '.alert-success', text: '更新しました。'
-        expect(page).to have_content 'トイレ,風呂,キッチン'
-        expect(page).to have_content '02/13'
-        expect(page).to have_content '高'
-        expect(Task.count).to eq 1
+        scenario '文字数に関するエラーメッセージが表示される' do
+          expect(page).to have_selector '#error_explanation', text: '30文字以内'
+          expect(page).to have_selector '#error_explanation', text: '800文字以内'
+        end
       end
     end
 
-    it_behaves_like 'validationエラーが表示される'
+    feature '登録' do
+      before do
+        visit root_path
+        click_on('タスク登録')
+        fill_in 'タスク名', with: task_name
+        fill_in '説明', with: task_description
+        fill_in '期限', with: '20190213'
+        select '高', from: 'task_priority'
+        click_on('送信')
+      end
+
+      context '名前と説明を入力したとき' do
+        let(:task_name) { '最初のタスク' }
+        let(:task_description) { '最初のタスクの説明' }
+
+        scenario '正常に登録される' do
+          expect(page).to have_selector '.alert-success', text: '最初のタスク'
+          expect(page).to have_content '02/13'
+          expect(page).to have_content '高'
+          expect(page).to have_content '未着手'
+          expect(Task.count).to eq 1
+        end
+      end
+
+      it_behaves_like 'validationエラーが表示される'
+    end
+
+    feature '編集' do
+      let!(:first_task) { FactoryBot.create(:task) }
+
+      before do
+        visit root_path
+        click_on('編集')
+        fill_in 'タスク名', with: task_name
+        fill_in '説明', with: task_description
+        fill_in '期限', with: '20190213'
+        select '高', from: 'task_priority'
+        click_on('送信')
+      end
+
+      context '名前と説明を入力したとき' do
+        let(:task_name) { '掃除' }
+        let(:task_description) { 'トイレ,風呂,キッチン' }
+
+        scenario '正常に更新される' do
+          expect(page).to have_selector '.alert-success', text: '更新しました。'
+          expect(page).to have_content 'トイレ,風呂,キッチン'
+          expect(page).to have_content '02/13'
+          expect(page).to have_content '高'
+          expect(page).to have_content '未着手'
+          expect(Task.count).to eq 1
+        end
+      end
+
+      it_behaves_like 'validationエラーが表示される'
+    end
   end
 
   feature '削除機能' do

--- a/task_app/spec/models/task_spec.rb
+++ b/task_app/spec/models/task_spec.rb
@@ -95,5 +95,59 @@ RSpec.describe Task, type: :model do
         end
       end
     end
+
+    describe 'ステータス' do
+      context '空のとき' do
+        task = FactoryBot.build(:task, status: '')
+        task.valid?
+        it_behaves_like '入力を求められる', task.errors[:status]
+      end
+
+      context 'enumに存在しない値のとき' do
+        scenario 'ArgumentErrorが発生する' do
+          expect { FactoryBot.build(:task, status: 5) }.to raise_error(ArgumentError)
+        end
+      end
+
+      context '文字列のとき' do
+        scenario 'ArgumentErrorが発生する' do
+          expect { FactoryBot.build(:task, status: 'abc') }.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
+
+  describe '検索機能' do
+    let!(:tasks) {
+      [
+        FactoryBot.create(:task, name: 'タスク', status: :to_do),
+        FactoryBot.create(:task, name: 'task', status: :in_progress),
+        FactoryBot.create(:task, name: 'タスク', status: :in_progress),
+      ]
+    }
+
+    context '「タスク」で名前検索したとき' do
+      it '2件のレコードを取得' do
+        expect(Task.search({ name: 'タスク' }).count).to eq 2
+      end
+    end
+
+    context '存在しない名前で検索したとき' do
+      it '0件のレコードを取得' do
+        expect(Task.search({ name: 'abc' }).count).to eq 0
+      end
+    end
+
+    context '「着手中」でステータス検索したとき' do
+      it '2件のレコードを取得' do
+        expect(Task.search({ status: Task.statuses[:in_progress] }).count).to eq 2
+      end
+    end
+
+    context '名前・ステータスで検索したとき' do
+      it '1件のレコードを取得' do
+        expect(Task.search({ name: 'タスク', status: Task.statuses[:in_progress] }).count).to eq 1
+      end
+    end
   end
 end


### PR DESCRIPTION
以下の機能を実装致しました。
お手数ですがご確認をお願い致します。

> ### ステップ13: ステータスを追加して、検索できるようにしよう
> - ステータス（未着手・着手中・完了）を追加してみよう
>   - 【オプション要件】初学者ではない場合はstateを管理するGemを導入しても構いません
> - 一覧画面でタイトルとステータスで検索ができるようにしよう
>   - 【オプション要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構いません
> - 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
>   - 以降のステップでも必要に応じて確認する癖をつけましょう
> - 検索インデックスを貼りましょう
> - 検索に対してmodel specを追加してみよう（feature specも拡充しておきましょう）

### 実装内容
- ステータスの追加
- 検索インデックスの追加
- タイトルとステータスによる検索機能の実装(※ransackは導入しておりません)
- featureとmodelにテスト追加