### PR TITLE
タスク一覧のソート順を作成日時で降順にする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,10 +2,11 @@
 
 <h1>Tasks</h1>
 
-<table>
+<table border="1">
   <thead>
     <tr>
       <th><%= Task.human_attribute_name(:name) %></th>
+      <th><%= Task.human_attribute_name(:created_at) %></th>
       <th><%= Task.human_attribute_name(:status) %></th>
       <th><%= Task.human_attribute_name(:description) %></th>
       <th colspan="3"></th>
@@ -16,6 +17,7 @@
     <% @tasks.each do |task| %>
       <tr>
         <td><%= task.name %></td>
+        <td><%= l(task.created_at, format: :long) %></td>
         <td><%= t(".status.#{task.status}") %></td>
         <td><%= task.description %></td>
         <td><%= link_to t('buttons.show'), task %></td>

--- a/config/locales/models/task/en.yml
+++ b/config/locales/models/task/en.yml
@@ -8,3 +8,4 @@ en:
         description: Description  #g
         name: Name  #g
         status: Status  #g
+        created_at: Created at

--- a/config/locales/models/task/ja.yml
+++ b/config/locales/models/task/ja.yml
@@ -8,3 +8,4 @@ ja:
         description: 説明
         name: タスク名
         status: ステータス
+        created_at: 作成日

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -42,4 +42,18 @@ RSpec.describe 'Tasks', type: :system do
     expect(page).to have_content('hoge-update')
     expect(page).to have_content('完了')
   end
+
+  context '一覧表示' do
+    before do
+      create(:task, { name: 'task1', created_at: Time.zone.now })
+      create(:task, { name: 'task2', created_at: 1.day.ago })
+    end
+
+    scenario '一覧のソート順が登録日の降順であること' do
+      visit root_path
+
+      tds = page.all('td')
+      expect(tds[0]).to have_content 'task1'
+    end
+  end
 end


### PR DESCRIPTION
### [ステップ10: タスク一覧を作成日時の順番で並び替えましょう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

![スクリーンショット 0031-05-28 午後4 44 04](https://user-images.githubusercontent.com/22090534/58460077-d6fc8a00-8167-11e9-973f-fba454d87310.png)
