### PR TITLE
[STEP14] add maintenance mode

### DIFF
--- a/todo_app/app/controllers/application_controller.rb
+++ b/todo_app/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :redirect_if_maintenance
+
   def login(user)
     session[:user_id] = user.id if user.present?
   end
@@ -17,4 +19,14 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id].present?
   end
+
+  private
+
+  # rubocop:disable Style/IfUnlessModifier, Style/GuardClause
+  def redirect_if_maintenance
+    if File.exist?(Rails.root.join('tmp', 'maintenance.txt')) && params[:controller] != 'maintenances'
+      redirect_to maintenance_path, status: 302
+    end
+  end
+  # rubocop:enable Style/IfUnlessModifier, Style/GuardClause
 end

--- a/todo_app/app/controllers/maintenances_controller.rb
+++ b/todo_app/app/controllers/maintenances_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MaintenancesController < ApplicationController
+  def show
+    if !File.exist?(Rails.root.join('tmp', 'maintenance.txt'))
+      redirect_to root_path, status: 302
+    else
+      render status: 503, layout: false
+    end
+  end
+end

--- a/todo_app/app/controllers/maintenances_controller.rb
+++ b/todo_app/app/controllers/maintenances_controller.rb
@@ -2,10 +2,9 @@
 
 class MaintenancesController < ApplicationController
   def show
-    if !File.exist?(Rails.root.join('tmp', 'maintenance.txt'))
-      redirect_to root_path, status: 302
-    else
-      render status: 503, layout: false
+    unless File.exist?(Rails.root.join('tmp', 'maintenance.txt'))
+      redirect_to(root_path, status: 302) and return
     end
+    render status: 503, layout: false
   end
 end

--- a/todo_app/app/views/maintenances/show.html
+++ b/todo_app/app/views/maintenances/show.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>メンテナンス中です (503)</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body class="rails-default-error-page">
+  <!-- This file lives in public/500.html -->
+  <div class="dialog">
+    <div>
+      <h1>メンテナンス中です</h1>
+    </div>
+  </div>
+</body>
+</html>

--- a/todo_app/config/routes.rb
+++ b/todo_app/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
 
   resources :tasks
   resource :session, only: [:new, :create, :destroy]
+  resource :maintenance, only: :show
 end

--- a/todo_app/lib/tasks/maintenance.rake
+++ b/todo_app/lib/tasks/maintenance.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc 'enable maintenance'
+  task enable: :environment do
+    File.write Rails.root.join('tmp', 'maintenance.txt'), ''
+  end
+
+  desc 'disable maintenance'
+  task disable: :environment do
+    File.delete Rails.root.join('tmp', 'maintenance.txt')
+  end
+end

--- a/todo_app/spec/requests/maintenances_request_spec.rb
+++ b/todo_app/spec/requests/maintenances_request_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Maintenances', type: :request do
+  context 'when maintenance disabled' do
+    it 'can displaying pages' do
+      get new_session_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  context 'when maintenance enabled' do
+    before :all do
+      File.write Rails.root.join('tmp', 'maintenance.txt'), ''
+    end
+
+    after :all do
+      File.delete Rails.root.join('tmp', 'maintenance.txt')
+    end
+
+    it 'redirects to maintenance#show' do
+      get new_session_path
+      expect(response).to have_http_status(302)
+
+      get response.header['Location']
+      expect(response).to have_http_status(503)
+      expect(response.body).to include('メンテナンス')
+    end
+  end
+end


### PR DESCRIPTION
### Rails研修カリキュラム STEP14 のPRとなります。

step13よりforkするつもりであやまってそのままcommit&pushしてしまったため、
step13側でrevertし、こちら側で復帰させています。

#### カリキュラム詳細

https://github.com/Fablic/training/tree/super-compact-version#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9714-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86


#### 対応内容

- [x] メンテナンスモード実装（ tmp/maintenance.txt が存在したらメンテ ）
  - [x] メンテナンス画面実装
  - [x] メンテナンス切り替えのrakeタスクを実装
    - [x] bin/rake maintenance:enable でメンテON
    - [x] bin/rake maintenance:disalbe でメンテOFF
- [x] テスト実装


### キャプチャ

**メンテナンス画面**

<img width="630" alt="スクリーンショット 2019-09-19 16 30 17" src="https://user-images.githubusercontent.com/11188134/65222914-078f7780-dafb-11e9-9fa1-881c452c8255.png">
