### PR TITLE
ステップ19: ユーザにロールを追加しよう

### DIFF
--- a/todoapp/app/controllers/admin/users_controller.rb
+++ b/todoapp/app/controllers/admin/users_controller.rb
@@ -67,6 +67,9 @@ class Admin::UsersController < ApplicationController
   end
 
   def login_required_as_admin
-    redirect_to login_path unless current_user&.admin?
+    return if current_user&.admin?
+
+    sign_out
+    redirect_to login_path, notice: t('sessions.flash.logout')
   end
 end

--- a/todoapp/app/controllers/admin/users_controller.rb
+++ b/todoapp/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
+  before_action :login_required_as_admin
 
   PER = 8
 
@@ -32,7 +33,11 @@ class Admin::UsersController < ApplicationController
   end
 
   def update
-    if @user.update(user_params)
+    @user.assign_attributes(user_params)
+    if @user.myself?(@current_user) && @user.role_changed?
+      redirect_to admin_users_path,
+                  notice: I18n.t('notification.update_failed_myself_role')
+    elsif @user.update(user_params)
       redirect_to admin_users_path,
                   notice: I18n.t('notification.update', value: @user.name)
     else
@@ -41,9 +46,14 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
-    @user.destroy
-    redirect_to admin_users_path,
-                notice: I18n.t('notification.destroy', value: @user.name)
+    if @user.myself?(@current_user)
+      redirect_to admin_users_path,
+                  notice: I18n.t('notification.destroy_failed_myself')
+    else
+      @user.destroy
+      redirect_to admin_users_path,
+                  notice: I18n.t('notification.destroy', value: @user.name)
+    end
   end
 
   private
@@ -54,5 +64,9 @@ class Admin::UsersController < ApplicationController
 
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def login_required_as_admin
+    redirect_to login_path unless current_user&.admin?
   end
 end

--- a/todoapp/app/models/user.rb
+++ b/todoapp/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ApplicationRecord
-
   has_secure_password validations: true
 
   validates :name, presence: true, length: { maximum: 12 }
@@ -25,6 +24,14 @@ class User < ApplicationRecord
     general: ROLE_GENERAL,
     admin: ROLE_ADMIN
   }
+
+  def admin?
+    ROLE_ADMIN == role_before_type_cast
+  end
+
+  def myself?(user)
+    id == user.id
+  end
 
   def self.new_remember_token
     SecureRandom.urlsafe_base64

--- a/todoapp/app/views/admin/users/_form.html.erb
+++ b/todoapp/app/views/admin/users/_form.html.erb
@@ -22,7 +22,10 @@
       </div>
       <div class="form-group row">
         <%= f.label :role, class: 'col-form-label col-lg-3 col-sm-3' %>
-        <%= f.select :role, User.roles_i18n.invert, {}, { class: 'form-control col-7' } %>
+        <%= f.select :role,
+                     User.roles_i18n.invert,
+                     {},
+                     { class: 'form-control col-7', disabled: user.myself?(@current_user) } %>
       </div>
 
       <%= f.submit class: 'btn btn-primary' %>

--- a/todoapp/app/views/admin/users/index.html.erb
+++ b/todoapp/app/views/admin/users/index.html.erb
@@ -15,7 +15,7 @@
   </thead>
   <tbody>
   <% @search_tasks.each do |user| %>
-    <tr>
+    <tr class="<%= 'bg-warning' if user.myself?(@current_user) %>">
       <td><%= link_to user.id, admin_user_path(user.id) %></td>
       <td><%= user.name %></td>
       <td><%= user.role_i18n %></td>
@@ -24,8 +24,12 @@
       <td><%= l(user.updated_at) %></td>
       <td><%= link_to t('common.edit'), edit_admin_user_path(user), class: 'btn btn-primary' %></td>
       <td>
-        <%= button_to t('common.delete'), admin_user_path(user), class: 'btn btn-primary',
-                      method: :delete, data: { confirm: t('notification.confirm_destroy', value: user.name) } %>
+        <%= button_to t('common.delete'),
+                      admin_user_path(user),
+                      class: 'btn btn-primary',
+                      method: :delete,
+                      data: { confirm: t('notification.confirm_destroy', value: user.name) },
+                      disabled: user.myself?(@current_user) %>
       </td>
     </tr>
   <% end %>

--- a/todoapp/app/views/admin/users/show.html.erb
+++ b/todoapp/app/views/admin/users/show.html.erb
@@ -42,7 +42,7 @@
         <tbody>
         <% @search_tasks.each do |task| %>
           <tr>
-            <td><%= link_to task.id, task_path(task.id) %></td>
+            <td><%= task.id %></td>
             <td><%= task.title %></td>
             <td><%= task.status_i18n %></td>
             <td><%= l(task.end_at) unless task.end_at.nil? %></td>

