### PR TITLE
Masahikokawai step19

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   class UsersController < ApplicationController
     before_action :user, only: %i[show edit update destroy]
+    before_action :authorize?
 
     def index
       @users = User.all.order(created_at: :desc)
@@ -37,8 +38,12 @@ module Admin
     end
 
     def destroy
-      @user.destroy!
-      redirect_to admin_users_path, success: t('messages.deleted', item: @user.model_name.human)
+      if current_user == @user
+        redirect_to admin_users_path, danger: t('errors.messages.can_not_delete_myself', item: @user.model_name.human)
+      else
+        @user.destroy!
+        redirect_to admin_users_path, success: t('messages.deleted', item: @user.model_name.human)
+      end
     end
 
     private
@@ -51,6 +56,7 @@ module Admin
       params.require(:user).permit(
         :id,
         :name,
+        :role,
         :email,
         :email_confirmation,
         user_credential_attributes: %i[

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action :redirect_if_unauthorized
 
     def index
-      @users = User.all.order(created_at: :desc)
+      @users = User.includes(:tasks).order(created_at: :desc)
     end
 
     def new

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class UsersController < ApplicationController
     before_action :user, only: %i[show edit update destroy]
-    before_action :authorize?
+    before_action :redirect_if_unauthorized
 
     def index
       @users = User.all.order(created_at: :desc)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,12 @@ class ApplicationController < ActionController::Base
     @current_user ||= session[:current_user_id] && User.find_by(id: session[:current_user_id])
   end
 
+  def authorize?
+    return if current_user.role_management?
+
+    redirect_to root_path
+  end
+
   def render_forbidden
     render file: 'public/403.html', layout: false, status: 403
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
     @current_user ||= session[:current_user_id] && User.find_by(id: session[:current_user_id])
   end
 
-  def authorize?
+  def redirect_if_unauthorized
     return if current_user.role_management?
 
     redirect_to root_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,9 +20,9 @@ class User < ApplicationRecord
   validates :email, confirmation: true
   validates :email_confirmation, presence: true, on: :create
 
-  validate :validates_last_admin_user, on: :update, if: -> { role_changed? }
+  validate :validates_last_admin_user, on: :update, if: -> { role_changed? && role_general? }
 
   def validates_last_admin_user
-    errors.add(:role, 'は、変更できません。変更する場合は、別の管理者ユーザーを用意してください。') if User.where(role: User.roles[:management]).count == MINIMUM_NUMBER_OF_ADMINISTRATORS
+    errors.add(:role, 'は、変更できません。変更する場合は、別の管理者ユーザーを用意してください。') if User.role_management.count == MINIMUM_NUMBER_OF_ADMINISTRATORS
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,4 +18,12 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :email, confirmation: true
   validates :email_confirmation, presence: true, on: :create
+
+  validate :validates_last_admin_user, on: :update, if: -> { role_changed? }
+
+  def validates_last_admin_user
+    if User.count == 1 && User.first.role_management?
+      errors.add(:role, 'は、最後の管理ユーザーは変更できません。')
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,6 @@ class User < ApplicationRecord
   validate :validates_last_admin_user, on: :update, if: -> { role_changed? }
 
   def validates_last_admin_user
-    errors.add(:role, 'は、最後の管理ユーザーは変更できません。') if User.count == 1 && User.first.role_management?
+    errors.add(:role, 'は、変更できません。変更する場合は、別の管理者ユーザーを用意してください。') if User.count == 1 && User.first.role_management?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   attr_accessor :email_confirmation
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  MINIMUM_NUMBER_OF_ADMINISTRATORS = 1
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
@@ -22,6 +23,6 @@ class User < ApplicationRecord
   validate :validates_last_admin_user, on: :update, if: -> { role_changed? }
 
   def validates_last_admin_user
-    errors.add(:role, 'は、変更できません。変更する場合は、別の管理者ユーザーを用意してください。') if User.count == 1 && User.first.role_management?
+    errors.add(:role, 'は、変更できません。変更する場合は、別の管理者ユーザーを用意してください。') if User.where(role: User.roles[:management]).count == MINIMUM_NUMBER_OF_ADMINISTRATORS
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :user_credential
 
+  enum role: { general: 1, management: 2 }
+
   attr_accessor :email_confirmation
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,8 +22,6 @@ class User < ApplicationRecord
   validate :validates_last_admin_user, on: :update, if: -> { role_changed? }
 
   def validates_last_admin_user
-    if User.count == 1 && User.first.role_management?
-      errors.add(:role, 'は、最後の管理ユーザーは変更できません。')
-    end
+    errors.add(:role, 'は、最後の管理ユーザーは変更できません。') if User.count == 1 && User.first.role_management?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :user_credential
 
-  enum role: { general: 1, management: 2 }
+  enum role: { general: 1, management: 2 }, _prefix: true
 
   attr_accessor :email_confirmation
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -24,7 +24,7 @@
 
     <div class="form-group">
       <%= form.label :role %>
-      <%= form.select :role, User.roles.map { |k, v| [t(".roles.#{k}"), k] }, {prompt: '選択してください'}, class: "form-control" %>
+      <%= form.select :role, User.roles.map { |k, _| [t(".roles.#{k}"), k] }, {prompt: '選択してください'}, class: "form-control" %>
     </div>
 
     <div class="form-group">

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -23,6 +23,11 @@
     </div>
 
     <div class="form-group">
+      <%= form.label :role %>
+      <%= form.select :role, User.roles.map { |k, v| [t(".roles.#{k}"), k] }, {prompt: '選択してください'}, class: "form-control" %>
+    </div>
+
+    <div class="form-group">
       <%= form.label :email %>
       <%= form.text_field :email, class: "form-control" %>
     </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -23,7 +23,7 @@
           <td><%= user.name %></td>
           <td><%= user.email %></td>
           <td><%= t(".roles.#{user.role}") %></td>
-          <td><%= user.tasks.count %></td>
+          <td><%= user.tasks.size.to_s(:delimited) %></td>
           <td><%= l(user.created_at, format: :long) %></td>
           <td><%= link_to t('buttons.show'), admin_user_path(user), class: "btn btn-info" %></td>
           <td><%= link_to t('buttons.edit'), edit_admin_user_path(user), class: "btn btn-primary" %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -8,10 +8,11 @@
   <table class='table table-striped table-bordered table-hover'>
     <thead>
       <tr>
-        <th><%= Task.human_attribute_name(:name) %></th>
-        <th><%= Task.human_attribute_name(:email) %></th>
+        <th><%= User.human_attribute_name(:name) %></th>
+        <th><%= User.human_attribute_name(:email) %></th>
+        <th><%= User.human_attribute_name(:role) %></th>
         <th>タスク数</th>
-        <th><%= Task.human_attribute_name(:created_at) %></th>
+        <th><%= User.human_attribute_name(:created_at) %></th>
         <th colspan="3"></th>
       </tr>
     </thead>
@@ -21,6 +22,7 @@
         <tr>
           <td><%= user.name %></td>
           <td><%= user.email %></td>
+          <td><%= t(".roles.#{user.role}") %></td>
           <td><%= user.tasks.count %></td>
           <td><%= l(user.created_at, format: :long) %></td>
           <td><%= link_to t('buttons.show'), admin_user_path(user), class: "btn btn-info" %></td>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
         <%= link_to "Rails Training", root_path, id: "logo", class: "navbar-brand" %>
         <ul class="navbar-nav ml-auto">
           <% if current_user.role_management? %>
-            <li class='nav-item'>
+            <li class="nav-item">
               <%= link_to 'ユーザー管理', admin_users_path, class: 'nav-link' %>
             </li>
           <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,11 @@
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark" style="background-color: #71da71;">
         <%= link_to "Rails Training", root_path, id: "logo", class: "navbar-brand" %>
         <ul class="navbar-nav ml-auto">
-          <li class='nav-item'>
-            <%= link_to 'ユーザー管理', admin_users_path, class: 'nav-link' %>
-          </li>
+          <% if current_user.role_management? %>
+            <li class='nav-item'>
+              <%= link_to 'ユーザー管理', admin_users_path, class: 'nav-link' %>
+            </li>
+          <% end %>
           <li class="nav-item">
             <%= link_to "タスク管理", root_path, class: "nav-link" %>
           </li>

--- a/config/locales/defaults/ja.yml
+++ b/config/locales/defaults/ja.yml
@@ -16,5 +16,6 @@ ja:
   errors:
     messages:
       past_days: は過去の日付を入力できません。
+      can_not_delete_myself: 自身のデータは削除できません
   page: ページ
   total_count: 総件数

--- a/config/locales/models/user/ja.yml
+++ b/config/locales/models/user/ja.yml
@@ -8,4 +8,5 @@ ja:
         name: ユーザー名
         email: メールアドレス
         email_confirmation: メールアドレス(確認)
+        role: 権限
         created_at: 作成日

--- a/config/locales/views/admin/users/ja.yml
+++ b/config/locales/views/admin/users/ja.yml
@@ -2,10 +2,16 @@ status: &status
   waiting: 未着手
   work_in_progress: 着手
   completed: 完了
+roles: &roles
+  general: 一般
+  management: 管理者
 ja:
   admin:
     users:
       index:
         title: ユーザー管理
+        roles: *roles
+      form:
+        roles: *roles
       show:
         status: *status

--- a/db/migrate/20190619071904_users.rb
+++ b/db/migrate/20190619071904_users.rb
@@ -1,0 +1,5 @@
+class Users < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer, null: false, default: 1, limit: 1, unsigned: true
+  end
+end

--- a/db/migrate/20190619071904_users.rb
+++ b/db/migrate/20190619071904_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Users < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :role, :integer, null: false, default: 1, limit: 1, unsigned: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,46 +12,44 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_071904) do
-
-  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", limit: 20, null: false
-    t.text "description"
-    t.integer "status", limit: 1, default: 1, null: false, unsigned: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.date "finished_on", null: false
-    t.bigint "user_id", null: false, unsigned: true
-    t.index ["finished_on"], name: "index_tasks_on_finished_on"
-    t.index ["status"], name: "index_tasks_on_status"
-    t.index ["user_id"], name: "index_tasks_on_user_id"
+ActiveRecord::Schema.define(version: 20_190_619_071_904) do
+  create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.bigint 'user_id', null: false, unsigned: true
+    t.string 'name', limit: 20, null: false
+    t.text 'description'
+    t.integer 'status', limit: 1, default: 1, null: false, unsigned: true
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.date 'finished_on', null: false
+    t.index ['finished_on'], name: 'index_tasks_on_finished_on'
+    t.index ['status'], name: 'index_tasks_on_status'
+    t.index ['user_id'], name: 'index_tasks_on_user_id'
   end
 
-  create_table "user_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false, unsigned: true
-    t.string "password_digest", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_user_credentials_on_user_id"
+  create_table 'user_credentials', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.bigint 'user_id', null: false, unsigned: true
+    t.string 'password_digest', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_user_credentials_on_user_id'
   end
 
-  create_table "user_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false, unsigned: true
-    t.string "token", null: false
-    t.timestamp "expires_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["token"], name: "index_user_tokens_on_token", unique: true
-    t.index ["user_id"], name: "index_user_tokens_on_user_id"
+  create_table 'user_tokens', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.bigint 'user_id', null: false, unsigned: true
+    t.string 'token', null: false
+    t.timestamp 'expires_at', default: -> { 'CURRENT_TIMESTAMP' }, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['token'], name: 'index_user_tokens_on_token', unique: true
+    t.index ['user_id'], name: 'index_user_tokens_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "role", limit: 1, default: 1, null: false, unsigned: true
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'name', null: false
+    t.integer 'role', limit: 1, default: 1, null: false, unsigned: true
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,43 +10,46 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_613_051_221) do
-  create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', null: false, unsigned: true
-    t.string 'name', limit: 20, null: false
-    t.text 'description'
-    t.integer 'status', limit: 1, default: 1, null: false, unsigned: true
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.date 'finished_on', null: false
-    t.index ['finished_on'], name: 'index_tasks_on_finished_on'
-    t.index ['status'], name: 'index_tasks_on_status'
-    t.index ['user_id'], name: 'index_tasks_on_user_id'
+ActiveRecord::Schema.define(version: 2019_06_19_071904) do
+
+  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", limit: 20, null: false
+    t.text "description"
+    t.integer "status", limit: 1, default: 1, null: false, unsigned: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "finished_on", null: false
+    t.bigint "user_id", null: false, unsigned: true
+    t.index ["finished_on"], name: "index_tasks_on_finished_on"
+    t.index ["status"], name: "index_tasks_on_status"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
-  create_table 'user_credentials', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', null: false, unsigned: true
-    t.string 'password_digest', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_user_credentials_on_user_id'
+  create_table "user_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false, unsigned: true
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_credentials_on_user_id"
   end
 
