### PR TITLE
2019/04/12 [Toyonaga/step10] ステップ10: タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/tudu/app/controllers/tasks_controller.rb
+++ b/tudu/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   # 一覧
   def index
     # TODO: ページネーション STEP14
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   # 詳細

--- a/tudu/spec/features/task_spec.rb
+++ b/tudu/spec/features/task_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "task management", :type => :feature do
 
   scenario "end user view task list and delete" do
 
-    visit "/tasks/#{@task.id}"
+    visit "/"
     expect(page).to have_text(@task.name)
     expect(page).to have_text(@task.content)
 
@@ -52,6 +52,22 @@ RSpec.feature "task management", :type => :feature do
     click_link "削除"
     expect(page).to have_text("タスクを削除しました")
     expect(page).not_to have_link("削除")
+
+    today = Time.zone.now
+    # 並び順のテスト
+    10.times do |i|
+      params = {
+        :name => "name_#{i}",
+        :content => "content_#{i}",
+        :created_at => today
+      }
+      @task = Task.new(params)
+      @task.save
+      today = today + 10
+    end
+    visit "/"
+    first_row = @task
+    expect(page.all("tr")[1].text).to include first_row.name
 
   end
 

--- a/tudu/spec/features/task_spec.rb
+++ b/tudu/spec/features/task_spec.rb
@@ -2,89 +2,111 @@ require "rails_helper"
 
 RSpec.feature "task management", :type => :feature do
 
-  scenario "End User Create a new task" do
+  describe "create task" do
+    context "create a new task" do
+      scenario "End User Create a new task" do
 
-    visit new_task_path
+        visit new_task_path
 
-    input_name = "タスク名1"
-    input_content = "タスク内容1"
-    fill_in "task[name]", with: input_name
-    fill_in "task[content]", with: input_content
-    click_button "登録"
-    expect(page).to have_text("タスクを登録しました")
+        input_name = "タスク名1"
+        input_content = "タスク内容1"
+        fill_in "task[name]", with: input_name
+        fill_in "task[content]", with: input_content
+        click_button "登録"
+        expect(page).to have_text("タスクを登録しました")
 
-    expect(page).to have_text(input_name)
-    expect(page).to have_text(input_content)
-  end
-
-  scenario "end user update a task" do
-
-    task = create(:task)
-    visit root_path
-    expect(page).to have_text(task.name)
-    expect(page).to have_text(task.content)
-
-    visit edit_task_path(task)
-
-    input_name = "タスク名1 update"
-    input_content = "タスク内容1 update"
-    fill_in "task[name]", with: input_name
-    fill_in "task[content]", with: input_content
-    click_button "変更を保存する"
-    expect(page).to have_text("タスクを保存しました")
-
-    expect(page).to have_text(input_name)
-    expect(page).to have_text(input_content)
-  end
-
-  scenario "end user show a task" do
-
-    task = create(:task)
-    visit task_path(task)
-    expect(page).to have_text(task.name)
-    expect(page).to have_text(task.content)
-
-  end
-
-  scenario "end user view task list and delete" do
-
-    task1 = create(:task)
-    task2 = create(
-      :task,
-      name: "dummy2 name",
-      content: "dummy2 content"
-    )
-    visit root_path
-    expect(page).to have_text(task1.name)
-    expect(page).to have_text(task1.content)
-    expect(page).to have_text(task2.name)
-    expect(page).to have_text(task2.content)
-
-    click_link("削除", match: :first)
-    expect(page).to have_text("タスクを削除しました")
-
-    expect(page).to have_text(task2.name)
-    expect(page).to have_text(task2.content)
-
-    expect(page).not_to have_text(task1.name)
-    expect(page).not_to have_text(task1.content)
-
-    today = Time.zone.now
-    task = nil
-    # 並び順のテスト
-    10.times do |i|
-      task = create(
-        :task,
-        name: "name_#{i}",
-        content: "content_#{i}",
-        created_at: today
-      )
-      today = today + 10
+        expect(page).to have_text(input_name)
+        expect(page).to have_text(input_content)
+      end
     end
-    visit root_path
-    first_row = task
-    expect(page.all("tr")[1].text).to include first_row.name
+  end
 
+  describe "update task" do
+    context "update a new task" do
+      scenario "End user update a task" do
+
+        task = create(:task)
+        visit root_path
+        expect(page).to have_text(task.name)
+        expect(page).to have_text(task.content)
+
+        visit edit_task_path(task)
+
+        input_name = "タスク名1 update"
+        input_content = "タスク内容1 update"
+        fill_in "task[name]", with: input_name
+        fill_in "task[content]", with: input_content
+        click_button "変更を保存する"
+        expect(page).to have_text("タスクを保存しました")
+
+        expect(page).to have_text(input_name)
+        expect(page).to have_text(input_content)
+      end
+    end
+  end
+
+  describe "show task" do
+    context "show a task" do
+      scenario "End user show a task" do
+        task = create(:task)
+        visit task_path(task)
+        expect(page).to have_text(task.name)
+        expect(page).to have_text(task.content)
+      end
+    end
+  end
+
+  describe "delete task" do
+    context "delete a task" do
+      scenario "End user delete task" do
+        task1 = create(:task)
+        task2 = create(
+          :task,
+          name: "dummy2 name",
+          content: "dummy2 content"
+        )
+        visit root_path
+        expect(page).to have_text(task1.name)
+        expect(page).to have_text(task1.content)
+        expect(page).to have_text(task2.name)
+        expect(page).to have_text(task2.content)
+
+        click_link("削除", match: :first)
+        expect(page).to have_text("タスクを削除しました")
+
+        expect(page).to have_text(task2.name)
+        expect(page).to have_text(task2.content)
+
+        expect(page).not_to have_text(task1.name)
+        expect(page).not_to have_text(task1.content)
+      end
+    end
+  end
+
+  describe "view task list" do
+    context "when default display" do
+      task = nil
+      background do
+        today = Time.zone.now
+        task = nil
+        10.times do |i|
+          task = create(
+            :task,
+            name: "name_#{i}",
+            content: "content_#{i}",
+            created_at: today
+          )
+          today = today + 10
+        end
+      end
+
+      scenario "End user view task list" do
+        visit root_path
+        first_row = task
+        expect(page.all("tr")[1].text).to include first_row.name
+
+      end
+    end
   end
 
 end


### PR DESCRIPTION
### 研修内容

- 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
- 並び替えがうまく行っていることをfeature specで書いてみましょう
