### PR TITLE
ステップ20: タスクにラベルをつける(Part1)

### DIFF
--- a/task_app/app/assets/javascripts/labels.coffee
+++ b/task_app/app/assets/javascripts/labels.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/task_app/app/assets/stylesheets/labels.scss
+++ b/task_app/app/assets/stylesheets/labels.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the labels controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/task_app/app/controllers/labels_controller.rb
+++ b/task_app/app/controllers/labels_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class LabelsController < ApplicationController
+  before_action :find_label, only: %i[edit update destroy]
+
+  def index
+    @labels = current_user.labels.order(created_at: :desc).page(params[:page])
+  end
+
+  def new
+    @label = current_user.labels.new
+  end
+
+  def create
+    @label = current_user.labels.new(label_params)
+
+    if @label.save
+      redirect_to labels_url, flash: { success: create_flash_message('create', 'success', @label, :name) }
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @label.update(label_params)
+      redirect_to labels_url, flash: { success: create_flash_message('update', 'success', @label, :name) }
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @label.destroy
+      flash[:success] = create_flash_message('destroy', 'success', @label, :name)
+    else
+      flash[:danger] = create_flash_message('destroy', 'failed', @label, :name)
+    end
+
+    redirect_to labels_url
+  end
+
+  private
+
+  def label_params
+    params.require(:label).permit(:name)
+  end
+
+  def find_label
+    @label = current_user.labels.find(params[:id])
+  end
+end

--- a/task_app/app/helpers/labels_helper.rb
+++ b/task_app/app/helpers/labels_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module LabelsHelper
+end

--- a/task_app/app/models/label.rb
+++ b/task_app/app/models/label.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Label < ApplicationRecord
+  belongs_to :user
+
+  validates :user_id, presence: true
+  validates :name, presence: true, length: { maximum: 10 }, uniqueness: { scope: :user_id } # user_idとnameの組み合わせが一意であること
+end

--- a/task_app/app/models/user.rb
+++ b/task_app/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 
   has_secure_password
+  has_many :labels, dependent: :delete_all
   has_many :tasks, dependent: :delete_all
 
   enum role: %i[general admin].freeze

--- a/task_app/app/views/labels/_form.html.erb
+++ b/task_app/app/views/labels/_form.html.erb
@@ -1,0 +1,24 @@
+<% if label.errors.any? %>
+  <ul id="error_explanation" class="alert alert-danger">
+    <% label.errors.full_messages.each do |message| %>
+      <li class="ml-2"><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= form_with model: label, local: true do |f| %>
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-3 col-lg-2 col-xl-2">
+      <%= f.label :name %>
+    </div>
+    <div class="col-6 col-sm-6 col-md-5 col-lg-3 col-xl-2">
+      <%= f.text_field :name, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <%= f.submit I18n.t('words.submit'), class: 'btn btn-primary btn-sm' %>
+    </div>
+  </div>
+<% end %>

--- a/task_app/app/views/labels/edit.html.erb
+++ b/task_app/app/views/labels/edit.html.erb
@@ -1,0 +1,5 @@
+<h3><%= I18n.t('actions_with_model.edit', model_name: Label.model_name.human) %></h3>
+<%= render partial: 'form', locals: { label: @label } %>
+<br>
+
+<%= link_to I18n.t('words.back'), labels_path %>

--- a/task_app/app/views/labels/index.html.erb
+++ b/task_app/app/views/labels/index.html.erb
@@ -1,0 +1,29 @@
+<h3><%= I18n.t('actions_with_model.index', model_name: Label.model_name.human) %></h3>
+
+<div class="label-pagination">
+  <%= paginate @labels %>
+  <%= page_entries_info @labels %>
+</div>
+
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th><%= Label.human_attribute_name(:name) %></th>
+      <th><%= Label.human_attribute_name(:created_at) %></th>
+      <th>アクション</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @labels.each do |label| %>
+      <tr>
+        <td><%= label.name %></td>
+        <td><%= I18n.l(label.created_at, format: :long) %></td>
+        <td>
+          <%= link_to I18n.t('actions.edit'), edit_label_path(label) %>
+          <%= link_to I18n.t('actions.destroy'), label_path(label), method: :delete,
+              data: { confirm: I18n.t(:dialog, target: "#{Label.model_name.human}「#{label.name}」", action: I18n.t('actions.destroy')) } %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/task_app/app/views/labels/new.html.erb
+++ b/task_app/app/views/labels/new.html.erb
@@ -1,0 +1,5 @@
+<h3><%= I18n.t('actions_with_model.new', model_name: Label.model_name.human) %></h3>
+<%= render partial: 'form', locals: { label: @label } %>
+<br>
+
+<%= link_to I18n.t('words.back'), labels_path %>