-  create_table 'user_tokens', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', null: false, unsigned: true
-    t.string 'token', null: false
-    t.timestamp 'expires_at', default: -> { 'CURRENT_TIMESTAMP' }, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['token'], name: 'index_user_tokens_on_token', unique: true
-    t.index ['user_id'], name: 'index_user_tokens_on_user_id'
+  create_table "user_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false, unsigned: true
+    t.string "token", null: false
+    t.timestamp "expires_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_user_tokens_on_token", unique: true
+    t.index ["user_id"], name: "index_user_tokens_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "role", limit: 1, default: 1, null: false, unsigned: true
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,46 +12,44 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_071904) do
-
-  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", limit: 20, null: false
-    t.text "description"
-    t.integer "status", limit: 1, default: 1, null: false, unsigned: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.date "finished_on", null: false
-    t.bigint "user_id", null: false, unsigned: true
-    t.index ["finished_on"], name: "index_tasks_on_finished_on"
-    t.index ["status"], name: "index_tasks_on_status"
-    t.index ["user_id"], name: "index_tasks_on_user_id"
+ActiveRecord::Schema.define(version: 20_190_619_071_904) do
+  create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name', limit: 20, null: false
+    t.text 'description'
+    t.integer 'status', limit: 1, default: 1, null: false, unsigned: true
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.date 'finished_on', null: false
+    t.bigint 'user_id', null: false, unsigned: true
+    t.index ['finished_on'], name: 'index_tasks_on_finished_on'
+    t.index ['status'], name: 'index_tasks_on_status'
+    t.index ['user_id'], name: 'index_tasks_on_user_id'
   end
 
