### PR TITLE
ステップ19: ユーザにロールを追加

### DIFF
--- a/task_app/app/controllers/admin/users_controller.rb
+++ b/task_app/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class UsersController < ApplicationController
-    before_action :forbid_accessing
+    before_action :forbid_access_except_admin
     before_action :find_user, only: %i[edit update destroy tasks]
 
     def index
@@ -52,7 +52,7 @@ module Admin
 
     private
 
-    def forbid_accessing
+    def forbid_access_except_admin
       raise Forbidden unless current_user.admin?
     end
 

--- a/task_app/app/controllers/admin/users_controller.rb
+++ b/task_app/app/controllers/admin/users_controller.rb
@@ -2,6 +2,7 @@
 
 module Admin
   class UsersController < ApplicationController
+    before_action :forbid_accessing
     before_action :find_user, only: %i[edit update destroy tasks]
 
     def index
@@ -51,8 +52,12 @@ module Admin
 
     private
 
+    def forbid_accessing
+      raise Forbidden unless current_user.admin?
+    end
+
     def user_params
-      params.require(:user).permit(:email, :password, :password_confirmation)
+      params.require(:user).permit(:email, :password, :password_confirmation, :role)
     end
 
     def find_user

--- a/task_app/app/controllers/application_controller.rb
+++ b/task_app/app/controllers/application_controller.rb
@@ -4,9 +4,16 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
   before_action :login_required
 
+  class Forbidden < ActionController::ActionControllerError; end
+
   rescue_from Exception, with: :render_500
+  rescue_from Forbidden, with: :render_403
   rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :render_404
   rescue_from ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique, with: :render_422
+
+  def render_403
+    render file: Rails.root.join('public', '403.html'), status: 403, layout: false, content_type: 'text/html'
+  end
 
   def render_404
     render file: Rails.root.join('public', '404.html'), status: 404, layout: false, content_type: 'text/html'

--- a/task_app/app/models/user.rb
+++ b/task_app/app/models/user.rb
@@ -6,12 +6,26 @@ class User < ApplicationRecord
   has_secure_password
   has_many :tasks, dependent: :delete_all
 
+  enum role: %i[general admin].freeze
+
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
-  validates :password, presence: true, length: { minimum: 6 }, format: { without: /\s/, message: I18n.t('errors.messages.space') }
+  validates :password, presence: true, length: { minimum: 6 }, format: { without: /\s/, message: I18n.t('errors.messages.space') }, on: :create
+  # パスワードが入力された時のみ実行される
+  validates :password, length: { minimum: 6 }, format: { without: /\s/, message: I18n.t('errors.messages.space') }, if: :password, on: :update
+  validates :role, presence: true
+  validate :keep_admin_more_than_one, if: :general?, on: :update # roleカラムがgeneralに更新された時に実行される
 
   def self.search(params)
     output = self.includes(:tasks)
     output = output.where('email LIKE ?', "%#{params[:email]}%") if params[:email].present?
     output
+  end
+
+  private
+
+  def keep_admin_more_than_one
+    return if User.admin.count > 1
+    errors.add(:base, :keep_admin_more_than_one)
+    throw :abort
   end
 end

--- a/task_app/app/models/user.rb
+++ b/task_app/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   # パスワードが入力された時のみ実行される
   validates :password, length: { minimum: 6 }, format: { without: /\s/, message: I18n.t('errors.messages.space') }, if: :password, on: :update
   validates :role, presence: true
-  validate :keep_admin_more_than_one, if: :general?, on: :update # roleカラムがgeneralに更新された時に実行される
+  validate :keep_admin_at_least_one, if: :general?, on: :update # roleカラムがgeneralに更新された時に実行される
 
   def self.search(params)
     output = self.includes(:tasks)
@@ -23,9 +23,9 @@ class User < ApplicationRecord
 
   private
 
-  def keep_admin_more_than_one
+  def keep_admin_at_least_one
     return if User.admin.count > 1
-    errors.add(:base, :keep_admin_more_than_one)
+    errors.add(:base, :keep_admin_at_least_one)
     throw :abort
   end
 end