--- a/task_app/app/views/layouts/_header.html.erb
+++ b/task_app/app/views/layouts/_header.html.erb
@@ -14,6 +14,16 @@
       </div>
     </li>
 
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle" href="#" id="navbarLabelMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <%= I18n.t('words.manage', model_name: Label.model_name.human) %>
+      </a>
+      <div class="dropdown-menu" aria-labelledby="navbarLabelMenuLink">
+        <%= link_to I18n.t('actions.index'), labels_path, class: 'dropdown-item' %>
+        <%= link_to I18n.t('actions_with_model.new', model_name: Label.model_name.human), new_label_path, class: 'dropdown-item' %>
+      </div>
+    </li>
+
     <% if current_user.admin? %>
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarUserMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/task_app/config/locales/ja.yml
+++ b/task_app/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
     models:
       task: タスク
       user: ユーザ
+      label: ラベル
     attributes:
       task:
         id: ID
@@ -20,6 +21,11 @@ ja:
         password: パスワード
         password_confirmation: パスワード(確認)
         role: 権限
+        created_at: 登録日時
+        updated_at: 更新日時
+      label:
+        id: ID
+        name: ラベル名
         created_at: 登録日時
         updated_at: 更新日時
     errors:

--- a/task_app/config/routes.rb
+++ b/task_app/config/routes.rb
@@ -7,11 +7,12 @@ Rails.application.routes.draw do
   post   '/login',  to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
 
+  resources :tasks, except: :show
+  resources :labels, except: :show
+
   namespace :admin do
     resources :users, except: :show do
       get :tasks, on: :member
     end
   end
-
-  resources :tasks, except: :show
 end

--- a/task_app/db/migrate/20190227060046_create_labels.rb
+++ b/task_app/db/migrate/20190227060046_create_labels.rb
@@ -1,0 +1,11 @@
+class CreateLabels < ActiveRecord::Migration[5.2]
+  def change
+    create_table :labels do |t|
+      t.integer :user_id, null: false
+      t.string :name, null: false
+      t.timestamps
+    end
+
+    add_index :labels, [:user_id, :name], unique: true
+  end
+end

--- a/task_app/db/schema.rb
+++ b/task_app/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_20_032506) do
+ActiveRecord::Schema.define(version: 2019_02_27_060046) do
+
+  create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "name"], name: "index_labels_on_user_id_and_name", unique: true
+  end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false

--- a/task_app/db/seeds.rb
+++ b/task_app/db/seeds.rb
@@ -3,3 +3,7 @@
 unless User.exists?(email: 'admin@example.com')
   User.create(email: 'admin@example.com', password: 'password', password_confirmation: 'password', role: User.roles[:admin])
 end
+
+%w[掃除 買い物 Ruby PHP Python JavaScript 予約 学習 プライベート 業務].each_with_index do |value, i|
+  User.first.labels.create(name: value, created_at: i.second.ago) unless User.first.labels.exists?(name: value)
+end

--- a/task_app/spec/factories/labels.rb
+++ b/task_app/spec/factories/labels.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :label do
+    name { 'テストラベル' }
+    user
+  end
+end

