### PR TITLE
ステップ20: タスクにラベルをつける(Part2)

### DIFF
--- a/task_app/app/controllers/tasks_controller.rb
+++ b/task_app/app/controllers/tasks_controller.rb
@@ -45,7 +45,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :description, :due_date, :priority, :status)
+    params.require(:task).permit(:name, :description, :due_date, :priority, :status, label_ids: [])
   end
 
   def find_task

--- a/task_app/app/helpers/tasks_helper.rb
+++ b/task_app/app/helpers/tasks_helper.rb
@@ -17,6 +17,7 @@ module TasksHelper
       sort_direction: direction,
       name:           params[:name],
       status:         params[:status],
+      label:          params[:label],
       page:           params[:page],
     }
   end

--- a/task_app/app/models/label.rb
+++ b/task_app/app/models/label.rb
@@ -2,6 +2,8 @@
 
 class Label < ApplicationRecord
   belongs_to :user
+  has_many :task_labels, dependent: :delete_all
+  has_many :tasks, through: :task_labels
 
   validates :user_id, presence: true
   validates :name, presence: true, length: { maximum: 10 }, uniqueness: { scope: :user_id } # user_idとnameの組み合わせが一意であること

--- a/task_app/app/models/task.rb
+++ b/task_app/app/models/task.rb
@@ -20,7 +20,7 @@ class Task < ApplicationRecord
   # 検索は渡されたレコード、または1から行う
   def self.search(params, initial_records = nil)
     initial_records ||= self
-    initial_records   = initial_records.where('tasks.name LIKE ?', "%#{sanitize_name_param(params[:name])}%") if params[:name].present?
+    initial_records   = initial_records.where('tasks.name LIKE ?', "%#{sanitize_sql_like(params[:name])}%") if params[:name].present?
     initial_records   = initial_records.where(tasks: { status: params[:status] }) if params[:status].present?
     search_by_label(initial_records, params[:label], params[:sort_column], params[:sort_direction])
   end
@@ -35,10 +35,6 @@ class Task < ApplicationRecord
     # 以下のunless文はどちらかがfalseの場合条件成立
     return { created_at: :desc } unless SORT_COLUMNS.include?(column&.to_sym) && SORT_DIRECTION.include?(direction&.to_sym)
     [[column, direction]].to_h
-  end
-
-  def self.sanitize_name_param(param)
-    param.gsub(/%|_/, '%' => '\%', '_' => '\_') # ハッシュロケットでないと正しく動作しない
   end
 
   private

--- a/task_app/app/models/task.rb
+++ b/task_app/app/models/task.rb
@@ -20,7 +20,7 @@ class Task < ApplicationRecord
   # 検索は渡されたレコード、または1から行う
   def self.search(params, initial_records = nil)
     initial_records ||= self
-    initial_records   = initial_records.where('tasks.name LIKE ?', "%#{params[:name]}%") if params[:name].present?
+    initial_records   = initial_records.where('tasks.name LIKE ?', "%#{sanitize_name_param(params[:name])}%") if params[:name].present?
     initial_records   = initial_records.where(tasks: { status: params[:status] }) if params[:status].present?
     search_by_label(initial_records, params[:label], params[:sort_column], params[:sort_direction])
   end
@@ -35,6 +35,10 @@ class Task < ApplicationRecord
     # 以下のunless文はどちらかがfalseの場合条件成立
     return { created_at: :desc } unless SORT_COLUMNS.include?(column&.to_sym) && SORT_DIRECTION.include?(direction&.to_sym)
     [[column, direction]].to_h
+  end
+
+  def self.sanitize_name_param(param)
+    param.gsub(/%|_/, '%' => '\%', '_' => '\_') # ハッシュロケットでないと正しく動作しない
   end
 
   private

--- a/task_app/app/models/task_label.rb
+++ b/task_app/app/models/task_label.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class TaskLabel < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+end

--- a/task_app/app/views/admin/users/tasks.html.erb
+++ b/task_app/app/views/admin/users/tasks.html.erb
@@ -1,9 +1,12 @@
 <h3 class="mb-3"><%= I18n.t('words.resource', owner: "#{@user.email}", item: I18n.t('actions_with_model.index', model_name: Task.model_name.human)) %></h3>
 
