### PR TITLE
Step_13: adding status. adding ransack for task searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,26 @@
 .DS_Store
 
 /yo_task_manager/vendor/bundle
+
+######### RubyMine related ##########
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+######### RubyMine related ##########
+

--- a/.idea/training.iml
+++ b/.idea/training.iml
@@ -4,7 +4,9 @@
     <shared />
   </component>
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/vendor" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.0.2, rbenv: 2.5.5) [gem]" level="application" />

--- a/.idea/training.iml
+++ b/.idea/training.iml
@@ -5,6 +5,7 @@
   </component>
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/vendor" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/yo_task_manager/Gemfile
+++ b/yo_task_manager/Gemfile
@@ -37,6 +37,9 @@ gem 'rails-i18n', '~> 6.0.0'
 # state management related. (aasm = acts_as_state_machine)
 gem 'aasm'
 
+# search function with ransack
+gem 'ransack'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/yo_task_manager/Gemfile
+++ b/yo_task_manager/Gemfile
@@ -34,6 +34,9 @@ gem 'foreman'
 
 gem 'rails-i18n', '~> 6.0.0'
 
+# state management related. (aasm = acts_as_state_machine)
+gem 'aasm'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/yo_task_manager/Gemfile.lock
+++ b/yo_task_manager/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.6)
+      concurrent-ruby (~> 1.0)
     actioncable (6.0.0)
       actionpack (= 6.0.0)
       nio4r (~> 2.0)
@@ -277,6 +279,7 @@ PLATFORMS
   x86-mswin32
 
 DEPENDENCIES
+  aasm
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/yo_task_manager/Gemfile.lock
+++ b/yo_task_manager/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    polyamorous (2.3.0)
+      activerecord (>= 5.0)
     powerpack (0.1.2)
     public_suffix (4.0.1)
     puma (3.12.1)
@@ -179,6 +181,12 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
+    ransack (2.3.0)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
+      polyamorous (= 2.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -292,6 +300,7 @@ DEPENDENCIES
   rails (~> 6.0.0)
   rails-controller-testing
   rails-i18n (~> 6.0.0)
+  ransack
   rspec-rails (~> 4.0.0.beta2)
   sass-rails (~> 5)
   selenium-webdriver

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -5,12 +5,8 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    if params[:title] || params[:aasm_state]
-      # add search logic here.
-      @tasks = Task.all.order(sort_column + ' ' + sort_direction)
-    else
-      @tasks = Task.all.order(sort_column + ' ' + sort_direction)
-    end
+    @q = Task.ransack(params[:q])
+    @tasks = @q.result(distinct: true).order(sort_column + ' ' + sort_direction)
   end
 
   def new

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class TasksController < ApplicationController
-  include TaskHelper
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
     @q = Task.ransack(params[:q])
-    @tasks = @q.result(distinct: true).order(sort_column + ' ' + sort_direction)
+    @tasks = @q.result(distinct: true)
   end
 
   def new

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -5,7 +5,12 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all.order(sort_column + ' ' + sort_direction)
+    if params[:title] || params[:aasm_state]
+      # add search logic here.
+      @tasks = Task.all.order(sort_column + ' ' + sort_direction)
+    else
+      @tasks = Task.all.order(sort_column + ' ' + sort_direction)
+    end
   end
 
   def new

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -49,7 +49,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :body, :task_limit)
+    params.require(:task).permit(:title, :body, :task_limit, :aasm_state)
   end
 
   def set_task

--- a/yo_task_manager/app/helpers/task_helper.rb
+++ b/yo_task_manager/app/helpers/task_helper.rb
@@ -1,21 +1,4 @@
 # frozen_string_literal: true
 
 module TaskHelper
-  def sort_asc(column_name)
-    link_to '▲', { column: column_name, direction: 'asc' }, id: column_name.dasherize + '-asc'
-  end
-
-  def sort_desc(column_name)
-    link_to '▼', { column: column_name, direction: 'desc' }, id: column_name.dasherize + '-desc'
-  end
-
-  def sort_direction
-    # If params[:direction] is nil, set sort_direction to 'desc' by default
-    %W[asc desc].include?(params[:direction]) ? params[:direction] : 'desc'
-  end
-
-  def sort_column
-    # If params[:column] is nil, set sort_column to 'created_date' by default
-    Task.column_names.include?(params[:column]) ? params[:column] : 'created_at'
-  end
 end

