### PR TITLE
Step_12: add task_limit to tasks, make task_limit column sortable

### DIFF
--- a/yo_task_manager/README.md
+++ b/yo_task_manager/README.md
@@ -1,24 +1,12 @@
-# README
+# 起動の仕方
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+### 一個目のterminalで
+- bundle install
+- bundle exec rails s
 
-Things you may want to cover:
+### もう一個のterminalで
+- bin/webpack-dev-server
 
-* Ruby version
+### browserで
+- localhost:3000/ にアクセス
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -47,7 +47,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :body, :limit)
+    params.require(:task).permit(:title, :body, :task_limit)
   end
 
   def set_task

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class TasksController < ApplicationController
+  include TaskHelper
   before_action :set_task, only: %i[show edit update destroy]
+
   def index
-    @tasks = Task.all.order(created_at: :desc)
+    @tasks = Task.all.order(sort_column + ' ' + sort_direction)
   end
 
   def new

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -47,7 +47,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :body)
+    params.require(:task).permit(:title, :body, :limit)
   end
 
   def set_task

--- a/yo_task_manager/app/helpers/task_helper.rb
+++ b/yo_task_manager/app/helpers/task_helper.rb
@@ -1,4 +1,21 @@
 # frozen_string_literal: true
 
 module TaskHelper
+  def sort_asc(column_name)
+    link_to '▲', { column: column_name, direction: 'asc' }
+  end
+
+  def sort_desc(column_name)
+    link_to '▼', { column: column_name, direction: 'desc' }
+  end
+
+  def sort_direction
+    # If params[:direction] is nil, set sort_direction to 'desc' by default
+    %W[asc desc].include?(params[:direction]) ? params[:direction] : 'desc'
+  end
+
+  def sort_column
+    # If params[:column] is nill, set sort_coumn to 'created_date' by default
+    Task.column_names.include?(params[:column]) ? params[:column] : 'created_at'
+  end
 end

--- a/yo_task_manager/app/helpers/task_helper.rb
+++ b/yo_task_manager/app/helpers/task_helper.rb
@@ -15,7 +15,7 @@ module TaskHelper
   end
 
   def sort_column
-    # If params[:column] is nill, set sort_coumn to 'created_date' by default
+    # If params[:column] is nil, set sort_column to 'created_date' by default
     Task.column_names.include?(params[:column]) ? params[:column] : 'created_at'
   end
 end

--- a/yo_task_manager/app/helpers/task_helper.rb
+++ b/yo_task_manager/app/helpers/task_helper.rb
@@ -2,11 +2,11 @@
 
 module TaskHelper
   def sort_asc(column_name)
-    link_to '▲', { column: column_name, direction: 'asc' }
+    link_to '▲', { column: column_name, direction: 'asc' }, id: column_name.dasherize + '-asc'
   end
 
   def sort_desc(column_name)
-    link_to '▼', { column: column_name, direction: 'desc' }
+    link_to '▼', { column: column_name, direction: 'desc' }, id: column_name.dasherize + '-desc'
   end
 
   def sort_direction

--- a/yo_task_manager/app/views/tasks/_form.html.erb
+++ b/yo_task_manager/app/views/tasks/_form.html.erb
@@ -22,7 +22,7 @@
           <%= f.label t('tasks.task_limit') %>
         </th>
         <td>
-          <%= f.datetime_select :limit, minute_step: 5, use_two_digit_numbers: true, date_separator: '- ', include_blank: true %>
+          <%= f.datetime_select :task_limit, minute_step: 5, use_two_digit_numbers: true, date_separator: '- ', include_blank: true %>
         </td>
       </tr>
       <tr>

--- a/yo_task_manager/app/views/tasks/_form.html.erb
+++ b/yo_task_manager/app/views/tasks/_form.html.erb
@@ -18,6 +18,14 @@
         </td>
       </tr>
       <tr>
+        <th scope="col">
+          <%= f.label t('tasks.task_limit') %>
+        </th>
+        <td>
+          <%= f.datetime_select :limit, minute_step: 5, use_two_digit_numbers: true, date_separator: '- ', include_blank: true %>
+        </td>
+      </tr>
+      <tr>
         <td colspan="2">
           <div class="d-flex justify-content-around">
             <%= f.submit button_name, class: 'btn btn-primary' %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -37,7 +37,7 @@
               <td><%= t.id %></td>
               <td class="task-name"><%= t.title %></td>
               <td><%= t.body %></td>
-              <td><%= t.task_limit %></td>
+              <td class="task-limit"><%= t.task_limit %></td>
               <td>
                 <%= button_to t('.detail'), task_path(t), method: :get, class: 'btn btn-info', form: { style: 'display: inline-block;' } %>
                 <%= button_to t('tasks.edit_text'), edit_task_path(t), method: :get, class: 'btn btn-warning', form: { style: 'display: inline-block;' } %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -27,6 +27,7 @@
             <th>ID</th>
             <th><%= t('tasks.task_name') %></th>
             <th><%= t('tasks.task_detail') %></th>
+            <th><%= t('tasks.task_limit') %></th>
             <th><%= t('.action') %></th>
           </tr>
         </thead>
@@ -36,6 +37,7 @@
               <td><%= t.id %></td>
               <td class="task-name"><%= t.title %></td>
               <td><%= t.body %></td>
+              <td><%= t.limit %></td>
               <td>
                 <%= button_to t('.detail'), task_path(t), method: :get, class: 'btn btn-info', form: { style: 'display: inline-block;' } %>
                 <%= button_to t('tasks.edit_text'), edit_task_path(t), method: :get, class: 'btn btn-warning', form: { style: 'display: inline-block;' } %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -27,7 +27,7 @@
             <th>ID</th>
             <th><%= t('tasks.task_name') %></th>
             <th><%= t('tasks.task_detail') %></th>
