### PR TITLE
ステップ18: ユーザの管理画面を実装(Part2)

### DIFF
--- a/task_app/app/controllers/admin/users_controller.rb
+++ b/task_app/app/controllers/admin/users_controller.rb
@@ -46,7 +46,7 @@ module Admin
     end
 
     def tasks
-      @tasks = Task.search(params, @user.tasks).order("#{params[:sort_column] || 'created_at'} #{params[:sort_direction] || 'desc'}").page(params[:page])
+      @tasks = Task.search(params, @user.tasks).page(params[:page])
     end
 
     private

--- a/task_app/app/controllers/admin/users_controller.rb
+++ b/task_app/app/controllers/admin/users_controller.rb
@@ -2,10 +2,35 @@
 
 module Admin
   class UsersController < ApplicationController
-    before_action :find_user, only: :destroy
+    before_action :find_user, only: %i[edit update destroy tasks]
 
     def index
       @users = User.search(params).page(params[:page])
+    end
+
+    def new
+      @user = User.new
+    end
+
+    def create
+      @user = User.new(user_params)
+
+      if @user.save
+        redirect_to admin_users_url, flash: { success: create_flash_message('create', 'success', @user, :email) }
+      else
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @user.update(user_params)
+        redirect_to admin_users_url, flash: { success: create_flash_message('update', 'success', @user, :email) }
+      else
+        render :edit
+      end
     end
 
     def destroy
@@ -18,6 +43,10 @@ module Admin
       end
 
       redirect_to admin_users_url
+    end
+
+    def tasks
+      @tasks = Task.search(params, @user.tasks).order("#{params[:sort_column] || 'created_at'} #{params[:sort_direction] || 'desc'}").page(params[:page])
     end
 
     private

--- a/task_app/app/controllers/tasks_controller.rb
+++ b/task_app/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :find_task, only: %i[edit update destroy]
 
   def index
-    @tasks = Task.search(params, current_user.tasks).order("#{params[:sort_column] || 'created_at'} #{params[:sort_direction] || 'desc'}").page(params[:page])
+    @tasks = Task.search(params, current_user.tasks).page(params[:page])
   end
 
   def new

--- a/task_app/app/helpers/tasks_helper.rb
+++ b/task_app/app/helpers/tasks_helper.rb
@@ -6,6 +6,11 @@ module TasksHelper
     output << link_to_unless_current('▼', root_path(take_search_params(column_name, :desc)))
   end
 