--- a/task_app/spec/features/labels/index_spec.rb
+++ b/task_app/spec/features/labels/index_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'ラベル一覧画面', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before { login(user) }
+
+  feature '画面表示機能', type: :feature do
+    let!(:label) { FactoryBot.create(:label, user: user) }
+    let!(:other_user) { FactoryBot.create(:user, email: 'otheruser@example.com') }
+    let!(:other_user_label) { FactoryBot.create(:label, name: 'other_user', user: other_user) }
+
+    context 'ログインせず画面へアクセスしたとき' do
+      before { logout(labels_path) }
+
+      scenario 'メッセージと共にログイン画面が表示される' do
+        expect(current_path).to eq login_path
+        expect(page).to have_selector('.alert-danger', text: 'サービスを利用するにはログインが必要です')
+        expect(page).to have_selector('form', count: 1)
+      end
+    end
+
+    context 'ログイン状態でアクセスしたとき' do
+      before { visit labels_path }
+
+      scenario 'ラベル一覧画面が表示され、ログインユーザのラベルを確認できる。他のユーザのラベルは確認できない。' do
+        expect(page.all('tbody tr').size).to eq 1
+        expect(page).to have_content label.name
+        expect(page).to have_no_content other_user_label.name
+      end
+    end
+  end
+
+  feature 'ラベル削除機能' do
+    let!(:label) { FactoryBot.create(:label, user: user) }
+
+    before do
+      visit labels_path
+      click_on('削除')
+    end
+
+    context '確認ダイアログでOKを押したとき' do
+      scenario 'ラベルは削除され、一覧画面にメッセージが表示される' do
+        page.accept_confirm
+        expect(page).to have_selector '.alert-success', text: 'ラベル「テストラベル」を削除しました。'
+        expect(page.all('tbody tr').size).to eq 0
+        expect(Label.count).to eq 0
+      end
+    end
+
+    context '確認ダイアログでキャンセルを押したとき' do
+      scenario 'ラベルは削除されず、そのまま一覧画面が表示される' do
+        page.dismiss_confirm
+        expect(page).to have_no_selector '.alert-success', text: 'ラベル「テストラベル」を削除しました。'
+        expect(page.all('tbody tr').size).to eq 1
+        expect(Label.count).to eq 1
+      end
+    end
+  end
+
+  feature 'ページネーション機能' do
+    before do
+      10.times { |i| FactoryBot.create(:label, name: "ラベル#{i}", user: user) }
+      visit labels_path
+    end
+
+    context 'ラベル数が10のとき' do
+      scenario '1ページ目に6ラベルが表示される' do
+        expect(page).to have_content '全10件中1 - 6件のラベルが表示されています'
+        expect(page).to have_link '次 ›'
+        expect(page).to have_no_link '‹ 前'
+        expect(page.all('tbody tr').size).to eq 6
+      end
+
+      scenario '2ページ目に4ラベルが表示される' do
+        find_link('次').click
+        expect(page).to have_content '全10件中7 - 10件のラベルが表示されています'
+        expect(page).to have_link '‹ 前'
+        expect(page).to have_no_link '次 ›'
+        expect(page.all('tbody tr').size).to eq 4
+      end
+    end
+  end
+end

--- a/task_app/spec/features/labels/new_edit_spec.rb
+++ b/task_app/spec/features/labels/new_edit_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+shared_examples_for '正常処理とバリデーションエラーの確認' do
+  before do
+    fill_in 'ラベル名', with: label_name
+    click_on('送信')
+  end
+
+  context '正常値を入力したとき' do
+    let(:label_name) { 'ダミーラベル' }
+
+    scenario '正常に処理される' do
+      expect(page).to have_selector '.alert-success'
+      expect(page).to have_no_selector '#error_explanation'
+      expect(page).to have_content 'ダミーラベル'
+      expect(page.all('tbody tr').size).to eq 1
+      expect(Label.count).to eq 1
+    end
+  end
+
+  context '空欄のまま送信したとき' do
+    let(:label_name) { '' }
+
+    scenario '入力を促すエラーメッセージが表示される' do
+      expect(page).to have_selector '#error_explanation', text: 'ラベル名を入力してください'
+    end
+  end
+
+  context '制限内の文字数を入力したとき' do
+    let(:label_name) { 'a' * 10 }
+
+    scenario '正常に処理される' do
+      expect(page).to have_no_selector '#error_explanation'
+      expect(page).to have_selector '.alert-success'
+    end
+  end
+
+  context '制限外の文字数を入力したとき' do
+    let(:label_name) { 'a' * 11 }
+
+    scenario '文字数に関するエラーメッセージが表示される' do
+      expect(page).to have_no_selector '.alert-success'
+      expect(page).to have_selector '#error_explanation', text: '10文字以内'
+    end
+  end
+
+  context '登録済みのラベル名を入力したとき' do
+    let!(:duplicate_label) { FactoryBot.create(:label, name: '重複ラベル', user: user) }
+    let(:label_name) { duplicate_label.name }
+
+    scenario '登録済みである旨を伝えるエラーメッセージが表示される' do
+      expect(page).to have_selector '#error_explanation', text: 'ラベル名はすでに存在します'
+    end
+  end
+end
+
+feature 'ラベル登録・編集', type: :feature do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before { login(user) }
+
+  feature 'ラベル登録画面(機能)' do
+    before { visit new_label_path }
+
+    context 'タスク一覧画面からボタンクリックで画面遷移したとき' do
+      before do
+        visit root_path
+        page.find('.navbar-toggler').click
+        page.find('#navbarLabelMenuLink').click
+        page.click_link('ラベル登録')
+      end
+
+      scenario 'ラベル登録画面に遷移する' do
+        expect(current_path).to eq new_label_path
+      end
+    end
+
+    it_behaves_like '正常処理とバリデーションエラーの確認'
+  end
+
+  feature 'ラベル編集機能' do
+    let!(:label) { FactoryBot.create(:label, user: user) }
+
+    before do
+      visit labels_path
+      click_on('編集')
+    end
+
+    it_behaves_like '正常処理とバリデーションエラーの確認'
+  end
+end