--- a/task_app/app/views/admin/users/_form.html.erb
+++ b/task_app/app/views/admin/users/_form.html.erb
@@ -34,6 +34,15 @@
     </div>
   </div>
 
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-3 col-lg-2 col-xl-2">
+      <%= f.label :role %>
+    </div>
+    <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
+      <%= f.select :role, User.roles.map { |key, _| [I18n.t("enums.user.role.#{key}"), key] } %>
+    </div>
+  </div>
+
   <div class="row">
     <div class="col-12">
       <%= f.submit I18n.t('words.submit'), class: 'btn btn-primary btn-sm' %>

--- a/task_app/app/views/admin/users/index.html.erb
+++ b/task_app/app/views/admin/users/index.html.erb
@@ -15,6 +15,7 @@
     <tr>
       <th><%= User.human_attribute_name(:email) %></th>
       <th><%= Task.model_name.human %>数</th>
+      <th><%= User.human_attribute_name(:role) %></th>
       <th><%= User.human_attribute_name(:created_at) %></th>
       <th><%= User.human_attribute_name(:updated_at) %></th>
       <th>アクション</th>
@@ -25,6 +26,7 @@
       <tr>
         <td><%= user.email %></td>
         <td><%= user.tasks.size.to_s(:delimited) %></td>
+        <td><%= I18n.t("enums.user.role.#{user.role}") %></td>
         <td><%= I18n.l(user.created_at, format: :long) %></td>
         <td><%= I18n.l(user.updated_at, format: :long) %></td>
         <td>

--- a/task_app/app/views/layouts/_header.html.erb
+++ b/task_app/app/views/layouts/_header.html.erb
@@ -14,15 +14,17 @@
       </div>
     </li>
 
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarUserMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <%= I18n.t('words.manage', model_name: User.model_name.human) %>
-      </a>
-      <div class="dropdown-menu" aria-labelledby="navbarUserMenuLink">
-        <%= link_to I18n.t('actions.index'), admin_users_path, class: 'dropdown-item' %>
-        <%= link_to I18n.t('actions_with_model.new', model_name: User.model_name.human), new_admin_user_path, class: 'dropdown-item' %>
-      </div>
-    </li>
+    <% if current_user.admin? %>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarUserMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <%= I18n.t('words.manage', model_name: User.model_name.human) %>
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarUserMenuLink">
+          <%= link_to I18n.t('actions.index'), admin_users_path, class: 'dropdown-item' %>
+          <%= link_to I18n.t('actions_with_model.new', model_name: User.model_name.human), new_admin_user_path, class: 'dropdown-item' %>
+        </div>
+      </li>
+    <% end %>
   </ul>
 
   <ul class="navbar-nav">

--- a/task_app/config/locales/ja.yml
+++ b/task_app/config/locales/ja.yml
@@ -189,7 +189,7 @@ ja:
       greater_than_or_equal_to: は%{count}以上の値にしてください
       inclusion: は一覧にありません
       invalid: は不正な値です
-      keep_admin_more_than_one: 管理者がいなくなる為、「権限」を更新できません
+      keep_admin_at_least_one: 管理者がいなくなる為、「権限」を更新できません
       less_than: は%{count}より小さい値にしてください
       less_than_or_equal_to: は%{count}以下の値にしてください
       model_invalid: "バリデーションに失敗しました: %{errors}"

--- a/task_app/config/locales/ja.yml
+++ b/task_app/config/locales/ja.yml
@@ -19,6 +19,7 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード(確認)
+        role: 権限
         created_at: 登録日時
         updated_at: 更新日時
     errors:
@@ -37,6 +38,10 @@ ja:
         to_do: 未着手
         in_progress: 着手中
         done: 完了
+    user:
+      role:
+        general: 一般
+        admin: 管理者
   actions:
     index: '一覧'
     new: '登録'
@@ -184,6 +189,7 @@ ja:
       greater_than_or_equal_to: は%{count}以上の値にしてください
       inclusion: は一覧にありません
       invalid: は不正な値です
+      keep_admin_more_than_one: 管理者がいなくなる為、「権限」を更新できません
       less_than: は%{count}より小さい値にしてください
       less_than_or_equal_to: は%{count}以下の値にしてください
       model_invalid: "バリデーションに失敗しました: %{errors}"