+  def admin_sort_link(user, column_name)
+    output = link_to_unless_current('▲', tasks_admin_user_path(user, take_search_params(column_name, :asc)))
+    output << link_to_unless_current('▼', tasks_admin_user_path(user, take_search_params(column_name, :desc)))
+  end
+
   def take_search_params(sort_column, direction)
     {
       sort_column:    sort_column,

--- a/task_app/app/models/task.rb
+++ b/task_app/app/models/task.rb
@@ -27,9 +27,7 @@ class Task < ApplicationRecord
   def self.sort_tasks(column, direction)
     # 以下のunless文はどちらかがfalseの場合条件成立
     return { created_at: :desc } unless SORT_COLUMNS.include?(column&.to_sym) && SORT_DIRECTION.include?(direction&.to_sym)
-    output = {}
-    output[column] = direction
-    output
+    [[column, direction]].to_h
   end
 
   private

--- a/task_app/app/models/task.rb
+++ b/task_app/app/models/task.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  SORT_COLUMNS = %i[priority due_date created_at].freeze
+  SORT_DIRECTION = %i[asc desc].freeze
+
   belongs_to :user
 
   enum priority: %i[low middle high].freeze
@@ -17,7 +20,16 @@ class Task < ApplicationRecord
     initial_records ||= self
     initial_records   = initial_records.where('name LIKE ?', "%#{params[:name]}%") if params[:name].present?
     initial_records   = initial_records.where(status: params[:status]) if params[:status].present?
+    initial_records   = initial_records.order(sort_tasks(params[:sort_column], params[:sort_direction]))
     initial_records
+  end
+
+  def self.sort_tasks(column, direction)
+    # 以下のunless文はどちらかがfalseの場合条件成立
+    return { created_at: :desc } unless SORT_COLUMNS.include?(column&.to_sym) && SORT_DIRECTION.include?(direction&.to_sym)
+    output = {}
+    output[column] = direction
+    output
   end
 
   private

--- a/task_app/app/views/admin/users/_form.html.erb
+++ b/task_app/app/views/admin/users/_form.html.erb
@@ -1,0 +1,42 @@
+<% if user.errors.any? %>
+  <ul id="error_explanation" class="alert alert-danger">
+    <% user.errors.full_messages.each do |message| %>
+      <li class="ml-2"><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_with model: [:admin, user], local: true do |f| %>
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+      <%= f.label :email %>
+    </div>
+    <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
+      <%= f.text_field :email, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+      <%= f.label :password %>
+    </div>
+    <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
+      <%= f.password_field :password, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+      <%= f.label :password_confirmation %>
+    </div>
+    <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <%= f.submit '送信', class: 'btn btn-primary btn-sm' %>
+    </div>
+  </div>
+<% end %>

--- a/task_app/app/views/admin/users/_form.html.erb
+++ b/task_app/app/views/admin/users/_form.html.erb
@@ -8,7 +8,7 @@
 
 <%= form_with model: [:admin, user], local: true do |f| %>
   <div class="form-group row">
-    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+    <div class="col-6 col-sm-4 col-md-3 col-lg-2 col-xl-2">
       <%= f.label :email %>
     </div>
     <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
@@ -17,7 +17,7 @@
   </div>
 
   <div class="form-group row">
-    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+    <div class="col-6 col-sm-4 col-md-3 col-lg-2 col-xl-2">
       <%= f.label :password %>
     </div>
     <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
@@ -26,7 +26,7 @@
   </div>
 
   <div class="form-group row">
-    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+    <div class="col-6 col-sm-4 col-md-3 col-lg-2 col-xl-2">
       <%= f.label :password_confirmation %>
     </div>
     <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">

--- a/task_app/app/views/admin/users/_form.html.erb
+++ b/task_app/app/views/admin/users/_form.html.erb
@@ -36,7 +36,7 @@
 
   <div class="row">
     <div class="col-12">
-      <%= f.submit '送信', class: 'btn btn-primary btn-sm' %>
+      <%= f.submit I18n.t('words.submit'), class: 'btn btn-primary btn-sm' %>
     </div>
   </div>
 <% end %>

--- a/task_app/app/views/admin/users/edit.html.erb
+++ b/task_app/app/views/admin/users/edit.html.erb
@@ -1,0 +1,5 @@
+<h3><%= I18n.t('actions_with_model.edit', model_name: User.model_name.human) %></h3>
+<%= render partial: 'form', locals: { user: @user } %>
+<br>
+
+<%= link_to I18n.t('words.back'), admin_users_path %>

--- a/task_app/app/views/admin/users/index.html.erb
+++ b/task_app/app/views/admin/users/index.html.erb
@@ -28,6 +28,8 @@
         <td><%= I18n.l(user.created_at, format: :long) %></td>
         <td><%= I18n.l(user.updated_at, format: :long) %></td>
         <td>
+          <%= link_to I18n.t('actions_with_model.index', model_name: Task.model_name.human), tasks_admin_user_path(user) %>
+          <%= link_to I18n.t('actions.edit'), edit_admin_user_path(user) %>
           <%= link_to I18n.t('actions.destroy'), admin_user_path(user), method: :delete,
               data: { confirm: I18n.t(:dialog, target: "#{User.model_name.human}「#{user.email}」", action: I18n.t('actions.destroy')) } unless user == current_user %>
         </td>

--- a/task_app/app/views/admin/users/new.html.erb
+++ b/task_app/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<h3><%= I18n.t('actions_with_model.new', model_name: User.model_name.human) %></h3>
+<%= render partial: 'form', locals: { user: @user } %>
+<br>
+
+<%= link_to I18n.t('words.back'), admin_users_path %>

--- a/task_app/app/views/admin/users/tasks.html.erb
+++ b/task_app/app/views/admin/users/tasks.html.erb
@@ -1,6 +1,6 @@
 <h3 class="mb-3"><%= I18n.t('words.resource', owner: "#{@user.email}", item: I18n.t('actions_with_model.index', model_name: Task.model_name.human)) %></h3>
 
-<%= form_with url: tasks_admin_user_path(@user), method: 'get', local: true, class: 'form-inline mb-3' do |form| %>
+<%= form_with url: tasks_admin_user_path(@user), method: :get, local: true, class: 'form-inline mb-3' do |form| %>
   <%= form.text_field :name, placeholder: 'タスク名を入力', value: params[:name], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
   <%= form.select :status, Task.statuses.map { |key, _| [I18n.t("enums.task.status.#{key}"), key] }, selected: params[:status], include_blank: '指定しない' %>
   <%= form.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-2' %>

--- a/task_app/app/views/admin/users/tasks.html.erb
+++ b/task_app/app/views/admin/users/tasks.html.erb
@@ -1,0 +1,39 @@
+<h3 class="mb-3"><%= I18n.t('words.resource', owner: "#{@user.email}", item: I18n.t('actions_with_model.index', model_name: Task.model_name.human)) %></h3>
+
+<%= form_with url: tasks_admin_user_path(@user), method: 'get', local: true, class: 'form-inline mb-3' do |form| %>
+  <%= form.text_field :name, placeholder: 'タスク名を入力', value: params[:name], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
+  <%= form.select :status, Task.statuses.map { |key, _| [I18n.t("enums.task.status.#{key}"), key] }, selected: params[:status], include_blank: '指定しない' %>
+  <%= form.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-2' %>
+<% end %>
+
+<div class="task-pagination">
+  <%= paginate @tasks %>
+  <%= page_entries_info @tasks %>
+</div>
+
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th><%= Task.human_attribute_name(:name) %></th>
+      <th><%= Task.human_attribute_name(:description) %></th>
+      <th><%= Task.human_attribute_name(:status) %></th>
+      <th><%= Task.human_attribute_name(:priority) %><%= admin_sort_link(@user, :priority) %></th>
+      <th><%= Task.human_attribute_name(:due_date) %><%= admin_sort_link(@user, :due_date) %></th>
+      <th><%= Task.human_attribute_name(:created_at) %><%= admin_sort_link(@user, :created_at) %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= task.name %></td>
+        <td><%= simple_format(task.description, class: 'mb-0') %></td>
+        <td><%= I18n.t("enums.task.status.#{task.status}") %></td>
+        <td><%= I18n.t("enums.task.priority.#{task.priority}") %></td>
+        <td><%= I18n.l(task.due_date, format: :short) %></td>
+        <td><%= I18n.l(task.created_at, format: :long) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to I18n.t('words.back'), admin_users_path %>

--- a/task_app/app/views/layouts/_header.html.erb
+++ b/task_app/app/views/layouts/_header.html.erb
@@ -20,6 +20,7 @@
       </a>
       <div class="dropdown-menu" aria-labelledby="navbarUserMenuLink">
         <%= link_to I18n.t('actions.index'), admin_users_path, class: 'dropdown-item' %>
+        <%= link_to I18n.t('actions_with_model.new', model_name: User.model_name.human), new_admin_user_path, class: 'dropdown-item' %>
       </div>
     </li>
   </ul>

--- a/task_app/app/views/tasks/edit.html.erb
+++ b/task_app/app/views/tasks/edit.html.erb
@@ -2,4 +2,4 @@
 <%= render partial: 'form', locals: { task: @task } %>
 <br>
 
-<%= link_to I18n.t('actions_with_model.index', model_name: Task.model_name.human), root_path %>
+<%= link_to I18n.t('words.back'), root_path %>

--- a/task_app/app/views/tasks/new.html.erb
+++ b/task_app/app/views/tasks/new.html.erb
@@ -2,4 +2,4 @@
 <%= render partial: 'form', locals: { task: @task } %>
 <br>
 
-<%= link_to I18n.t('actions_with_model.index', model_name: Task.model_name.human), root_path %>
+<%= link_to I18n.t('words.back'), root_path %>

--- a/task_app/config/locales/ja.yml
+++ b/task_app/config/locales/ja.yml
@@ -57,6 +57,8 @@ ja:
     login: ログイン
     logout: ログアウト
     manage: "%{model_name}管理"
+    back: 戻る
+    resource: "%{owner}の%{item}"
   flash:
     success: "%{target}を%{action}しました。"
     failed: "%{target}の%{action}に失敗しました。"

--- a/task_app/config/routes.rb
+++ b/task_app/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
 
   namespace :admin do
-    resources :users, except: :show
+    resources :users, except: :show do
+      get :tasks, on: :member
+    end
   end
 
   resources :tasks, except: :show

--- a/task_app/spec/features/tasks/index/sort_pagination_spec.rb
+++ b/task_app/spec/features/tasks/index/sort_pagination_spec.rb
@@ -14,7 +14,7 @@ feature 'タスクソート機能', type: :feature do
 
   shared_examples_for '任意の順でソートされる' do |options = {}|
     before do
-      visit login(user)
+      login(user)
       until has_text?(options[:sort_column]); end
       page.find('th', text: options[:sort_column]).click_link(options[:direction]) if options[:sort_column].present? && options[:direction].present?
     end
@@ -51,7 +51,7 @@ end
 
 feature 'ページネーション機能', type: :feature do
   let!(:user) { FactoryBot.create(:user) }
-  let!(:tasks) { 10.times { FactoryBot.create(:task, user: user) } }
+  let!(:tasks) { FactoryBot.create_list(:task, 10, user: user) }
 
   before { login(user) }
 

--- a/task_app/spec/features/tasks/index/sort_pagination_spec.rb
+++ b/task_app/spec/features/tasks/index/sort_pagination_spec.rb
@@ -12,7 +12,7 @@ feature 'タスクソート機能', type: :feature do
     ]
   }
 
