### PR TITLE
[donghee] ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/dongheetodo/app/controllers/tasks_controller.rb
+++ b/dongheetodo/app/controllers/tasks_controller.rb
@@ -1,11 +1,6 @@
 class TasksController < ApplicationController
   def index
-    @created_at_sort = params[:created_at_sort]
-    @tasks = if @created_at_sort === 'desc' || @created_at_sort === 'asc'
-               Task.all.order(created_at: @created_at_sort)
-             else
-               Task.all
-             end
+    @tasks = Task.search(params)
   end
 
   def show

--- a/dongheetodo/app/models/task.rb
+++ b/dongheetodo/app/models/task.rb
@@ -4,6 +4,8 @@ class Task < ApplicationRecord
 
   enum status: {todo: 1, doing: 2, done: 3}
   enum priority: {low: 1, mid: 2, high: 3}
+  enum sort_by: [:id, :duedate, :created_at]
+  enum order: [:desc, :asc]
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 255 }

--- a/dongheetodo/app/models/task.rb
+++ b/dongheetodo/app/models/task.rb
@@ -5,7 +5,7 @@ class Task < ApplicationRecord
   enum status: {todo: 1, doing: 2, done: 3}
   enum priority: {low: 1, mid: 2, high: 3}
   enum sort_by: [:id, :duedate, :created_at]
-  enum order: [:desc, :asc]
+  enum order: [:asc, :desc]
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :description, length: { maximum: 255 }

--- a/dongheetodo/app/models/task.rb
+++ b/dongheetodo/app/models/task.rb
@@ -11,4 +11,31 @@ class Task < ApplicationRecord
   validates :description, length: { maximum: 255 }
   validates :status, presence: true, inclusion: { in: Task.statuses.keys }
   validates :priority, presence: true, inclusion: { in: Task.priorities.keys }
+
+  scope :search_with_name, ->(name) {
+    if name.present?
+      where('name LIKE ?', "%#{sanitize_sql_like(name)}%")
+    end
+  }
+  scope :search_with_status, ->(status) {
+    if status.present?
+      where(status: status)
+    end
+  }
+  scope :order_by, ->(target, order) {
+    if target.present?
+      if target === 'id'
+        order(id: order)
+      elsif target === 'duedate'
+        order(duedate: order)
+      elsif target === 'created_at'
+        order(created_at: order)
+      end
+    end
+  }
+  scope :search, ->(params) {
+    search_with_name(params[:name])
+      .search_with_status(params[:status])
+      .order_by(params[:target], params[:order])
+  }
 end

--- a/dongheetodo/app/views/tasks/index.html.erb
+++ b/dongheetodo/app/views/tasks/index.html.erb
@@ -1,5 +1,18 @@
 <%= render "layouts/notice" %>
 <h1><%= t("activerecord.tasks.index.title") %></h1>
+<div>
+  <%= form_tag(tasks_path, method: :get) do %>
+    <%= label_tag(:name, t('label.task.name')) %>:
+    <%= text_field_tag(:name) %>
+    <%= label_tag(:status, t('label.task.status')) %>:
+    <%= select_tag(:status, options_for_select(Task.statuses.map{ |k,v| [t("activerecord.attributes.task.status.#{k}"), k] }, params[:status]), include_blank: true) %>
+    <%= label_tag(:sort_by, t('label.sort.by')) %>
+    <%= select_tag(:sort_by, options_for_select(Task.sort_bies.map{ |k,v| [t("label.task.#{k}"), k] }, params[:sort_by])) %>
+    <%= label_tag(:order, t('label.sort.order')) %>:
+    <%= select_tag(:order, options_for_select(Task.orders.map{ |k,v| [t("label.sort.#{k}"), k] }, params[:order])) %>
+    <%= submit_tag(t('button.search'), name: nil) %>
+  <% end %>
+</div>
 <%= link_to t("button.create"), new_task_path %>
 <table>
   <thead>

--- a/dongheetodo/app/views/tasks/index.html.erb
+++ b/dongheetodo/app/views/tasks/index.html.erb
@@ -1,18 +1,19 @@
 <%= render "layouts/notice" %>
 <h1><%= t("activerecord.tasks.index.title") %></h1>
-<div>
+<fieldset>
+  <legend><%= t('button.search') %></legend>
   <%= form_tag(tasks_path, method: :get) do %>
     <%= label_tag(:name, t('label.task.name')) %>:
-    <%= text_field_tag(:name) %>
+    <%= text_field_tag(:name, params[:name]) %>
     <%= label_tag(:status, t('label.task.status')) %>:
     <%= select_tag(:status, options_for_select(Task.statuses.map{ |k,v| [t("activerecord.attributes.task.status.#{k}"), k] }, params[:status]), include_blank: t('activerecord.enum.task.status.all')) %>
