### PR TITLE
[STEP19] ユーザにロールを追加しよう

### DIFF
--- a/task_list/app/assets/stylesheets/users.scss
+++ b/task_list/app/assets/stylesheets/users.scss
@@ -16,4 +16,3 @@
   margin: 0;
   padding: 0;
 }
-

--- a/task_list/app/controllers/admin/users_controller.rb
+++ b/task_list/app/controllers/admin/users_controller.rb
@@ -1,5 +1,7 @@
 class Admin::UsersController < ApplicationController
-  before_action :set_user, only: %i[show destroy]
+  before_action :admin_user
+  before_action :set_user, only: %i[show destroy update edit]
+  before_action :count_admin_user, only: %i[destroy update]
   before_action :login_check, only: %i[destroy index]
   before_action :user_destroy_login_check, only: %i[destroy]
 
@@ -11,6 +13,18 @@ class Admin::UsersController < ApplicationController
     @users = User.all
   end
 
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), notice: I18n.t('activerecord.flash.user_edit')
+    else
+      flash[:alert] = "#{@user.errors.count}件のエラーがあります"
+      redirect_to admin_user_path(@user)
+    end
+  end
+
   def destroy
     @user.destroy
     redirect_to admin_users_path, notice: I18n.t('activerecord.flash.user_delete')
@@ -18,15 +32,29 @@ class Admin::UsersController < ApplicationController
 
   private
 
+  def user_params
+    params.require(:user).permit(:admin, :name, :password, :password_confirmation)
+  end
+
   def set_user
     @user = User.find(params[:id])
   end
 
   def user_destroy_login_check
-    session.delete(:user_id) if session[:user_id].present?
+    session.delete(:@user_id) if session[:@user_id].present?
   end
 
   def login_check
     redirect_to new_user_path if session[:user_id].nil?
+  end
+
+  def admin_user
+    redirect_to root_path, alert: '管理者以外は閲覧することができません' unless current_user.admin?
+  end
+
+  def count_admin_user
+    if User.where(admin: true).count == 1 && @user.admin == true && @user == current_user
+      redirect_to admin_user_path(@user), alert: I18n.t('activerecord.flash.last_admin_user_delete')
+    end
   end
 end

--- a/task_list/app/controllers/admin/users_controller.rb
+++ b/task_list/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < ApplicationController
-  before_action :admin_user
+  before_action :admin_user_check
   before_action :set_user, only: %i[show destroy update edit]
   before_action :count_admin_user, only: %i[destroy update]
   before_action :login_check, only: %i[destroy index]
@@ -20,7 +20,7 @@ class Admin::UsersController < ApplicationController
     if @user.update(user_params)
       redirect_to admin_user_path(@user), notice: I18n.t('activerecord.flash.user_edit')
     else
-      flash[:alert] = "#{@user.errors.count}件のエラーがあります"
+      flash[:alert] = "#{@user.errors.count}件のエラーがあります、#{@user.errors.full_messages}"
       redirect_to admin_user_path(@user)
     end
   end
@@ -48,7 +48,7 @@ class Admin::UsersController < ApplicationController
     redirect_to new_user_path if session[:user_id].nil?
   end
 
-  def admin_user
+  def admin_user_check
     redirect_to root_path, alert: '管理者以外は閲覧することができません' unless current_user.admin?
   end
 

--- a/task_list/app/controllers/tasks_controller.rb
+++ b/task_list/app/controllers/tasks_controller.rb
@@ -31,7 +31,6 @@ class TasksController < ApplicationController
   end
 
   def update
-    @task = Task.find(params[:id])
     if @task.update(task_params)
       redirect_to tasks_path, notice: I18n.t('activerecord.flash.task_edit')
     else

--- a/task_list/app/controllers/users_controller.rb
+++ b/task_list/app/controllers/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to admin_users_path, notice: I18n.t('activerecord.flash.user_edit')
+      redirect_to user_path(@user), notice: I18n.t('activerecord.flash.user_edit')
     else
       flash[:alert] = "#{@user.errors.count}件のエラーがあります"
       render 'edit'
@@ -32,7 +32,6 @@ class UsersController < ApplicationController
   end
 
   def show
-    @tasks = @user.tasks.page(params[:page]).per(10)
   end
 
   private

--- a/task_list/app/models/user.rb
+++ b/task_list/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { maximum: 255 }, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }, uniqueness: true
   has_many :tasks, dependent: :destroy
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 end

--- a/task_list/app/views/admin/users/index.html.erb
+++ b/task_list/app/views/admin/users/index.html.erb
@@ -4,6 +4,11 @@
   <div class = 'user_index'>
     <p><%= I18n.t('activerecord.attributes.user.name') %>:<%= user.name %></p>
     <p><%= I18n.t('activerecord.attributes.user.task_amount') %>:<%= tasks_amount(user) %></p>
