### PR TITLE
Step_19: adding role to user

### DIFF
--- a/.idea/training.iml
+++ b/.idea/training.iml
@@ -5,9 +5,14 @@
   </component>
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/log" />
+      <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/node_modules" />
+      <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/public/packs" />
+      <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/public/packs-test" />
       <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/yo_task_manager/vendor" />
     </content>
+    <content url="file://$MODULE_DIR$/yo_task_manager/node_modules" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.0.2, rbenv: 2.5.5) [gem]" level="application" />

--- a/yo_task_manager/app/controllers/admin/users_controller.rb
+++ b/yo_task_manager/app/controllers/admin/users_controller.rb
@@ -4,6 +4,7 @@ module Admin
   class UsersController < ApplicationController
     before_action :user_is_logged_in
     before_action :set_user, only: %i[show edit update destroy]
+    before_action :user_is_admin
 
     def index
       @q = User.includes(:tasks).all.ransack(params[:q])

--- a/yo_task_manager/app/controllers/admin/users_controller.rb
+++ b/yo_task_manager/app/controllers/admin/users_controller.rb
@@ -50,7 +50,7 @@ module Admin
       if @user.destroy
         flash[:success] = [t('.user_deleted')]
       else
-        flash[:danger] = [(t('something_is_wrong') + t('user_is_not_deleted')).to_s, @user.errors.full_messages].flatten
+        flash[:danger] = [(t('something_is_wrong') + t('.user_is_not_deleted')).to_s, @user.errors.full_messages].flatten
       end
       redirect_to admin_users_path
     end

--- a/yo_task_manager/app/controllers/admin/users_controller.rb
+++ b/yo_task_manager/app/controllers/admin/users_controller.rb
@@ -57,7 +57,7 @@ module Admin
     private
 
     def user_params
-      params.require(:user).permit(:login_id, :password, :display_name)
+      params.require(:user).permit(:login_id, :password, :role, :display_name)
     end
 
     def set_user

--- a/yo_task_manager/app/controllers/application_controller.rb
+++ b/yo_task_manager/app/controllers/application_controller.rb
@@ -25,4 +25,9 @@ class ApplicationController < ActionController::Base
     flash[:danger] = [t('please_login')] unless session[:user_id]
     redirect_to login_path unless session[:user_id]
   end
+
+  def user_is_admin
+    flash[:danger] = [t('not_admin')] unless current_user.admin?
+    redirect_to root_path unless current_user.admin?
+  end
 end

--- a/yo_task_manager/app/models/application_record.rb
+++ b/yo_task_manager/app/models/application_record.rb
@@ -2,4 +2,16 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.human_attribute_enum_value(attr_name, value)
+    human_attribute_name("#{attr_name}.#{value}")
+  end
+
+  def human_attribute_enum(attr_name)
+    self.class.human_attribute_enum_value(attr_name, self[attr_name])
+  end
+
+  def self.enum_options_for_select(attr_name)
+    self.send(attr_name.to_s.pluralize).map { |k, _| [self.human_attribute_enum_value(attr_name, k), k] }.to_h
+  end
 end

--- a/yo_task_manager/app/models/user.rb
+++ b/yo_task_manager/app/models/user.rb
@@ -14,16 +14,13 @@ class User < ApplicationRecord
 
   def update_the_last_admin_validator
     # updateの場合、 'admin' -> 'common'の場合のみvalidatorが必要
-    if self.role == 'common'
-      destroy_the_last_admin_validator
-    end
+    destroy_the_last_admin_validator if self.role == 'common'
   end
 
   def destroy_the_last_admin_validator
     # destroyの場合、'admin' のままで削除されるので、 `if self.role == 'common'`のチェックは必要ない
-    if User.admin.count == 1 && User.admin.first.id == self.id
-      errors.add(:role, :cannot_update_or_destroy_final_admin)
-      throw :abort
-    end
+    return unless User.admin.count == 1 && User.admin.first.id == self.id
+    errors.add(:role, :cannot_update_or_destroy_final_admin)
+    throw :abort
   end
 end

--- a/yo_task_manager/app/models/user.rb
+++ b/yo_task_manager/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   validates :login_id, presence: true
   validates :password, presence: true, on: :create
+
+  enum role: { admin: 'admin', common: 'common' }
 end