--- a/todoapp/app/views/layouts/application.html.erb
+++ b/todoapp/app/views/layouts/application.html.erb
@@ -19,8 +19,10 @@
           <ul class="navbar-nav">
             <li><%= link_to t('tasks.index.title'), tasks_path, class: 'nav-link' %></li>
             <li><%= link_to t('tasks.new.title'), new_task_path, class: 'nav-link' %></li>
-            <li><%= link_to t('admin.users.index.title'), admin_users_path, class: 'nav-link' %></li>
-            <li><%= link_to t('admin.users.new.title'), new_admin_user_path, class: 'nav-link' %></li>
+            <% if @current_user.admin? %>
+              <li><%= link_to t('admin.users.index.title'), admin_users_path, class: 'nav-link' %></li>
+              <li><%= link_to t('admin.users.new.title'), new_admin_user_path, class: 'nav-link' %></li>
+            <% end %>
           </ul>
           <div class="ml-auto">
             <%= button_to t('sessions.logout_btn'), logout_path, method: :delete, class: 'btn btn-dark' %>

--- a/todoapp/config/locales/views/ja.yml
+++ b/todoapp/config/locales/views/ja.yml
@@ -41,6 +41,8 @@ ja:
     update: '「%{value}」を更新しました。'
     destroy: '「%{value}」を削除しました。'
     confirm_destroy: '「%{value}」を削除します。よろしいですか？'
+    update_failed_myself_role: '自分の役割は変えれないよ'
+    destroy_failed_myself: '自分は消せないよ'
   views:
     pagination:
       first: "&laquo; 最初"

--- a/todoapp/spec/features/users/edit_spec.rb
+++ b/todoapp/spec/features/users/edit_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 feature '管理者機能', type: :feature do
-  let!(:user_a) { create(:user, name: 'ユーザーA', role: 2) }
-  let!(:user_b) { create(:user, name: 'ユーザーB', email: 'b@a.a', role: 2) }
+  let!(:user_a) { create(:user, name: 'ユーザーA', role: User::ROLE_ADMIN) }
+  let!(:user_b) { create(:user, name: 'ユーザーB', email: 'b@a.a', role: User::ROLE_ADMIN) }
 
   describe '更新機能' do
     context '更新画面へ遷移した時' do
@@ -23,10 +23,17 @@ feature '管理者機能', type: :feature do
       end
 
       scenario 'ログインしているユーザの役割は変更できない' do
+        expect(page).to have_field '役割', disabled: true
+        find("option[value='general']").select_option
+        expect(page).to have_field '役割', disabled: true
+
         js = "document.querySelector('#user_role').disabled = false;"
         page.execute_script js
+        expect(page).to have_field '役割', disabled: false
 
         find("option[value='general']").select_option
+        expect(page).to have_select('user[role]', selected: '一般')
+
         click_button '更新する'
         expect(page).to have_content '自分の役割は変えれないよ'
       end

--- a/todoapp/spec/features/users/edit_spec.rb
+++ b/todoapp/spec/features/users/edit_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+feature '管理者機能', type: :feature do
+  let!(:user_a) { create(:user, name: 'ユーザーA', role: 2) }
+  let!(:user_b) { create(:user, name: 'ユーザーB', email: 'b@a.a', role: 2) }
+
+  describe '更新機能' do
+    context '更新画面へ遷移した時' do
+      background do
+        login
+        visit edit_admin_user_path(user_a)
+      end
+
+      scenario '入力フォームがある' do
+        expect(page).to have_content '入力フォーム'
+      end
+    end
+
+    context '更新画面へ遷移した時', js: true do
+      background do
+        login
+        visit edit_admin_user_path(user_a)
+      end
+
+      scenario 'ログインしているユーザの役割は変更できない' do
+        js = "document.querySelector('#user_role').disabled = false;"
+        page.execute_script js
+
+        find("option[value='general']").select_option
+        click_button '更新する'
+        expect(page).to have_content '自分の役割は変えれないよ'
+      end
+    end
+
+    context '更新画面へ遷移した時' do
+      background do
+        login
+        visit edit_admin_user_path(user_b)
+      end
+
+      scenario 'ログインしてないユーザの役割は変更できる' do
+        find("option[value='general']").select_option
+        click_button '更新する'
+        expect(page).to have_content '「ユーザーB」を更新しました。'
+      end
+    end
+  end
+end

--- a/todoapp/spec/features/users/index_spec.rb
+++ b/todoapp/spec/features/users/index_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 feature '管理者機能', type: :feature do
-  let!(:user_a) { create(:user, name: 'ユーザーA') }
-  let!(:user_b) { create(:user, name: 'ユーザーB', email: 'b@a.a') }
-  let!(:user_c) { create(:user, name: 'ユーザーC', email: 'c@a.a') }
+  let!(:user_a) { create(:user, name: 'ユーザーA', role: 2) }
+  let!(:user_b) { create(:user, name: 'ユーザーB', email: 'b@a.a', role: 2) }
+  let!(:user_c) { create(:user, name: 'ユーザーC', email: 'c@a.a', role: 2) }
 
   describe 'ユーザー一覧表示機能' do
     context 'ユーザー一覧画面へ遷移した時' do