+    <% if user.admin? %>
+      <p><%= I18n.t('activerecord.attributes.user.admin') %>:あり</p>
+    <% else %>
+      <p><%= I18n.t('activerecord.attributes.user.admin') %>:なし</p>
+    <% end %>
     <p><%= link_to I18n.t('activerecord.attributes.user.show'), admin_user_path(user.id) %></p>
   </div>
 <% end %>

--- a/task_list/app/views/admin/users/show.html.erb
+++ b/task_list/app/views/admin/users/show.html.erb
@@ -1,5 +1,31 @@
-<h1><%= @user.name %>さんのタスク一覧</h1>
-<%= link_to '削除', admin_user_path(user_id: @user.id), class: 'btn btn-danger', method: :delete, data: { confirm: '本当に削除していいですか？' } %>
+<h1><%= @user.name %>さんのページ</h1>
+
+<% if @user.errors.present? %>
+  <div id='error_explanation'>
+    <h2><%= pluralize(@user.errors.count, 'error') %></h2>
+    <ul>
+    <% @user.errors.full_messages.each do |message| %>
+      <li class = 'list'><%= message %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with(model:[:admin, @user], local: true) do |form| %>
+
+  <%= form.label :admin %>
+　<label><%= form.radio_button :admin, true %>あり</label>
+　<label><%= form.radio_button :admin, false %>なし</label>
+
+  <div class = admin_user_password>
+    <%= form.label :password %>
+    <%= form.password_field :password, class:"form-control" %>
+  </div>
+
+  <%= form.submit '管理者権限変更', class:'btn btn-primary' %>
+<% end %>
+
+<p><%= link_to 'ユーザー削除', admin_user_path(user_id: @user.id), class: 'btn btn-danger', method: :delete, data: { confirm: '本当に削除していいですか？' } %></p>
 <h2><%= @user.name %>さんのタスク一覧</h2>
 <%= page_entries_info @tasks %>
 
@@ -21,12 +47,12 @@
     <td class = 'col-md-1 col-xs-3'><%= task.priority_i18n %></td>
     <td class = 'col-md-1 col-xs-3'><%= task.status_i18n %></td>
     <% if task.endtime %>
-    <td class = 'col-md-2 col-xs-3'><%= task.endtime.strftime('%Y/%m/%d %H:%M') %></td>
+      <td class = 'col-md-2 col-xs-3'><%= task.endtime.strftime('%Y/%m/%d %H:%M') %></td>
     <% else %>
-    <td class = 'col-md-2 col-xs-3'><%= task.endtime %></td>
+      <td class = 'col-md-2 col-xs-3'><%= task.endtime %></td>
     <% end %>
     <% if task.user == current_user %>
-    <td class = 'col-md-1 col-xs-3'><%= link_to '詳細', task_path(task.id) %></td>
+      <td class = 'col-md-1 col-xs-3'><%= link_to '詳細', task_path(task.id) %></td>
     <% end %>
   </tr>
   </div>

--- a/task_list/app/views/admin/users/show.html.erb
+++ b/task_list/app/views/admin/users/show.html.erb
@@ -12,14 +12,10 @@
 <% end %>
 
 <%= form_with(model:[:admin, @user], local: true) do |form| %>
-
-  <%= form.label :admin %>
-　<label><%= form.radio_button :admin, true %>あり</label>
-　<label><%= form.radio_button :admin, false %>なし</label>
-
-  <div class = admin_user_password>
-    <%= form.label :password %>
-    <%= form.password_field :password, class:"form-control" %>
+  <div>
+    <%= form.label :admin %>
+　  <label><%= form.radio_button :admin, true %>あり</label>
+　  <label><%= form.radio_button :admin, false %>なし</label>
   </div>
 
   <%= form.submit '管理者権限変更', class:'btn btn-primary' %>

--- a/task_list/app/views/layouts/application.html.erb
+++ b/task_list/app/views/layouts/application.html.erb
@@ -14,7 +14,9 @@
     <% if logged_in? %>
       <ul>
         <li><%= link_to 'ログアウト', session_path(current_user.id), method: :delete %></li>
-        <li><%= link_to 'ユーザー管理', admin_users_path %></li>
+        <% if current_user.admin? %>
+          <li><%= link_to 'ユーザー管理', admin_users_path %></li>
+        <% end %>
         <li><%= link_to 'マイページ', user_path(current_user.id) %></li>
         <li><%= link_to 'タスク一覧', tasks_path %></li>
         <li><%= link_to 'タスク投稿', new_task_path %></li>

--- a/task_list/app/views/users/edit.html.erb
+++ b/task_list/app/views/users/edit.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-<%= form_with(model:[:admin, @user], local: true) do |form| %>
+<%= form_with(model: @user, local: true) do |form| %>
 
   <%= form.label :name %>
   <%= form.text_field :name %>