-  shared_examples_for '任意の順でソートされる' do |options = {}|
+  shared_examples 'リンククリックでソートされる' do |options = {}|
     before do
       login(user)
       until has_text?(options[:sort_column]); end
@@ -20,7 +20,20 @@ feature 'タスクソート機能', type: :feature do
     end
 
     scenario '並び順が一致する' do
-      until has_table?; end
+      until has_selector?('tbody tr', count: 3); end
+      tr = page.all('tbody tr')
+
+      tr.each.with_index do |element, i|
+        expect(element.text).to have_content(tasks[options[:order][i]].name)
+      end
+    end
+  end
+
+  shared_examples 'パラメータ指定でソートされる' do |options = {}|
+    before { login(user, tasks_path(sort_column: options[:sort_column], sort_direction: options[:direction])) }
+
+    scenario '並び順が一致する' do
+      until has_selector?('tbody tr', count: 3); end
       tr = page.all('tbody tr')
 
       tr.each.with_index do |element, i|
@@ -30,22 +43,34 @@ feature 'タスクソート機能', type: :feature do
   end
 
   context '一覧画面で何もしないとき' do
-    it_behaves_like '任意の順でソートされる', { order: [0, 1, 2] }
+    it_behaves_like 'リンククリックでソートされる', { order: [0, 1, 2] }
   end
 
   context '列「登録日時」の「▲/▼」をクリックした時' do
