### PR TITLE
Kenkaton step18

### DIFF
--- a/task_manager/app/controllers/admin/users_controller.rb
+++ b/task_manager/app/controllers/admin/users_controller.rb
@@ -1,63 +1,65 @@
 # frozen_string_literal: true
 
-class Admin::UsersController < ApplicationController
-  skip_before_action :require_login, only: %i[new create]
-  before_action :set_user, only: %i[show edit update destroy]
+module Admin
+  class UsersController < ApplicationController
+    skip_before_action :require_login, only: %i[new create]
+    before_action :set_user, only: %i[show edit update destroy]
 
-  # GET /admin/users
-  def index
-    @users = User.all.page(params[:page])
-    @tasks_count = Task.group(:user_id).count
-  end
-
-  # GET /admin/users/1
-  def show
-  end
-
-  # GET /admin/users/new
-  def new
-    @user = User.new
-  end
-
-  # GET /admin/users/1/edit
-  def edit
-  end
-
-  # POST /admin/users
-  def create
-    @user = User.new(user_params)
-
-    if @user.save
-      redirect_to admin_users_path, success: I18n.t('.flash.success.user.create')
-    else
-      render :new
+    # GET /admin/users
+    def index
+      @users = User.all.page(params[:page])
+      @tasks_count = Task.group(:user_id).count
     end
-  end
 
-  # PATCH/PUT /admin/users/1
-  def update
-    if @user.update(user_params)
-      redirect_to admin_users_path, success: I18n.t('.flash.success.user.update')
-    else
-      render :edit
+    # GET /admin/users/1
+    def show
     end
-  end
 
-  # DELETE /admin/users/1
-  def destroy
-    @user.destroy
-    redirect_to admin_users_path, success: I18n.t('.flash.success.user.destroy')
-  end
+    # GET /admin/users/new
+    def new
+      @user = User.new
+    end
 
-  private
+    # GET /admin/users/1/edit
+    def edit
+    end
 
-  # Use callbacks to share common setup or constraints between actions.
-  def set_user
-    @user = User.find(params[:id])
-  end
+    # POST /admin/users
+    def create
+      @user = User.new(user_params)
 
-  # Never trust parameters from the scary internet, only allow the white list through.
-  def user_params
-    params.require(:user).permit(:name, :password, :password_confirmation)
+      if @user.save
+        redirect_to admin_users_path, success: I18n.t('.flash.success.user.create')
+      else
+        render :new
+      end
+    end
+
+    # PATCH/PUT /admin/users/1
+    def update
+      if @user.update(user_params)
+        redirect_to admin_users_path, success: I18n.t('.flash.success.user.update')
+      else
+        render :edit
+      end
+    end
+
+    # DELETE /admin/users/1
+    def destroy
+      @user.destroy
+      redirect_to admin_users_path, success: I18n.t('.flash.success.user.destroy')
+    end
+
+    private
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_user
+      @user = User.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def user_params
+      params.require(:user).permit(:name, :password, :password_confirmation)
+    end
   end
 end

--- a/task_manager/app/controllers/admin/users_controller.rb
+++ b/task_manager/app/controllers/admin/users_controller.rb
@@ -6,8 +6,8 @@ class Admin::UsersController < ApplicationController
 
   # GET /admin/users
   def index
+    @users = User.all.page(params[:page])
     @tasks_count = Task.group(:user_id).count
-    @users = User.all
   end
 
   # GET /admin/users/1

--- a/task_manager/app/controllers/admin/users_controller.rb
+++ b/task_manager/app/controllers/admin/users_controller.rb
@@ -1,52 +1,51 @@
 # frozen_string_literal: true
 
-class UsersController < ApplicationController
+class Admin::UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
   before_action :set_user, only: %i[show edit update destroy]
 
-  # GET /users
+  # GET /admin/users
   def index
     @users = User.all
   end
 
-  # GET /users/1
+  # GET /admin/users/1
   def show
   end
 
-  # GET /users/new
+  # GET /admin/users/new
   def new
     @user = User.new
   end
 
-  # GET /users/1/edit
+  # GET /admin/users/1/edit
   def edit
   end
 
-  # POST /users
+  # POST /admin/users
   def create
     @user = User.new(user_params)
 
     if @user.save
-      log_in @user
-      redirect_to tasks_path, success: I18n.t('.flash.success.user.create')
+      redirect_to admin_users_path, success: I18n.t('.flash.success.user.create')
     else
       render :new
     end
   end
 
-  # PATCH/PUT /users/1
+  # PATCH/PUT /admin/users/1
   def update
     if @user.update(user_params)
-      redirect_to @user, success: I18n.t('.flash.success.user.update')
+      redirect_to admin_users_path, success: I18n.t('.flash.success.user.update')
     else
       render :edit
     end
   end
 
-  # DELETE /users/1
+  # DELETE /admin/users/1
   def destroy
     @user.destroy
-    redirect_to login_path, success: I18n.t('.flash.success.user.destroy')
+    redirect_to admin_users_path, success: I18n.t('.flash.success.user.destroy')
   end
 
   private

