### PR TITLE
[STEP8] set TimeZone to Asia/Tokyo

### DIFF
--- a/todo_app/config/application.rb
+++ b/todo_app/config/application.rb
@@ -15,5 +15,8 @@ module TodoApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    #add custom config
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/todo_app/config/application.rb
+++ b/todo_app/config/application.rb
@@ -18,5 +18,6 @@ module TodoApp
 
     #add custom config
     config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
### Rails研修カリキュラム STEP8 のPRとなります。

#### 概要

Railsのタイムゾーンを日本（東京）に設定しましょう

#### カリキュラム詳細

https://github.com/Fablic/training/tree/super-compact-version#%E3%82%B9%E3%83%86%E3%83%83%E3%83%978-%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E3%82%BF%E3%82%A4%E3%83%A0%E3%82%BE%E3%83%BC%E3%83%B3%E8%A8%AD%E5%AE%9A%E3%82%92%E8%A1%8C%E3%81%84%E3%81%BE%E3%81%97%E3%82%87%E3%81%86

#### 対応内容

- [x] application.rb へタイムゾーンを東京に設定
- [x] 確認 OK

### キャプチャ

<img width="934" alt="スクリーンショット 2019-09-17 12 10 39" src="https://user-images.githubusercontent.com/11188134/65009059-57790d80-d946-11e9-8687-21454c2a701e.png">