-  create_table "user_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false, unsigned: true
-    t.string "password_digest", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_user_credentials_on_user_id"
+  create_table 'user_credentials', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.bigint 'user_id', null: false, unsigned: true
+    t.string 'password_digest', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_user_credentials_on_user_id'
   end
 
-  create_table "user_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false, unsigned: true
-    t.string "token", null: false
-    t.timestamp "expires_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["token"], name: "index_user_tokens_on_token", unique: true
-    t.index ["user_id"], name: "index_user_tokens_on_user_id"
+  create_table 'user_tokens', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.bigint 'user_id', null: false, unsigned: true
+    t.string 'token', null: false
+    t.timestamp 'expires_at', default: -> { 'CURRENT_TIMESTAMP' }, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['token'], name: 'index_user_tokens_on_token', unique: true
+    t.index ['user_id'], name: 'index_user_tokens_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "role", limit: 1, default: 1, null: false, unsigned: true
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'role', limit: 1, default: 1, null: false, unsigned: true
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,44 +10,46 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_190_619_071_904) do
-  create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', null: false, unsigned: true
-    t.string 'name', limit: 20, null: false
-    t.text 'description'
-    t.integer 'status', limit: 1, default: 1, null: false, unsigned: true
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.date 'finished_on', null: false
-    t.index ['finished_on'], name: 'index_tasks_on_finished_on'
-    t.index ['status'], name: 'index_tasks_on_status'
-    t.index ['user_id'], name: 'index_tasks_on_user_id'
+ActiveRecord::Schema.define(version: 2019_06_19_071904) do
+
+  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", limit: 20, null: false
+    t.text "description"
+    t.integer "status", limit: 1, default: 1, null: false, unsigned: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "finished_on", null: false
+    t.bigint "user_id", null: false, unsigned: true
+    t.index ["finished_on"], name: "index_tasks_on_finished_on"
+    t.index ["status"], name: "index_tasks_on_status"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
-  create_table 'user_credentials', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', null: false, unsigned: true
-    t.string 'password_digest', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_user_credentials_on_user_id'
+  create_table "user_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false, unsigned: true
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_credentials_on_user_id"
   end
 