--- a/task_manager/app/controllers/admin/users_controller.rb
+++ b/task_manager/app/controllers/admin/users_controller.rb
@@ -6,6 +6,7 @@ class Admin::UsersController < ApplicationController
 
   # GET /admin/users
   def index
+    @tasks_count = Task.group(:user_id).count
     @users = User.all
   end
 

--- a/task_manager/app/controllers/sessions_controller.rb
+++ b/task_manager/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
     user = User.find_by(name: params[:session][:name])
     if user&.authenticate(params[:session][:password])
       log_in user
-      redirect_to user
+      redirect_to tasks_path
     else
       flash.now[:danger] = I18n.t('.flash.errors.session_params')
       render 'new'

--- a/task_manager/app/controllers/sessions_controller.rb
+++ b/task_manager/app/controllers/sessions_controller.rb
@@ -2,14 +2,14 @@
 
 class SessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
+  before_action :set_user, only: %i[create]
 
   def new
   end
 
   def create
-    user = User.find_by(name: params[:session][:name])
-    if user&.authenticate(params[:session][:password])
-      log_in user
+    if @user&.authenticate(params[:session][:password])
+      log_in @user
       redirect_to tasks_path
     else
       flash.now[:danger] = I18n.t('.flash.errors.session_params')
@@ -20,5 +20,11 @@ class SessionsController < ApplicationController
   def destroy
     log_out if logged_in?
     redirect_to login_path
+  end
+
+  private
+
+  def set_user
+    @user = User.find_by(name: params[:session][:name])
   end
 end

--- a/task_manager/app/controllers/sessions_controller.rb
+++ b/task_manager/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
   def create
     if @user&.authenticate(params[:session][:password])
       log_in @user
-      redirect_to tasks_path
+      redirect_to user_tasks_path(@user)
     else
       flash.now[:danger] = I18n.t('.flash.errors.session_params')
       render 'new'

--- a/task_manager/app/controllers/tasks_controller.rb
+++ b/task_manager/app/controllers/tasks_controller.rb
@@ -2,10 +2,11 @@
 
 class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
+  before_action :set_tasks_user, only: %i[index new edit create update destroy]
 
   # GET /tasks
   def index
-    @q = Task.where(user_id: params[:scope_id] || current_user.id).ransack(params[:q])
+    @q = Task.includes(:user).where(user_id: params[:user_id]).ransack(params[:q])
     @tasks = @q.result.page(params[:page])
   end
 
@@ -24,10 +25,10 @@ class TasksController < ApplicationController
 
   # POST /tasks
   def create
-    @task = current_user.tasks.new(task_params)
+    task = @tasks_user.tasks.new(task_params)
 
-    if @task.save
-      redirect_to @task, success: I18n.t('.flash.success.task.create')
+    if task.save
+      redirect_to [@tasks_user, task], success: I18n.t('.flash.success.task.create')
     else
       render :new
     end
@@ -36,7 +37,7 @@ class TasksController < ApplicationController
   # PATCH/PUT /tasks/1
   def update
     if @task.update(task_params)
-      redirect_to @task, success: I18n.t('.flash.success.task.update')
+      redirect_to [@tasks_user, @task], success: I18n.t('.flash.success.task.update')
     else
       render :edit
     end
@@ -45,7 +46,7 @@ class TasksController < ApplicationController
   # DELETE /tasks/1
   def destroy
     @task.destroy
-    redirect_to tasks_url, success: I18n.t('.flash.success.task.destroy')
+    redirect_to user_tasks_path(@tasks_user), success: I18n.t('.flash.success.task.destroy')
   end
 
   private
@@ -58,5 +59,9 @@ class TasksController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def task_params
     params.require(:task).permit(:name, :status, :description, :due_date)
+  end
+
+  def set_tasks_user
+    @tasks_user = User.find(params[:user_id] || current_user.id)
   end
 end

--- a/task_manager/app/controllers/tasks_controller.rb
+++ b/task_manager/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
 
   # GET /tasks
   def index
-    @q = Task.where(user_id: current_user.id).ransack(params[:q])
+    @q = Task.where(user_id: params[:scope_id] || current_user.id).ransack(params[:q])
     @tasks = @q.result.page(params[:page])
   end
 

--- a/task_manager/app/controllers/users_controller.rb
+++ b/task_manager/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
 
     if @user.save
       log_in @user
-      redirect_to tasks_path, success: I18n.t('.flash.success.user.create')
+      redirect_to root_path, success: I18n.t('.flash.success.user.create')
     else
       render :new
     end

--- a/task_manager/app/views/admin/users/_form.html.erb
+++ b/task_manager/app/views/admin/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: user, url: admin_users_path, local: true) do |form| %>
+<%= form_with(model: [ :admin, user ], local: true) do |form| %>
   <% if user.errors.any? %>
     <div id="error_explanation">
       <div class="alert alert-danger">