--- a/yo_task_manager/app/models/user.rb
+++ b/yo_task_manager/app/models/user.rb
@@ -6,5 +6,24 @@ class User < ApplicationRecord
   validates :login_id, presence: true
   validates :password, presence: true, on: :create
 
+  # prevent losing all admin on DB by limiting update and destroy.
+  validate :update_the_last_admin_validator, on: :update
+  before_destroy :destroy_the_last_admin_validator
+
   enum role: { admin: 'admin', common: 'common' }
+
+  def update_the_last_admin_validator
+    # updateの場合、 'admin' -> 'common'の場合のみvalidatorが必要
+    if self.role == 'common'
+      destroy_the_last_admin_validator
+    end
+  end
+
+  def destroy_the_last_admin_validator
+    # destroyの場合、'admin' のままで削除されるので、 `if self.role == 'common'`のチェックは必要ない
+    if User.admin.count == 1 && User.admin.first.id == self.id
+      errors.add(:role, :cannot_update_or_destroy_final_admin)
+      throw :abort
+    end
+  end
 end

--- a/yo_task_manager/app/views/admin/users/_form.html.erb
+++ b/yo_task_manager/app/views/admin/users/_form.html.erb
@@ -19,6 +19,14 @@
       </tr>
       <tr>
         <th scope="col">
+          <%= f.label t('admin.users.role') %>
+        </th>
+        <td>
+          <%= f.select :role, User.enum_options_for_select(:role) %>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col">
           <%= f.label t('admin.users.display_name') %>
         </th>
         <td>

--- a/yo_task_manager/app/views/admin/users/index.html.erb
+++ b/yo_task_manager/app/views/admin/users/index.html.erb
@@ -32,6 +32,7 @@
               <th><%= sort_link(@q, :id, 'ID') %></th>
               <th><%= sort_link(@q, :login_id, t('admin.users.login_id')) %></th>
               <th><%= sort_link(@q, :display_name, t('admin.users.display_name')) %></th>
+              <th><%= sort_link(@q, :role, t('admin.users.role')) %></th>
               <th><%= sort_link(@q, :task_count, t('admin.users.task_count')) %></th>
               <th><%= t('action') %></th>
             </tr>
@@ -41,7 +42,8 @@
               <tr id="user-<%= u.id %>">
                 <td><%= u.id %></td>
                 <td><%= u.login_id %></td>
-                <td><%= u.display_name %></td>
+                <td><%= u.display_name || '-' %></td>
+                <td><%= u.human_attribute_enum(:role) %></td>
                 <td><%= u.tasks.size %></td>
                 <td>
                   <%= button_to t('button.detail'), admin_user_path(u), method: :get, class: 'btn btn-info', form: { style: 'display: inline-block;' } %>

--- a/yo_task_manager/app/views/admin/users/show.html.erb
+++ b/yo_task_manager/app/views/admin/users/show.html.erb
@@ -24,8 +24,12 @@
             <td><%= @user.login_id %></td>
           </tr>
           <tr>
+            <th><%= t('admin.users.role') %></th>
+            <td><%= @user.human_attribute_enum(:role) %></td>
+          </tr>
+          <tr>
             <th><%= t('admin.users.display_name') %></th>
-            <td><%= @user.display_name %></td>
+            <td><%= @user.display_name || '-' %></td>
           </tr>
           <tr>
             <th colspan="2">

--- a/yo_task_manager/app/views/admin/users/show.html.erb
+++ b/yo_task_manager/app/views/admin/users/show.html.erb
@@ -36,7 +36,7 @@
               <div class="d-flex justify-content-around">
                 <%= button_to t('.back_to_users'), admin_users_path, method: :get, class: 'btn btn-primary' %>
                 <%= button_to t('button.edit'), edit_admin_user_path(@user), method: :get, class: 'btn btn-warning' %>
-                <%= button_to t('button.delete'), admin_users_path(id: @user.id), method: :delete, class: 'btn btn-danger' %>
+                <%= button_to t('button.delete'), admin_user_path(@user.id), method: :delete, class: 'btn btn-danger' %>
               </div>
             </th>
           </tr>

--- a/yo_task_manager/app/views/admin/users/show.html.erb
+++ b/yo_task_manager/app/views/admin/users/show.html.erb
@@ -12,7 +12,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-3">
+    <div class="col-12 col-lg-4">
       <table class="table table-dark">
         <tbody>
           <tr>