-    it_behaves_like '任意の順でソートされる', { sort_column: '登録日時', direction: '▲', order: [2, 1, 0] }
-    it_behaves_like '任意の順でソートされる', { sort_column: '登録日時', direction: '▼', order: [0, 1, 2] }
+    it_behaves_like 'リンククリックでソートされる', { sort_column: '登録日時', direction: '▲', order: [2, 1, 0] }
+    it_behaves_like 'リンククリックでソートされる', { sort_column: '登録日時', direction: '▼', order: [0, 1, 2] }
+    it_behaves_like 'パラメータ指定でソートされる', { sort_column: 'created_at', direction: 'asc',  order: [2, 1, 0] }
+    it_behaves_like 'パラメータ指定でソートされる', { sort_column: 'created_at', direction: 'desc', order: [0, 1, 2] }
   end
 
   context '列「優先度」の「▲/▼」をクリックした時' do
-    it_behaves_like '任意の順でソートされる', { sort_column: '優先度', direction: '▲', order: [2, 0, 1] }
-    it_behaves_like '任意の順でソートされる', { sort_column: '優先度', direction: '▼', order: [1, 0, 2] }
+    it_behaves_like 'リンククリックでソートされる', { sort_column: '優先度', direction: '▲', order: [2, 0, 1] }
+    it_behaves_like 'リンククリックでソートされる', { sort_column: '優先度', direction: '▼', order: [1, 0, 2] }
+    it_behaves_like 'パラメータ指定でソートされる', { sort_column: 'priority', direction: 'asc',  order: [2, 0, 1] }
+    it_behaves_like 'パラメータ指定でソートされる', { sort_column: 'priority', direction: 'desc', order: [1, 0, 2] }
   end
 
   context '列「期限」の「▲/▼」をクリックした時' do