-<%= form_with url: tasks_admin_user_path(@user), method: :get, local: true, class: 'form-inline mb-3' do |form| %>
-  <%= form.text_field :name, placeholder: 'タスク名を入力', value: params[:name], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
-  <%= form.select :status, Task.statuses.map { |key, _| [I18n.t("enums.task.status.#{key}"), key] }, selected: params[:status], include_blank: '指定しない' %>
-  <%= form.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-2' %>
+<%= form_with url: tasks_admin_user_path(@user), method: :get, local: true, class: 'form-inline mb-3' do |f| %>
+  <%= f.text_field :name, placeholder: 'タスク名を入力', value: params[:name], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
+  <%= f.label Task.human_attribute_name(:status), class: 'mr-1' %>
+  <%= f.select :status, Task.statuses.map { |key, _| [I18n.t("enums.task.status.#{key}"), key] }, selected: params[:status], include_blank: '指定しない' %>
+  <%= f.label Label.model_name.human, class: 'ml-3 mr-1' %>
+  <%= f.select :label, current_user.labels.map { |label| [label.name, label.name] }, selected: params[:label], include_blank: '指定しない' %>
+  <%= f.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-3' %>
 <% end %>
 
 <div class="task-pagination">
@@ -17,6 +20,7 @@
       <th><%= Task.human_attribute_name(:name) %></th>
       <th><%= Task.human_attribute_name(:description) %></th>
       <th><%= Task.human_attribute_name(:status) %></th>
+      <th><%= Label.model_name.human %></th>
       <th><%= Task.human_attribute_name(:priority) %><%= admin_sort_link(@user, :priority) %></th>
       <th><%= Task.human_attribute_name(:due_date) %><%= admin_sort_link(@user, :due_date) %></th>
       <th><%= Task.human_attribute_name(:created_at) %><%= admin_sort_link(@user, :created_at) %></th>
@@ -28,6 +32,11 @@
         <td><%= task.name %></td>
         <td><%= simple_format(task.description, class: 'mb-0') %></td>
         <td><%= I18n.t("enums.task.status.#{task.status}") %></td>
+        <td>
+          <% task.labels.each do |label| %>
+            <span class="badge badge-info"><%= label.name %></span>
+          <% end %>
+        </td>
         <td><%= I18n.t("enums.task.priority.#{task.priority}") %></td>
         <td><%= I18n.l(task.due_date, format: :short) %></td>
         <td><%= I18n.l(task.created_at, format: :long) %></td>

--- a/task_app/app/views/tasks/_form.html.erb
+++ b/task_app/app/views/tasks/_form.html.erb
@@ -52,6 +52,17 @@
     </div>
   </div>
 
+  <div class="form-group row">
+    <div class="col-6 col-sm-4 col-md-2 col-lg-2 col-xl-2">
+      <%= f.label Label.model_name.human %>
+    </div>
+    <div class="col-6 col-sm-8 col-md-10 col-lg-10 col-xl-10">
+      <%= f.collection_check_boxes :label_ids, current_user.labels, :id, :name do |cb| %>
+        <% cb.label(class: "checkbox-inline input_checkbox mr-2") { cb.check_box(class: "checkbox") + cb.text } %>
+      <% end %>
+    </div>
+  </div>
+
   <div class="row">
     <div class="col-12">
       <%= f.submit I18n.t('words.submit'), class: 'btn btn-primary btn-sm' %>

--- a/task_app/app/views/tasks/index.html.erb
+++ b/task_app/app/views/tasks/index.html.erb
@@ -1,9 +1,12 @@
 <h3><%= I18n.t('actions_with_model.index', model_name: Task.model_name.human) %></h3>
 
-<%= form_with url: root_path, method: 'get', local: true, class: 'form-inline mb-3' do |form| %>
-  <%= form.text_field :name, placeholder: 'タスク名を入力', value: params[:name], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
-  <%= form.select :status, Task.statuses.map { |key, _| [I18n.t("enums.task.status.#{key}"), key] }, selected: params[:status], include_blank: '指定しない' %>
-  <%= form.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-2' %>
+<%= form_with url: root_path, method: 'get', local: true, class: 'form-inline mb-3' do |f| %>
+  <%= f.text_field :name, placeholder: 'タスク名を入力', value: params[:name], class: 'form-control mr-2 col-5 col-sm-4 col-md-3 col-lg-2 col-xl-2' %>
+  <%= f.label Task.human_attribute_name(:status), class: 'mr-1' %>
+  <%= f.select :status, Task.statuses.map { |key, _| [I18n.t("enums.task.status.#{key}"), key] }, selected: params[:status], include_blank: '指定しない' %>
+  <%= f.label Label.model_name.human, class: 'ml-3 mr-1' %>
+  <%= f.select :label, current_user.labels.map { |label| [label.name, label.name] }, selected: params[:label], include_blank: '指定しない' %>
+  <%= f.submit I18n.t('words.search'), class: 'btn btn-primary btn-sm ml-3' %>
 <% end %>
 
 