--- a/yo_task_manager/app/helpers/task_helper.rb
+++ b/yo_task_manager/app/helpers/task_helper.rb
@@ -3,6 +3,6 @@
 module TaskHelper
   def aasm_states_option
     # generates [ ['', ''], ['未着手', :not_yet], ['着手中', :on_going], ... ]
-    [['', '']].concat(Task.aasm.states.map(&:name).collect {|t| [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]})
+    [['', '']].concat(Task.aasm.states.map(&:name).collect { |t| [Task.human_attribute_name("aasm_state.#{t}"), t] })
   end
 end

--- a/yo_task_manager/app/helpers/task_helper.rb
+++ b/yo_task_manager/app/helpers/task_helper.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 module TaskHelper
+  def aasm_states_option
+    # generates [ ['', ''], ['未着手', :not_yet], ['着手中', :on_going], ... ]
+    [['', '']].concat(Task.aasm.states.map(&:name).collect {|t| [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]})
+  end
 end

--- a/yo_task_manager/app/models/task.rb
+++ b/yo_task_manager/app/models/task.rb
@@ -3,8 +3,6 @@
 class Task < ApplicationRecord
   include AASM
 
-  aasm do
-  end
   validates :title, presence: true
   include AASM
 

--- a/yo_task_manager/app/models/task.rb
+++ b/yo_task_manager/app/models/task.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  include AASM
+
+  aasm do
+  end
   validates :title, presence: true
+  include AASM
+
+  aasm do
+    # 未着手
+    state :not_yet, initial: true
+    # 着手中
+    state :on_going
+    # 完了
+    state :done
+
+    event :start do
+      transitions from: :not_yet, to: :on_going
+    end
+
+    event :finish do
+      transitions from: :on_going, to: :done
+    end
+
+    event :restart do
+      transitions from: [:on_going, :done], to: :not_yet
+    end
+  end
 end

--- a/yo_task_manager/app/models/task.rb
+++ b/yo_task_manager/app/models/task.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
-  include AASM
-
   validates :title, presence: true
+  default_scope { order(created_at: :desc) }
   include AASM
 
   aasm do

--- a/yo_task_manager/app/models/task.rb
+++ b/yo_task_manager/app/models/task.rb
@@ -22,7 +22,7 @@ class Task < ApplicationRecord
     end
 
     event :restart do
-      transitions from: [:on_going, :done], to: :not_yet
+      transitions from: %i[on_going done], to: :not_yet
     end
   end
 end

--- a/yo_task_manager/app/views/tasks/_form.html.erb
+++ b/yo_task_manager/app/views/tasks/_form.html.erb
@@ -26,6 +26,14 @@
         </td>
       </tr>
       <tr>
+        <th scope="col">
+          <%= f.label t('tasks.task_state') %>
+        </th>
+        <td>
+          <%= f.select :aasm_state, Task.aasm.states.map(&:name).collect {|t| p [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]} %>
+        </td>
+      </tr>
+      <tr>
         <td colspan="2">
           <div class="d-flex justify-content-around">
             <%= f.submit button_name, class: 'btn btn-primary' %>

--- a/yo_task_manager/app/views/tasks/_form.html.erb
+++ b/yo_task_manager/app/views/tasks/_form.html.erb
@@ -30,7 +30,7 @@
           <%= f.label t('tasks.task_state') %>
         </th>
         <td>
-          <%= f.select :aasm_state, Task.aasm.states.map(&:name).collect {|t| p [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]} %>
+          <%= f.select :aasm_state, Task.aasm.states.map(&:name).collect {|t| [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]} %>
         </td>
       </tr>
       <tr>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -10,7 +10,7 @@
       <%= f.search_field :title_cont %>
 
       <%= f.label t('tasks.task_state') %>:
-      <%= f.select :aasm_state_eq, Task.aasm.states.map(&:name).collect {|t| [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]} %>
+      <%= f.select :aasm_state_eq, [['', '']].concat(Task.aasm.states.map(&:name).collect {|t| [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]}) %>
 
       <%= f.submit t('.search'), name: nil, class: 'btn btn-primary' %>
     <% end %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -10,7 +10,7 @@
       <%= f.search_field :title_cont %>
 
       <%= f.label t('tasks.task_state') %>:
-      <%= f.select :aasm_state_eq, [['', '']].concat(Task.aasm.states.map(&:name).collect {|t| [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]}) %>
+      <%= f.select :aasm_state_eq, aasm_states_option %>
 
       <%= f.submit t('.search'), name: nil, class: 'btn btn-primary' %>
     <% end %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -28,6 +28,7 @@
             <th><%= t('tasks.task_name') %></th>
             <th><%= t('tasks.task_detail') %></th>
             <th><%= t('tasks.task_limit') %> <%= sort_asc('task_limit') %><%= sort_desc('task_limit') %></th>
+            <th><%= t('tasks.task_state') %></th>
             <th><%= t('.action') %></th>
           </tr>
         </thead>
@@ -38,6 +39,7 @@
               <td class="task-name"><%= t.title %></td>
               <td><%= t.body %></td>
               <td class="task-limit"><%= t.task_limit %></td>
+              <td><%= Task.human_attribute_name("aasm_state.#{t.aasm_state}") %></td>
               <td>
                 <%= button_to t('.detail'), task_path(t), method: :get, class: 'btn btn-info', form: { style: 'display: inline-block;' } %>
                 <%= button_to t('tasks.edit_text'), edit_task_path(t), method: :get, class: 'btn btn-warning', form: { style: 'display: inline-block;' } %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -36,11 +36,11 @@
       <table class="table table-striped table-bordered">
         <thead class="thead-dark">
           <tr>
-            <th>ID</th>
-            <th><%= t('tasks.task_name') %></th>
-            <th><%= t('tasks.task_detail') %></th>
-            <th><%= t('tasks.task_limit') %> <%= sort_asc('task_limit') %><%= sort_desc('task_limit') %></th>
-            <th><%= t('tasks.task_state') %></th>
+            <th><%= sort_link(@q, :id, 'ID') %></th>
+            <th><%= sort_link(@q, :title, t('tasks.task_name')) %></th>
+            <th><%= sort_link(@q, :body, t('tasks.task_detail')) %></th>
+            <th><%= sort_link(@q, :task_limit, t('tasks.task_limit')) %></th>
+            <th><%= sort_link(@q, :aasm_state, t('tasks.task_state')) %></th>
             <th><%= t('.action') %></th>
           </tr>
         </thead>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -10,7 +10,7 @@
       <%= f.search_field :title_cont %>
 
       <%= f.label t('tasks.task_state') %>:
-      <%= f.select :aasm_state_eq, Task.aasm.states.map(&:name).collect {|t| p [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]} %>
+      <%= f.select :aasm_state_eq, Task.aasm.states.map(&:name).collect {|t| [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]} %>
 
       <%= f.submit t('.search'), name: nil, class: 'btn btn-primary' %>
     <% end %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -4,6 +4,26 @@
       <h1><%= t('.task_list') %></h1>
     </div>
   </div>
+  <div class="search-form" style="background-color: lightgray">
+    <%= form_tag(tasks_path, method: :get) do %>
+      <div class="row">
+        <div class="col-sm">
+          <%= t('tasks.task_name') %>:
+          <%= text_field_tag :title, params[:title] %>
+        </div>
+        <div class="col-sm">
+          <%= t('tasks.task_state') %>:
+          <%= text_field_tag :aasm_state, params[:aasm_state] %>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm">
+          <%= submit_tag t('.search'), name: nil, class: 'btn btn-primary' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
   <div class="row">
     <div class="col-sm">
       <% if @tasks.present? %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -1,26 +1,18 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-sm">
-      <h1><%= t('.task_list') %></h1>
+      <h1><%= link_to t('.task_list'), tasks_path %></h1>
     </div>
   </div>
   <div class="search-form" style="background-color: lightgray">
