### PR TITLE
tasks.nameに必須と桁数のバリデーション処理を入れる

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,6 @@
 
 class Task < ApplicationRecord
   enum status: { waiting: 1, work_in_progress: 2, completed: 3 }
+
+  validates :name, presence: true, length: { maximum: 20 }
 end

--- a/db/migrate/20190531002052_change_column_to_task.rb
+++ b/db/migrate/20190531002052_change_column_to_task.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeColumnToTask < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks, :name, :string, limit: 20
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,9 +12,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_521_053_254) do
+ActiveRecord::Schema.define(version: 20_190_531_002_052) do
   create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name', null: false
+    t.string 'name', limit: 20, null: false
     t.text 'description'
     t.integer 'status', limit: 1, default: 1, null: false, unsigned: true
     t.datetime 'created_at', null: false

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe '#save' do
-    let(:task) { build(:task, name: 'a' * 1) }
+    let(:task) { build(:task, name: 'a' * 1, status: 1) }
 
     before do
       task.save
@@ -25,7 +25,7 @@ RSpec.describe Task, type: :model do
     end
 
     context 'nameへ20文字の入力があると' do
-      let(:task) { build(:task, name: 'a' * 20) }
+      let(:task) { build(:task, name: 'a' * 20, status: 2) }
 
       it 'creates records in task' do
         expect(Task.count).to eq(1)
@@ -39,6 +39,24 @@ RSpec.describe Task, type: :model do
       it '桁数超過のエラーメッセージが出ること' do
         expect(Task.count).to eq(0)
         expect(task.errors[:name]).to include('は20文字以内で入力してください')
+      end
+    end
+
+    context 'statusへ既定値以外(-1)の入力があると' do
+      it 'statusにマイナスの値で永続化できないこと' do
+        expect { task.assign_attributes(status: -1)}.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'statusへ既定値以外(0)の入力があると' do
+      it 'statusに0の値で永続化できないこと' do
+        expect { task.assign_attributes(status: 0)}.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'statusへ既定値以外(4)の入力があると' do
+      it 'statusに4の値で永続化できないこと' do
+        expect { task.assign_attributes(status: 4)}.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  describe '#save' do
+    let(:task) { described_class.new(name: 'hoge') }
+
+    it 'creates records in task' do
+      task.save
+      expect(Task.count).to eq(1)
+      expect(task.errors.count).to eq(0)
+    end
+
+    context 'nameへの入力がない' do
+      let(:task) { described_class.new(name: nil) }
+
+      it '必須のエラーメッセージが出ること' do
+        task.save
+
+        expect(Task.count).to eq(0)
+        expect(task.errors[:name]).to include('を入力してください')
+      end
+    end
+
+    context 'nameへ21文字以上の入力があると' do
+      let(:task) { described_class.new(name: '１２３４５６７８９０１２３４５６７８９０a') }
+
+      it '桁数超過のエラーメッセージが出ること' do
+        task.save
+
+        expect(Task.count).to eq(0)
+        expect(task.errors[:name]).to include('は20文字以内で入力してください')
+      end
+    end
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe '#save' do
-    let(:task) { build(:task, name: 'a' * 1, status: 1) }
+    let(:task) { build(:task, name: 'a' * 1) }
 
     before do
       task.save
@@ -25,7 +25,7 @@ RSpec.describe Task, type: :model do
     end
 
     context 'nameへ20文字の入力があると' do
-      let(:task) { build(:task, name: 'a' * 20, status: 2) }
+      let(:task) { build(:task, name: 'a' * 20) }
 
       it 'creates records in task' do
         expect(Task.count).to eq(1)