@@ -18,6 +21,7 @@
       <th><%= Task.human_attribute_name(:name) %></th>
       <th><%= Task.human_attribute_name(:description) %></th>
       <th><%= Task.human_attribute_name(:status) %></th>
+      <th><%= Label.model_name.human %></th>
       <th><%= Task.human_attribute_name(:priority) %><%= sort_link(:priority) %></th>
       <th><%= Task.human_attribute_name(:due_date) %><%= sort_link(:due_date) %></th>
       <th><%= Task.human_attribute_name(:created_at) %><%= sort_link(:created_at) %></th>
@@ -30,6 +34,11 @@
         <td><%= task.name %></td>
         <td><%= simple_format(task.description, class: 'mb-0') %></td>
         <td><%= I18n.t("enums.task.status.#{task.status}") %></td>
+        <td>
+          <% task.labels.each do |label| %>
+            <span class="badge badge-info"><%= label.name %></span>
+          <% end %>
+        </td>
         <td><%= I18n.t("enums.task.priority.#{task.priority}") %></td>
         <td><%= I18n.l(task.due_date, format: :short) %></td>
         <td><%= I18n.l(task.created_at, format: :long) %></td>

--- a/task_app/db/migrate/20190228055933_create_task_labels.rb
+++ b/task_app/db/migrate/20190228055933_create_task_labels.rb
@@ -1,0 +1,11 @@
+class CreateTaskLabels < ActiveRecord::Migration[5.2]
+  def change
+    create_table :task_labels do |t|
+      t.integer :task_id, null: false
+      t.integer :label_id, null: false
+      t.timestamps
+    end
+
+    add_index :task_labels, [:task_id, :label_id], unique: true
+  end
+end

--- a/task_app/db/schema.rb
+++ b/task_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_27_060046) do
+ActiveRecord::Schema.define(version: 2019_02_28_055933) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -18,6 +18,14 @@ ActiveRecord::Schema.define(version: 2019_02_27_060046) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id", "name"], name: "index_labels_on_user_id_and_name", unique: true
+  end
+
+  create_table "task_labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "task_id", null: false
+    t.integer "label_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id", "label_id"], name: "index_task_labels_on_task_id_and_label_id", unique: true
   end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/task_app/spec/features/tasks/index/base_spec.rb
+++ b/task_app/spec/features/tasks/index/base_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 feature '一覧画面表示機能', type: :feature do
   let!(:user1) { FactoryBot.create(:user, email: 'user1@example.com') }
   let!(:user2) { FactoryBot.create(:user, email: 'user2@example.com') }
-  let!(:user1_task) { FactoryBot.create(:task, name: 'user1のタスク', user: user1) }
+  let!(:label1) { FactoryBot.create(:label, name: 'ラベル1', user: user1) }
+  let!(:user1_task) { FactoryBot.create(:task, name: 'user1のタスク', labels: [label1], user: user1) }
 
   context 'ログインせず画面へアクセスしたとき' do
     before { visit root_path }
@@ -25,6 +26,7 @@ feature '一覧画面表示機能', type: :feature do
 
       expect(current_path).to eq root_path
       expect(tr.size).to eq 1
+      expect(tr[0].text).to have_content 'ラベル1'
       expect(tr[0].text).to have_content user1_task.name
     end
   end

--- a/task_app/spec/features/tasks/index/search_spec.rb
+++ b/task_app/spec/features/tasks/index/search_spec.rb
@@ -4,12 +4,54 @@ require 'rails_helper'
 
 feature 'タスク検索機能', type: :feature do
   let!(:user) { FactoryBot.create(:user) }