-  create_table 'user_tokens', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', null: false, unsigned: true
-    t.string 'token', null: false
-    t.timestamp 'expires_at', default: -> { 'CURRENT_TIMESTAMP' }, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['token'], name: 'index_user_tokens_on_token', unique: true
-    t.index ['user_id'], name: 'index_user_tokens_on_user_id'
+  create_table "user_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false, unsigned: true
+    t.string "token", null: false
+    t.timestamp "expires_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_user_tokens_on_token", unique: true
+    t.index ["user_id"], name: "index_user_tokens_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'name', null: false
-    t.integer 'role', limit: 1, default: 1, null: false, unsigned: true
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "role", limit: 1, default: 1, null: false, unsigned: true
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,7 @@ user = User.create!(
   name: 'User-name',
   email: 'test@example.com',
   email_confirmation: 'test@example.com',
+  role: User.roles[:management],
 )
 user_credential = UserCredential.new(user: user, password_digest: BCrypt::Password.create('123456'))
 user_credential.save!(validate: false)

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Admin::UsersController, type: :controller do
     user_login(user: user)
 
     create(:user,
-      email: 'test2@example.com',
-      email_confirmation: 'test2@example.com',
-    )
+           email: 'test2@example.com',
+           email_confirmation: 'test2@example.com',
+          )
   end
 
   shared_context 'without_permission' do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Admin::UsersController, type: :controller do
 
   before do
     user_login(user: user)