@@ -51,6 +51,36 @@ RSpec.describe Task, type: :model do
     context 'statusへ既定値以外(0)の入力があると' do
       it 'statusに0の値で永続化できないこと' do
         expect { task.assign_attributes(status: 0) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'statusへ1(waiting)の入力があると' do
+      let(:task) { build(:task, status: :waiting) }
+
+      it 'creates records in task' do
+        expect(Task.count).to eq(1)
+        expect(task.reload.status).to eq('waiting')
+        expect(task.errors.count).to eq(0)
+      end
+    end
+
+    context 'statusへ2(work_in_progress)の入力があると' do
+      let(:task) { build(:task, status: :work_in_progress) }
+
+      it 'creates records in task' do
+        expect(Task.count).to eq(1)
+        expect(task.reload.status).to eq('work_in_progress')
+        expect(task.errors.count).to eq(0)
+      end
+    end
+
+    context 'statusへ3(completed)の入力があると' do
+      let(:task) { build(:task, status: :completed) }
+
+      it 'creates records in task' do
+        expect(Task.count).to eq(1)
+        expect(task.reload.status).to eq('completed')
+        expect(task.errors.count).to eq(0)
       end
     end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -44,19 +44,19 @@ RSpec.describe Task, type: :model do
 
     context 'statusへ既定値以外(-1)の入力があると' do
       it 'statusにマイナスの値で永続化できないこと' do
-        expect { task.assign_attributes(status: -1)}.to raise_error(ArgumentError)
+        expect { task.assign_attributes(status: -1) }.to raise_error(ArgumentError)
       end
     end
 
     context 'statusへ既定値以外(0)の入力があると' do
       it 'statusに0の値で永続化できないこと' do
-        expect { task.assign_attributes(status: 0)}.to raise_error(ArgumentError)
+        expect { task.assign_attributes(status: 0) }.to raise_error(ArgumentError)
       end
     end
 
     context 'statusへ既定値以外(4)の入力があると' do
       it 'statusに4の値で永続化できないこと' do
-        expect { task.assign_attributes(status: 4)}.to raise_error(ArgumentError)
+        expect { task.assign_attributes(status: 4) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -4,31 +4,39 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe '#save' do
-    let(:task) { described_class.new(name: 'hoge') }
+    let(:task) { build(:task, name: 'a' * 1) }
+
+    before do
+      task.save
+    end
 
     it 'creates records in task' do
-      task.save
       expect(Task.count).to eq(1)
       expect(task.errors.count).to eq(0)
     end
 
     context 'nameへの入力がない' do
-      let(:task) { described_class.new(name: nil) }
+      let(:task) { build(:task, name: nil) }
 
       it '必須のエラーメッセージが出ること' do
-        task.save
-
         expect(Task.count).to eq(0)
         expect(task.errors[:name]).to include('を入力してください')
       end
     end
 
+    context 'nameへ20文字の入力があると' do
+      let(:task) { build(:task, name: 'a' * 20) }
+
+      it 'creates records in task' do
+        expect(Task.count).to eq(1)
+        expect(task.errors.count).to eq(0)
+      end
+    end
+
     context 'nameへ21文字以上の入力があると' do
-      let(:task) { described_class.new(name: '１２３４５６７８９０１２３４５６７８９０a') }
+      let(:task) { build(:task, name: 'a' * 21) }
 
       it '桁数超過のエラーメッセージが出ること' do
-        task.save
-
         expect(Task.count).to eq(0)
         expect(task.errors[:name]).to include('は20文字以内で入力してください')
       end


### PR DESCRIPTION
### [ステップ11: バリデーションを設定してみよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)


### ■桁数超過
![スクリーンショット 0031-05-31 午前10 14 04](https://user-images.githubusercontent.com/22090534/58684582-af99fd00-83b3-11e9-9e49-ad45101bc93b.png)

### ■必須
![スクリーンショット 0031-05-31 午前10 14 15](https://user-images.githubusercontent.com/22090534/58684589-b294ed80-83b3-11e9-8cb3-8d495848d15c.png)

デザインは何もしてないです。
(field_with_errors を自動で差し込んでくれるのに対して)