+  let!(:label1) { create(:label, name: 'Ruby', user: user) }
+  let!(:label2) { create(:label, name: 'PHP', user: user) }
+  let!(:label3) { create(:label, name: 'Python', user: user) }
   let!(:tasks) {
     [
-      FactoryBot.create(:task, name: 'タスク1', due_date: '20190203', priority: :middle, status: :in_progress, created_at: Time.zone.now, user: user),
-      FactoryBot.create(:task, name: 'タスク2', due_date: '20190209', priority: :high,   status: :to_do,       created_at: 1.day.ago,     user: user),
-      FactoryBot.create(:task, name: 'task3',  due_date: '20190206', priority: :low,    status: :in_progress, created_at: 2.days.ago,    user: user),
-      FactoryBot.create(:task, name: 'ラスク4', due_date: '20190212', priority: :low,    status: :in_progress, created_at: 3.days.ago,    user: user),
+      FactoryBot.create(
+        :task,
+        name: 'タスク1',
+        labels: [label1, label2],
+        due_date: '20190203',
+        priority: :middle,
+        status: :in_progress,
+        created_at: Time.zone.now,
+        user: user,
+      ),
+
+      FactoryBot.create(
+        :task,
+        name: 'タスク2',
+        labels: [label1, label3],
+        due_date: '20190209',
+        priority: :high,
+        status: :to_do,
+        created_at: 1.day.ago,
+        user: user,
+      ),
+
+      FactoryBot.create(
+        :task,
+        name: 'task3',
+        labels: [label2, label3],
+        due_date: '20190206',
+        priority: :low,
+        status: :in_progress,
+        created_at: 2.days.ago,
+        user: user,
+      ),
+
+      FactoryBot.create(
+        :task,
+        name: 'ラスク4',
+        labels: [label1, label2, label3],
+        due_date: '20190212',
+        priority: :low,
+        status: :in_progress,
+        created_at: 3.days.ago,
+        user: user,
+      ),
     ]
   }
 
@@ -17,12 +59,14 @@ feature 'タスク検索機能', type: :feature do
     login(user)
     fill_in 'name', with: task_name
     select status, from: 'status'
+    select label, from: 'label'
     click_on('検索')
   end
 
   context '「タスク」で名前検索したとき' do
     let(:task_name) { 'タスク' }
     let(:status) { '指定しない' }
+    let(:label) { '指定しない' }
 
     scenario '検索結果は2件' do
       expect(page.all('tbody tr').size).to eq 2
@@ -35,6 +79,7 @@ feature 'タスク検索機能', type: :feature do
   context '「hoge」で名前検索したとき' do
     let(:task_name) { 'hoge' }
     let(:status) { '指定しない' }
+    let(:label) { '指定しない' }
 
     scenario '検索結果は0件' do
       expect(page.all('tbody tr').size).to eq 0
@@ -45,6 +90,7 @@ feature 'タスク検索機能', type: :feature do
   context '「着手中」でステータス検索したとき' do
     let(:task_name) { '' }
     let(:status) { '着手中' }
+    let(:label) { '指定しない' }
 
     scenario '検索結果は3件' do
       expect(page.all('tbody tr').size).to eq 3
@@ -55,9 +101,21 @@ feature 'タスク検索機能', type: :feature do
     end
   end
 
+  context '「Ruby」でラベル検索したとき' do
+    let(:task_name) { '' }
+    let(:status) { '指定しない' }
+    let(:label) { 'Ruby' }
+
+    scenario '検索結果は3件' do
+      expect(page.all('tbody tr').size).to eq 3
+      expect(page).to have_select('label', selected: 'Ruby')
+    end
+  end
+
   context '「指定しない」でステータス検索したとき' do
     let(:task_name) { '' }
     let(:status) { '指定しない' }
+    let(:label) { '指定しない' }
 
     scenario '検索結果は4件' do
       expect(page.all('tbody tr').size).to eq 4
@@ -65,9 +123,10 @@ feature 'タスク検索機能', type: :feature do
     end
   end
 
-  context '名前&ステータス検索したとき' do
+  context '名前&ステータス&ラベル検索したとき' do
     let(:task_name) { 'スク' }
     let(:status) { '着手中' }
+    let(:label) { 'PHP' }
 
     scenario '検索結果は2件' do
       expect(page.all('tbody tr').size).to eq 2
@@ -75,12 +134,14 @@ feature 'タスク検索機能', type: :feature do
       expect(page).to have_content('ラスク4', count: 1)
       expect(find_field('name').value).to eq 'スク'
       expect(page).to have_select('status', selected: '着手中')
+      expect(page).to have_select('label', selected: 'PHP')
     end
   end
 
   context '検索後、期限で降順ソートしたとき' do
     let(:task_name) { 'スク' }
     let(:status) { '着手中' }
+    let(:label) { 'PHP' }
 
     before { page.find('th', text: '期限').click_link('▼') }
 
@@ -93,12 +154,14 @@ feature 'タスク検索機能', type: :feature do
       expect(tr[1].text).to have_content tasks[0].name
       expect(find_field('name').value).to eq 'スク'
       expect(page).to have_select('status', selected: '着手中')
+      expect(page).to have_select('label', selected: 'PHP')
     end
   end
 
   context '検索後、優先度で昇順ソートしたとき' do
     let(:task_name) { 'スク' }
     let(:status) { '着手中' }
+    let(:label) { 'PHP' }
 
     before { page.find('th', text: '優先度').click_link('▲') }
 