--- a/task_app/spec/models/label_spec.rb
+++ b/task_app/spec/models/label_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Task, type: :model do
+  describe 'validation' do
+    let!(:user) { FactoryBot.create(:user) }
+
+    context '正常値のとき' do
+      it { expect(FactoryBot.build(:label, user: user)).to be_valid }
+    end
+
+    describe 'ラベル名' do
+      let!(:label) { FactoryBot.build(:label, name: name, user: user) }
+      subject { label }
+
+      context '空のとき' do
+        let(:name) { '' }
+        it { is_expected.to be_invalid }
+      end
+
+      context '1文字のとき' do
+        let(:name) { 'a' }
+        it { is_expected.to be_valid }
+      end
+
+      context '10文字のとき' do
+        let(:name) { 'a' * 10 }
+        it { is_expected.to be_valid }
+      end
+
+      context '11文字のとき' do
+        let(:name) { 'a' * 11 }
+        it { is_expected.to be_invalid }
+      end
+
+      context '登録済みのラベル名のとき' do
+        let!(:duplicate_label) { FactoryBot.create(:label, user: user) }
+        let(:name) { duplicate_label.name }
+        it { is_expected.to be_invalid }
+      end
+
+      context '他のユーザが登録したラベル名のとき' do
+        let!(:other_user) { FactoryBot.create(:user, email: 'otheruser@example.com') }
+        let!(:other_user_label) { FactoryBot.create(:label, name: 'other', user: other_user) }
+        let(:name) { other_user_label.name }
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end

--- a/task_app/spec/models/user_spec.rb
+++ b/task_app/spec/models/user_spec.rb
@@ -141,6 +141,22 @@ describe User, type: :model do
     end
   end
 
+  describe 'has_many :labels, dependent: :delete_all' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:label1) { FactoryBot.create(:label, name: 'ラベル1', user: user) }
+    let!(:label2) { FactoryBot.create(:label, name: 'ラベル2', user: user) }
+
+    context 'ユーザを削除したとき' do
+      it '削除されたユーザのラベルも削除される' do
+        expect(User.count).to eq 1
+        expect(Label.where(user_id: user.id).count).to eq 2
+        user.destroy
+        expect(User.count).to eq 0
+        expect(Label.where(user_id: user.id).empty?).to eq true
+      end
+    end
+  end
+
   describe '検索機能' do
     let!(:user1) { FactoryBot.create(:user, email: 'test1@gmail.com') }
     let!(:user2) { FactoryBot.create(:user, email: 'test2@gmail.com') }


### PR DESCRIPTION
以下を参考に機能を実装しました。
ご確認をお願いします。
※prが大きくなる為、分割しております

> ### ステップ20: タスクにラベルをつけられるようにしよう
> - タスクに複数のラベルをつけられるようにしてみましょう
> - つけたラベルで検索できるようにしてみましょう

### 確認手順
1. `bundle exec rake db:migrate:reset`
2. `bundle exec rake db:seed`
3. `bundle exec rails s`

### 実装内容
- ラベルモデル・コントローラの作成
- ラベルのCUD機能実装

### 未実装機能
- タスクに複数のラベルをつけられるようにしてみましょう
- つけたラベルで検索できるようにしてみましょう

### ラベル一覧一覧画面
<img width="1439" alt="2019-02-25 15 32 06" src="https://user-images.githubusercontent.com/27676848/53318532-ea068080-3912-11e9-9734-7e55e4bfa0d4.png">

### ラベル登録画面
<img width="1440" alt="2019-02-25 15 32 18" src="https://user-images.githubusercontent.com/27676848/53318539-f7236f80-3912-11e9-803b-7c0b45a1154f.png">

### ラベル編集画面
<img width="1438" alt="2019-02-25 15 32 54" src="https://user-images.githubusercontent.com/27676848/53318551-01de0480-3913-11e9-93f1-53ea04c6cc1a.png">

### ラベル登録画面(バリデーションエラー)
![2019-02-28 12 10 01](https://user-images.githubusercontent.com/27676848/53538643-ee6cac80-3b51-11e9-8db4-37a31d0f5992.png)

### タスク登録画面(実装予定)
![2019-02-28 12 13 53](https://user-images.githubusercontent.com/27676848/53538792-73f05c80-3b52-11e9-9b35-b9acdd3fce6d.png)

### タスク一覧画面(実装予定)
![2019-02-28 12 14 05](https://user-images.githubusercontent.com/27676848/53538806-82d70f00-3b52-11e9-9ad8-2be7db0ffdef.png)