@@ -43,7 +43,7 @@
         </tbody>
       </table>
     </div>
-    <div class="col-9">
+    <div class="col-12 col-lg-8">
       <h3>このユーザーのタスク数: <%= @tasks.size %></h3>
       <% if @tasks.any? %>
         <table class="table table-dark">

--- a/yo_task_manager/app/views/layouts/_header.html.erb
+++ b/yo_task_manager/app/views/layouts/_header.html.erb
@@ -8,9 +8,11 @@
       <li class="nav-item">
         <%= link_to t('tasks.index.task_list'), tasks_path, class: "nav-link #{active_path?(tasks_path)}" %>
       </li>
-      <li clas="nav-item">
-        <%= link_to t('admin.users.index.user_list'), admin_users_path, class: "nav-link #{active_path?(admin_users_path)}" %>
-      </li>
+      <% if current_user&.admin? %>
+        <li clas="nav-item">
+          <%= link_to t('admin.users.index.user_list'), admin_users_path, class: "nav-link #{active_path?(admin_users_path)}" %>
+        </li>
+      <% end %>
     </ul>
     <%= button_to t('sessions.log_out'), logout_path, method: :get, class: 'btn btn-secondary' %>
   </div>

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
       login_id: Login ID
       password: Password
       display_name: Display Name
+      role: Role
       task_count: Task count
       user_not_found: The user is not exist!
       # controllers
@@ -92,6 +93,9 @@ en:
       user:
         login_id: Login ID
         password: Password
+      user/role:
+        admin: Admin
+        common: Common
       task:
         aasm_state/not_yet: not yet started
         aasm_state/on_going: on going

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -101,4 +101,10 @@ en:
         aasm_state/not_yet: not yet started
         aasm_state/on_going: on going
         aasm_state/done: done
+    errors:
+      models:
+        user:
+          attributes:
+            role:
+              cannot_update_or_destroy_final_admin: cannot update/remove final admin!
   # pagination related(not needed)

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
   # error messages
   please_login: Please Login first before proceed.
   something_is_wrong: Something wrong is happened.
+  not_admin: Access denied. Not Admin.
 
   #models
   tasks:

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
   activerecord:
     attributes:
       user:
+        role: Role
         login_id: Login ID
         password: Password
       user/role:

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -92,6 +92,7 @@ ja:
   activerecord:
     attributes:
       user:
+        role: ロール
         login_id: ログインID
         password: パスワード
       user/role:
@@ -101,6 +102,14 @@ ja:
         not_yet: 未着手
         on_going: 着手中
         done: 完了
+    errors:
+      models:
+        user:
+          attributes:
+            role:
+              cannot_update_or_destroy_final_admin: ' 最後のアドミンなので、変更・削除はできません！'
+
+
   # pagination related
   views:
     pagination:

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -62,6 +62,7 @@ ja:
       login_id: ログインID
       password: パスワード
       display_name: 表示名
+      role: ロール
       task_count: タスク数
       user_not_found: アクセスしようとしているユーザーはありません!
       # controllers
@@ -92,6 +93,9 @@ ja:
       user:
         login_id: ログインID
         password: パスワード
+      user/role:
+        admin: アドミン
+        common: 一般
       task/aasm_state:
         not_yet: 未着手
         on_going: 着手中

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -11,6 +11,7 @@ ja:
   # error messages
   please_login: 先にログインしてください。
   something_is_wrong: 問題が発生しました。
+  not_admin: アドミンではないので、アクセスできません。
 
   # models
   tasks:

--- a/yo_task_manager/db/migrate/20191015070752_add_role_to_users.rb
+++ b/yo_task_manager/db/migrate/20191015070752_add_role_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRoleToUsers < ActiveRecord::Migration[6.0]
   def up
     execute <<-SQL

--- a/yo_task_manager/db/migrate/20191015070752_add_role_to_users.rb
+++ b/yo_task_manager/db/migrate/20191015070752_add_role_to_users.rb
@@ -1,0 +1,11 @@
+class AddRoleToUsers < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      ALTER TABLE users ADD role enum('admin', 'common') DEFAULT 'common' AFTER login_id, COMMENT 'ロール';
+    SQL
+  end
+
+  def down
+    remove_column :users, :role
+  end
+end

