### PR TITLE
setup database.yml and creating Database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+/yo_task_manager/vendor/bundle

--- a/yo_task_manager/Gemfile
+++ b/yo_task_manager/Gemfile
@@ -5,8 +5,8 @@ ruby '2.5.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.0'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+# Use mysql2 as the database for Active Record
+gem 'mysql2'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets

--- a/yo_task_manager/Gemfile.lock
+++ b/yo_task_manager/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.12.0)
     msgpack (1.3.1)
+    mysql2 (0.5.2)
     nio4r (2.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -168,7 +169,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -206,13 +206,13 @@ DEPENDENCIES
   capybara (>= 2.15)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mysql2
   puma (~> 3.11)
   rails (~> 6.0.0)
   sass-rails (~> 5)
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3 (~> 1.4)
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/yo_task_manager/config/database.yml
+++ b/yo_task_manager/config/database.yml
@@ -8,15 +8,15 @@ default: &default
 
 development:
   <<: *default
-  database: development
+  database: yo_task_manager_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: test
+  database: yo_task_manager_test
 
 production:
   <<: *default
-  database: production
+  database: yo_task_manager_production

--- a/yo_task_manager/config/database.yml
+++ b/yo_task_manager/config/database.yml
@@ -1,25 +1,22 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: mysql2
+  encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  username: root
+  password:
+  socket: /tmp/mysql.sock
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: production


### PR DESCRIPTION
- ステップ5: データベースの接続設定（周辺設定）をしましょう

### 関連URL
- https://github.com/Fablic/training#ステップ5-データベースの接続設定周辺設定をしましょう

### 実装内容
- `bundle install --path vendor/bundle` 実行
- `.gitignore` に `app/vendor/bundle/` を除外対象に設定
- config/database.yml を sqlite3 → mysql2 に変更
- `bundle exec rake db:create` 実行