-    it_behaves_like '任意の順でソートされる', { sort_column: '期限', direction: '▲', order: [0, 2, 1] }
-    it_behaves_like '任意の順でソートされる', { sort_column: '期限', direction: '▼', order: [1, 2, 0] }
+    it_behaves_like 'リンククリックでソートされる', { sort_column: '期限', direction: '▲', order: [0, 2, 1] }
+    it_behaves_like 'リンククリックでソートされる', { sort_column: '期限', direction: '▼', order: [1, 2, 0] }
+    it_behaves_like 'パラメータ指定でソートされる', { sort_column: 'due_date', direction: 'asc',  order: [0, 2, 1] }
+    it_behaves_like 'パラメータ指定でソートされる', { sort_column: 'due_date', direction: 'desc', order: [1, 2, 0] }
+  end
+
+  context '空や許可されていないパラメータを指定してソートしたとき(column: foo, direction: bar)' do
+    # 登録日時の降順でソートされる
+    it_behaves_like 'パラメータ指定でソートされる', { sort_column: 'priority', direction: '',    order: [0, 1, 2] }
+    it_behaves_like 'パラメータ指定でソートされる', { sort_column: 'foo',      direction: 'bar', order: [0, 1, 2] }
   end
 end
 

--- a/task_app/spec/features/users/new_edit_spec.rb
+++ b/task_app/spec/features/users/new_edit_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+shared_examples '正常処理とバリデーションメッセージの確認' do |user_email, user_password, number_of_user|
+  before do
+    fill_in 'メールアドレス', with: email
+    fill_in 'パスワード', with: password
+    fill_in 'パスワード(確認)', with: password_confirmation
+    click_on('送信')
+  end
+
+  context '正常値を入力したとき' do
+    let(:email) { user_email }
+    let(:password) { user_password }
+    let(:password_confirmation) { user_password }
+
+    scenario 'メッセージと共にユーザ一覧画面が表示され、ユーザ数が2であることが確認できる' do
+      expect(current_path).to eq admin_users_path
+      expect(page).to have_selector('.alert-success')
+      expect(page).to have_selector('tr', text: user_email)
+      expect(page.all('tbody tr').size).to eq number_of_user
+    end
+  end
+
+  context '全て空欄のまま送信したとき' do
+    let(:email) { '' }
+    let(:password) { '' }
+    let(:password_confirmation) { '' }
+
+    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワードを入力してください')
+      expect(page).to have_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスを入力してください')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスは不正な値です')
+    end
+  end
+
+  context '誤ったメールアドレス・一致しないパスワードを入力したとき' do
+    let(:email) { 'foo@example' }
+    let(:password) { 'password123' }
+    let(:password_confirmation) { 'password' }
+
+    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワード(確認)とパスワードの入力が一致しません')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスは不正な値です')
+    end
+  end
+
+  context '6文字以下のパスワードを入力したとき' do
+    let(:email) { 'foo@example.com' }
+    let(:password) { 'pass' }
+    let(:password_confirmation) { 'pass' }
+
+    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
+    end
+  end
+
+  context 'スペースを含むパスワードを入力したとき' do
+    let(:email) { 'foo@example.com' }
+    let(:password) { 'pass word' }
+    let(:password_confirmation) { 'pass word' }
+
+    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワードにスペースを含めないでください')
+    end
+  end
+end
+
+feature 'ユーザ登録機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    login(user, new_admin_user_path)
+  end
+
+  context 'タスク一覧画面からボタンクリックで画面遷移したとき' do
+    before do
+      visit root_path
+      page.find('.navbar-toggler').click
+      page.find('#navbarUserMenuLink').click
+      page.click_link('ユーザ登録')
+    end
+
+    scenario 'ユーザ登録画面に遷移する' do
+      expect(current_path).to eq new_admin_user_path
+    end
+  end
+
+  it_behaves_like '正常処理とバリデーションメッセージの確認', 'foo@example.com', 'password', 2
+end
+
+feature 'ユーザ編集機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    login(user, admin_users_path)
+    click_on('編集')
+  end
+
+  it_behaves_like '正常処理とバリデーションメッセージの確認', 'bar@example.com', 'password', 1
+end

