### PR TITLE
[WIP]ステップ18: ユーザの管理画面を実装

### DIFF
--- a/task_app/app/assets/javascripts/admin/users.coffee
+++ b/task_app/app/assets/javascripts/admin/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/task_app/app/assets/stylesheets/admin/users.scss
+++ b/task_app/app/assets/stylesheets/admin/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Admin::Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/task_app/app/controllers/admin/users_controller.rb
+++ b/task_app/app/controllers/admin/users_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Admin
+  class UsersController < ApplicationController
+    before_action :find_user, only: %i[edit update destroy tasks]
+
+    def index
+      @users = User.search(params).page(params[:page])
+    end
+
+    def new
+      @user = User.new
+    end
+
+    def create
+      @user = User.new(user_params)
+
+      if @user.save
+        redirect_to admin_root_url, flash: { success: create_flash_message('create', 'success') }
+      else
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @user.update(user_params)
+        redirect_to admin_root_url, flash: { success: create_flash_message('update', 'success') }
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      if @user == current_user
+        flash[:danger] = I18n.t('flash.user_self_destroy')
+      elsif @user.destroy
+        flash[:success] = create_flash_message('update', 'success')
+      else
+        flash[:danger] = create_flash_message('destroy', 'failed')
+      end
+
+      redirect_to admin_root_url
+    end
+
+    def tasks
+      @tasks = Task.search(params, @user.tasks).order("#{params[:sort_column] || 'created_at'} #{params[:sort_direction] || 'desc'}").page(params[:page])
+    end
+
+    private
+
+    def user_params
+      params.require(:user).permit(:email, :password, :password_confirmation)
+    end
+
+    def find_user
+      @user = User.find(params[:id])
+    end
+
+    def create_flash_message(action, result)
+      I18n.t("flash.#{result}", target: "#{User.model_name.human}「#{@user.email}」", action: I18n.t("actions.#{action}"))
+    end
+  end
+end

--- a/task_app/app/controllers/admin/users_controller.rb
+++ b/task_app/app/controllers/admin/users_controller.rb
@@ -37,7 +37,7 @@ module Admin
       if @user == current_user
         flash[:danger] = I18n.t('flash.user_self_destroy')
       elsif @user.destroy
-        flash[:success] = create_flash_message('update', 'success')
+        flash[:success] = create_flash_message('destroy', 'success')
       else
         flash[:danger] = create_flash_message('destroy', 'failed')
       end

--- a/task_app/app/controllers/tasks_controller.rb
+++ b/task_app/app/controllers/tasks_controller.rb
@@ -17,7 +17,7 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to root_url, flash: { success: create_flash_message('create', 'success') }
     else
-      render 'new'
+      render :new
     end
   end
 
@@ -28,16 +28,18 @@ class TasksController < ApplicationController
     if @task.update(task_params)
       redirect_to root_url, flash: { success: create_flash_message('update', 'success') }
     else
-      render 'edit'
+      render :edit
     end
   end
 
   def destroy
     if @task.destroy
-      redirect_to root_url, flash: { success: create_flash_message('destroy', 'success') }
+      flash[:success] = create_flash_message('destroy', 'success')
     else
-      redirect_to root_url, flash: { danger: create_flash_message('destroy', 'failed') }
+      flash[:danger] = create_flash_message('destroy', 'failed')
     end
+
+    redirect_to root_url
   end
 
   private

--- a/task_app/app/helpers/admin/users_helper.rb
+++ b/task_app/app/helpers/admin/users_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Admin
+  module UsersHelper
+  end
+end

--- a/task_app/app/helpers/tasks_helper.rb
+++ b/task_app/app/helpers/tasks_helper.rb
@@ -6,6 +6,11 @@ module TasksHelper
     output << link_to_unless_current('▼', root_path(take_search_params(column_name, :desc)))
   end
 