--- a/task_app/db/migrate/20190220032506_add_role_to_user.rb
+++ b/task_app/db/migrate/20190220032506_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer, after: :password_digest, limit: 1, null: false, default: 0
+  end
+end

--- a/task_app/db/schema.rb
+++ b/task_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_06_044149) do
+ActiveRecord::Schema.define(version: 2019_02_20_032506) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2019_02_06_044149) do
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
+    t.integer "role", limit: 1, default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/task_app/db/seeds.rb
+++ b/task_app/db/seeds.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-User.create(email: 'admin@gmail.com', password: 'password123', password_confirmation: 'password123') unless User.exists?(email: 'admin@gmail.com')
+unless User.exists?(email: 'admin@example.com')
+  User.create(email: 'admin@example.com', password: 'password', password_confirmation: 'password', role: User.roles[:admin])
+end

--- a/task_app/public/403.html
+++ b/task_app/public/403.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>指定されたページへのアクセスは禁止されています</title>
+</head>
+<body>
+  <h1>403:指定されたページへのアクセスは禁止されています</h1>
+</body>
+</html>

--- a/task_app/spec/factories/users.rb
+++ b/task_app/spec/factories/users.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :user do
     email { 'test@example.com' }
     password { 'password' }
+    role { User.roles[:admin] }
   end
 end

--- a/task_app/spec/factories/users.rb
+++ b/task_app/spec/factories/users.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :user do
     email { 'test@example.com' }
     password { 'password' }
-    role { User.roles[:admin] }
+    role { User.roles[:general] }
   end
 end

--- a/task_app/spec/features/error_pages_spec.rb
+++ b/task_app/spec/features/error_pages_spec.rb
@@ -30,7 +30,7 @@ feature 'エラー画面の表示機能(非ログイン状態)', type: :feature 
 end
 
 feature 'エラー画面の表示機能(ログイン状態)', type: :feature do
-  let!(:user) { FactoryBot.create(:user, role: :general) }
+  let!(:user) { FactoryBot.create(:user) }
 
   shared_examples '内部エラーによりエラー画面が表示される' do |http_status, content|
     before do

--- a/task_app/spec/features/users/edit_spec.rb
+++ b/task_app/spec/features/users/edit_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature '更新とバリデーションエラー機能', type: :feature do
+  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
+  let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
+
+  before do
+    login(user1, admin_users_path)
+    page.find('tr', text: user2.email).click_link('編集')
+    fill_in 'メールアドレス', with: email
+    fill_in 'パスワード', with: password
+    fill_in 'パスワード(確認)', with: password_confirmation
+    select '一般', from: 'user_role'
+    click_on('送信')
+  end
+
+  context 'メールアドレス・パスワード・権限を更新したとき(正常処理)' do
+    let(:email) { 'foo@example.com' }
+    let(:password) { 'passwooord' }
+    let(:password_confirmation) { 'passwooord' }
+
+    scenario 'メッセージと共にユーザ一覧画面が表示される' do
+      expect(current_path).to eq admin_users_path
+      expect(page).to have_selector('.alert-success')
+      expect(page).to have_selector('tr', text: 'foo@example.com')
+      expect(page).to have_selector('tr', text: '一般')
+      expect(page.all('tbody tr').size).to eq 2
+    end
+  end
+
+  context 'メールアドレス・権限のみ更新したとき(正常処理)' do
+    let(:email) { 'foo@example.com' }
+    let(:password) { '' }
+    let(:password_confirmation) { '' }
+
+    scenario 'メッセージと共にユーザ一覧画面が表示される' do
+      expect(current_path).to eq admin_users_path
+      expect(page).to have_no_selector('.alert-danger', text: 'パスワードを入力してください') # 入力しない限りパスワードのバリデーションは実行されない
+      expect(page).to have_no_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
+      expect(page).to have_selector('.alert-success')
+      expect(page).to have_selector('tr', text: 'foo@example.com')
+      expect(page).to have_selector('tr', text: '一般')
+      expect(page.all('tbody tr').size).to eq 2
+    end
+  end
+
+  context '全て空欄のまま送信したとき' do
+    let(:email) { '' }
+    let(:password) { '' }
+    let(:password_confirmation) { '' }
+
+    scenario 'バリデーションメッセージと共に編集画面が表示される' do
+      expect(page).to have_no_selector('.alert-danger', text: 'パスワードを入力してください') # 入力しない限りパスワードのバリデーションは実行されない
+      expect(page).to have_no_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスを入力してください')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスは不正な値です')
+    end
+  end
+
+  context '誤ったメールアドレス・一致しないパスワードを入力したとき' do
+    let(:email) { 'foo@example' }
+    let(:password) { 'password123' }
+    let(:password_confirmation) { 'password' }
+
+    scenario 'バリデーションメッセージと共に編集画面が表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワード(確認)とパスワードの入力が一致しません')
+      expect(page).to have_selector('.alert-danger', text: 'メールアドレスは不正な値です')
+    end
+  end
+
+  context '6文字以下のパスワードを入力したとき' do
+    let(:email) { 'foo@example.com' }
+    let(:password) { 'pass' }
+    let(:password_confirmation) { 'pass' }
+
+    scenario 'バリデーションメッセージと共に編集画面が表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
+    end
+  end
+
+  context 'スペースを含むパスワードを入力したとき' do
+    let(:email) { 'foo@example.com' }
+    let(:password) { 'pass word' }
+    let(:password_confirmation) { 'pass word' }
+
+    scenario 'バリデーションメッセージと共に編集画面が表示される' do
+      expect(page).to have_selector('.alert-danger', text: 'パスワードにスペースを含めないでください')
+    end
+  end
+end
+
+feature '管理者数制御機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    login(user, admin_users_path)
+    click_on('編集')
+    select '一般', from: 'user_role'
+    click_on('送信')
+  end
+
+  context '管理者が1人の状態で、権限を一般に更新したとき' do
+    scenario 'バリデーションメッセージと共に編集画面が表示される' do
+      expect(page).to have_selector('.alert-danger', text: '管理者がいなくなる為、「権限」を更新できません')
+    end
+  end
+end

