### PR TITLE
ステップ8: アプリのタイムゾーン設定を行いましょう

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,9 @@ module TrainingApp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.time_zone = 'Asia/Tokyo'
+
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
**関連URL**
- [株式会社Fablicの新入社員教育用カリキュラム（簡略版）ステップ8](https://github.com/Fablic/training/tree/super-compact-version#%E3%82%B9%E3%83%86%E3%83%83%E3%83%978-%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E3%82%BF%E3%82%A4%E3%83%A0%E3%82%BE%E3%83%BC%E3%83%B3%E8%A8%AD%E5%AE%9A%E3%82%92%E8%A1%8C%E3%81%84%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)

**やったこと**
- [x] Railsのタイムゾーンを日本（東京）に設定しましょう

**その他**
特になし