-            <th><%= t('tasks.task_limit') %></th>
+            <th><%= t('tasks.task_limit') %> <%= sort_asc('task_limit') %><%= sort_desc('task_limit') %></th>
             <th><%= t('.action') %></th>
           </tr>
         </thead>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -37,7 +37,7 @@
               <td><%= t.id %></td>
               <td class="task-name"><%= t.title %></td>
               <td><%= t.body %></td>
-              <td><%= t.limit %></td>
+              <td><%= t.task_limit %></td>
               <td>
                 <%= button_to t('.detail'), task_path(t), method: :get, class: 'btn btn-info', form: { style: 'display: inline-block;' } %>
                 <%= button_to t('tasks.edit_text'), edit_task_path(t), method: :get, class: 'btn btn-warning', form: { style: 'display: inline-block;' } %>

--- a/yo_task_manager/app/views/tasks/show.html.erb
+++ b/yo_task_manager/app/views/tasks/show.html.erb
@@ -23,7 +23,7 @@
       </tr>
       <tr>
         <th><%= t('tasks.task_limit') %></th>
-        <td><%= @task.limit %></td>
+        <td><%= @task.task_limit %></td>
       </tr>
     </tbody>
   </table>

--- a/yo_task_manager/app/views/tasks/show.html.erb
+++ b/yo_task_manager/app/views/tasks/show.html.erb
@@ -21,6 +21,10 @@
         <th><%= t('tasks.task_detail') %></th>
         <td><%= @task.body %></td>
       </tr>
+      <tr>
+        <th><%= t('tasks.task_limit') %></th>
+        <td><%= @task.limit %></td>
+      </tr>
     </tbody>
   </table>
   <div class="d-flex justify-content-around">

--- a/yo_task_manager/bin/rails
+++ b/yo_task_manager/bin/rails
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/yo_task_manager/bin/rake
+++ b/yo_task_manager/bin/rake
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
   tasks:
     task_name: Task Name
     task_detail: Task Detail
+    task_limit: Task Limit
     edit_text: Edit
     delete: Delete
     cancel: Cancel

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   tasks:
     task_name: タスク名
     task_detail: 詳細
+    task_limit: 終了期限
     edit_text: 編集
     delete: 削除
     cancel: 取り消し

--- a/yo_task_manager/db/migrate/20191008005616_add_limit_to_task.rb
+++ b/yo_task_manager/db/migrate/20191008005616_add_limit_to_task.rb
@@ -1,0 +1,5 @@
+class AddLimitToTask < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :limit, :datetime, after: :body, comment: '終了期限'
+  end
+end

--- a/yo_task_manager/db/migrate/20191008044923_rename_limit_to_task_limit.rb
+++ b/yo_task_manager/db/migrate/20191008044923_rename_limit_to_task_limit.rb
@@ -1,0 +1,5 @@
+class RenameLimitToTaskLimit < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :tasks, :limit, :task_limit
+  end
+end

--- a/yo_task_manager/db/schema.rb
+++ b/yo_task_manager/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_07_004447) do
+ActiveRecord::Schema.define(version: 2019_10_08_005616) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
     t.text "body"
+    t.datetime "limit", comment: "終了期限"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/yo_task_manager/db/schema.rb
+++ b/yo_task_manager/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_08_005616) do
+ActiveRecord::Schema.define(version: 2019_10_08_044923) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
     t.text "body"
-    t.datetime "limit", comment: "終了期限"
+    t.datetime "task_limit"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/yo_task_manager/spec/system/tasks_spec.rb
+++ b/yo_task_manager/spec/system/tasks_spec.rb
@@ -88,4 +88,18 @@ RSpec.describe 'Tasks', type: :system do
     click_button '追加'
     expect(page).to have_text('Titleを入力してください')
   end
+
+  scenario 'task can be order by task_limit' do
+    Task.create!(title: 'task1', task_limit: '2020-01-01 01:01:01')
+    Task.create!(title: 'task2', task_limit: '2020-02-02 02:02:02')
+    Task.create!(title: 'task3', task_limit: '2020-03-03 03:03:03')
+    visit '/ja/tasks'
+    expect(page.all('.task-limit').map(&:text)).to eq ['2020-03-03 03:03:03 +0900', '2020-02-02 02:02:02 +0900', '2020-01-01 01:01:01 +0900']
+    find('#task-limit-asc').click
+    sleep 0.5
+    expect(page.all('.task-limit').map(&:text)).to eq ['2020-03-03 03:03:03 +0900', '2020-02-02 02:02:02 +0900', '2020-01-01 01:01:01 +0900'].reverse
+    find('#task-limit-desc').click
+    sleep 0.5
+    expect(page.all('.task-limit').map(&:text)).to eq ['2020-03-03 03:03:03 +0900', '2020-02-02 02:02:02 +0900', '2020-01-01 01:01:01 +0900']
+  end
 end


### PR DESCRIPTION
- ステップ12: 終了期限を追加しよう ★ スキップ可能

## 関連URL
- [ステップ12: 終了期限を追加しよう ★ スキップ可能](https://github.com/Fablic/training/tree/change_feature_test_to_system_test#ステップ12-終了期限を追加しよう--スキップ可能)

## 実装内容
- `rails g migration AddTaskLimitToTask`, `rake db:migrate`
- task_limit(終了期限)を各ページ上に表示・入力出来るようにする
- ローカルでアプリ起動するときのステップ（webpackerビルダーの起動手順)を `yo_task_manager/README.md`に追加
- task_limitをソート出来るようにする
- system testのscenario追加

## screenshot
![image](https://user-images.githubusercontent.com/10822260/66372387-ce9f4000-e9e0-11e9-9015-49291e85226f.png)