-    <%= form_tag(tasks_path, method: :get) do %>
-      <div class="row">
-        <div class="col-sm">
-          <%= t('tasks.task_name') %>:
-          <%= text_field_tag :title, params[:title] %>
-        </div>
-        <div class="col-sm">
-          <%= t('tasks.task_state') %>:
-          <%= text_field_tag :aasm_state, params[:aasm_state] %>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-sm">
-          <%= submit_tag t('.search'), name: nil, class: 'btn btn-primary' %>
-        </div>
-      </div>
+    <%= search_form_for @q do |f| %>
+      <%= f.label t('tasks.task_name') %>:
+      <%= f.search_field :title_cont %>
+
+      <%= f.label t('tasks.task_state') %>:
+      <%= f.select :aasm_state_eq, Task.aasm.states.map(&:name).collect {|t| p [Task.human_attribute_name("aasm_state.#{t.to_s}"), t]} %>
+
+      <%= f.submit t('.search'), name: nil, class: 'btn btn-primary' %>
     <% end %>
   </div>
 

--- a/yo_task_manager/app/views/tasks/show.html.erb
+++ b/yo_task_manager/app/views/tasks/show.html.erb
@@ -25,6 +25,10 @@
         <th><%= t('tasks.task_limit') %></th>
         <td><%= @task.task_limit %></td>
       </tr>
+      <tr>
+        <th><%= t('tasks.task_state') %></th>
+        <td><%= Task.human_attribute_name("aasm_state.#{@task.aasm_state}") %></td>
+      </tr>
     </tbody>
   </table>
   <div class="d-flex justify-content-around">

--- a/yo_task_manager/config/database.yml
+++ b/yo_task_manager/config/database.yml
@@ -1,6 +1,8 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
+  charset: utf8mb4
+  collation: utf8mb4_general_ci
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
       add_task: Add Task
       action: Action
       detail: Detail
+      search: Search
     show:
       task_detail: Task Detail
       back_to_tasks: ←Back to Task list

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     task_name: Task Name
     task_detail: Task Detail
     task_limit: Task Limit
+    task_state: Task Status
     edit_text: Edit
     delete: Delete
     cancel: Cancel
@@ -28,3 +29,10 @@ en:
       task_updated: Task is updated.
     destroy:
       task_deleted: Task was deleted.
+
+  activerecord:
+    attributes:
+      task:
+        aasm_state/not_yet: not yet started
+        aasm_state/on_going: on going
+        aasm_state/done: done

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -14,6 +14,7 @@ ja:
       add_task: タスク追加
       action: 操作
       detail: 詳細
+      search: 検索
     show:
       task_detail: タスク詳細
       back_to_tasks: ←タスク一覧へ

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     task_name: タスク名
     task_detail: 詳細
     task_limit: 終了期限
+    task_state: ステータス
     edit_text: 編集
     delete: 削除
     cancel: 取り消し
@@ -28,3 +29,10 @@ ja:
       task_updated: タスクが更新されました。
     destroy:
       task_deleted: タスクが削除されました。
+
+  activerecord:
+    attributes:
+      task/aasm_state:
+        not_yet: 未着手
+        on_going: 着手中
+        done: 完了

--- a/yo_task_manager/db/migrate/20191008005616_add_limit_to_task.rb
+++ b/yo_task_manager/db/migrate/20191008005616_add_limit_to_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLimitToTask < ActiveRecord::Migration[6.0]
   def change
     add_column :tasks, :limit, :datetime, after: :body, comment: '終了期限'

--- a/yo_task_manager/db/migrate/20191008044923_rename_limit_to_task_limit.rb
+++ b/yo_task_manager/db/migrate/20191008044923_rename_limit_to_task_limit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameLimitToTaskLimit < ActiveRecord::Migration[6.0]
   def change
     rename_column :tasks, :limit, :task_limit

--- a/yo_task_manager/db/migrate/20191009014150_add_aasm_state_to_tasks.rb
+++ b/yo_task_manager/db/migrate/20191009014150_add_aasm_state_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddAasmStateToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :aasm_state, :string
+  end
+end

--- a/yo_task_manager/db/migrate/20191009014150_add_aasm_state_to_tasks.rb
+++ b/yo_task_manager/db/migrate/20191009014150_add_aasm_state_to_tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAasmStateToTasks < ActiveRecord::Migration[6.0]
   def change
     add_column :tasks, :aasm_state, :string, after: :task_limit

