### PR TITLE
Sangjin step21

### DIFF
--- a/simple_todo/Gemfile
+++ b/simple_todo/Gemfile
@@ -42,6 +42,8 @@ gem 'kaminari'
 
 gem 'enum_help'
 
+gem 'turnout'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/simple_todo/Gemfile.lock
+++ b/simple_todo/Gemfile.lock
@@ -132,6 +132,8 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.2)
@@ -221,6 +223,11 @@ GEM
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    turnout (2.5.0)
+      i18n (>= 0.7, < 2)
+      rack (>= 1.3, < 3)
+      rack-accept (~> 0.4)
+      tilt (>= 1.4, < 3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -263,6 +270,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
+  turnout
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/simple_todo/app/controllers/tasks_controller.rb
+++ b/simple_todo/app/controllers/tasks_controller.rb
@@ -32,6 +32,7 @@ class TasksController < ApplicationController
   end
 
   def create
+    @labels = Label.all
     @task = Task.new(task_params)
     if @task.save
       redirect_to @task, notice: t('flash.task.created')

--- a/simple_todo/config/maintenance.yml
+++ b/simple_todo/config/maintenance.yml
@@ -1,0 +1,8 @@
+---
+reason: |-
+  The site is temporarily down for maintenance.
+  Please check back soon.
+allowed_paths: []
+allowed_ips: []
+response_code: 503
+retry_after: 7200

--- a/simple_todo/db/seeds.rb
+++ b/simple_todo/db/seeds.rb
@@ -8,3 +8,7 @@
 User.create(:email => 'sangjin.oh@rakuten.com', :name => 'Sangjin oh', :password => '1234', :admin_flag => 1)
 User.create(:email => 'test1@test.com', :name => 'test1', :password => '1234', :admin_flag => 0)
 User.create(:email => 'test2@test.com', :name => 'test2', :password => '1234', :admin_flag => 1)
+
+Label.create(:name => 'work')
+Label.create(:name => 'family')
+Label.create(:name => 'private')

--- a/simple_todo/lib/tasks/mainte_mode.rake
+++ b/simple_todo/lib/tasks/mainte_mode.rake
@@ -1,8 +1,9 @@
 namespace :mainte_mode do
-  desc "maintenance mode start"
+  desc "to start maintenance mode"
   task :start do
     sh 'cp config/maintenance.yml tmp'
   end
+  desc "to finish maintenance mode"
   task :end do
     if File.exists? 'tmp/maintenance.yml'
       sh 'rm tmp/maintenance.yml'

--- a/simple_todo/lib/tasks/mainte_mode.rake
+++ b/simple_todo/lib/tasks/mainte_mode.rake
@@ -1,0 +1,11 @@
+namespace :mainte_mode do
+  desc "maintenance mode start"
+  task :start do
+    sh 'cp config/maintenance.yml tmp'
+  end
+  task :end do
+    if File.exists? 'tmp/maintenance.yml'
+      sh 'rm tmp/maintenance.yml'
+    end
+  end
+end


### PR DESCRIPTION
[ステップ21: メンテナンス機能を作ろう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)
## 実装内容
メンテ画面追加(turnout)
メンテーモード切り替えのバッチコマンド追加
(turnoutの機能で既に出来るが、勉強の為に)
## 確認内容
rakeコマンドでメンテモードのon/offが出来るか
on: rake mainte_mode:start
off: rake mainte_mode:end