+
+    create(:user,
+      email: 'test2@example.com',
+      email_confirmation: 'test2@example.com',
+    )
   end
 
   shared_context 'without_permission' do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -9,12 +9,29 @@ RSpec.describe Admin::UsersController, type: :controller do
     user_login(user: user)
   end
 
+  shared_context 'without_permission' do
+    before do
+      user.role_general!
+    end
+  end
+
   describe 'GET #index' do
     it 'returns http success' do
       get :index, params: {}
 
       expect(response).to be_successful
       expect(response).to render_template('admin/users/index')
+    end
+
+    context 'without user permission' do
+      include_context 'without_permission'
+
+      it 'redirects to root_path page' do
+        get :index, params: {}
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 
@@ -40,6 +57,17 @@ RSpec.describe Admin::UsersController, type: :controller do
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(admin_users_path)
     end
+
+    context 'without user permission' do
+      include_context 'without_permission'
+
+      it 'redirects to root_path page' do
+        post :create, params: params
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 
   describe 'GET #show' do
@@ -49,6 +77,17 @@ RSpec.describe Admin::UsersController, type: :controller do
       expect(response).to be_successful
       expect(response).to render_template('admin/users/show')
     end
+
+    context 'without user permission' do
+      include_context 'without_permission'
+
+      it 'redirects to root_path page' do
+        get :show, params: { id: user.to_param }
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 
   describe 'GET #edit' do
@@ -57,6 +96,17 @@ RSpec.describe Admin::UsersController, type: :controller do
 
       expect(response).to be_successful
       expect(response).to render_template('admin/users/edit')
+    end
+
+    context 'without user permission' do
+      include_context 'without_permission'
+
+      it 'redirects to root_path page' do
+        get :edit, params: { id: user.to_param }
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 
@@ -94,6 +144,17 @@ RSpec.describe Admin::UsersController, type: :controller do
       expect(response).to redirect_to(admin_users_path)
       expect(user_1.reload.name).to eq('user2')
     end
+
+    context 'without user permission' do
+      include_context 'without_permission'
+
+      it 'redirects to root_path page' do
+        patch :update, params: params
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 
   describe 'DELETE #destroy' do
@@ -113,6 +174,27 @@ RSpec.describe Admin::UsersController, type: :controller do
       expect(response).to have_http_status(:redirect)
       expect(response).to redirect_to(admin_users_path)
       expect(Task.count).to eq(0)
+    end
+
+    context 'without user permission' do
+      include_context 'without_permission'
+
+      it 'redirects to root_path page' do
+        delete :destroy, params: { id: user_2.to_param }
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'ログインユーザー自身のデータを削除しようとすると' do
+      it '削除できないこと' do
+        delete :destroy, params: { id: user.to_param }
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(admin_users_path)
+        expect(user.reload.name).to eq('User Name')
+      end
     end
   end
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -160,6 +160,43 @@ RSpec.describe Admin::UsersController, type: :controller do
         expect(response).to redirect_to(root_path)
       end
     end