--- a/task_manager/app/views/admin/users/_form.html.erb
+++ b/task_manager/app/views/admin/users/_form.html.erb
@@ -1,0 +1,38 @@
+<%= form_with(model: user, url: admin_users_path, local: true) do |form| %>
+  <% if user.errors.any? %>
+    <div id="error_explanation">
+      <div class="alert alert-danger">
+        <div class='alert-heading'>
+          <h2><%= t('errors.template.header', model: user.model_name.human, count: user.errors.count) %></h2>
+        </div>
+
+        <ul>
+        <% user.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
+  <div class='row'>
+    <div class='col-md-6 col-md-offset-3'>
+      <div class="form-group">
+        <%= form.label :name %>
+        <%= form.text_field :name, class: 'form-control' %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :password %>
+        <%= form.password_field :password, class: 'form-control' %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :password_confirmation %>
+        <%= form.password_field :password_confirmation, class: 'form-control' %>
+      </div>
+
+      <%= form.submit "Submit", class: "btn btn-default btn-primary" %>
+    </div>
+  </div>
+<% end %>

--- a/task_manager/app/views/admin/users/edit.html.erb
+++ b/task_manager/app/views/admin/users/edit.html.erb
@@ -1,0 +1,9 @@
+<h1><%= t('.title') %></h1>
+
+<%= render 'form', user: @user %>
+
+<div class="mt-1">
+  <div class="btn-group">
+    <%= link_to 'Back', admin_users_path, class: 'btn btn-outline-dark' %>
+  </div>
+</div>

--- a/task_manager/app/views/admin/users/index.html.erb
+++ b/task_manager/app/views/admin/users/index.html.erb
@@ -4,6 +4,8 @@
 
 <%= link_to 'New User', new_admin_user_path, class: 'btn btn-outline-primary m-1' %>
 
+<%= paginate @users %>
+
 <table class='table table-striped'>
   <thead>
     <tr>
@@ -29,3 +31,4 @@
 
 <br>
 
+<%= paginate @users%>

--- a/task_manager/app/views/admin/users/index.html.erb
+++ b/task_manager/app/views/admin/users/index.html.erb
@@ -21,7 +21,7 @@
       <tr>
         <td><%= user.name %></td>
         <td><%= l(user.created_at, format: :long) %></td>
-        <td><%= link_to @tasks_count[user.id] || '0', tasks_path(scope_id: user), class: 'btn btn-link font-weight-bold' %></td>
+        <td><%= link_to @tasks_count[user.id] || '0', user_tasks_path(user), class: 'btn btn-link font-weight-bold' %></td>
         <td><%= link_to 'Edit', edit_admin_user_path(user), class: 'btn btn-outline-info' %></td>
         <td><%= link_to 'Destroy', admin_user_path(user), method: :delete, class: 'btn btn-outline-danger', data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/task_manager/app/views/admin/users/index.html.erb
+++ b/task_manager/app/views/admin/users/index.html.erb
@@ -2,7 +2,9 @@
 
 <h1>Users</h1>
 
-<table>
+<%= link_to 'New User', new_admin_user_path, class: 'btn btn-outline-primary m-1' %>
+
+<table class='table table-striped'>
   <thead>
     <tr>
       <th><%= t('activerecord.attributes.user.name') %></th>
@@ -16,10 +18,10 @@
     <% @users.each do |user| %>
       <tr>
         <td><%= user.name %></td>
-        <td><%= user.created_at %></td>
-        <td><%= link_to @tasks_count[user.id] || '0', tasks_path(scope_id: user) %></td>
-        <td><%= link_to 'Edit', edit_admin_user_path(user) %></td>
-        <td><%= link_to 'Destroy', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= l(user.created_at, format: :long) %></td>
+        <td><%= link_to @tasks_count[user.id] || '0', tasks_path(scope_id: user), class: 'btn btn-link font-weight-bold' %></td>
+        <td><%= link_to 'Edit', edit_admin_user_path(user), class: 'btn btn-outline-info' %></td>
+        <td><%= link_to 'Destroy', admin_user_path(user), method: :delete, class: 'btn btn-outline-danger', data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -27,4 +29,3 @@
 
 <br>
 
-<%= link_to 'New User', new_admin_user_path %>

--- a/task_manager/app/views/admin/users/index.html.erb
+++ b/task_manager/app/views/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<p id="notice"><%= notice %></p>
+<%= render 'shared/flash_messages' %>
 
 <h1>Users</h1>
 
@@ -7,7 +7,7 @@
     <tr>
       <th><%= t('activerecord.attributes.user.name') %></th>
       <th><%= t('activerecord.attributes.user.created_at') %></th>
-      <th colspan="3"></th>
+      <th colspan="2"></th>
     </tr>
   </thead>
 
@@ -16,9 +16,8 @@
       <tr>
         <td><%= user.name %></td>
         <td><%= user.created_at %></td>
-        <td><%= link_to 'Show', user %></td>
-        <td><%= link_to 'Edit', edit_user_path(user) %></td>
-        <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Edit', edit_admin_user_path(user) %></td>
+        <td><%= link_to 'Destroy', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -26,4 +25,4 @@
 
 <br>
 