--- a/task_app/spec/features/users/tasks/base_spec.rb
+++ b/task_app/spec/features/users/tasks/base_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# 各ユーザのタスク一覧画面に関するspec
+
+require 'rails_helper'
+
+feature '画面表示機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  context 'ログインせず画面へアクセスしたとき' do
+    before { visit tasks_admin_user_path(user) }
+
+    scenario 'メッセージと共にログイン画面が表示される' do
+      expect(current_path).to eq login_path
+      expect(page).to have_selector('.alert-danger', text: 'サービスを利用するにはログインが必要です')
+      expect(page).to have_selector('form', count: 1)
+    end
+  end
+
+  context 'ログインした状態でアクセスしたとき' do
+    before { login(user, tasks_admin_user_path(user)) }
+
+    scenario 'ユーザのタスク一覧画面が表示される' do
+      expect(current_path).to eq tasks_admin_user_path(user)
+      expect(page).to have_content "#{user.email}のタスク一覧"
+      expect(page).to have_selector('table', count: 1)
+    end
+  end
+end
+
+feature 'タスクソート機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:tasks) {
+    [
+      FactoryBot.create(:task, name: 'タスク1', due_date: '20190203', priority: :middle, status: :in_progress, created_at: Time.zone.now, user: user),
+      FactoryBot.create(:task, name: 'タスク2', due_date: '20190209', priority: :high,   status: :done,        created_at: 1.day.ago,     user: user),
+      FactoryBot.create(:task, name: 'タスク3', due_date: '20190206', priority: :low,    status: :to_do,       created_at: 2.days.ago,    user: user),
+    ]
+  }
+
+  shared_examples_for '任意の順でソートされる' do |options = {}|
+    before do
+      visit login(user, tasks_admin_user_path(user))
+      until has_text?(options[:sort_column]); end
+      page.find('th', text: options[:sort_column]).click_link(options[:direction]) if options[:sort_column].present? && options[:direction].present?
+    end
+
+    scenario '並び順が一致する' do
+      until has_table?; end
+      tr = page.all('tbody tr')
+
+      tr.each.with_index do |element, i|
+        expect(element.text).to have_content(tasks[options[:order][i]].name)
+      end
+    end
+  end
+
+  context '一覧画面で何もしないとき' do
+    it_behaves_like '任意の順でソートされる', { order: [0, 1, 2] }
+  end
+
+  context '列「登録日時」の「▲/▼」をクリックした時' do
+    it_behaves_like '任意の順でソートされる', { sort_column: '登録日時', direction: '▲', order: [2, 1, 0] }
+    it_behaves_like '任意の順でソートされる', { sort_column: '登録日時', direction: '▼', order: [0, 1, 2] }
+  end
+
+  context '列「優先度」の「▲/▼」をクリックした時' do
+    it_behaves_like '任意の順でソートされる', { sort_column: '優先度', direction: '▲', order: [2, 0, 1] }
+    it_behaves_like '任意の順でソートされる', { sort_column: '優先度', direction: '▼', order: [1, 0, 2] }
+  end
+
+  context '列「期限」の「▲/▼」をクリックした時' do
+    it_behaves_like '任意の順でソートされる', { sort_column: '期限', direction: '▲', order: [0, 2, 1] }
+    it_behaves_like '任意の順でソートされる', { sort_column: '期限', direction: '▼', order: [1, 2, 0] }
+  end
+end
+
+feature 'ページネーション機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:tasks) { 10.times { FactoryBot.create(:task, user: user) } }
+
+  before { login(user, tasks_admin_user_path(user)) }
+
+  context 'タスク件数が10件のとき' do
+    scenario '1ページ目に6件表示される' do
+      expect(page).to have_content '全10件中1 - 6件のタスクが表示されています'
+      expect(page).to have_link '次 ›'
+      expect(page).to have_no_link '‹ 前'
+      expect(page.all('tbody tr').size).to eq 6
+    end
+
+    scenario '2ページ目に4件表示される' do
+      find_link('次').click
+      expect(page).to have_content '全10件中7 - 10件のタスクが表示されています'
+      expect(page).to have_link '‹ 前'
+      expect(page).to have_no_link '次 ›'
+      expect(page.all('tbody tr').size).to eq 4
+    end
+  end
+end