--- a/yo_task_manager/db/schema.rb
+++ b/yo_task_manager/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_022505) do
+ActiveRecord::Schema.define(version: 2019_10_15_070752) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -24,8 +24,9 @@ ActiveRecord::Schema.define(version: 2019_10_10_022505) do
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", comment: "ロール", force: :cascade do |t|
     t.string "login_id", null: false
+    t.column "role", "enum('admin','common')", default: "common"
     t.string "password_digest", null: false
     t.string "display_name"
     t.datetime "created_at", precision: 6, null: false

--- a/yo_task_manager/spec/controllers/admin/users_controller_spec.rb
+++ b/yo_task_manager/spec/controllers/admin/users_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Admin::UsersController, type: :controller do
-  let!(:user) { create(:user) }
+  let!(:user) { create(:user, role: 'admin') }
   before do
     login(user)
   end

--- a/yo_task_manager/spec/models/user_spec.rb
+++ b/yo_task_manager/spec/models/user_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe User, type: :model do
     context 'change role from admin to common' do
       let(:role) { 'admin' }
       it 'role cannot be changed and have errors msg' do
-        expect {user.common!}.to raise_error(ActiveRecord::RecordInvalid)
-        expect(user.errors[:role]).to eq [" 最後のアドミンなので、変更・削除はできません！"]
+        expect { user.common! }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(user.errors[:role]).to eq [' 最後のアドミンなので、変更・削除はできません！']
         expect(user.reload.role).to eq 'admin'
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe User, type: :model do
       let(:role) { 'admin' }
       it 'cannot destroy record and have errors msg' do
         expect(user.destroy).to be_falsey
-        expect(user.errors[:role]).to eq [" 最後のアドミンなので、変更・削除はできません！"]
+        expect(user.errors[:role]).to eq [' 最後のアドミンなので、変更・削除はできません！']
       end
     end
   end

--- a/yo_task_manager/spec/models/user_spec.rb
+++ b/yo_task_manager/spec/models/user_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'many admins' do
+    let!(:admin_users) { create_list(:user, 3, role: 'admin') }
+    let!(:user) { create(:user, role: role) }
+    context 'change role from admin to common' do
+      let(:role) { 'admin' }
+      it 'role should be updated' do
+        expect(user.common!).to be true
+        expect(user.role).to eq 'common'
+      end
+    end
+    context 'change role from common to admin' do
+      let(:role) { 'common' }
+      it 'role should be updated' do
+        expect(user.admin!).to be true
+        expect(user.role).to eq 'admin'
+      end
+    end
+  end
+
+  describe 'final admin' do
+    let!(:common_users) { create_list(:user, 3, role: 'common') }
+    let!(:user) { create(:user, role: role) }
+    context 'change role from admin to common' do
+      let(:role) { 'admin' }
+      it 'role cannot be changed and have errors msg' do
+        expect {user.common!}.to raise_error(ActiveRecord::RecordInvalid)
+        expect(user.errors[:role]).to eq [" 最後のアドミンなので、変更・削除はできません！"]
+        expect(user.reload.role).to eq 'admin'
+      end
+    end
+
+    context 'destroy final admin' do
+      let(:role) { 'admin' }
+      it 'cannot destroy record and have errors msg' do
+        expect(user.destroy).to be_falsey
+        expect(user.errors[:role]).to eq [" 最後のアドミンなので、変更・削除はできません！"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 関連URL
- [ステップ19: ユーザにロールを追加しよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
  - ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
  - 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
  - ユーザ管理画面でロールを選択できるようにしましょう
  - 管理ユーザが1人もいなくならないように削除の制御をしましょう

## 実装内容
- roleのカラムを追加（enumでDB定義しますので、生のSQL文をmigrationの中に書いてました）
- usersの views, controllerにroleを追加
- admin/users/* 配下をadminのチェックを入れる
- 最後の管理者(admin)が削除できないようにする＆Roleを「一般」に変更できないようにvalidatorを追加

## Screenshot
DB内にもちゃんとEnumになってる：
![image](https://user-images.githubusercontent.com/10822260/66883724-d6c33500-f009-11e9-98cf-34f8b3e6783b.png)

削除しようとする時：
![image](https://user-images.githubusercontent.com/10822260/66883381-bf377c80-f008-11e9-80e5-1fadf7f1617d.png)

ロールを「一般」に変更しようとする時：
![image](https://user-images.githubusercontent.com/10822260/66883405-d24a4c80-f008-11e9-9419-73956d9d57b2.png)