+  def admin_sort_link(user, column_name)
+    output = link_to_unless_current('▲', tasks_admin_user_path(user, take_search_params(column_name, :asc)))
+    output << link_to_unless_current('▼', tasks_admin_user_path(user, take_search_params(column_name, :desc)))
+  end
+
   def take_search_params(sort_column, direction)
     {
       sort_column:    sort_column,

--- a/task_app/app/models/user.rb
+++ b/task_app/app/models/user.rb
@@ -8,4 +8,10 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :password, presence: true, length: { minimum: 6 }, format: { without: /\s/, message: I18n.t('errors.messages.space') }
+
+  def self.search(params)
+    output = self
+    output = output.where('email LIKE ?', "%#{params[:email]}%") if params[:email].present?
+    output
+  end
 end

--- a/task_app/app/views/admin/users/_form.html.erb
+++ b/task_app/app/views/admin/users/_form.html.erb
@@ -1,0 +1,42 @@
+<% if user.errors.any? %>
+  <ul id="error_explanation" class="alert alert-danger">
+    <% user.errors.full_messages.each do |message| %>
+      <li class="ml-2"><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_with model: [:admin, user], local: true do |f| %>
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+      <%= f.label :email %>
+    </div>
+    <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
+      <%= f.text_field :email, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+      <%= f.label :password %>
+    </div>
+    <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
+      <%= f.password_field :password, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+      <%= f.label :password_confirmation %>
+    </div>
+    <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <%= f.submit '送信', class: 'btn btn-primary btn-sm' %>
+    </div>
+  </div>
+<% end %>

--- a/task_app/app/views/admin/users/edit.html.erb
+++ b/task_app/app/views/admin/users/edit.html.erb
@@ -1,0 +1,5 @@
+<h3><%= I18n.t('actions_with_model.edit', model_name: User.model_name.human) %></h3>
+<%= render partial: 'form', locals: { user: @user } %>
+<br>
+
+<%= link_to I18n.t('actions_with_model.index', model_name: User.model_name.human), admin_root_path %>

--- a/task_app/app/views/admin/users/index.html.erb
+++ b/task_app/app/views/admin/users/index.html.erb
@@ -13,7 +13,6 @@
 <table class="table table-bordered table-hover">
   <thead>
     <tr>
-      <th><%= User.human_attribute_name(:id) %></th>
       <th><%= User.human_attribute_name(:email) %></th>
       <th><%= Task.model_name.human %>数</th>
       <th><%= User.human_attribute_name(:created_at) %></th>
@@ -24,7 +23,6 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
-        <td><%= user.id %></td>
         <td><%= user.email %></td>
         <td><%= user.tasks.count %></td>
         <td><%= I18n.l(user.created_at, format: :long) %></td>

--- a/task_app/app/views/admin/users/index.html.erb
+++ b/task_app/app/views/admin/users/index.html.erb
@@ -1,7 +1,7 @@
 <h3><%= I18n.t('actions_with_model.index', model_name: User.model_name.human) %></h3>
 
 <%= form_with url: admin_root_path, method: 'get', local: true, class: 'form-inline mb-3' do |form| %>
-  <%= form.text_field :email, placeholder: 'メールアドレスを入力', value: params[:email], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
+  <%= form.text_field :email, placeholder: 'メールアドレスを入力', value: params[:email], class: 'form-control mr-2 col-6 col-sm-6 col-md-4 col-lg-3 col-xl-2' %>
   <%= form.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-2' %>
 <% end %>
 

--- a/task_app/app/views/admin/users/index.html.erb
+++ b/task_app/app/views/admin/users/index.html.erb
@@ -1,0 +1,41 @@
+<h3><%= I18n.t('actions_with_model.index', model_name: User.model_name.human) %></h3>
+
+<%= form_with url: admin_root_path, method: 'get', local: true, class: 'form-inline mb-3' do |form| %>
+  <%= form.text_field :email, placeholder: 'メールアドレスを入力', value: params[:email], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
+  <%= form.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-2' %>
+<% end %>
+
+<div class="user-pagination">
+  <%= paginate @users %>
+  <%= page_entries_info @users %>
+</div>
+
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th><%= User.human_attribute_name(:id) %></th>
+      <th><%= User.human_attribute_name(:email) %></th>
+      <th><%= Task.model_name.human %>数</th>
+      <th><%= User.human_attribute_name(:created_at) %></th>
+      <th><%= User.human_attribute_name(:updated_at) %></th>
+      <th>アクション</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.id %></td>
+        <td><%= user.email %></td>
+        <td><%= user.tasks.count %></td>
+        <td><%= I18n.l(user.created_at, format: :long) %></td>
+        <td><%= I18n.l(user.updated_at, format: :long) %></td>
+        <td>
+          <%= link_to I18n.t('actions_with_model.index', model_name: Task.model_name.human), tasks_admin_user_path(user) %>
+          <%= link_to I18n.t('actions.edit'), edit_admin_user_path(user) %>
+          <%= link_to I18n.t('actions.destroy'), admin_user_path(user), method: :delete,
+              data: { confirm: I18n.t(:dialog, target: "#{User.model_name.human}「#{user.email}」", action: I18n.t('actions.destroy')) } unless user == current_user %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/task_app/app/views/admin/users/new.html.erb
+++ b/task_app/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<h3><%= I18n.t('actions_with_model.new', model_name: User.model_name.human) %></h3>
+<%= render partial: 'form', locals: { user: @user } %>
+<br>
+
+<%= link_to I18n.t('actions_with_model.index', model_name: User.model_name.human), admin_root_path %>

--- a/task_app/app/views/admin/users/tasks.html.erb
+++ b/task_app/app/views/admin/users/tasks.html.erb
@@ -1,11 +1,10 @@
-<h3><%= I18n.t('actions_with_model.index', model_name: Task.model_name.human) %></h3>
+<h3 class="mb-3"><%= I18n.t('words.own', obj1: "#{@user.email}", obj2: I18n.t('actions_with_model.index', model_name: Task.model_name.human)) %></h3>
 
-<%= form_with url: root_path, method: 'get', local: true, class: 'form-inline mb-3' do |form| %>
+<%= form_with url: tasks_admin_user_path(@user), method: 'get', local: true, class: 'form-inline mb-3' do |form| %>
   <%= form.text_field :name, placeholder: 'タスク名を入力', value: params[:name], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
   <%= form.select :status, Task.statuses.map { |key, value| [I18n.t("enums.task.status.#{key}"), key] }, selected: params[:status], include_blank: '指定しない' %>
   <%= form.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-2' %>
 <% end %>
-
 
 <div class="task-pagination">
   <%= paginate @tasks %>
@@ -19,10 +18,9 @@
       <th><%= Task.human_attribute_name(:name) %></th>
       <th><%= Task.human_attribute_name(:description) %></th>
       <th><%= Task.human_attribute_name(:status) %></th>
-      <th><%= Task.human_attribute_name(:priority) %><%= sort_link(:priority) %></th>
-      <th><%= Task.human_attribute_name(:due_date) %><%= sort_link(:due_date) %></th>
-      <th><%= Task.human_attribute_name(:created_at) %><%= sort_link(:created_at) %></th>
-      <th>アクション</th>
+      <th><%= Task.human_attribute_name(:priority) %><%= admin_sort_link(@user, :priority) %></th>
+      <th><%= Task.human_attribute_name(:due_date) %><%= admin_sort_link(@user, :due_date) %></th>
+      <th><%= Task.human_attribute_name(:created_at) %><%= admin_sort_link(@user, :created_at) %></th>
     </tr>
   </thead>
   <tbody>
@@ -35,12 +33,9 @@
         <td><%= I18n.t("enums.task.priority.#{task.priority}") %></td>
         <td><%= I18n.l(task.due_date, format: :short) %></td>
         <td><%= I18n.l(task.created_at, format: :long) %></td>
-        <td>
-          <%= link_to I18n.t('actions.edit'), edit_task_path(task) %>
-          <%= link_to I18n.t('actions.destroy'), task_path(task), method: :delete,
-              data: { confirm: I18n.t(:dialog, target: "#{Task.model_name.human}「#{task.name}」", action: I18n.t('actions.destroy')) } %>
-        </td>
       </tr>
     <% end %>
   </tbody>
 </table>
+
+<%= link_to I18n.t('actions_with_model.index', model_name: User.model_name.human), admin_root_path %>

--- a/task_app/app/views/admin/users/tasks.html.erb
+++ b/task_app/app/views/admin/users/tasks.html.erb
@@ -14,7 +14,6 @@
 <table class="table table-bordered table-hover">
   <thead>
     <tr>
-      <th><%= Task.human_attribute_name(:id) %></th>
       <th><%= Task.human_attribute_name(:name) %></th>
       <th><%= Task.human_attribute_name(:description) %></th>
       <th><%= Task.human_attribute_name(:status) %></th>
@@ -26,7 +25,6 @@
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
-        <td><%= task.id %></td>
         <td><%= task.name %></td>
         <td><%= simple_format(task.description, class: 'mb-0') %></td>
         <td><%= I18n.t("enums.task.status.#{task.status}") %></td>

--- a/task_app/app/views/layouts/_header.html.erb
+++ b/task_app/app/views/layouts/_header.html.erb
@@ -5,23 +5,33 @@
 <div class="collapse navbar-collapse" id="navbarNavDropdown">
   <ul class="navbar-nav mr-auto">
     <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <%= I18n.t('links.manage', model_name: Task.model_name.human) %>
+      <a class="nav-link dropdown-toggle" href="#" id="navbarTaskMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <%= I18n.t('words.manage', model_name: Task.model_name.human) %>
       </a>
-      <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+      <div class="dropdown-menu" aria-labelledby="navbarTaskMenuLink">
         <%= link_to I18n.t('actions.index'), root_path, class: 'dropdown-item' %>
         <%= link_to I18n.t('actions_with_model.new', model_name: Task.model_name.human), new_task_path, class: 'dropdown-item' %>
+      </div>
+    </li>
+
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle" href="#" id="navbarUserMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <%= I18n.t('words.manage', model_name: User.model_name.human) %>
+      </a>
+      <div class="dropdown-menu" aria-labelledby="navbarUserMenuLink">
+        <%= link_to I18n.t('actions.index'), admin_root_path, class: 'dropdown-item' %>
+        <%= link_to I18n.t('actions_with_model.new', model_name: User.model_name.human), new_admin_user_path, class: 'dropdown-item' %>
       </div>
     </li>
   </ul>
 
   <ul class="navbar-nav">
     <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <a class="nav-link dropdown-toggle" href="#" id="navbarLoginUserMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <%= current_user.email %>
       </a>
-      <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-        <%= link_to I18n.t('links.logout'), logout_path, method: :delete, class: 'dropdown-item' %>
+      <div class="dropdown-menu" aria-labelledby="navbarLoginUserMenuLink">
+        <%= link_to I18n.t('words.logout'), logout_path, method: :delete, class: 'dropdown-item' %>
       </div>
     </li>
   </ul>

--- a/task_app/app/views/sessions/new.html.erb
+++ b/task_app/app/views/sessions/new.html.erb
@@ -8,7 +8,7 @@
       <div class="form-group">
         <%= f.password_field :password, class: 'form-control', placeholder: User.human_attribute_name(:password) %>
       </div>
-      <%= f.submit I18n.t('links.login'), class: 'btn btn-primary btn-sm btn-block' %>
+      <%= f.submit I18n.t('words.login'), class: 'btn btn-primary btn-sm btn-block' %>
     <% end %>
   </div>
 </div>

--- a/task_app/app/views/tasks/index.html.erb
+++ b/task_app/app/views/tasks/index.html.erb
@@ -15,7 +15,6 @@
 <table class="table table-bordered table-hover">
   <thead>
     <tr>
-      <th><%= Task.human_attribute_name(:id) %></th>
       <th><%= Task.human_attribute_name(:name) %></th>
       <th><%= Task.human_attribute_name(:description) %></th>
       <th><%= Task.human_attribute_name(:status) %></th>
@@ -28,7 +27,6 @@
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
-        <td><%= task.id %></td>
         <td><%= task.name %></td>
         <td><%= simple_format(task.description, class: 'mb-0') %></td>
         <td><%= I18n.t("enums.task.status.#{task.status}") %></td>

--- a/task_app/config/locales/ja.yml
+++ b/task_app/config/locales/ja.yml
@@ -3,7 +3,7 @@ ja:
   activerecord:
     models:
       task: タスク
-      user: ユーザー
+      user: ユーザ
     attributes:
       task:
         id: ID
@@ -51,7 +51,8 @@ ja:
     edit: "%{model_name}編集"
     update: "%{model_name}更新"
     destroy: "%{model_name}削除"
-  links:
+  words:
+    own: "%{obj1}の%{obj2}"
     manage: "%{model_name}管理"
     search: 検索
     logout: ログアウト
@@ -64,6 +65,7 @@ ja:
       failed: メールアドレスまたはパスワードが正しくありません
       required: サービスを利用するにはログインが必要です
     logout: ログアウトしました
+    user_self_destroy: 自身のアカウントは削除できません
   dialog: "%{target}を%{action}します。よろしいでしょうか？"
 
   date:

--- a/task_app/config/routes.rb
+++ b/task_app/config/routes.rb
@@ -8,4 +8,11 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
 
   resources :tasks, except: %i[show]
+
+  namespace :admin do
+    root to: 'users#index'
+    resources :users, except: %i[show] do
+      get :tasks, on: :member
+    end
+  end
 end

--- a/task_app/spec/features/tasks/index/base_spec.rb
+++ b/task_app/spec/features/tasks/index/base_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-feature '一覧画面表示機能', type: :feature do
+feature '画面表示機能', type: :feature do
   let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
   let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
   let!(:user1_task) { FactoryBot.create(:task, name: 'user1のタスク', user: user1) }
@@ -20,7 +20,7 @@ feature '一覧画面表示機能', type: :feature do
   context 'user1でログインした状態でアクセスしたとき' do
     before { login(user1) }
 
-    scenario '一覧画面が表示され、user1のタスクが確認できる' do
+    scenario 'タスク一覧画面が表示され、user1のタスクが確認できる' do
       tr = page.all('tbody tr')
 
       expect(current_path).to eq root_path
@@ -32,7 +32,7 @@ feature '一覧画面表示機能', type: :feature do
   context 'user2でログインした状態でアクセスしたとき' do
     before { login(user2) }
 
-    scenario '一覧画面が表示されるが、user1のタスクは確認できない' do
+    scenario 'タスク一覧画面が表示されるが、user1のタスクは確認できない' do
       expect(current_path).to eq root_path
       expect(page.all('tbody tr').size).to eq 0
     end
@@ -49,7 +49,7 @@ feature 'タスク削除機能', type: :feature do
   end
 
   context '確認ダイアログでOKを押したとき' do
-    scenario 'タスクは削除され、一覧画面にメッセージが表示される' do
+    scenario 'タスクは削除され、タスク一覧画面にメッセージが表示される' do
       page.accept_confirm
       expect(page).to have_selector '.alert-success', text: 'タスク「掃除」を削除しました。'
       expect(page.all('tbody tr').size).to eq 0
@@ -58,7 +58,7 @@ feature 'タスク削除機能', type: :feature do
   end
 
   context '確認ダイアログでキャンセルを押したとき' do
-    scenario 'タスクは削除されず、そのまま一覧画面が表示される' do
+    scenario 'タスクは削除されず、そのままタスク一覧画面が表示される' do
       page.dismiss_confirm
       expect(page).to have_no_selector '.alert-success', text: 'タスク「掃除」を削除しました。'
       expect(page.all('tbody tr').size).to eq 1

--- a/task_app/spec/features/tasks/new_edit_spec.rb
+++ b/task_app/spec/features/tasks/new_edit_spec.rb
@@ -12,7 +12,7 @@ feature 'タスク登録・編集機能', type: :feature do
       if action == :create
         # ハンバーガーボタン→タスク管理→タスク登録の順でクリック(capybaraのscreen sizeはmd以下らしい。)
         page.find('.navbar-toggler').click
-        page.find('#navbarDropdownMenuLink').click
+        page.find('#navbarTaskMenuLink').click
         page.click_link('タスク登録')
 
       elsif action == :update

--- a/task_app/spec/features/tasks/new_edit_spec.rb
+++ b/task_app/spec/features/tasks/new_edit_spec.rb
@@ -2,83 +2,93 @@
 
 require 'rails_helper'
 
-feature 'タスク登録・編集機能', type: :feature do
+shared_examples_for '正常処理とバリデーションエラーの確認' do |name, description|
+  before do
+    fill_in 'タスク名', with: task_name
+    fill_in '説明', with: task_description
+    fill_in '期限', with: '20190213'
+    select '高', from: 'task_priority'
+    select '着手中', from: 'task_status'
+    click_on('送信')
+  end
+
+  context '正常値を入力したとき' do
+    let(:task_name) { name }
+    let(:task_description) { description }
+
+    scenario '正常に処理される' do
+      expect(page).to have_selector '.alert-success'
+      expect(page).to have_content name
+      expect(page).to have_content '02/13'
+      expect(page).to have_content '高'
+      expect(page).to have_content '着手中'
+      expect(page.all('tbody tr').size).to eq 1
+      expect(Task.count).to eq 1
+    end
+  end
+
+  context '制限内の文字数を入力したとき' do
+    let(:task_name) { 'a' * 30 }
+    let(:task_description) { 'a' * 800 }
+
+    scenario '正常に処理される' do
+      expect(page).to have_no_selector '#error_explanation'
+      expect(page).to have_selector '.alert-success'
+    end
+  end
+
+  context '空欄のまま送信したとき' do
+    let(:task_name) { '' }
+    let(:task_description) { '' }
+
+    scenario '入力を促すエラーメッセージが表示される' do
+      expect(page).to have_selector '#error_explanation', text: 'タスク名を入力してください'
+      expect(page).to have_selector '#error_explanation', text: '説明を入力してください'
+    end
+  end
+
+  context '制限外の文字数を入力したとき' do
+    let(:task_name) { 'a' * 31 }
+    let(:task_description) { 'a' * 801 }
+
+    scenario '文字数に関するエラーメッセージが表示される' do
+      expect(page).to have_selector '#error_explanation', text: '30文字以内'
+      expect(page).to have_selector '#error_explanation', text: '800文字以内'
+    end
+  end
+end
+
+feature 'タスク登録機能', type: :feature do
   let!(:user) { FactoryBot.create(:user) }
 
-  shared_examples_for '正常処理とバリデーションエラーの確認' do |action, name, description|
+  before do
+    login(user, new_task_path)
+  end
+
+  context 'タスク一覧画面からボタンクリックで画面遷移したとき' do
     before do
-      login(user)
-
-      if action == :create
-        # ハンバーガーボタン→タスク管理→タスク登録の順でクリック(capybaraのscreen sizeはmd以下らしい。)
-        page.find('.navbar-toggler').click
-        page.find('#navbarTaskMenuLink').click
-        page.click_link('タスク登録')
-
-      elsif action == :update
-        click_on('編集')
-      end
-
-      fill_in 'タスク名', with: task_name
-      fill_in '説明', with: task_description
-      fill_in '期限', with: '20190213'
-      select '高', from: 'task_priority'
-      select '着手中', from: 'task_status'
-      click_on('送信')
+      visit root_path
+      page.find('.navbar-toggler').click
+      page.find('#navbarTaskMenuLink').click
+      page.click_link('タスク登録')
     end
 
-    context '正常値を入力したとき' do
-      let(:task_name) { name }
-      let(:task_description) { description }
-
-      scenario '正常に処理される' do
-        expect(page).to have_selector '.alert-success'
-        expect(page).to have_content name
-        expect(page).to have_content '02/13'
-        expect(page).to have_content '高'
-        expect(page).to have_content '着手中'
-        expect(page.all('tbody tr').size).to eq 1
-        expect(Task.count).to eq 1
-      end
-    end
-
-    context '制限内の文字数を入力したとき' do
-      let(:task_name) { 'a' * 30 }
-      let(:task_description) { 'a' * 800 }
-
-      scenario '正常に処理される' do
-        expect(page).to have_no_selector '#error_explanation'
-        expect(page).to have_selector '.alert-success'
-      end
-    end
-
-    context '空欄のまま送信したとき' do
-      let(:task_name) { '' }
-      let(:task_description) { '' }
-
-      scenario '入力を促すエラーメッセージが表示される' do
-        expect(page).to have_selector '#error_explanation', text: 'タスク名を入力してください'
-        expect(page).to have_selector '#error_explanation', text: '説明を入力してください'
-      end
-    end
-
-    context '制限外の文字数を入力したとき' do
-      let(:task_name) { 'a' * 31 }
-      let(:task_description) { 'a' * 801 }
-
-      scenario '文字数に関するエラーメッセージが表示される' do
-        expect(page).to have_selector '#error_explanation', text: '30文字以内'
-        expect(page).to have_selector '#error_explanation', text: '800文字以内'
-      end
+    scenario 'タスク登録画面に遷移する' do
+      expect(current_path).to eq new_task_path
     end
   end
 
-  feature '登録' do
-    it_behaves_like '正常処理とバリデーションエラーの確認', :create, '最初のタスク', '最初のタスクの説明'
+  it_behaves_like '正常処理とバリデーションエラーの確認', '最初のタスク', '最初のタスクの説明'
+end
+
+feature 'タスク編集機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:task) { FactoryBot.create(:task, user: user) }
+
+  before do
+    login(user)
+    click_on('編集')
   end
 
-  feature '編集' do
-    let!(:first_task) { FactoryBot.create(:task, user: user) }
-    it_behaves_like '正常処理とバリデーションエラーの確認', :update, '掃除', 'トイレ,風呂,キッチン'
-  end
+  it_behaves_like '正常処理とバリデーションエラーの確認', '掃除', 'トイレ,風呂,キッチン'
 end

--- a/task_app/spec/features/test_helper.rb
+++ b/task_app/spec/features/test_helper.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 module TestHelper
-  def login(user)
+  def login(user, visit_path = nil)
     visit login_path
     fill_in 'session_email', with: user.email
     fill_in 'session_password', with: user.password
     click_on('ログイン')
+    visit visit_path if visit_path
   end
 end

--- a/task_app/spec/features/users/index_spec.rb
+++ b/task_app/spec/features/users/index_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature '画面表示機能', type: :feature do
+  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
+  let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
+
+  context 'ログインせず画面へアクセスしたとき' do
+    before { visit admin_root_path }
+
+    scenario 'メッセージと共にログイン画面が表示される' do
+      expect(current_path).to eq login_path
+      expect(page).to have_selector('.alert-danger', text: 'サービスを利用するにはログインが必要です')
+      expect(page).to have_selector('form', count: 1)
+    end
+  end
+
+  context 'user1でログインした状態でアクセスしたとき' do
+    before do
+      3.times { FactoryBot.create(:task, user: user1) }
+      2.times { FactoryBot.create(:task, user: user2) }
+    end
+
+    before { login(user1, admin_root_path) }
+
+    scenario 'ユーザ一覧画面が表示され、ユーザ数と各ユーザのタスク数を確認できる' do
+      expect(current_path).to eq admin_root_path
+      expect(page.all('tbody tr').size).to eq 2
+      expect(page).to have_content(user1.email, count: 1)
+      expect(page).to have_content(user2.email, count: 1)
+      expect(page.find('tr', text: user1.email).text).to include('3')
+      expect(page.find('tr', text: user2.email).text).to include('2')
+    end
+  end
+end
+
+feature 'ユーザ削除機能', type: :feature do
+  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
+  let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
+
+  before do
+    2.times { FactoryBot.create(:task, user: user2) }
+    login(user1, admin_root_path)
+  end
+
+  context 'user1でログイン後、user2を削除する確認ダイアログでOKを押したとき' do
+    scenario 'user2は削除され、ユーザ一覧画面にメッセージが表示される' do
+      page.find('tr', text: user2.email).click_link('削除')
+      page.accept_confirm
+      expect(page).to have_selector '.alert-success', text: 'ユーザ「user2@example.com」を削除しました。'
+      expect(page.all('tbody tr').size).to eq 1
+      expect(Task.where(user_id: user2.id).count).to eq 0
+    end
+  end
+
+  context 'user1でログイン後、user2を削除する確認ダイアログでキャンセルを押したとき' do
+    scenario 'user2は削除されず、そのままユーザ一覧画面が表示される' do
+      page.find('tr', text: user2.email).click_link('削除')
+      page.dismiss_confirm
+      expect(page).to have_no_selector '.alert-success', text: 'ユーザ「user2@example.com」を削除しました。'
+      expect(page.all('tbody tr').size).to eq 2
+      expect(page.find('tr', text: user2.email).text).to include('2')
+    end
+  end
+
+  context 'user1でログイン時、自身のアカウントを削除しようとしたとき' do
+    scenario 'ユーザ一覧画面に削除するリンクは存在しない' do
+      expect(page.find('tr', text: user1.email)).to have_no_link('削除')
+    end
+  end
+end
+
+feature 'ユーザ検索機能', type: :feature do
+  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
+  let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
+
+  before do
+    login(user1, admin_root_path)
+    fill_in 'email', with: email
+    click_on('検索')
+  end
+
+  context '「user1」でアドレス検索をしたとき' do
+    let(:email) { 'user1' }
+
+    scenario '検索結果は1件' do
+      expect(page.all('tbody tr').size).to eq 1
+      expect(page).to have_content(user1.email, count: 1)
+      expect(find_field('email').value).to eq 'user1'
+    end
+  end
+
+  context '「hoge」でアドレス検索をしたとき' do
+    let(:email) { 'hoge' }
+
+    scenario '検索結果は0件' do
+      expect(page.all('tbody tr').size).to eq 0
+      expect(find_field('email').value).to eq 'hoge'
+    end
+  end
+end
+
+feature 'ページネーション機能', type: :feature do
+  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
+
+  before do
+    (2..10).each { |i| FactoryBot.create(:user, email: "user#{i}@example.com") }
+    login(user1, admin_root_path)
+  end
+
+  context 'ユーザ数が10のとき' do
+    scenario '1ページ目に6ユーザが表示される' do
+      expect(page).to have_content '全10件中1 - 6件のユーザが表示されています'
+      expect(page).to have_link '次 ›'
+      expect(page).to have_no_link '‹ 前'
+      expect(page.all('tbody tr').size).to eq 6
+    end
+
+    scenario '2ページ目に4ユーザが表示される' do
+      find_link('次').click
+      expect(page).to have_content '全10件中7 - 10件のユーザが表示されています'
+      expect(page).to have_link '‹ 前'
+      expect(page).to have_no_link '次 ›'
+      expect(page.all('tbody tr').size).to eq 4
+    end
+  end
+end

--- a/task_app/spec/features/users/new_edit_spec.rb
+++ b/task_app/spec/features/users/new_edit_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+shared_examples '正常処理とバリデーションメッセージの確認' do |user_email, user_password, number_of_user|
+  before do
+    fill_in 'メールアドレス', with: email
+    fill_in 'パスワード', with: password
+    fill_in 'パスワード(確認)', with: password_confirmation
+    click_on('送信')
+  end
+
+  context '正常値を入力したとき' do
+    let(:email) { user_email }
+    let(:password) { user_password }
+    let(:password_confirmation) { user_password }
+
+    scenario 'メッセージと共にユーザ一覧画面が表示され、ユーザ数が2であることが確認できる' do
+      expect(current_path).to eq admin_root_path
+      expect(page).to have_selector('.alert-success')
+      expect(page).to have_selector('tr', text: user_email)
+      expect(page.all('tbody tr').size).to eq number_of_user
+    end
+  end
+
+  context '全て空欄のまま送信したとき' do
+    let(:email) { '' }
+    let(:password) { '' }
+    let(:password_confirmation) { '' }
+
+    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワードを入力してください')
+      expect(page).to have_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスを入力してください')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスは不正な値です')
+    end
+  end
+
+  context '誤ったメールアドレス・一致しないパスワードを入力したとき' do
+    let(:email) { 'foo@example' }
+    let(:password) { 'password123' }
+    let(:password_confirmation) { 'password' }
+
+    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワード(確認)とパスワードの入力が一致しません')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスは不正な値です')
+    end
+  end
+
+  context '6文字以下のパスワードを入力したとき' do
+    let(:email) { 'foo@example.com' }
+    let(:password) { 'pass' }
+    let(:password_confirmation) { 'pass' }
+
+    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
+    end
+  end
+
+  context 'スペースを含むパスワードを入力したとき' do
+    let(:email) { 'foo@example.com' }
+    let(:password) { 'pass word' }
+    let(:password_confirmation) { 'pass word' }
+
+    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワードにスペースを含めないでください')
+    end
+  end
+end
+
+feature 'ユーザ登録機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    login(user, new_admin_user_path)
+  end
+
+  context 'タスク一覧画面からボタンクリックで画面遷移したとき' do
+    before do
+      visit root_path
+      page.find('.navbar-toggler').click
+      page.find('#navbarUserMenuLink').click
+      page.click_link('ユーザ登録')
+    end
+
+    scenario 'ユーザ登録画面に遷移する' do
+      expect(current_path).to eq new_admin_user_path
+    end
+  end
+
+  it_behaves_like '正常処理とバリデーションメッセージの確認', 'foo@example.com', 'password', 2
+end
+
+feature 'ユーザ編集機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    login(user, admin_root_path)
+    click_on('編集')
+  end
+
+  it_behaves_like '正常処理とバリデーションメッセージの確認', 'bar@example.com', 'password', 1
+end