--- a/task_app/spec/features/users/tasks/base_spec.rb
+++ b/task_app/spec/features/users/tasks/base_spec.rb
@@ -40,7 +40,7 @@ feature 'タスクソート機能', type: :feature do
 
   shared_examples_for '任意の順でソートされる' do |options = {}|
     before do
-      visit login(user, tasks_admin_user_path(user))
+      login(user, tasks_admin_user_path(user))
       until has_text?(options[:sort_column]); end
       page.find('th', text: options[:sort_column]).click_link(options[:direction]) if options[:sort_column].present? && options[:direction].present?
     end
@@ -77,7 +77,7 @@ end
 
 feature 'ページネーション機能', type: :feature do
   let!(:user) { FactoryBot.create(:user) }
-  let!(:tasks) { 10.times { FactoryBot.create(:task, user: user) } }
+  let!(:tasks) { FactoryBot.create_list(:task, 10, user: user) }
 
   before { login(user, tasks_admin_user_path(user)) }
 

--- a/task_app/spec/features/users/tasks/search_spec.rb
+++ b/task_app/spec/features/users/tasks/search_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# 各ユーザのタスク一覧画面に関するspec
+
+require 'rails_helper'
+
+feature 'タスク検索機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:tasks) {
+    [
+      FactoryBot.create(:task, name: 'タスク1', due_date: '20190203', priority: :middle, status: :in_progress, created_at: Time.zone.now, user: user),
+      FactoryBot.create(:task, name: 'タスク2', due_date: '20190209', priority: :high,   status: :to_do,       created_at: 1.day.ago,     user: user),
+      FactoryBot.create(:task, name: 'task3',  due_date: '20190206', priority: :low,    status: :in_progress, created_at: 2.days.ago,    user: user),
+      FactoryBot.create(:task, name: 'ラスク4', due_date: '20190212', priority: :low,    status: :in_progress, created_at: 3.days.ago,    user: user),
+    ]
+  }
+
+  before do
+    login(user, tasks_admin_user_path(user))
+    fill_in 'name', with: task_name
+    select status, from: 'status'
+    click_on('検索')
+  end
+
+  context '「タスク」で名前検索したとき' do
+    let(:task_name) { 'タスク' }
+    let(:status) { '指定しない' }
+
+    scenario '検索結果は2件' do
+      expect(page.all('tbody tr').size).to eq 2
+      expect(page).to have_content('タスク1', count: 1)
+      expect(page).to have_content('タスク2', count: 1)
+      expect(find_field('name').value).to eq 'タスク'
+    end
+  end
+
+  context '「hoge」で名前検索したとき' do
+    let(:task_name) { 'hoge' }
+    let(:status) { '指定しない' }
+
+    scenario '検索結果は0件' do
+      expect(page.all('tbody tr').size).to eq 0
+      expect(find_field('name').value).to eq 'hoge'
+    end
+  end
+
+  context '「着手中」でステータス検索したとき' do
+    let(:task_name) { '' }
+    let(:status) { '着手中' }
+
+    scenario '検索結果は3件' do
+      expect(page.all('tbody tr').size).to eq 3
+      expect(page).to have_content('タスク1', count: 1)
+      expect(page).to have_content('task3', count: 1)
+      expect(page).to have_content('ラスク4', count: 1)
+      expect(page).to have_select('status', selected: '着手中')
+    end
+  end
+
+  context '「指定しない」でステータス検索したとき' do
+    let(:task_name) { '' }
+    let(:status) { '指定しない' }
+
+    scenario '検索結果は4件' do
+      expect(page.all('tbody tr').size).to eq 4
+      expect(page).to have_select('status', selected: '指定しない')
+    end
+  end
+
+  context '名前&ステータス検索したとき' do
+    let(:task_name) { 'スク' }
+    let(:status) { '着手中' }
+
+    scenario '検索結果は2件' do
+      expect(page.all('tbody tr').size).to eq 2
+      expect(page).to have_content('タスク1', count: 1)
+      expect(page).to have_content('ラスク4', count: 1)
+      expect(find_field('name').value).to eq 'スク'
+      expect(page).to have_select('status', selected: '着手中')
+    end
+  end
+
+  context '検索後、期限で降順ソートしたとき' do
+    let(:task_name) { 'スク' }
+    let(:status) { '着手中' }
+
+    before { page.find('th', text: '期限').click_link('▼') }
+
+    scenario '検索結果2件が期限で降順ソートされる' do
+      until has_table?; end
+      tr = page.all('tbody tr')
+
+      expect(tr.size).to eq 2
+      expect(tr[0].text).to have_content tasks[3].name
+      expect(tr[1].text).to have_content tasks[0].name
+      expect(find_field('name').value).to eq 'スク'
+      expect(page).to have_select('status', selected: '着手中')
+    end
+  end
+
+  context '検索後、優先度で昇順ソートしたとき' do
+    let(:task_name) { 'スク' }
+    let(:status) { '着手中' }
+
+    before { page.find('th', text: '優先度').click_link('▲') }
+
+    scenario '検索結果2件が優先度で昇順ソートされる' do
+      until has_table?; end
+      tr = page.all('tbody tr')
+
+      expect(tr.size).to eq 2
+      expect(tr[0].text).to have_content tasks[3].name
+      expect(tr[1].text).to have_content tasks[0].name
+      expect(find_field('name').value).to eq 'スク'
+      expect(page).to have_select('status', selected: '着手中')
+    end
+  end
+end


### PR DESCRIPTION
以下を参考に一部の機能を実装しました。
ご確認をお願いしますm(_ _)m

> ### ステップ18: ユーザの管理画面を実装しよう
> - 画面上に管理メニューを追加しましょう
> - 管理画面にはかならず `/admin` というURLを先頭につけるようにしましょう
>   - `routes.rb` に追加する前に、あらかじめURLやルーティング名（ `*_path` となる名前）を想定して設計してみましょう
> - ユーザ一覧・作成・更新・削除を実装しましょう
> - ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう
> - ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう
> - ユーザが作成したタスクの一覧が見られるようにしてみましょう

### 実装内容
- new, create, edit, updateアクションの実装&テストの追加
- ユーザが作成したタスク一覧画面の作成
※prのサイズが大きくなってしまった為、分割してprさせて頂きました

### 実装済の機能
- Admin::Usersコントローラ作成
- index, destroyアクションの実装&テストの追加
- ユーザを削除したら、そのユーザが抱えているタスクを削除
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示