-<%= link_to 'New User', new_user_path %>
+<%= link_to 'New User', new_admin_user_path %>

--- a/task_manager/app/views/admin/users/index.html.erb
+++ b/task_manager/app/views/admin/users/index.html.erb
@@ -7,6 +7,7 @@
     <tr>
       <th><%= t('activerecord.attributes.user.name') %></th>
       <th><%= t('activerecord.attributes.user.created_at') %></th>
+      <th><%= t('activerecord.attributes.user.number_of_tasks') %></th>
       <th colspan="2"></th>
     </tr>
   </thead>
@@ -16,6 +17,7 @@
       <tr>
         <td><%= user.name %></td>
         <td><%= user.created_at %></td>
+        <td><%= link_to @tasks_count[user.id] || '0', tasks_path(scope_id: user) %></td>
         <td><%= link_to 'Edit', edit_admin_user_path(user) %></td>
         <td><%= link_to 'Destroy', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/task_manager/app/views/admin/users/index.html.erb
+++ b/task_manager/app/views/admin/users/index.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/flash_messages' %>
 
-<h1>Users</h1>
+<h1><%= t('.title') %></h1>
 
 <%= link_to 'New User', new_admin_user_path, class: 'btn btn-outline-primary m-1' %>
 

--- a/task_manager/app/views/admin/users/new.html.erb
+++ b/task_manager/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('.title') %></h1>
+
+<%= render 'form', user: @user %>
+
+<%= link_to 'Back', admin_users_path, class: 'btn btn-outline-secondary mt-1' %>

--- a/task_manager/app/views/admin/users/show.html.erb
+++ b/task_manager/app/views/admin/users/show.html.erb
@@ -1,0 +1,23 @@
+<%= render 'shared/flash_messages' %>
+
+<h1><%= t('.title') %></h1>
+
+<p>
+  <strong><%= t('activerecord.attributes.user.name') + ':' %></strong>
+  <%= @user.name %>
+</p>
+
+<p>
+  <strong><%= t('activerecord.attributes.user.created_at') + ':' %></strong>
+  <%= l(@user.created_at, format: :short) %>
+</p>
+
+<div class="btn-group">
+  <%= link_to 'Edit', edit_user_path(@user), class: 'btn btn-outline-info' %>
+</div>
+<div class="btn-group">
+  <%= link_to 'Back', root_url, class: 'btn btn-outline-secondary' %>
+</div>
+<div class="btn-group">
+  <%= link_to 'Destroy', @user, method: :delete, class: 'btn btn-outline-danger', data: { confirm: 'Are you sure?' } %>
+</div>

--- a/task_manager/app/views/layouts/_header.html.erb
+++ b/task_manager/app/views/layouts/_header.html.erb
@@ -6,6 +6,9 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarNavDropdown">
     <ul class="navbar-nav ml-auto">
+      <li class="nav-item">
+        <%= link_to "Users", admin_users_path, class: 'nav-link' %>
+      </li>
     <% if logged_in? %>
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -17,7 +20,7 @@
         </div>
       </li>
     <% else %>
-      <li><%= link_to 'Log in', login_path %></li>
+      <li><%= link_to 'Log in', login_path, class: 'nav-link' %></li>
     <% end %>
     </ul>
   </div>

--- a/task_manager/app/views/tasks/_form.html.erb
+++ b/task_manager/app/views/tasks/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: task, local: true, class: 'form-horizontal center') do |form| %>
+<%= form_with(model: task, url: [@tasks_user, task], local: true, class: 'form-horizontal center') do |form| %>
   <% if task.errors.any? %>
     <div id="error_explanation">
       <div class="alert alert-danger">

--- a/task_manager/app/views/tasks/_task.json.jbuilder
+++ b/task_manager/app/views/tasks/_task.json.jbuilder
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-json.extract! task, :id, :name, :description, :created_at, :updated_at
-json.url task_url(task, format: :json)

--- a/task_manager/app/views/tasks/edit.html.erb
+++ b/task_manager/app/views/tasks/edit.html.erb
@@ -4,9 +4,9 @@
 
 <div class="mt-1">
   <div class="btn-group">
-    <%= link_to 'Show', @task, class: 'btn btn-outline-dark' %>
+    <%= link_to 'Show', [@task.user, @task], class: 'btn btn-outline-dark' %>
   </div>
   <div class="btn-group">
-    <%= link_to 'Back', tasks_path, class: 'btn btn-outline-secondary' %>
+    <%= link_to 'Back', user_tasks_path, class: 'btn btn-outline-secondary' %>
   </div>
 </div>

--- a/task_manager/app/views/tasks/index.html.erb
+++ b/task_manager/app/views/tasks/index.html.erb
@@ -1,8 +1,8 @@
 <%= render 'shared/flash_messages' %>
 
-<h1><%= t('.title') %></h1>
+<h1><%= @tasks_user.name + t('.title') %></h1>
 
-<%= search_form_for @q do |f| %>
+<%= search_form_for @q, url: user_tasks_path(@tasks_user) do |f| %>
   <%= f.label :name_cont, t('activerecord.attributes.task.name') %>
   <%= f.search_field :name_cont %>
 
