### PR TITLE
Kenkaton step10

### DIFF
--- a/task_manager/Gemfile
+++ b/task_manager/Gemfile
@@ -38,6 +38,9 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+# Use Ransack for search and sort
+gem 'ransack'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/task_manager/Gemfile.lock
+++ b/task_manager/Gemfile.lock
@@ -252,11 +252,8 @@ DEPENDENCIES
   mysql2
   puma (~> 3.11)
   rails (~> 5.2.3)
-<<<<<<< HEAD
   ransack
-=======
   rambulance
->>>>>>> cbcad5c674eaf93184a64dac204998a221f5fae3
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/task_manager/Gemfile.lock
+++ b/task_manager/Gemfile.lock
@@ -147,6 +147,11 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
+    ransack (2.1.1)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -243,6 +248,7 @@ DEPENDENCIES
   mysql2
   puma (~> 3.11)
   rails (~> 5.2.3)
+  ransack
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/task_manager/app/controllers/tasks_controller.rb
+++ b/task_manager/app/controllers/tasks_controller.rb
@@ -5,7 +5,8 @@ class TasksController < ApplicationController
 
   # GET /tasks
   def index
-    @tasks = Task.all
+    @q = Task.ransack(params[:q])
+    @tasks = @q.result
   end
 
   # GET /tasks/1

--- a/task_manager/app/views/tasks/index.html.erb
+++ b/task_manager/app/views/tasks/index.html.erb
@@ -7,7 +7,7 @@
     <tr>
       <th><%= t('activerecord.attributes.task.name') %></th>
       <th><%= t('activerecord.attributes.task.description') %></th>
-      <th><%= sort_link(@q, :created_at, 'Created at', default_order: :desc) %></th>
+      <th><%= sort_link(@q, :created_at, t('activerecord.attributes.task.created_at'), default_order: :desc) %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/task_manager/app/views/tasks/index.html.erb
+++ b/task_manager/app/views/tasks/index.html.erb
@@ -7,6 +7,7 @@
     <tr>
       <th>Name</th>
       <th>Description</th>
+      <th>Created at</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -16,6 +17,7 @@
       <tr>
         <td><%= task.name %></td>
         <td><%= task.description %></td>
+        <td><%= task.created_at %></td>
         <td><%= link_to 'Show', task %></td>
         <td><%= link_to 'Edit', edit_task_path(task) %></td>
         <td><%= link_to 'Destroy', task, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/task_manager/app/views/tasks/index.html.erb
+++ b/task_manager/app/views/tasks/index.html.erb
@@ -7,7 +7,7 @@
     <tr>
       <th>Name</th>
       <th>Description</th>
-      <th>Created at</th>
+      <th><%= sort_link(@q, :created_at, 'Created at', default_order: :desc) %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/task_manager/config/environments/development.rb
+++ b/task_manager/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/task_manager/config/locales/en.yml
+++ b/task_manager/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
       task:
         name: name
         description: description
+        created_at: created at
   tasks:
     index:
       title: Tasks
@@ -30,7 +31,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -56,7 +57,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March

--- a/task_manager/config/locales/ja.yml
+++ b/task_manager/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
       task:
         name: 名前
         description: 詳細
+        created_at: 作成日時
   tasks:
     index:
       title: タスク一覧


### PR DESCRIPTION
## ステップ10: タスク一覧を作成日時の順番で並び替えましょう
- 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう

## 変更点
- タスク一覧画面にタスク作成日時の表示
  - I18n対応
- Ransack gemを導入し、ソート機能の追加
  - ソート前
    <img width="537" alt="Screen Shot 2019-04-18 at 16 31 46" src="https://user-images.githubusercontent.com/13181932/56344117-9ff59900-61f7-11e9-9d82-8cb9ba8bdd44.png">
  - ソート後
    <img width="537" alt="Screen Shot 2019-04-18 at 16 32 06" src="https://user-images.githubusercontent.com/13181932/56344137-a8e66a80-61f7-11e9-9962-557ad0d42528.png">