--- a/todoapp/spec/features/users/index_spec.rb
+++ b/todoapp/spec/features/users/index_spec.rb
@@ -18,5 +18,29 @@ feature '管理者機能', type: :feature do
         expect(page).to have_content 'ユーザーC'
       end
     end
+
+    context 'ユーザー一覧画面へ遷移した時' do
+      background do
+        login
+        visit admin_users_path
+      end
+
+      scenario 'ユーザーの削除ができる' do
+        find('/html/body/article/table/tbody/tr[2]/td[8]/form/input[2]').click
+        expect(page).to have_content '「ユーザーB」を削除しました。'
+      end
+    end
+
+    context 'ユーザー一覧画面へ遷移した時' do
+      background do
+        login
+        visit admin_users_path
+      end
+
+      scenario 'ログイン中のユーザーは消せない' do
+        find('/html/body/article/table/tbody/tr[1]/td[8]/form/input[2]').click
+        expect(page).to have_content '自分は消せないよ'
+      end
+    end
   end
 end

--- a/todoapp/spec/features/users/index_spec.rb
+++ b/todoapp/spec/features/users/index_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 feature '管理者機能', type: :feature do
-  let!(:user_a) { create(:user, name: 'ユーザーA', role: 2) }
-  let!(:user_b) { create(:user, name: 'ユーザーB', email: 'b@a.a', role: 2) }
-  let!(:user_c) { create(:user, name: 'ユーザーC', email: 'c@a.a', role: 2) }
+  let!(:user_a) { create(:user, name: 'ユーザーA', role: User::ROLE_ADMIN) }
+  let!(:user_b) { create(:user, name: 'ユーザーB', email: 'b@a.a', role: User::ROLE_ADMIN) }
+  let!(:user_c) { create(:user, name: 'ユーザーC', email: 'c@a.a', role: User::ROLE_ADMIN) }
 
   describe 'ユーザー一覧表示機能' do
     context 'ユーザー一覧画面へ遷移した時' do

--- a/todoapp/spec/features/users/new_spec.rb
+++ b/todoapp/spec/features/users/new_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature '管理者機能', type: :feature do
-  let!(:user_a) { create(:user, name: 'ユーザーA', role: 2) }
+  let!(:user_a) { create(:user, name: 'ユーザーA', role: User::ROLE_ADMIN) }
 
   describe '新規作成機能' do
     background do

--- a/todoapp/spec/features/users/new_spec.rb
+++ b/todoapp/spec/features/users/new_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature '管理者機能', type: :feature do
-  let!(:user_a) { create(:user, name: 'ユーザーA') }
+  let!(:user_a) { create(:user, name: 'ユーザーA', role: 2) }
 
   describe '新規作成機能' do
     background do

--- a/todoapp/spec/features/users/show_spec.rb
+++ b/todoapp/spec/features/users/show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature '管理者機能', type: :feature do
-  let(:user_a) { create(:user, name: 'ユーザーA', role: 2) }
+  let(:user_a) { create(:user, name: 'ユーザーA', role: User::ROLE_ADMIN) }
   let!(:task_a) { create(:task, :first_task, user: user_a) }
 
   describe '詳細表示機能' do

--- a/todoapp/spec/features/users/show_spec.rb
+++ b/todoapp/spec/features/users/show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature '管理者機能', type: :feature do
-  let!(:user_a) { create(:user, name: 'ユーザーA') }
+  let!(:user_a) { create(:user, name: 'ユーザーA', role: 2) }
 
   describe '詳細表示機能' do
     context '詳細表示画面へ遷移した時' do


### PR DESCRIPTION
## やったこと
[ステップ19: ユーザにロールを追加しよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)
  * `管理ユーザが1人もいなくならないように削除の制御をしましょう` この対応として、下記仕様としました
    * ログイン中の管理者ユーザーは、自身のユーザー情報を削除できなくした
    * ログイン中の管理者ユーザーは、自身の役割を変更できなくした

## 確認手順
`$ bundle`
`$ bin/rake db:migrate`
`$ bin/rails db:reset`
→ seedsにログイン情報があるので、そちらのメールアドレスとパスワードで確認お願いします

`$ brew install yarn`=> 既にインストールしている場合は不要
`$ yarn install`=> 必要なモジュールをインストール
`$ bin/webpack`=> 静的ファイルの出力
`$ bin/rails s`=> サーバ起動

## その他
- [x] 依存 https://github.com/Fablic/training/pull/241