@@ -11,7 +11,7 @@
   <%= f.submit t('helpers.submit.search'), class: "btn page-link text-dark d-inline-block" %>
 <% end %>
 
-<%= link_to 'New Task', new_task_path, class: 'btn btn-outline-primary m-1' %>
+<%= link_to 'New Task', new_user_task_path(@tasks_user), class: 'btn btn-outline-primary m-1' %>
 
 <%= paginate @tasks %>
 
@@ -35,9 +35,9 @@
         <td><%= task.description %></td>
         <td><%= task.due_date ? l(task.due_date) : '-'  %></td>
         <td><%= l(task.created_at, format: :short) %></td>
-        <td><%= link_to 'Show', task, class: 'btn btn-outline-dark' %></td>
-        <td><%= link_to 'Edit', edit_task_path(task), class: 'btn btn-outline-info' %></td>
-        <td><%= link_to 'Destroy', task, method: :delete, class: 'btn btn-outline-danger', data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Show', [task.user, task], class: 'btn btn-outline-dark' %></td>
+        <td><%= link_to 'Edit', edit_user_task_path(task.user, task), class: 'btn btn-outline-info' %></td>
+        <td><%= link_to 'Destroy', [task.user, task], method: :delete, class: 'btn btn-outline-danger', data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/task_manager/app/views/tasks/index.json.jbuilder
+++ b/task_manager/app/views/tasks/index.json.jbuilder
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-json.array! @tasks, partial: 'tasks/task', as: :task

--- a/task_manager/app/views/tasks/new.html.erb
+++ b/task_manager/app/views/tasks/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', task: @task %>
 
-<%= link_to 'Back', tasks_path, class: 'btn btn-outline-secondary mt-1' %>
+<%= link_to 'Back', user_tasks_path, class: 'btn btn-outline-secondary mt-1' %>

--- a/task_manager/app/views/tasks/show.html.erb
+++ b/task_manager/app/views/tasks/show.html.erb
@@ -23,8 +23,8 @@
 </p>
 
 <div class="btn-group" >
-  <%= link_to 'Edit', edit_task_path(@task), class: 'btn btn-outline-info' %>
+  <%= link_to 'Edit', edit_user_task_path(@task.user, @task), class: 'btn btn-outline-info' %>
 </div>
 <div class="btn-group" >
-  <%= link_to 'Back', tasks_path, class: 'btn btn-outline-secondary' %>
+  <%= link_to 'Back', user_tasks_path, class: 'btn btn-outline-secondary' %>
 </div>

--- a/task_manager/app/views/tasks/show.json.jbuilder
+++ b/task_manager/app/views/tasks/show.json.jbuilder
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-json.partial! 'tasks/task', task: @task

--- a/task_manager/app/views/users/_user.json.jbuilder
+++ b/task_manager/app/views/users/_user.json.jbuilder
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-json.extract! user, :id, :created_at, :updated_at
-json.url user_url(user, format: :json)

--- a/task_manager/app/views/users/index.json.jbuilder
+++ b/task_manager/app/views/users/index.json.jbuilder
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-json.array! @users, partial: 'users/user', as: :user

--- a/task_manager/app/views/users/show.json.jbuilder
+++ b/task_manager/app/views/users/show.json.jbuilder
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-json.partial! 'users/user', user: @user

--- a/task_manager/config/locales/en.yml
+++ b/task_manager/config/locales/en.yml
@@ -54,6 +54,10 @@ en:
       title: sign up
     show:
       title: user info
+  admin:
+    users:
+      index:
+        title: Users
   date:
     abbr_day_names:
     - Sun

--- a/task_manager/config/locales/en.yml
+++ b/task_manager/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
       user:
         name: name
         created_at: created at
+        number_of_tasks: tasks
         password: password
         password_confirmation: confirmation
   enumerize:

--- a/task_manager/config/locales/ja.yml
+++ b/task_manager/config/locales/ja.yml
@@ -21,6 +21,7 @@ ja:
       user:
         name: 名前
         created_at: 作成日時
+        number_of_tasks: タスク数
         password: パスワード
         password_confirmation: パスワード(確認)
   enumerize:

--- a/task_manager/config/locales/ja.yml
+++ b/task_manager/config/locales/ja.yml
@@ -54,6 +54,10 @@ ja:
       title: 新規登録
     show:
       title: ユーザー設定
+  admin:
+    users:
+      index:
+        title: ユーザ一覧
   date:
     abbr_day_names:
     - 日

--- a/task_manager/config/routes.rb
+++ b/task_manager/config/routes.rb
@@ -4,9 +4,15 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'tasks#index'
   resources :tasks
+
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
+
   get '/signup', to: 'users#new'
-  resources :users
+  resources :users, except: [:index]
+
+  namespace :admin do
+    resources :users, except: [:show]
+  end
 end

--- a/task_manager/config/routes.rb
+++ b/task_manager/config/routes.rb
@@ -3,14 +3,15 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'tasks#index'
-  resources :tasks
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
 
   get '/signup', to: 'users#new'