--- a/task_app/spec/features/users/tasks/base_spec.rb
+++ b/task_app/spec/features/users/tasks/base_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# 各ユーザのタスク一覧画面に関するspec
+
+require 'rails_helper'
+
+feature '画面表示機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  context 'ログインせず画面へアクセスしたとき' do
+    before { visit tasks_admin_user_path(user) }
+
+    scenario 'メッセージと共にログイン画面が表示される' do
+      expect(current_path).to eq login_path
+      expect(page).to have_selector('.alert-danger', text: 'サービスを利用するにはログインが必要です')
+      expect(page).to have_selector('form', count: 1)
+    end
+  end
+
+  context 'ログインした状態でアクセスしたとき' do
+    before { login(user, tasks_admin_user_path(user)) }
+
+    scenario 'ユーザのタスク一覧画面が表示される' do
+      expect(current_path).to eq tasks_admin_user_path(user)
+      expect(page).to have_content "#{user.email}のタスク一覧"
+      expect(page).to have_selector('table', count: 1)
+    end
+  end
+end
+
+feature 'タスクソート機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:tasks) {
+    [
+      FactoryBot.create(:task, name: 'タスク1', due_date: '20190203', priority: :middle, status: :in_progress, created_at: Time.zone.now, user: user),
+      FactoryBot.create(:task, name: 'タスク2', due_date: '20190209', priority: :high,   status: :done,        created_at: 1.day.ago,     user: user),
+      FactoryBot.create(:task, name: 'タスク3', due_date: '20190206', priority: :low,    status: :to_do,       created_at: 2.days.ago,    user: user),
+    ]
+  }
+
+  shared_examples_for '任意の順でソートされる' do |options = {}|
+    before do
+      visit login(user, tasks_admin_user_path(user))
+      until has_text?(options[:sort_column]); end
+      page.find('th', text: options[:sort_column]).click_link(options[:direction]) if options[:sort_column].present? && options[:direction].present?
+    end
+
+    scenario '並び順が一致する' do
+      until has_table?; end
+      tr = page.all('tbody tr')
+
+      tr.each.with_index do |element, i|
+        expect(element.text).to have_content(tasks[options[:order][i]].name)
+      end
+    end
+  end
+
+  context '一覧画面で何もしないとき' do
+    it_behaves_like '任意の順でソートされる', { order: [0, 1, 2] }
+  end
+
+  context '列「登録日時」の「▲/▼」をクリックした時' do
+    it_behaves_like '任意の順でソートされる', { sort_column: '登録日時', direction: '▲', order: [2, 1, 0] }
+    it_behaves_like '任意の順でソートされる', { sort_column: '登録日時', direction: '▼', order: [0, 1, 2] }
+  end
+
+  context '列「優先度」の「▲/▼」をクリックした時' do
+    it_behaves_like '任意の順でソートされる', { sort_column: '優先度', direction: '▲', order: [2, 0, 1] }
+    it_behaves_like '任意の順でソートされる', { sort_column: '優先度', direction: '▼', order: [1, 0, 2] }
+  end
+
+  context '列「期限」の「▲/▼」をクリックした時' do
+    it_behaves_like '任意の順でソートされる', { sort_column: '期限', direction: '▲', order: [0, 2, 1] }
+    it_behaves_like '任意の順でソートされる', { sort_column: '期限', direction: '▼', order: [1, 2, 0] }
+  end
+end
+
+feature 'ページネーション機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:tasks) { 10.times { FactoryBot.create(:task, user: user) } }
+
+  before { login(user, tasks_admin_user_path(user)) }
+
+  context 'タスク件数が10件のとき' do
+    scenario '1ページ目に6件表示される' do
+      expect(page).to have_content '全10件中1 - 6件のタスクが表示されています'
+      expect(page).to have_link '次 ›'
+      expect(page).to have_no_link '‹ 前'
+      expect(page.all('tbody tr').size).to eq 6
+    end
+
+    scenario '2ページ目に4件表示される' do
+      find_link('次').click
+      expect(page).to have_content '全10件中7 - 10件のタスクが表示されています'
+      expect(page).to have_link '‹ 前'
+      expect(page).to have_no_link '次 ›'
+      expect(page.all('tbody tr').size).to eq 4
+    end
+  end
+end