@@ -111,6 +174,7 @@ feature 'タスク検索機能', type: :feature do
       expect(tr[1].text).to have_content tasks[0].name
       expect(find_field('name').value).to eq 'スク'
       expect(page).to have_select('status', selected: '着手中')
+      expect(page).to have_select('label', selected: 'PHP')
     end
   end
 end

--- a/task_app/spec/features/tasks/new_edit_spec.rb
+++ b/task_app/spec/features/tasks/new_edit_spec.rb
@@ -6,9 +6,11 @@ shared_examples_for '正常処理とバリデーションエラーの確認' do 
   before do
     fill_in 'タスク名', with: task_name
     fill_in '説明', with: task_description
-    fill_in '期限', with: '20190213'
     select '高', from: 'task_priority'
     select '着手中', from: 'task_status'
+    check "task_label_ids_#{label1.id}"
+    # 期限を入力するとカレンダーのフォームが開いたままになりチェックボックスがelement not foundになる為、最後に入力
+    fill_in '期限', with: '20190213'
     click_on('送信')
   end
 
@@ -22,6 +24,7 @@ shared_examples_for '正常処理とバリデーションエラーの確認' do 
       expect(page).to have_content '02/13'
       expect(page).to have_content '高'
       expect(page).to have_content '着手中'
+      expect(page).to have_content 'ラベル1'
       expect(page.all('tbody tr').size).to eq 1
       expect(Task.count).to eq 1
     end
@@ -60,6 +63,7 @@ end
 
 feature 'タスク登録機能', type: :feature do
   let!(:user) { FactoryBot.create(:user) }
+  let!(:label1) { FactoryBot.create(:label, name: 'ラベル1', user: user) }
 
   before do
     login(user, new_task_path)
@@ -83,6 +87,7 @@ end
 
 feature 'タスク編集機能', type: :feature do
   let!(:user) { FactoryBot.create(:user) }
+  let!(:label1) { FactoryBot.create(:label, name: 'ラベル1', user: user) }
   let!(:task) { FactoryBot.create(:task, user: user) }
 
   before do

--- a/task_app/spec/features/users/tasks/search_spec.rb
+++ b/task_app/spec/features/users/tasks/search_spec.rb
@@ -6,12 +6,53 @@ require 'rails_helper'
 
 feature 'タスク検索機能', type: :feature do
   let!(:user) { FactoryBot.create(:user, role: :admin) }
+  let!(:label1) { create(:label, name: 'Ruby', user: user) }
+  let!(:label2) { create(:label, name: 'PHP', user: user) }
+  let!(:label3) { create(:label, name: 'Python', user: user) }
   let!(:tasks) {
     [
-      FactoryBot.create(:task, name: 'タスク1', due_date: '20190203', priority: :middle, status: :in_progress, created_at: Time.zone.now, user: user),
-      FactoryBot.create(:task, name: 'タスク2', due_date: '20190209', priority: :high,   status: :to_do,       created_at: 1.day.ago,     user: user),
-      FactoryBot.create(:task, name: 'task3',  due_date: '20190206', priority: :low,    status: :in_progress, created_at: 2.days.ago,    user: user),
-      FactoryBot.create(:task, name: 'ラスク4', due_date: '20190212', priority: :low,    status: :in_progress, created_at: 3.days.ago,    user: user),
+      FactoryBot.create(
+        :task,
+        name: 'タスク1',
+        labels: [label1, label2],
+        due_date: '20190203',
+        priority: :middle,
+        status: :in_progress,
+        created_at: Time.zone.now,
+        user: user,
+      ),
+
+      FactoryBot.create(
+        :task,
+        name: 'タスク2',
+        labels: [label1, label3],
+        due_date: '20190209',
+        priority: :high,
+        status: :to_do,
+        created_at: 1.day.ago,
+        user: user,
+      ),
+      FactoryBot.create(
+        :task,
+        name: 'task3',
+        labels: [label2, label3],
+        due_date: '20190206',
+        priority: :low,
+        status: :in_progress,
+        created_at: 2.days.ago,
+        user: user,
+      ),
+
+      FactoryBot.create(
+        :task,
+        name: 'ラスク4',
+        labels: [label1, label2, label3],
+        due_date: '20190212',
+        priority: :low,
+        status: :in_progress,
+        created_at: 3.days.ago,
+        user: user,
+      ),
     ]
   }
 
@@ -19,12 +60,14 @@ feature 'タスク検索機能', type: :feature do
     login(user, tasks_admin_user_path(user))
     fill_in 'name', with: task_name
     select status, from: 'status'