--- a/task_app/spec/features/users/edit_spec.rb
+++ b/task_app/spec/features/users/edit_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 feature 'ユーザ編集機能', type: :feature do
-  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
-  let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
+  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com', role: :admin) }
+  let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com', role: :admin) }
 
   before do
     login(user1, admin_users_path)
@@ -92,7 +92,7 @@ feature 'ユーザ編集機能', type: :feature do
 end
 
 feature '管理者数制御機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
+  let!(:user) { FactoryBot.create(:user, role: :admin) }
 
   before do
     login(user, admin_users_path)

--- a/task_app/spec/features/users/edit_spec.rb
+++ b/task_app/spec/features/users/edit_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-feature '更新とバリデーションエラー機能', type: :feature do
+feature 'ユーザ編集機能', type: :feature do
   let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
   let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
 

--- a/task_app/spec/features/users/index_spec.rb
+++ b/task_app/spec/features/users/index_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 feature 'ユーザ管理', type: :feature do
-  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
+  let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com', role: :admin) }
   let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
 
   before do

--- a/task_app/spec/features/users/new_spec.rb
+++ b/task_app/spec/features/users/new_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 feature '画面表示機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
+  let!(:user) { FactoryBot.create(:user, role: :admin) }
 
   context 'タスク一覧画面からボタンクリックで画面遷移したとき' do
     before do
@@ -20,7 +20,7 @@ feature '画面表示機能', type: :feature do
 end
 
 feature 'ユーザ登録機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
+  let!(:user) { FactoryBot.create(:user, role: :admin) }
 
   before do
     login(user, new_admin_user_path)

--- a/task_app/spec/features/users/new_spec.rb
+++ b/task_app/spec/features/users/new_spec.rb
@@ -2,24 +2,45 @@
 
 require 'rails_helper'
 
-shared_examples '正常処理とバリデーションメッセージの確認' do |user_email, user_password, number_of_user|
+feature '画面表示機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  context 'タスク一覧画面からボタンクリックで画面遷移したとき' do
+    before do
+      login(user)
+      page.find('.navbar-toggler').click
+      page.find('#navbarUserMenuLink').click
+      page.click_link('ユーザ登録')
+    end
+
+    scenario 'ユーザ登録画面に遷移する' do
+      expect(current_path).to eq new_admin_user_path
+    end
+  end
+end
+
+feature 'ユーザ登録機能', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
   before do