-    <%= label_tag(:sort_by, t('label.sort.by')) %>
-    <%= select_tag(:sort_by, options_for_select(Task.sort_bies.map{ |k,v| [t("label.task.#{k}"), k] }, params[:sort_by])) %>
+    <%= label_tag(:sort_by, t('label.sort.by')) %>:
+    <%= select_tag(:target, options_for_select(Task.sort_bies.map{ |k,v| [t("label.task.#{k}"), k] }, params[:target])) %>
     <%= label_tag(:order, t('label.sort.order')) %>:
     <%= select_tag(:order, options_for_select(Task.orders.map{ |k,v| [t("label.sort.#{k}"), k] }, params[:order])) %>
     <%= submit_tag(t('button.search'), name: nil) %>
   <% end %>
-</div>
+</fieldset>
 <%= link_to t("button.create"), new_task_path %>
 <table>
   <thead>

--- a/dongheetodo/app/views/tasks/index.html.erb
+++ b/dongheetodo/app/views/tasks/index.html.erb
@@ -5,7 +5,7 @@
     <%= label_tag(:name, t('label.task.name')) %>:
     <%= text_field_tag(:name) %>
     <%= label_tag(:status, t('label.task.status')) %>:
-    <%= select_tag(:status, options_for_select(Task.statuses.map{ |k,v| [t("activerecord.attributes.task.status.#{k}"), k] }, params[:status]), include_blank: true) %>
+    <%= select_tag(:status, options_for_select(Task.statuses.map{ |k,v| [t("activerecord.attributes.task.status.#{k}"), k] }, params[:status]), include_blank: t('activerecord.enum.task.status.all')) %>
     <%= label_tag(:sort_by, t('label.sort.by')) %>
     <%= select_tag(:sort_by, options_for_select(Task.sort_bies.map{ |k,v| [t("label.task.#{k}"), k] }, params[:sort_by])) %>
     <%= label_tag(:order, t('label.sort.order')) %>:

--- a/dongheetodo/app/views/tasks/index.html.erb
+++ b/dongheetodo/app/views/tasks/index.html.erb
@@ -21,13 +21,7 @@
     <th><%= t("label.task.status") %></th>
     <th><%= t("label.task.priority") %></th>
     <th><%= t("label.task.duedate") %></th>
-    <th><%= t('label.task.created_at') %>
-    <% if @created_at_sort == 'desc' %>
-      <a id="created_at_sort_asc" href="<%= tasks_path(created_at_sort: 'asc') %>">▼</a>
-    <% else %>
-      <a id="created_at_sort_desc" href="<%= tasks_path(created_at_sort: 'desc') %>">▲</a>
-    <% end %>
-    </th>
+    <th><%= t('label.task.created_at') %></th>
     <th><%= t('label.task.updated_at') %></th>
     <th colspan="3"><%= t("label.task.config") %></th>
   </thead>

--- a/dongheetodo/app/views/tasks/index.html.erb
+++ b/dongheetodo/app/views/tasks/index.html.erb
@@ -2,7 +2,7 @@
 <h1><%= t("activerecord.tasks.index.title") %></h1>
 <fieldset>
   <legend><%= t('button.search') %></legend>
-  <%= form_tag(tasks_path, method: :get) do %>
+  <%= form_tag(tasks_path, method: :get, id: 'search_form') do %>
     <%= label_tag(:name, t('label.task.name')) %>:
     <%= text_field_tag(:name, params[:name]) %>
     <%= label_tag(:status, t('label.task.status')) %>:

--- a/dongheetodo/config/locales/defaults/en.yml
+++ b/dongheetodo/config/locales/defaults/en.yml
@@ -1,6 +1,11 @@
 en:
   label:
     colon: ":"
+    sort:
+      by: 'sort by'
+      order: 'order'
+      asc: 'ascending'
+      desc: 'descending'
     task:
       id: "ID"
       name: "name"
@@ -17,6 +22,7 @@ en:
     delete: "delete"
     create: "create"
     back: "back"
+    search: "search"
   alert:
     task:
       delete: "Are you sure you want to delete this task？"

--- a/dongheetodo/config/locales/defaults/ja.yml
+++ b/dongheetodo/config/locales/defaults/ja.yml
@@ -1,6 +1,11 @@
 ja:
   label:
     colon: "："
+    sort:
+      by: '並び替え対象'
+      order: 'ソート順'
+      asc: '昇順'
+      desc: '降順'
     task:
       id: "ID"
       name: "タスク名"
@@ -17,6 +22,7 @@ ja:
     delete: "削除"
     create: "作成"
     back: "戻る"
+    search: "検索"
   alert:
     task:
       delete: "本当に削除しますか？"