+    select label, from: 'label'
     click_on('検索')
   end
 
   context '「タスク」で名前検索したとき' do
     let(:task_name) { 'タスク' }
     let(:status) { '指定しない' }
+    let(:label) { '指定しない' }
 
     scenario '検索結果は2件' do
       expect(page.all('tbody tr').size).to eq 2
@@ -37,6 +80,7 @@ feature 'タスク検索機能', type: :feature do
   context '「hoge」で名前検索したとき' do
     let(:task_name) { 'hoge' }
     let(:status) { '指定しない' }
+    let(:label) { '指定しない' }
 
     scenario '検索結果は0件' do
       expect(page.all('tbody tr').size).to eq 0
@@ -47,6 +91,7 @@ feature 'タスク検索機能', type: :feature do
   context '「着手中」でステータス検索したとき' do
     let(:task_name) { '' }
     let(:status) { '着手中' }
+    let(:label) { '指定しない' }
 
     scenario '検索結果は3件' do
       expect(page.all('tbody tr').size).to eq 3
@@ -57,9 +102,21 @@ feature 'タスク検索機能', type: :feature do
     end
   end
 
+  context '「Ruby」でラベル検索したとき' do
+    let(:task_name) { '' }
+    let(:status) { '指定しない' }
+    let(:label) { 'Ruby' }
+
+    scenario '検索結果は3件' do
+      expect(page.all('tbody tr').size).to eq 3
+      expect(page).to have_select('label', selected: 'Ruby')
+    end
+  end
+
   context '「指定しない」でステータス検索したとき' do
     let(:task_name) { '' }
     let(:status) { '指定しない' }
+    let(:label) { '指定しない' }
 
     scenario '検索結果は4件' do
       expect(page.all('tbody tr').size).to eq 4
@@ -67,9 +124,10 @@ feature 'タスク検索機能', type: :feature do
     end
   end
 
-  context '名前&ステータス検索したとき' do
+  context '名前&ステータス&ラベル検索したとき' do
     let(:task_name) { 'スク' }
     let(:status) { '着手中' }
+    let(:label) { 'PHP' }
 
     scenario '検索結果は2件' do
       expect(page.all('tbody tr').size).to eq 2
@@ -77,12 +135,14 @@ feature 'タスク検索機能', type: :feature do
       expect(page).to have_content('ラスク4', count: 1)
       expect(find_field('name').value).to eq 'スク'
       expect(page).to have_select('status', selected: '着手中')
+      expect(page).to have_select('label', selected: 'PHP')
     end
   end
 
   context '検索後、期限で降順ソートしたとき' do
     let(:task_name) { 'スク' }
     let(:status) { '着手中' }
+    let(:label) { 'PHP' }
 
     before { page.find('th', text: '期限').click_link('▼') }
 
@@ -95,12 +155,14 @@ feature 'タスク検索機能', type: :feature do
       expect(tr[1].text).to have_content tasks[0].name
       expect(find_field('name').value).to eq 'スク'
       expect(page).to have_select('status', selected: '着手中')
+      expect(page).to have_select('label', selected: 'PHP')
     end
   end
 
   context '検索後、優先度で昇順ソートしたとき' do
     let(:task_name) { 'スク' }
     let(:status) { '着手中' }
+    let(:label) { 'PHP' }
 
     before { page.find('th', text: '優先度').click_link('▲') }
 
@@ -113,6 +175,7 @@ feature 'タスク検索機能', type: :feature do
       expect(tr[1].text).to have_content tasks[0].name
       expect(find_field('name').value).to eq 'スク'
       expect(page).to have_select('status', selected: '着手中')
+      expect(page).to have_select('label', selected: 'PHP')
     end
   end
 end

--- a/task_app/spec/models/label_spec.rb
+++ b/task_app/spec/models/label_spec.rb
@@ -48,4 +48,21 @@ describe Task, type: :model do
       end
     end
   end
+
+  describe 'has_many :task_labels, dependent: :delete_all' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:label1) { FactoryBot.create(:label, name: 'ラベル1', user: user) }
+    let!(:label2) { FactoryBot.create(:label, name: 'ラベル2', user: user) }
+    let!(:task) { FactoryBot.create(:task, labels: [label1, label2], user: user) }
+
+    context 'ラベル2を削除したとき' do
+      it 'タスクからラベル2が削除される' do
+        expect(Label.count).to eq 2
+        expect(task.labels.exists?(name: label2.name)).to eq true
+        label2.destroy
+        expect(Label.count).to eq 1
+        expect(task.labels.exists?(name: label2.name)).to eq false
+      end
+    end
+  end
 end