--- a/task_list/config/locales/ja.yml
+++ b/task_list/config/locales/ja.yml
@@ -20,12 +20,14 @@ ja:
         remember_me: 'ログインを記憶'
         task_amount: 'タスク数'
         show: '詳細'
+        admin: '管理者権限'
     flash:
       task_create: 'タスクを作成しました！'
       task_edit: 'タスクを編集しました！'
       task_delete: 'タスクを削除しました！'
       user_edit: 'ユーザー情報を編集しました！'
       user_delete: 'ユーザー情報を削除しました！'
+      last_admin_user_delete: '管理者がいなくなってしまいます（ ;  ; ）'
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/task_list/config/routes.rb
+++ b/task_list/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resources :sessions, only: [:new, :create, :destroy]
   resources :users, only: [:new, :create, :edit, :update, :show]
   namespace :admin do
-    resources :users, only: [:index, :show, :destroy]
+    resources :users, only: [:index, :show, :destroy, :edit, :update]
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/task_list/db/migrate/20190326065227_add_admin_to_users.rb
+++ b/task_list/db/migrate/20190326065227_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/task_list/db/schema.rb
+++ b/task_list/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_20_002512) do
+ActiveRecord::Schema.define(version: 2019_03_26_065227) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "name", null: false
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 2019_03_20_002512) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin_flg"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/task_list/spec/features/admin/users_spec.rb
+++ b/task_list/spec/features/admin/users_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.feature 'AdminUsers', type: :feature do
   describe Admin::UsersController do
     background do
-    @user = create(:user)
-    login(@user)
-    @task = create(:task, user_id: @user.id)
+    @admin_user = create(:user, admin: true)
+    @general_user = create(:user)
+    login(@admin_user)
     end
 
     feature '画面遷移' do
@@ -17,8 +17,46 @@ RSpec.feature 'AdminUsers', type: :feature do
 
       scenario 'ユーザー管理画面からユーザー詳細画面に遷移できる' do
         visit admin_users_path
-        click_link '詳細'
-        expect(page).to have_content @user.name
+        click_link '詳細', match: :first
+        expect(page).to have_content @admin_user.name
+      end
+    end
+
+    feature '管理者権限の更新、ユーザー削除' do
+      scenario '一般ユーザーの管理者権限をありに変更できること' do
+        visit admin_user_path(@general_user)
+        choose 'あり'
+        fill_in 'パスワード', with: @general_user.password
+        click_button '管理者権限変更'
+        expect(page).to have_checked_field('あり')
+      end
+
+      scenario '自分以外の管理者権限をなしに変更できること' do
+        visit admin_user_path(@general_user)
+        choose 'なし'
+        fill_in 'パスワード', with: @general_user.password
+        click_button '管理者権限変更'
+        expect(page).to have_checked_field('なし')
+      end
+
+      scenario '自分以外のユーザーを削除できること' do
+        visit admin_user_path(@general_user)
+        click_link 'ユーザー削除'
+        expect(page).to have_content 'ユーザー情報を削除しました！'
+      end
+
+      scenario '管理者が自分だけの時に、管理者権限をなしに変更できないこと' do
+        visit admin_user_path(@admin_user)
+        choose 'なし'
+        fill_in 'パスワード', with: @admin_user.password
+        click_button '管理者権限変更'
+        expect(page).to have_content '管理者がいなくなってしまいます（ ; ; ）'
+      end
+
+      scenario '管理者が自分だけの時に、自分のユーザー情報を削除できないこと' do
+        visit admin_user_path(@admin_user)
+        click_link 'ユーザー削除'
+        expect(page).to have_content '管理者がいなくなってしまいます（ ; ; ）'
       end
     end
   end


### PR DESCRIPTION
- 管理ユーザーと一般ユーザーを区別
boolean型のadminカラムをuserテーブルに追加
- 管理ユーザだけがユーザ管理画面にアクセスできる
 コントローラーにてバリデーション、管理ユーザー以外には管理画面へのリンクを表示させない
- ユーザ管理画面でロールを選択できるように変更
- 管理ユーザが1人もいなくならないように削除の制御


管理者画面のユーザー一覧にて、管理者権限の有無を確認できるようにしました！
<img width="1402" alt="スクリーンショット 2019-03-28 11 15 57" src="https://user-images.githubusercontent.com/42290873/55125550-675d2500-514d-11e9-96a4-a55cd197a318.png">

管理者画面のユーザー詳細にて、管理者権限の変更を行えるようにしました！
<img width="1430" alt="スクリーンショット 2019-03-28 11 16 24" src="https://user-images.githubusercontent.com/42290873/55125560-6cba6f80-514d-11e9-90b7-44c77e3624ed.png">