-  resources :users, except: [:index]
+  resources :users, except: [:index] do
+    resources :tasks
+  end
 
   namespace :admin do
     resources :users, except: [:show]

--- a/task_manager/spec/controllers/admin/users_controller_spec.rb
+++ b/task_manager/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController, type: :controller do
+  before do
+    user = create(:user)
+    log_in user
+  end
+  # This should return the minimal set of attributes required to create a valid
+  # User. As you add validations to User, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) {
+    {
+      name: 'user name',
+      password: 'password',
+      password_digest: User.digest('password'),
+    }
+  }
+
+  let(:invalid_attributes) {
+    {
+      name: '',
+    }
+  }
+
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # UsersController. Be sure to keep this updated too.
+  let(:valid_session) { {} }
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      User.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      user = User.create! valid_attributes
+      get :edit, params: { id: user.to_param }, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new User' do
+        expect {
+          post :create, params: { user: valid_attributes }, session: valid_session
+        }.to change(User, :count).by(1)
+      end
+
+      it 'redirects to the created user' do
+        post :create, params: { user: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(admin_users_path)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { user: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) {
+        { name: 'new user name', password: 'password', password_digest: User.digest('password') }
+      }
+
+      it 'updates the requested user' do
+        user = User.create! valid_attributes
+        put :update, params: { id: user.to_param, user: new_attributes }, session: valid_session
+        expect { user.reload }.to(
+          change(user, :name).from('user name').to('new user name'),
+        )
+      end
+
+      it 'redirects to the user' do
+        user = User.create! valid_attributes
+        put :update, params: { id: user.to_param, user: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(admin_users_path)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        user = User.create! valid_attributes
+        put :update, params: { id: user.to_param, user: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested user' do
+      user = User.create! valid_attributes
+      expect {
+        delete :destroy, params: { id: user.to_param }, session: valid_session
+      }.to change(User, :count).by(-1)
+    end
+
+    it 'redirects to the users list' do
+      user = User.create! valid_attributes
+      delete :destroy, params: { id: user.to_param }, session: valid_session
+      expect(response).to redirect_to(admin_users_path)
+    end
+  end
+end

--- a/task_manager/spec/controllers/tasks_controller_spec.rb
+++ b/task_manager/spec/controllers/tasks_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe TasksController, type: :controller do
 
   describe 'GET #new' do
     it 'returns a success response' do
-      get :new, params: { user_id: current_user.id,}, session: valid_session
+      get :new, params: { user_id: current_user.id }, session: valid_session
       expect(response).to be_successful
     end
   end

--- a/task_manager/spec/controllers/tasks_controller_spec.rb
+++ b/task_manager/spec/controllers/tasks_controller_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe TasksController, type: :controller do
   describe 'GET #show' do
     it 'returns a success response' do
       task = current_user.tasks.create! valid_attributes
-      get :show, params: { id: task.to_param }, session: valid_session
+      get :show, params: { user_id: task.user.id, id: task.to_param }, session: valid_session
       expect(response).to be_successful
     end
   end
 
   describe 'GET #new' do
     it 'returns a success response' do
-      get :new, params: {}, session: valid_session
+      get :new, params: { user_id: current_user.id,}, session: valid_session
       expect(response).to be_successful
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe TasksController, type: :controller do
   describe 'GET #edit' do
     it 'returns a success response' do
       task = current_user.tasks.create! valid_attributes
-      get :edit, params: { id: task.to_param }, session: valid_session
+      get :edit, params: { user_id: task.user.id, id: task.to_param }, session: valid_session
       expect(response).to be_successful
     end
   end
@@ -71,19 +71,19 @@ RSpec.describe TasksController, type: :controller do
     context 'with valid params' do
       it 'creates a new Task' do
         expect {
-          post :create, params: { task: valid_attributes }, session: valid_session
+          post :create, params: { user_id: current_user.id, task: valid_attributes }, session: valid_session
         }.to change(Task, :count).by(1)
       end
 
       it 'redirects to the created task' do
-        post :create, params: { task: valid_attributes }, session: valid_session
-        expect(response).to redirect_to(Task.last)
+        post :create, params: { user_id: current_user.id, task: valid_attributes }, session: valid_session
+        expect(response).to redirect_to([current_user, Task.last])
       end
     end
 
     context 'with invalid params' do
       it 'returns a success response (i.e. to display the "new" template)' do
-        post :create, params: { task: invalid_attributes }, session: valid_session
+        post :create, params: { user_id: current_user.id, task: invalid_attributes }, session: valid_session
         expect(response).to be_successful
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe TasksController, type: :controller do
 
       it 'updates the requested task' do
         task = current_user.tasks.create! valid_attributes
-        put :update, params: { id: task.to_param, task: new_attributes }, session: valid_session
+        put :update, params: { user_id: task.user.id, id: task.to_param, task: new_attributes }, session: valid_session
         expect { task.reload }.to(
           change(task, :name).from('name').to('new name')
           .and(change(task, :status).from(0).to(1))
@@ -108,15 +108,15 @@ RSpec.describe TasksController, type: :controller do
 
       it 'redirects to the task' do
         task = current_user.tasks.create! valid_attributes
-        put :update, params: { id: task.to_param, task: valid_attributes }, session: valid_session
-        expect(response).to redirect_to(task)
+        put :update, params: { user_id: task.user.id, id: task.to_param, task: valid_attributes }, session: valid_session
+        expect(response).to redirect_to([current_user, task])
       end
     end
 
     context 'with invalid params' do
       it 'returns a success response (i.e. to display the "edit" template)' do
         task = current_user.tasks.create! valid_attributes
-        put :update, params: { id: task.to_param, task: invalid_attributes }, session: valid_session
+        put :update, params: { user_id: task.user.id, id: task.to_param, task: invalid_attributes }, session: valid_session
         expect(response).to be_successful
       end
     end
@@ -126,14 +126,14 @@ RSpec.describe TasksController, type: :controller do
     it 'destroys the requested task' do
       task = current_user.tasks.create! valid_attributes
       expect {
-        delete :destroy, params: { id: task.to_param }, session: valid_session
+        delete :destroy, params: { user_id: task.user.id, id: task.to_param }, session: valid_session
       }.to change(Task, :count).by(-1)
     end
 
     it 'redirects to the tasks list' do
       task = current_user.tasks.create! valid_attributes
-      delete :destroy, params: { id: task.to_param }, session: valid_session
-      expect(response).to redirect_to(tasks_url)
+      delete :destroy, params: { user_id: task.user.id, id: task.to_param }, session: valid_session
+      expect(response).to redirect_to(user_tasks_path(current_user))
     end
   end
 end

--- a/task_manager/spec/controllers/users_controller_spec.rb
+++ b/task_manager/spec/controllers/users_controller_spec.rb
@@ -23,14 +23,6 @@ RSpec.describe UsersController, type: :controller do
   # UsersController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  describe 'GET #index' do
-    it 'returns a success response' do
-      User.create! valid_attributes
-      get :index, params: {}, session: valid_session
-      expect(response).to be_successful
-    end
-  end
-
   describe 'GET #show' do
     it 'returns a success response' do
       user = User.create! valid_attributes

--- a/task_manager/spec/controllers/users_controller_spec.rb
+++ b/task_manager/spec/controllers/users_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe UsersController, type: :controller do
 
       it 'redirects to the created user' do
         post :create, params: { user: valid_attributes }, session: valid_session
-        expect(response).to redirect_to(User.last)
+        expect(response).to redirect_to(root_path)
       end
     end
 

--- a/task_manager/spec/routing/admin/users_routing_spec.rb
+++ b/task_manager/spec/routing/admin/users_routing_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController, type: :routing do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/admin/users').to route_to('admin/users#index')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/admin/users/new').to route_to('admin/users#new')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/admin/users/1').to_not route_to('admin/users#show', id: '1')
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/admin/users/1/edit').to route_to('admin/users#edit', id: '1')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/admin/users').to route_to('admin/users#create')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(put: '/admin/users/1').to route_to('admin/users#update', id: '1')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(patch: '/admin/users/1').to route_to('admin/users#update', id: '1')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/admin/users/1').to route_to('admin/users#destroy', id: '1')
+    end
+  end
+end

--- a/task_manager/spec/routing/tasks_routing_spec.rb
+++ b/task_manager/spec/routing/tasks_routing_spec.rb
@@ -5,35 +5,35 @@ require 'rails_helper'
 RSpec.describe TasksController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
-      expect(get: '/tasks').to route_to('tasks#index')
+      expect(get: '/users/1/tasks').to route_to('tasks#index', user_id: '1')
     end
 
     it 'routes to #new' do
-      expect(get: '/tasks/new').to route_to('tasks#new')
+      expect(get: '/users/1/tasks/new').to route_to('tasks#new', user_id: '1')
     end
 
     it 'routes to #show' do
-      expect(get: '/tasks/1').to route_to('tasks#show', id: '1')
+      expect(get: '/users/1/tasks/1').to route_to('tasks#show', id: '1', user_id: '1')
     end
 
     it 'routes to #edit' do
-      expect(get: '/tasks/1/edit').to route_to('tasks#edit', id: '1')
+      expect(get: '/users/1/tasks/1/edit').to route_to('tasks#edit', id: '1', user_id: '1')
     end
 
     it 'routes to #create' do
-      expect(post: '/tasks').to route_to('tasks#create')
+      expect(post: '/users/1/tasks').to route_to('tasks#create', user_id: '1')
     end
 
     it 'routes to #update via PUT' do
-      expect(put: '/tasks/1').to route_to('tasks#update', id: '1')
+      expect(put: '/users/1/tasks/1').to route_to('tasks#update', id: '1', user_id: '1')
     end
 
     it 'routes to #update via PATCH' do
-      expect(patch: '/tasks/1').to route_to('tasks#update', id: '1')
+      expect(patch: '/users/1/tasks/1').to route_to('tasks#update', id: '1', user_id: '1')
     end
 
     it 'routes to #destroy' do
-      expect(delete: '/tasks/1').to route_to('tasks#destroy', id: '1')
+      expect(delete: '/users/1/tasks/1').to route_to('tasks#destroy', id: '1', user_id: '1')
     end
   end
 end

--- a/task_manager/spec/routing/users_routing_spec.rb
+++ b/task_manager/spec/routing/users_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Admin::UsersController, type: :routing do
+RSpec.describe UsersController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/users').to_not route_to('users#index')
@@ -34,38 +34,6 @@ RSpec.describe Admin::UsersController, type: :routing do
 
     it 'routes to #destroy' do
       expect(delete: '/users/1').to route_to('users#destroy', id: '1')
-    end
-
-    it 'routes to #index' do
-      expect(get: '/admin/users').to route_to('admin/users#index')
-    end
-
-    it 'routes to #new' do
-      expect(get: '/admin/users/new').to route_to('admin/users#new')
-    end
-
-    it 'routes to #show' do
-      expect(get: '/admin/users/1').to_not route_to('admin/users#show', id: '1')
-    end
-
-    it 'routes to #edit' do
-      expect(get: '/admin/users/1/edit').to route_to('admin/users#edit', id: '1')
-    end
-
-    it 'routes to #create' do
-      expect(post: '/admin/users').to route_to('admin/users#create')
-    end
-
-    it 'routes to #update via PUT' do
-      expect(put: '/admin/users/1').to route_to('admin/users#update', id: '1')
-    end
-
-    it 'routes to #update via PATCH' do
-      expect(patch: '/admin/users/1').to route_to('admin/users#update', id: '1')
-    end
-
-    it 'routes to #destroy' do
-      expect(delete: '/admin/users/1').to route_to('admin/users#destroy', id: '1')
     end
   end
 end

--- a/task_manager/spec/routing/users_routing_spec.rb
+++ b/task_manager/spec/routing/users_routing_spec.rb
@@ -2,10 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe UsersController, type: :routing do
+RSpec.describe Admin::UsersController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
-      expect(get: '/users').to route_to('users#index')
+      expect(get: '/users').to_not route_to('users#index')
     end
 
     it 'routes to #new' do
@@ -34,6 +34,38 @@ RSpec.describe UsersController, type: :routing do
 
     it 'routes to #destroy' do
       expect(delete: '/users/1').to route_to('users#destroy', id: '1')
+    end
+
+    it 'routes to #index' do
+      expect(get: '/admin/users').to route_to('admin/users#index')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/admin/users/new').to route_to('admin/users#new')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/admin/users/1').to_not route_to('admin/users#show', id: '1')
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/admin/users/1/edit').to route_to('admin/users#edit', id: '1')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/admin/users').to route_to('admin/users#create')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(put: '/admin/users/1').to route_to('admin/users#update', id: '1')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(patch: '/admin/users/1').to route_to('admin/users#update', id: '1')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/admin/users/1').to route_to('admin/users#destroy', id: '1')
     end
   end
 end


### PR DESCRIPTION
## [ステップ18: ユーザの管理画面を実装しよう ](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
- 画面上に管理メニューを追加しましょう
- 管理画面にはかならず `/admin` というURLを先頭につけるようにしましょう
  - `routes.rb` に追加する前に、あらかじめURLやルーティング名（ `*_path` となる名前）を想定して設計してみましょう
- ユーザ一覧・作成・更新・削除を実装しましょう
- ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう
- ユーザが作成したタスクの一覧が見られるようにしてみましょう

## 変更点・確認点
- 管理画面の追加( `/admin/users` )
  <img width="1235" alt="Screen Shot 2019-05-17 at 12 24 16" src="https://user-images.githubusercontent.com/13181932/57901221-15a85f80-789f-11e9-981b-0f07e44607ef.png">
  <img width="1235" alt="Screen Shot 2019-05-17 at 12 24 47" src="https://user-images.githubusercontent.com/13181932/57901226-1b9e4080-789f-11e9-8395-2ad92eed6089.png">
  - `/admin/users` と `/users` の２つの controller と views を共存させた
    - 新規登録や退会を自分で操作できる、かつ、管理画面から誰でも登録更新削除操作できる、という状態を作るため
- ユーザ削除時の関連タスク削除(元から関連付け済み)
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示https://github.com/Fablic/training/pull/328/commits/f89722cf9c8e85247264efaf50ed25768d9d91b9
- ユーザが作成したタスクの一覧が見られるようにするhttps://github.com/Fablic/training/pull/328/commits/f89722cf9c8e85247264efaf50ed25768d9d91b9

## 新規追加画面
- ユーザ管理画面(`/admin/users`)
  <img width="1235" alt="Screen Shot 2019-05-17 at 12 24 47" src="https://user-images.githubusercontent.com/13181932/57901302-75066f80-789f-11e9-8597-f60efca217a5.png">

## 共有事項
- シードデータ作成コマンド
    ` bundle exec rails db:seed `
- ログインユーザ情報

    |name|password|
    |:--|:--|
    |username0|password|