+    login(user, new_admin_user_path)
     fill_in 'メールアドレス', with: email
     fill_in 'パスワード', with: password
     fill_in 'パスワード(確認)', with: password_confirmation
+    select '管理者', from: 'user_role'
     click_on('送信')
   end
 
   context '正常値を入力したとき' do
-    let(:email) { user_email }
-    let(:password) { user_password }
-    let(:password_confirmation) { user_password }
+    let(:email) { 'foo@example.com' }
+    let(:password) { 'password' }
+    let(:password_confirmation) { 'password' }
 
     scenario 'メッセージと共にユーザ一覧画面が表示され、ユーザ数が2であることが確認できる' do
       expect(current_path).to eq admin_users_path
       expect(page).to have_selector('.alert-success')
-      expect(page).to have_selector('tr', text: user_email)
-      expect(page.all('tbody tr').size).to eq number_of_user
+      expect(page).to have_selector('tr', text: 'foo@example.com')
+      expect(page.all('tbody tr').size).to eq 2
     end
   end
 
@@ -28,7 +49,7 @@ shared_examples '正常処理とバリデーションメッセージの確認' d
     let(:password) { '' }
     let(:password_confirmation) { '' }
 
-    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+    scenario 'バリデーションメッセージと共に登録画面が表示される' do
       expect(page).to have_selector('.alert-danger', text: 'パスワードを入力してください')
       expect(page).to have_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
       expect(page).to have_selector('.alert-danger', text: 'メールアドレスを入力してください')
@@ -41,7 +62,7 @@ shared_examples '正常処理とバリデーションメッセージの確認' d
     let(:password) { 'password123' }
     let(:password_confirmation) { 'password' }
 
-    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+    scenario 'バリデーションメッセージと共に登録画面が表示される' do
       expect(page).to have_selector('.alert-danger', text: 'パスワード(確認)とパスワードの入力が一致しません')
       expect(page).to have_selector('.alert-danger', text: 'メールアドレスは不正な値です')
     end
@@ -52,7 +73,7 @@ shared_examples '正常処理とバリデーションメッセージの確認' d
     let(:password) { 'pass' }
     let(:password_confirmation) { 'pass' }
 
-    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+    scenario 'バリデーションメッセージと共に登録画面が表示される' do
       expect(page).to have_selector('.alert-danger', text: 'パスワードは6文字以上で入力してください')
     end
   end
@@ -62,42 +83,8 @@ shared_examples '正常処理とバリデーションメッセージの確認' d
     let(:password) { 'pass word' }
     let(:password_confirmation) { 'pass word' }
 
-    scenario 'バリデーションメッセージと共に登録画面が再表示される' do
+    scenario 'バリデーションメッセージと共に登録画面が表示される' do
       expect(page).to have_selector('.alert-danger', text: 'パスワードにスペースを含めないでください')
     end
   end
-end
-
-feature 'ユーザ登録機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
-
-  before do
-    login(user, new_admin_user_path)
-  end
-
-  context 'タスク一覧画面からボタンクリックで画面遷移したとき' do
-    before do
-      visit root_path
-      page.find('.navbar-toggler').click
-      page.find('#navbarUserMenuLink').click
-      page.click_link('ユーザ登録')
-    end
-
-    scenario 'ユーザ登録画面に遷移する' do
-      expect(current_path).to eq new_admin_user_path
-    end
-  end
-
-  it_behaves_like '正常処理とバリデーションメッセージの確認', 'foo@example.com', 'password', 2
-end
-
-feature 'ユーザ編集機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
-
-  before do
-    login(user, admin_users_path)
-    click_on('編集')
-  end
-
-  it_behaves_like '正常処理とバリデーションメッセージの確認', 'bar@example.com', 'password', 1
 end

--- a/task_app/spec/features/users/tasks/base_spec.rb
+++ b/task_app/spec/features/users/tasks/base_spec.rb
@@ -5,7 +5,7 @@
 require 'rails_helper'
 
 feature '画面表示機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
+  let!(:user) { FactoryBot.create(:user, role: :admin) }
 
   context 'ログインせず画面へアクセスしたとき' do
     before { visit tasks_admin_user_path(user) }
@@ -29,7 +29,7 @@ feature '画面表示機能', type: :feature do
 end
 
 feature 'タスクソート機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