--- a/dongheetodo/config/locales/defaults/ja.yml
+++ b/dongheetodo/config/locales/defaults/ja.yml
@@ -2,8 +2,8 @@ ja:
   label:
     colon: "："
     sort:
-      by: '並び替え対象'
-      order: 'ソート順'
+      by: '並び替え'
+      order: '並び順'
       asc: '昇順'
       desc: '降順'
     task:

--- a/dongheetodo/config/locales/models/task/en.yml
+++ b/dongheetodo/config/locales/models/task/en.yml
@@ -6,10 +6,12 @@ en:
           todo: "to-do"
           doing: "doing"
           done: "done"
+          all: 'all'
         priority:
           low: "low"
           mid: "middle"
           high: "high"
+          all: 'all'
 
     models:
       task: "task"

--- a/dongheetodo/config/locales/models/task/ja.yml
+++ b/dongheetodo/config/locales/models/task/ja.yml
@@ -6,10 +6,12 @@ ja:
           todo: "未着手"
           doing: "着手中"
           done: "完了"
+          all: 'すべて'
         priority:
           low: "低"
           mid: "中"
           high: "高"
+          all: 'すべて'
 
     models:
       task: "タスク"

--- a/dongheetodo/db/migrate/20191003043554_add_index_tasks_name.rb
+++ b/dongheetodo/db/migrate/20191003043554_add_index_tasks_name.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksName < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :name
+  end
+end

--- a/dongheetodo/db/migrate/20191003043554_add_index_tasks_name.rb
+++ b/dongheetodo/db/migrate/20191003043554_add_index_tasks_name.rb
@@ -1,5 +1,5 @@
 class AddIndexTasksName < ActiveRecord::Migration[6.0]
   def change
-    add_index :tasks, :name
+    add_index :tasks, :name, length: 10
   end
 end

--- a/dongheetodo/db/schema.rb
+++ b/dongheetodo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_234341) do
+ActiveRecord::Schema.define(version: 2019_10_03_043554) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "task_id", null: false
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2019_09_16_234341) do
     t.datetime "duedate", comment: "終了期限"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_tasks_on_name"
     t.index ["user_id"], name: "fk_rails_4d2a9e4d7e"
   end
 

--- a/dongheetodo/db/schema.rb
+++ b/dongheetodo/db/schema.rb
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2019_10_03_043554) do
     t.datetime "duedate", comment: "終了期限"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_tasks_on_name"
+    t.index ["name"], name: "index_tasks_on_name", length: 10
     t.index ["user_id"], name: "fk_rails_4d2a9e4d7e"
   end
 

--- a/dongheetodo/spec/feature/tasks_spec.rb
+++ b/dongheetodo/spec/feature/tasks_spec.rb
@@ -4,12 +4,12 @@ RSpec.feature "Tasks", type: :feature, js: true do
 
   given!(:user) { create(:user, :with_tasks) }
 
-  scenario "タスク一覧を表示する" do
+  scenario "タスク一覧を表示する", open_on_error: true do
     visit tasks_path
     expect(page).to have_content "タスク一覧"
   end
 
-  scenario "タスクを作成する" do
+  scenario "タスクを作成する", open_on_error: true do
     visit new_task_path
     fill_in "task_name", with: "ダミーデータ"
     fill_in "task_description", with: "ダミー内容"
@@ -19,13 +19,13 @@ RSpec.feature "Tasks", type: :feature, js: true do
     expect(page).to have_content "正常に作成しました"
   end
 
-  scenario "タスク詳細を表示する" do
+  scenario "タスク詳細を表示する", open_on_error: true do
     visit root_path
     all("tbody tr ")[0].click_link "詳細"
     expect(page).to have_content "タスク詳細"
   end
 
-  scenario "タスクを更新する" do
+  scenario "タスクを更新する", open_on_error: true do
     visit root_path
     all("tbody tr ")[0].click_link "修正"
     fill_in "task_name", with: "更新するよー"
@@ -36,7 +36,7 @@ RSpec.feature "Tasks", type: :feature, js: true do
     expect(page).to have_content "正常に更新しました"
   end
 
-  scenario "タスクを削除する" do
+  scenario "タスクを削除する", open_on_error: true do
     visit tasks_path
     all("tbody tr ")[0].click_link "削除"
     accept_alert "本当に削除しますか？"

--- a/dongheetodo/spec/models/task_spec.rb
+++ b/dongheetodo/spec/models/task_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'faker'
+require 'factory_bot'
 
 RSpec.describe Task, type: :model do
   describe '#create' do
@@ -64,6 +65,89 @@ RSpec.describe Task, type: :model do
       it 'エラーが発生する' do
         wrong_priority = Faker::Creature::Cat.name
         expect{ task.priority = wrong_priority }.to raise_error ArgumentError