+
+    context '2人以上の管理者ユーザーのみの状態から、一般ユーザーに更新すると' do
+      let(:user_3) {
+        create(:user,
+               name: 'user3',
+               email: 'user3@example.com',
+               email_confirmation: 'user3@example.com',
+              )
+      }
+      let(:user_credential_3) { user_3.create_user_credential(password: 'password') }
+
+      let(:password) { 'a' * 6 }
+      let(:params) do
+        {
+          id: user_3.id,
+          user: {
+            name: 'user3-update',
+            email: 'user3@example.com',
+            email_confirmation: 'user3@example.com',
+            role: :general,
+            user_credential_attributes: {
+              id: user_credential_3.id,
+              password: password,
+              password_confirmation: password,
+            },
+          },
+        }
+      end
+
+      it '一般ユーザーに更新できること' do
+        patch :update, params: params
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(admin_users_path)
+        expect(user_3.reload.name).to eq('user3-update')
+      end
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     email { 'test@test.com' }
     email_confirmation { 'test@test.com' }
     name { 'User Name' }
+    role { :management }
   end
 end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe 'Admin::Users', type: :system do
   end
 
   context '一人のみ管理者ユーザーが自身の権限を一般に変更しようとすると' do
+    before do
+      create(:user,
+             email: 'test3@example.com',
+             email_confirmation: 'test3@example.com',
+             role: :general,
+            )
+    end
+
     specify '権限を変更できないこと' do
       user_login(user: user)
 
@@ -85,7 +93,12 @@ RSpec.describe 'Admin::Users', type: :system do
 
       expect(page).to have_content('ユーザー管理')
 
-      click_on '編集'
+      # TODO: headless chromeを有効にしないと下記コメントアウトでの指定ができない(?)ので直接遷移するように記述しています
+      # tds = all('td')
+      # tds[14].click
+      visit edit_admin_user_path(user)
+
+      expect(page).to have_content('ユーザー編集')
 
       select '一般', from: '権限'
       fill_in 'メールアドレス(確認)', with: 'test@test.com'

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -72,4 +72,23 @@ RSpec.describe 'Admin::Users', type: :system do
       expect(page).not_to have_content('ユーザー登録')
     end
   end
+
+  context '一人のみ管理者ユーザーが自身の権限を一般に変更しようとすると' do
+    specify '権限を変更できないこと' do
+      user_login(user: user)
+
+      click_on 'ユーザー管理'
+
+      expect(page).to have_content('ユーザー管理')
+
+      click_on '編集'
+
+      select '一般', from: '権限'
+      fill_in 'メールアドレス(確認)', with: 'test@test.com'
+
+      click_on '更新する'
+
+      expect(page).to have_content('権限は、最後の管理ユーザーは変更できません。')
+    end
+  end
 end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Admin::Users', type: :system do
 
       click_on '更新する'
 
-      expect(page).to have_content('権限は、最後の管理ユーザーは変更できません。')
+      expect(page).to have_content('権限は、変更できません。変更する場合は、別の管理者ユーザーを用意してください。')
     end
   end
 end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Admin::Users', type: :system do
   let(:user) { create(:user) }
 
-  specify 'User operates from creation to editing to deletion' do
+  specify 'Administrator user operates from creation to editing to deletion' do
     user_login(user: user)
 
     click_on 'ユーザー管理'
@@ -50,5 +50,26 @@ RSpec.describe 'Admin::Users', type: :system do
     # page.driver.browser.switch_to.alert.accept
 
     expect(page).to have_content('ユーザーの削除が完了しました。')
+  end
+
+  context '一般ユーザーがユーザー管理機能を操作するしようとすると' do
+    before do
+      user.role_general!
+    end
+
+    specify 'redirects to root_path page' do
+      user_login(user: user)
+
+      expect(page).not_to have_content('ユーザー管理')
+
+      visit admin_users_path
+
+      expect(page).not_to have_content('ユーザー管理')
+
+      visit new_admin_user_path
+
+      expect(page).not_to have_content('ユーザー管理')
+      expect(page).not_to have_content('ユーザー登録')
+    end
   end
 end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe 'Admin::Users', type: :system do
 
   context '一般ユーザーがユーザー管理機能を操作するしようとすると' do
     before do
+      create(:user,
+             email: 'test2@example.com',
+             email_confirmation: 'test2@example.com',
+            )
       user.role_general!
     end
 


### PR DESCRIPTION
### ・[ステップ19: ユーザにロールを追加しよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

以下を追加しました。
- 管理ユーザ(management)と一般ユーザ(general)を追加
- 管理ユーザ(management)だけがユーザー管理機能にアクセスできるように
- ユーザー管理画面でロールを選択できるように
- 管理ユーザが1人もいなくならないように、ログインユーザー自身を削除できないように