--- a/task_app/spec/features/users/tasks/search_spec.rb
+++ b/task_app/spec/features/users/tasks/search_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# 各ユーザのタスク一覧画面に関するspec
+
 require 'rails_helper'
 
 feature 'タスク検索機能', type: :feature do
@@ -14,7 +16,7 @@ feature 'タスク検索機能', type: :feature do
   }
 
   before do
-    login(user)
+    login(user, tasks_admin_user_path(user))
     fill_in 'name', with: task_name
     select status, from: 'status'
     click_on('検索')


### PR DESCRIPTION
以下を参考に機能を実装致しました。
ご確認のほどよろしくお願いします。

> ### ステップ18: ユーザの管理画面を実装しよう
> - 画面上に管理メニューを追加しましょう
> - 管理画面にはかならず `/admin` というURLを先頭につけるようにしましょう
>   - `routes.rb` に追加する前に、あらかじめURLやルーティング名（ `*_path` となる名前）を想定して設計してみましょう
> - ユーザ一覧・作成・更新・削除を実装しましょう
> - ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう
> - ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう
> - ユーザが作成したタスクの一覧が見られるようにしてみましょう

### 実装内容
- `Admin::UsersController`を作成
- 管理画面にユーザモデルのCUD機能実装
- 各ユーザのタスク一覧画面を実装
- ユーザに関するfeature spec追加

### 補足
- ユーザモデルにroleカラムは追加しておりません。その為、ログインユーザ全員が管理画面にアクセス可能できる状態です