+      end
+    end
+  end
+
+  describe '#search' do
+    let!(:user) { create(:user) }
+    let!(:task1) { create(:task, user_id: user.id) }
+    let!(:task2) { create(:task, user_id: user.id) }
+    let!(:task3) { create(:task, user_id: user.id) }
+    let!(:task4) { create(:task, user_id: user.id) }
+    let!(:task5) { create(:task, user_id: user.id) }
+
+    context '存在するタスク名で検索する場合' do
+      it '検索結果を返す' do
+        result = Task.search_with_name(task1.name)
+        expect(result).not_to be_empty
+      end
+    end
+
+    context '存在しないタスク名で検索する場合' do
+      it '検索結果を返す' do
+        result = Task.search_with_name(Faker::Name.name)
+        expect(result).to be_empty
+      end
+    end
+
+    context '存在するステータスで絞り込む場合' do
+      it '検索結果を返す' do
+        result = Task.search_with_status(task1.status)
+        expect(result).not_to be_empty
+      end
+    end
+
+    context '存在しないステータスで検索する場合' do
+      it '検索結果がない' do
+        result = Task.search_with_status(Faker::Sports::Football.team)
+        expect(result).to be_empty
+      end
+    end
+
+    context 'IDで並び替える場合' do
+      it '正常に並び替える' do
+        result = Task.order_by('id', 'asc')
+        first_id = result.first.id
+        last_id = result.last.id
+        expect(first_id).to be < last_id
+      end
+    end
+
+    context '完了期限で並び替える場合' do
+      it '正常に並び替える' do
+        result = Task.order_by('duedate', 'asc')
+        first_duedate = result.first.duedate
+        last_duedate = result.last.duedate
+        expect(first_duedate).to be < last_duedate
+      end
+    end
+
+    context '作成日で並び替える場合' do
+      it '正常に並び替える' do
+        result = Task.order_by('created_at', 'asc')
+        first_created_at = result.first.created_at
+        last_created_at = result.last.created_at
+        expect(first_created_at).to be < last_created_at
+      end
+    end
+
+    context 'タスク名とステータスで絞り込みつつIDの降順で並ぶ場合' do
+      it '検索結果を返す' do
+        result = Task.search({name: 'hoge',
+                              status: Task.statuses[:doing],
+                              target: 'id',
+                              order: 'desc'})
+        p result.length
+        if result.length === 1
+          expect(result).not_to be_empty
+        elsif result.length > 1
+          first_id = result.first.id
+          last_id = result.last.id
+          expect(first_id).to be > last_id
+        else
+          expect(result).to be_empty
+        end
       end
     end
   end

--- a/dongheetodo/spec/models/task_spec.rb
+++ b/dongheetodo/spec/models/task_spec.rb
@@ -138,7 +138,6 @@ RSpec.describe Task, type: :model do
                               status: Task.statuses[:doing],
                               target: 'id',
                               order: 'desc'})
-        p result.length
         if result.length === 1
           expect(result).not_to be_empty
         elsif result.length > 1

--- a/dongheetodo/spec/rails_helper.rb
+++ b/dongheetodo/spec/rails_helper.rb
@@ -62,7 +62,11 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-  RSpec.configure do |config|
-    config.include FactoryBot::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
+  # テストが失敗したときにだけ自動的にsave_and_open_pageを呼んでブラウザを起動する
+  config.after do |example|
+    if example.metadata[:type] == :feature && example.exception.present? && example.metadata[:open_on_error] == true
+      save_and_open_page
+    end
   end
 end


### PR DESCRIPTION
### 研修内容
* ステータス（未着手・着手中・完了）を追加してみよう
  * 【オプション要件】初学者ではない場合はstateを管理するGemを導入しても構いません
* 一覧画面でタイトルとステータスで検索ができるようにしよう
  * 【オプション要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構いません
* 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
  * 以降のステップでも必要に応じて確認する癖をつけましょう
* 検索インデックスを貼りましょう
* 検索に対してmodel specを追加してみよう（feature specも拡充しておきましょう）

### 実装内容
- タスク名・ステータスで検索する機能を追加
  - フォーム作成
<kbd>![Dongheetodo 2019-10-03 12-01-09](https://user-images.githubusercontent.com/18328030/66096671-c3aa7100-e5d6-11e9-8a70-70da32163e62.png)</kbd>
  - 検索実行時のログ
<kbd><img width="982" alt="dongheetodo  ~:Repos:training:dongheetodo  -  :spec:feature:tasks_spec rb 2019-10-03 12-05-09" src="https://user-images.githubusercontent.com/18328030/66096687-cc02ac00-e5d6-11e9-8c2e-0164fa65a10b.png"></kbd>

- `Task`のmodel spec作成
-  feature spec作成
- `Tasks`テーブルにインデックスを生成するマイグレーションを追加 