--- a/yo_task_manager/db/migrate/20191009014150_add_aasm_state_to_tasks.rb
+++ b/yo_task_manager/db/migrate/20191009014150_add_aasm_state_to_tasks.rb
@@ -1,5 +1,5 @@
 class AddAasmStateToTasks < ActiveRecord::Migration[6.0]
   def change
-    add_column :tasks, :aasm_state, :string
+    add_column :tasks, :aasm_state, :string, after: :task_limit
   end
 end

--- a/yo_task_manager/db/migrate/20191009041551_add_index_tasks_title_aasm_state.rb
+++ b/yo_task_manager/db/migrate/20191009041551_add_index_tasks_title_aasm_state.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksTitleAasmState < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, [:title, :aasm_state]
+  end
+end

--- a/yo_task_manager/db/migrate/20191009041551_add_index_tasks_title_aasm_state.rb
+++ b/yo_task_manager/db/migrate/20191009041551_add_index_tasks_title_aasm_state.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class AddIndexTasksTitleAasmState < ActiveRecord::Migration[6.0]
   def change
-    add_index :tasks, [:title, :aasm_state]
+    add_index :tasks, %i[title aasm_state]
   end
 end

--- a/yo_task_manager/db/schema.rb
+++ b/yo_task_manager/db/schema.rb
@@ -10,15 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_09_014150) do
+ActiveRecord::Schema.define(version: 2019_10_09_041551) do
 
-  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "title", null: false
     t.text "body"
     t.datetime "task_limit"
     t.string "aasm_state"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["title", "aasm_state"], name: "index_tasks_on_title_and_aasm_state"
   end
 
 end

--- a/yo_task_manager/db/schema.rb
+++ b/yo_task_manager/db/schema.rb
@@ -16,9 +16,9 @@ ActiveRecord::Schema.define(version: 2019_10_09_014150) do
     t.string "title", null: false
     t.text "body"
     t.datetime "task_limit"
+    t.string "aasm_state"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "aasm_state"
   end
 
 end

--- a/yo_task_manager/db/schema.rb
+++ b/yo_task_manager/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_08_044923) do
+ActiveRecord::Schema.define(version: 2019_10_09_014150) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2019_10_08_044923) do
     t.datetime "task_limit"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "aasm_state"
   end
 
 end

--- a/yo_task_manager/spec/models/task_spec.rb
+++ b/yo_task_manager/spec/models/task_spec.rb
@@ -18,4 +18,30 @@ RSpec.describe Task, type: :model do
       expect(task.valid?).to eq false
     end
   end
+
+  context 'task searching' do
+    let!(:task1) { Task.create(title: 'task1', aasm_state: 'not_yet') }
+    let!(:task2) { Task.create(title: 'task2', aasm_state: 'on_going') }
+    let!(:task3) { Task.create(title: 'task3', aasm_state: 'done') }
+    let!(:task4) { Task.create(title: 'task4', aasm_state: 'on_going') }
+    subject { Task.ransack(params).result(distinct: true) }
+    context 'search with non exist title' do
+      let(:params) {{ title_cont: 'not exist', aasm_state_eq: '' }}
+      it 'should return 0 result' do
+        expect(subject.count).to eq 0
+      end
+    end
+    context 'search with existed title' do
+      let(:params) {{ title_cont: 'task', aasm_state_eq: '' }}
+      it 'should return 4 result' do
+        expect(subject.count).to eq 4
+      end
+    end
+    context 'search with aasm_state' do
+      let(:params) {{ title_cont: '', aasm_state_eq: 'on_going' }}
+      it 'should return 2 result' do
+        expect(subject.count).to eq 2
+      end
+    end
+  end
 end

--- a/yo_task_manager/spec/models/task_spec.rb
+++ b/yo_task_manager/spec/models/task_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe Task, type: :model do
     let!(:task4) { Task.create(title: 'task4', aasm_state: 'on_going') }
     subject { Task.ransack(params).result(distinct: true) }
     context 'search with non exist title' do
-      let(:params) {{ title_cont: 'not exist', aasm_state_eq: '' }}
+      let(:params) { { title_cont: 'not exist', aasm_state_eq: '' } }
       it 'should return 0 result' do
         expect(subject.count).to eq 0
       end
     end
     context 'search with existed title' do