+  let!(:user) { FactoryBot.create(:user, role: :admin) }
   let!(:tasks) {
     [
       FactoryBot.create(:task, name: 'タスク1', due_date: '20190203', priority: :middle, status: :in_progress, created_at: Time.zone.now, user: user),
@@ -101,7 +101,7 @@ feature 'タスクソート機能', type: :feature do
 end
 
 feature 'ページネーション機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
+  let!(:user) { FactoryBot.create(:user, role: :admin) }
   let!(:tasks) { FactoryBot.create_list(:task, 10, user: user) }
 
   before { login(user, tasks_admin_user_path(user)) }

--- a/task_app/spec/features/users/tasks/search_spec.rb
+++ b/task_app/spec/features/users/tasks/search_spec.rb
@@ -5,7 +5,7 @@
 require 'rails_helper'
 
 feature 'タスク検索機能', type: :feature do
-  let!(:user) { FactoryBot.create(:user) }
+  let!(:user) { FactoryBot.create(:user, role: :admin) }
   let!(:tasks) {
     [
       FactoryBot.create(:task, name: 'タスク1', due_date: '20190203', priority: :middle, status: :in_progress, created_at: Time.zone.now, user: user),

--- a/task_app/spec/models/user_spec.rb
+++ b/task_app/spec/models/user_spec.rb
@@ -83,6 +83,46 @@ describe User, type: :model do
         it { is_expected.to be_invalid }
       end
     end
+
+    describe '権限(role)' do
+      let(:user) { FactoryBot.build(:user, role: role) }
+      subject { user }
+
+      context '空のとき' do
+        let(:role) { '' }
+        it { is_expected.to be_invalid }
+      end
+
+      context '正常値(整数)のとき' do
+        let(:role) { User.roles[:admin] }
+        it { is_expected.to be_valid }
+      end
+
+      context '正常値(シンボル)のとき' do
+        let(:role) { :admin }
+        it { is_expected.to be_valid }
+      end
+
+      context '正常値(文字列)のとき' do
+        let(:role) { 'admin' }
+        it { is_expected.to be_valid }
+      end
+
+      context '不整値(整数)のとき' do
+        let(:role) { 5 }
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+
+      context '不整値(シンボル)のとき' do
+        let(:role) { :abc }
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+
+      context '不整値(文字列)のとき' do
+        let(:role) { 'abc' }
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+    end
   end
 
   describe 'has_many :tasks, dependent: :delete_all' do

--- a/task_app/spec/models/user_spec.rb
+++ b/task_app/spec/models/user_spec.rb
@@ -118,4 +118,22 @@ describe User, type: :model do
       end
     end
   end
+
+  describe '管理者数制御機能' do
+    let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
+    let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
+
+    context 'user2の権限を一般に更新したとき' do
+      it '正常に更新される' do
+        expect(user2.update(role: :general)).to eq true
+      end
+    end
+
+    context 'user2->user1の順で権限を一般に更新したとき' do
+      it 'user1の権限は更新できない' do
+        expect(user2.update(role: :general)).to eq true
+        expect(user1.update(role: :general)).to eq false
+      end
+    end
+  end
 end

--- a/task_app/spec/models/user_spec.rb
+++ b/task_app/spec/models/user_spec.rb
@@ -160,8 +160,8 @@ describe User, type: :model do
   end
 
   describe '管理者数制御機能' do
-    let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
-    let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
+    let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com', role: :admin) }
+    let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com', role: :admin) }
 
     context 'user2の権限を一般に更新したとき' do
       it '正常に更新される' do


### PR DESCRIPTION
以下を参考に機能を実装しました。
ご確認のほどよろしくお願いします。

> ### ステップ19: ユーザにロールを追加しよう
> - ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
> - 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
> - ユーザ管理画面でロールを選択できるようにしましょう
> - 管理ユーザが1人もいなくならないように削除の制御をしましょう
> - ※ Gemの使用・不使用は自由です

### 実装内容
- ロールカラム追加
- 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
- ユーザ管理画面でロールを選択できるようにしましょう
- 管理ユーザが1人もいなくならないように削除の制御をしましょう

### 確認手順
1. `bundle exec rake db:migrate:reset`
2. `bundle exec rake db:seed`