--- a/task_app/spec/models/task_spec.rb
+++ b/task_app/spec/models/task_spec.rb
@@ -166,12 +166,43 @@ describe Task, type: :model do
 
   describe '検索機能' do
     let!(:user) { FactoryBot.create(:user) }
+    let!(:label1) { FactoryBot.create(:label, name: 'ラベル1', user: user) }
+    let!(:label2) { FactoryBot.create(:label, name: 'ラベル2', user: user) }
     let!(:tasks) {
       [
         # userを指定せずにtaskをcreateした場合、createする度に同一のuserを作成する為、emailのunique制約にひっかかる
-        FactoryBot.create(:task, due_date: '20190203', priority: :middle, name: 'タスク1', created_at: Time.zone.now, status: :to_do,       user: user),
-        FactoryBot.create(:task, due_date: '20190209', priority: :high,   name: 'task2',  created_at: 1.day.ago,     status: :in_progress, user: user),
-        FactoryBot.create(:task, due_date: '20190206', priority: :low,    name: 'タスク3', created_at: 2.days.ago,    status: :in_progress, user: user),
+        FactoryBot.create(
+          :task,
+          labels: [label1],
+          due_date: '20190203',
+          priority: :middle,
+          name: 'タスク1',
+          created_at: Time.zone.now,
+          status: :to_do,
+          user: user,
+        ),
+
+        FactoryBot.create(
+          :task,
+          labels: [label1, label2],
+          due_date: '20190209',
+          priority: :high,
+          name: 'task2',
+          created_at: 1.day.ago,
+          status: :in_progress,
+          user: user,
+        ),
+
+        FactoryBot.create(
+          :task,
+          labels: [label2],
+          due_date: '20190206',
+          priority: :low,
+          name: 'タスク3',
+          created_at: 2.days.ago,
+          status: :in_progress,
+          user: user,
+        ),
       ]
     }
 
@@ -193,9 +224,9 @@ describe Task, type: :model do
       end
     end
 
-    context '名前・ステータスで検索したとき' do
+    context '名前・ステータス・ラベルで検索したとき' do
       it '1件のレコードを取得' do
-        expect(Task.search({ name: 'タスク', status: Task.statuses[:in_progress] }).count).to eq 1
+        expect(Task.search({ name: 'タスク', status: Task.statuses[:in_progress], label: label2.name }).count).to eq 1
       end
     end
 

--- a/task_app/spec/models/task_spec.rb
+++ b/task_app/spec/models/task_spec.rb
@@ -223,6 +223,18 @@ describe Task, type: :model do
       end
     end
 
+    context '「%」で名前検索したとき' do
+      it '0件のレコードを取得' do
+        expect(Task.search({ name: '%' }).count).to eq 0
+      end
+    end
+
+    context '「_」で名前検索したとき' do
+      it '0件のレコードを取得' do
+        expect(Task.search({ name: '_' }).count).to eq 0
+      end
+    end
+
     context '存在しない名前で検索したとき' do
       it '0件のレコードを取得' do
         expect(Task.search({ name: 'abc' }).count).to eq 0

--- a/task_app/spec/models/task_spec.rb
+++ b/task_app/spec/models/task_spec.rb
@@ -195,11 +195,22 @@ describe Task, type: :model do
 
         FactoryBot.create(
           :task,
-          labels: [label2],
+          labels: [label1],
           due_date: '20190206',
           priority: :low,
           name: 'タスク3',
           created_at: 2.days.ago,
+          status: :in_progress,
+          user: user,
+        ),
+
+        FactoryBot.create(
+          :task,
+          labels: [label1, label2],
+          due_date: '20190212',
+          priority: :middle,
+          name: 'タスク4',
+          created_at: 3.days.ago,
           status: :in_progress,
           user: user,
         ),
@@ -208,7 +219,7 @@ describe Task, type: :model do
 
     context '「タスク」で名前検索したとき' do
       it '2件のレコードを取得' do
-        expect(Task.search({ name: 'タスク' }).count).to eq 2
+        expect(Task.search({ name: 'タスク' }).count).to eq 3
       end
     end
 
@@ -220,52 +231,61 @@ describe Task, type: :model do
 
     context '「着手中」でステータス検索したとき' do
       it '2件のレコードを取得' do
-        expect(Task.search({ status: Task.statuses[:in_progress] }).count).to eq 2
+        expect(Task.search({ status: Task.statuses[:in_progress] }).count).to eq 3
+      end
+    end
+
+    context '「ラベル1」でラベル検索したとき' do
+      it '3件のレコードを取得' do
+        expect(Task.search({ label: label1.name }).count).to eq 4
       end
     end
 
     context '名前・ステータス・ラベルで検索したとき' do
       it '1件のレコードを取得' do