-      let(:params) {{ title_cont: 'task', aasm_state_eq: '' }}
+      let(:params) { { title_cont: 'task', aasm_state_eq: '' } }
       it 'should return 4 result' do
         expect(subject.count).to eq 4
       end
     end
     context 'search with aasm_state' do
-      let(:params) {{ title_cont: '', aasm_state_eq: 'on_going' }}
+      let(:params) { { title_cont: '', aasm_state_eq: 'on_going' } }
       it 'should return 2 result' do
         expect(subject.count).to eq 2
       end

--- a/yo_task_manager/spec/system/tasks_spec.rb
+++ b/yo_task_manager/spec/system/tasks_spec.rb
@@ -95,10 +95,10 @@ RSpec.describe 'Tasks', type: :system do
     Task.create!(title: 'task3', task_limit: '2020-03-03 03:03:03')
     visit '/ja/tasks'
     expect(page.all('.task-limit').map(&:text)).to eq ['2020-03-03 03:03:03 +0900', '2020-02-02 02:02:02 +0900', '2020-01-01 01:01:01 +0900']
-    find('#task-limit-asc').click
+    click_link('終了期限')
     sleep 0.5
     expect(page.all('.task-limit').map(&:text)).to eq ['2020-03-03 03:03:03 +0900', '2020-02-02 02:02:02 +0900', '2020-01-01 01:01:01 +0900'].reverse
-    find('#task-limit-desc').click
+    click_link('終了期限')
     sleep 0.5
     expect(page.all('.task-limit').map(&:text)).to eq ['2020-03-03 03:03:03 +0900', '2020-02-02 02:02:02 +0900', '2020-01-01 01:01:01 +0900']
   end

--- a/yo_task_manager/spec/system/tasks_spec.rb
+++ b/yo_task_manager/spec/system/tasks_spec.rb
@@ -102,4 +102,26 @@ RSpec.describe 'Tasks', type: :system do
     sleep 0.5
     expect(page.all('.task-limit').map(&:text)).to eq ['2020-03-03 03:03:03 +0900', '2020-02-02 02:02:02 +0900', '2020-01-01 01:01:01 +0900']
   end
+
+  scenario 'task searching with title and aasm_state' do
+    Task.create!(title: 'task1', aasm_state: 'not_yet')
+    Task.create!(title: '2nd t(ask)', aasm_state: 'on_going')
+    Task.create!(title: 'no. 3rd', aasm_state: 'done')
+    visit '/ja/tasks'
+    expect(page.all('.task-name').map(&:text)).to eq ['no. 3rd', '2nd t(ask)', 'task1']
+    fill_in 'q[title_cont]', with: '2nd'
+    click_button('検索')
+    expect(page.all('.task-name').map(&:text)).to eq ['2nd t(ask)']
+    fill_in 'q[title_cont]', with: 'ask'
+    click_button('検索')
+    expect(page.all('.task-name').map(&:text)).to eq ['2nd t(ask)', 'task1']
+    fill_in 'q[title_cont]', with: ''
+    select '完了', from: 'q[aasm_state_eq]'
+    click_button('検索')
+    expect(page.all('.task-name').map(&:text)).to eq ['no. 3rd']
+    fill_in 'q[title_cont]', with: '4th'
+    select '', from: 'q[aasm_state_eq]'
+    click_button('検索')
+    expect(page).to have_text('タスクはありません。')
+  end
 end


### PR DESCRIPTION
## 関連URL
- [ステップ13: ステータスを追加して、検索できるようにしよう](https://github.com/Fablic/training/tree/change_feature_test_to_system_test#ステップ13-ステータスを追加して検索できるようにしよう)

## 実装内容
- ステータス管理機能で [aasm](https://github.com/aasm/aasm) のGemを追加
- `rails generate aasm Task` で `aasm_state` のcolumn追加
- view側にステータスを表示させる
- 検索機能で `ransack` のGemを追加して、機能実装する(controller、view側)。
- view側のソートを ransackの sort_linkに変更
- model specを追加、 system specを追加

## Screenshot
`#index`: 
![image](https://user-images.githubusercontent.com/10822260/66459597-52742d80-eab0-11e9-94c2-a8ebf59eee5d.png)
検索結果：
![image](https://user-images.githubusercontent.com/10822260/66459645-69b31b00-eab0-11e9-9ee6-c64c4ea51dbc.png)