-        expect(Task.search({ name: 'タスク', status: Task.statuses[:in_progress], label: label2.name }).count).to eq 1
+        expect(Task.search({ name: 'タスク', status: Task.statuses[:in_progress], label: label1.name }).count).to eq 2
       end
     end
 
     context '期限の降順でソートしたとき' do
       it '期限の降順で3件のレコードを取得' do
         records = Task.search({ sort_column: 'due_date', sort_direction: 'desc' })
-        expect(records.count).to eq 3
-        expect(records[0].name).to eq 'task2'
-        expect(records[1].name).to eq 'タスク3'
-        expect(records[2].name).to eq 'タスク1'
+        expect(records.count).to eq 4
+        expect(records[0].name).to eq 'タスク4'
+        expect(records[1].name).to eq 'task2'
+        expect(records[2].name).to eq 'タスク3'
+        expect(records[3].name).to eq 'タスク1'
       end
     end
 
-    context '名前検索した結果を優先順位の昇順でソートしたとき' do
+    context '名前・ステータス・ラベルで検索した結果を優先順位の昇順でソートしたとき' do
       it '優先順位の昇順で2件のレコードを取得' do
-        records = Task.search({ name: 'タスク', sort_column: 'priority', sort_direction: 'asc' })
+        records = Task.search({ name: 'タスク', status: Task.statuses[:in_progress], label: label1.name, sort_column: 'priority', sort_direction: 'asc' })
         expect(records.count).to eq 2
         expect(records[0].name).to eq 'タスク3'
-        expect(records[1].name).to eq 'タスク1'
+        expect(records[1].name).to eq 'タスク4'
       end
     end
 
     context '許可されていないパラメータでソートしたとき' do
       it '登録日時の降順でソートされる' do
         records = Task.search({ sort_column: 'foo', sort_direction: 'bar' })
-        expect(records.count).to eq 3
+        expect(records.count).to eq 4
         expect(records[0].name).to eq 'タスク1'
         expect(records[1].name).to eq 'task2'
         expect(records[2].name).to eq 'タスク3'
+        expect(records[3].name).to eq 'タスク4'
       end
     end
 
     context '空のパラメータでソートしたとき' do
       it '登録日時の降順でソートされる' do
         records = Task.search({ sort_column: '', sort_direction: 'desc' })
-        expect(records.count).to eq 3
+        expect(records.count).to eq 4
         expect(records[0].name).to eq 'タスク1'
         expect(records[1].name).to eq 'task2'
         expect(records[2].name).to eq 'タスク3'
+        expect(records[3].name).to eq 'タスク4'
       end
     end
   end


### PR DESCRIPTION
以下を参考に機能を実装しました。
ご確認をお願いします。
※prが大きくなる為、分割しております

> ### ステップ20: タスクにラベルをつけられるようにしよう
> - タスクに複数のラベルをつけられるようにしてみましょう
> - つけたラベルで検索できるようにしてみましょう

### 確認手順
1. `bundle exec rake db:migrate:reset`
2. `bundle exec rake db:seed`
3. `bundle exec rails s`

### 実装内容
- TaskLabelモデルの作成
- タスクに複数のラベルを登録する機能
- ラベル検索機能

### 実装済機能
- ラベルモデル・コントローラの作成
- ラベルのCUD機能

### ラベル一覧一覧画面
<img width="1439" alt="2019-02-25 15 32 06" src="https://user-images.githubusercontent.com/27676848/53318532-ea068080-3912-11e9-9734-7e55e4bfa0d4.png">

### ラベル登録画面
<img width="1440" alt="2019-02-25 15 32 18" src="https://user-images.githubusercontent.com/27676848/53318539-f7236f80-3912-11e9-803b-7c0b45a1154f.png">

### ラベル編集画面
<img width="1438" alt="2019-02-25 15 32 54" src="https://user-images.githubusercontent.com/27676848/53318551-01de0480-3913-11e9-93f1-53ea04c6cc1a.png">

### タスク登録画面
![2019-02-28 12 13 53](https://user-images.githubusercontent.com/27676848/53538792-73f05c80-3b52-11e9-9b35-b9acdd3fce6d.png)

### タスク一覧画面
![2019-02-28 12 14 05](https://user-images.githubusercontent.com/27676848/53538806-82d70f00-3b52-11e9-9ad8-2be7db0ffdef.png)
