### PR TITLE
Step_20: add label to tasks

### DIFF
--- a/yo_task_manager/app/controllers/labels_controller.rb
+++ b/yo_task_manager/app/controllers/labels_controller.rb
@@ -51,7 +51,7 @@ class LabelsController < ApplicationController
   private
 
   def set_label
-    @label = Label.find(params[:id])
+    @label = Label.find_by(id: params[:id])
     unless @label
       flash[:danger] = [t('labels.label_not_found')]
       redirect_to labels_path

--- a/yo_task_manager/app/controllers/labels_controller.rb
+++ b/yo_task_manager/app/controllers/labels_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LabelsController < ApplicationController
-  before_action :set_label, only: %i[show edit update destroy]
+  before_action :set_label, only: %i[edit update destroy]
   before_action :user_is_logged_in
 
   def index
@@ -25,8 +25,6 @@ class LabelsController < ApplicationController
     end
   end
   # rubocop:enable Metrics/AbcSize
-
-  def show; end
 
   def edit; end
 

--- a/yo_task_manager/app/controllers/labels_controller.rb
+++ b/yo_task_manager/app/controllers/labels_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class LabelsController < ApplicationController
+  before_action :set_label, only: %i[show edit update destroy]
+  before_action :user_is_logged_in
+
+  def index
+    @q = Label.all.ransack(params[:q])
+    @labels = @q.result(distinct: true).page(params[:page])
+  end
+
+  def new
+    @label = Label.new
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def create
+    @label = Label.new(label_params)
+    if @label.save
+      flash[:success] = [t('.label_saved')]
+      redirect_to labels_path
+    else
+      flash.now[:danger] = [(t('something_is_wrong') + t('labels.label_is_not_saved')).to_s, @label.errors.full_messages].flatten
+      render :new
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def show; end
+
+  def edit; end
+
+  # rubocop:disable Metrics/AbcSize
+  def update
+    if @label.update(label_params)
+      flash[:success] = [t('.label_updated')]
+      redirect_to labels_path
+    else
+      flash.now[:danger] = [(t('something_is_wrong') + t('labels.label_is_not_updated')).to_s, @label.errors.full_messages].flatten
+      render :edit
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def destroy
+    byebug
+    if @label.destroy
+      flash[:success] = [t('.label_deleted')]
+    else
+      flash[:danger] = [(t('something_is_wrong') + t('labels.label_is_not_destroyed')).to_s, @label.errors.full_messages].flatten
+    end
+    redirect_to labels_path
+  end
+
+  private
+
+  def set_label
+    @label = Label.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    flash[:danger] = [t('labels.label_not_found')]
+    redirect_to labels_path
+  end
+
+  def label_params
+    params.require(:label).permit(:name)
+  end
+end

--- a/yo_task_manager/app/controllers/labels_controller.rb
+++ b/yo_task_manager/app/controllers/labels_controller.rb
@@ -43,7 +43,6 @@ class LabelsController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   def destroy
-    byebug
     if @label.destroy
       flash[:success] = [t('.label_deleted')]
     else

--- a/yo_task_manager/app/controllers/labels_controller.rb
+++ b/yo_task_manager/app/controllers/labels_controller.rb
@@ -32,11 +32,10 @@ class LabelsController < ApplicationController
   def update
     if @label.update(label_params)
       flash[:success] = [t('.label_updated')]
-      redirect_to labels_path
-    else
-      flash.now[:danger] = [(t('something_is_wrong') + t('labels.label_is_not_updated')).to_s, @label.errors.full_messages].flatten
-      render :edit
+      return redirect_to labels_path
     end
+    flash.now[:danger] = [(t('something_is_wrong') + t('labels.label_is_not_updated')).to_s, @label.errors.full_messages].flatten
+    render :edit
   end
   # rubocop:enable Metrics/AbcSize
 
@@ -53,9 +52,10 @@ class LabelsController < ApplicationController
 
   def set_label
     @label = Label.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    flash[:danger] = [t('labels.label_not_found')]
-    redirect_to labels_path
+    unless @label
+      flash[:danger] = [t('labels.label_not_found')]
+      redirect_to labels_path
+    end
   end
 
   def label_params

--- a/yo_task_manager/app/controllers/labels_controller.rb
+++ b/yo_task_manager/app/controllers/labels_controller.rb
@@ -52,10 +52,10 @@ class LabelsController < ApplicationController
 
   def set_label
     @label = Label.find_by(id: params[:id])
-    unless @label
-      flash[:danger] = [t('labels.label_not_found')]
-      redirect_to labels_path
-    end
+    return if @label
+
+    flash[:danger] = [t('labels.label_not_found')]
+    redirect_to labels_path
   end
 
   def label_params

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -7,7 +7,7 @@ class TasksController < ApplicationController
 
   def index
     @q = @user.tasks.ransack(params[:q])
-    @tasks = @q.result(distinct: true).page(params[:page])
+    @tasks = @q.result(distinct: true).includes(:labels).page(params[:page])
   end
 
   def new

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -59,10 +59,11 @@ class TasksController < ApplicationController
   end
 
   def set_task
-    @task = @user.tasks.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    flash[:danger] = [t('tasks.task_not_found')]
-    redirect_to tasks_path
+    @task = @user.tasks.find_by(id: params[:id])
+    unless @task
+      flash[:danger] = [t('tasks.task_not_found')]
+      redirect_to tasks_path
+    end
   end
 
   def set_user

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -55,7 +55,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :body, :task_limit, :aasm_state)
+    params.require(:task).permit(:title, :body, :task_limit, :aasm_state, { label_ids: [] })
   end
 
   def set_task

--- a/yo_task_manager/app/controllers/tasks_controller.rb
+++ b/yo_task_manager/app/controllers/tasks_controller.rb
@@ -60,10 +60,10 @@ class TasksController < ApplicationController
 
   def set_task
     @task = @user.tasks.find_by(id: params[:id])
-    unless @task
-      flash[:danger] = [t('tasks.task_not_found')]
-      redirect_to tasks_path
-    end
+    return if @task
+
+    flash[:danger] = [t('tasks.task_not_found')]
+    redirect_to tasks_path
   end
 
   def set_user

--- a/yo_task_manager/app/models/label.rb
+++ b/yo_task_manager/app/models/label.rb
@@ -1,0 +1,2 @@
+class Label < ApplicationRecord
+end

--- a/yo_task_manager/app/models/label.rb
+++ b/yo_task_manager/app/models/label.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Label < ApplicationRecord
   has_many :labelings, dependent: :destroy
   has_many :tasks, through: :labellings

--- a/yo_task_manager/app/models/label.rb
+++ b/yo_task_manager/app/models/label.rb
@@ -1,2 +1,4 @@
 class Label < ApplicationRecord
+  has_many :labelings, dependent: :destroy
+  has_many :tasks, through: :labellings
 end

--- a/yo_task_manager/app/models/labeling.rb
+++ b/yo_task_manager/app/models/labeling.rb
@@ -1,0 +1,4 @@
+class Labeling < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+end

--- a/yo_task_manager/app/models/labeling.rb
+++ b/yo_task_manager/app/models/labeling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Labeling < ApplicationRecord
   belongs_to :task
   belongs_to :label

--- a/yo_task_manager/app/models/task.rb
+++ b/yo_task_manager/app/models/task.rb
@@ -5,6 +5,8 @@ class Task < ApplicationRecord
   validates :title, presence: true
   default_scope { order(created_at: :desc) }
   belongs_to :user
+  has_many :labellings, dependent: :destroy
+  has_many :labels, through: :labellings
 
   include AASM
 

--- a/yo_task_manager/app/models/task.rb
+++ b/yo_task_manager/app/models/task.rb
@@ -5,8 +5,8 @@ class Task < ApplicationRecord
   validates :title, presence: true
   default_scope { order(created_at: :desc) }
   belongs_to :user
-  has_many :labellings, dependent: :destroy
-  has_many :labels, through: :labellings
+  has_many :labelings, dependent: :destroy
+  has_many :labels, through: :labelings
 
   include AASM
 

--- a/yo_task_manager/app/views/admin/users/show.html.erb
+++ b/yo_task_manager/app/views/admin/users/show.html.erb
@@ -54,6 +54,7 @@
               <th><%= t('tasks.task_detail') %></th>
               <th><%= t('tasks.task_limit') %></th>
               <th><%= t('tasks.task_state') %></th>
+              <th><%= t('tasks.task_label') %></th>
             </tr>
           </thead>
           <tbody>
@@ -64,6 +65,11 @@
                 <td><%= t.body %></td>
                 <td><%= l(t.task_limit, format: :long, default: '-') %></td>
                 <td><%= Task.human_attribute_name("aasm_state.#{t.aasm_state}") %></td>
+                <td>
+                  <% t.labels&.each do |l| %>
+                    <%= label_tag l.name, nil, class: 'badge badge-pill badge-primary' %>
+                  <% end %>
+                </td>
               </tr>
             <% end %>
           </tbody>

--- a/yo_task_manager/app/views/admin/users/show.html.erb
+++ b/yo_task_manager/app/views/admin/users/show.html.erb
@@ -66,9 +66,7 @@
                 <td><%= l(t.task_limit, format: :long, default: '-') %></td>
                 <td><%= Task.human_attribute_name("aasm_state.#{t.aasm_state}") %></td>
                 <td>
-                  <% t.labels&.each do |l| %>
-                    <%= label_tag l.name, nil, class: 'badge badge-pill badge-primary' %>
-                  <% end %>
+                  <%= render partial: 'labels/label', collection: t.labels %>
                 </td>
               </tr>
             <% end %>

--- a/yo_task_manager/app/views/labels/_form.html.erb
+++ b/yo_task_manager/app/views/labels/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_for label do |f| %>
+  <table class="table table-dark">
+    <tbody>
+    <tr>
+      <th scope="col">
+        <%= f.label t('labels.label_name') %>
+      </th>
+      <td>
+        <%= f.text_field :name %>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <div class="d-flex justify-content-around">
+          <%= f.submit button_name, class: 'btn btn-primary' %>
+          <%= link_to t('button.cancel'), labels_path, class: 'btn btn-light' %>
+        </div>
+      </td>
+    </tr>
+    </tbody>
+<% end %>
+</table>

--- a/yo_task_manager/app/views/labels/_form.html.erb
+++ b/yo_task_manager/app/views/labels/_form.html.erb
@@ -18,5 +18,5 @@
       </td>
     </tr>
     </tbody>
+  </table>
 <% end %>
-</table>

--- a/yo_task_manager/app/views/labels/_label.html.erb
+++ b/yo_task_manager/app/views/labels/_label.html.erb
@@ -1,0 +1,1 @@
+<%= label_tag label.name, nil, class: 'badge badge-pill badge-primary mr-1' %>

--- a/yo_task_manager/app/views/labels/edit.html.erb
+++ b/yo_task_manager/app/views/labels/edit.html.erb
@@ -1,0 +1,19 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-12">
+      <h1><%= t('.updating_label') %></h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <% flash.each do |name, msg| %>
+        <%= content_tag :div, msg.join('<br>').html_safe, class: "alert-#{name}" %>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <%= render partial: 'form', locals: { label: @label, button_name: t('button.update') } %>
+    </div>
+  </div>
+</div>

--- a/yo_task_manager/app/views/labels/index.html.erb
+++ b/yo_task_manager/app/views/labels/index.html.erb
@@ -1,0 +1,58 @@
+<div class="container-fluid">
+  <div class="row justify-content-end mt-3 mb-2">
+    <div class="col-8">
+      <%= button_to t('.add_label'), new_label_path, method: :get, class: 'btn btn-primary' %>
+    </div>
+    <div class="col-4 d-flex justify-content-end">
+      <% if @labels.present? %>
+        <p><%= t('.label_count') %>: <%= @labels.count %></p>
+      <% else %>
+        <p><%= t('.no_label') %></p>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <% flash.each do |name, msg| %>
+        <%= content_tag :div, msg.join('<br>').html_safe, class: "alert-#{name}" %>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-4">
+      <%= paginate @labels %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <% if @labels.present? %>
+        <table class="table table-striped table-bordered">
+          <thead class="thead-dark">
+            <tr>
+              <th><%= sort_link(@q, :id, 'ID') %></th>
+              <th><%= sort_link(@q, :name, t('labels.label_name')) %></th>
+              <th><%= t('action') %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @labels.each do |l| %>
+              <tr id="task-<%= l.id %>">
+                <td><%= l.id %></td>
+                <td><%= l.name %></td>
+                <td>
+                  <%= button_to t('button.edit'), edit_label_path(l), method: :get, class: 'btn btn-warning', form: { style: 'display: inline-block;' } %>
+                  <%= button_to t('button.delete'), label_path(l), method: :delete, class: 'btn btn-danger', form: { style: 'display: inline-block;' } %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% end %>
+    </div>
+  </div>
+  <div class="row justify-content-end">
+    <div class="col-4">
+      <%= paginate @labels %>
+    </div>
+  </div>
+</div>

--- a/yo_task_manager/app/views/labels/index.html.erb
+++ b/yo_task_manager/app/views/labels/index.html.erb
@@ -18,7 +18,7 @@
       <% end %>
     </div>
   </div>
-  <div class="row">
+  <div class="row justify-content-end">
     <div class="col-4">
       <%= paginate @labels %>
     </div>

--- a/yo_task_manager/app/views/labels/new.html.erb
+++ b/yo_task_manager/app/views/labels/new.html.erb
@@ -1,0 +1,19 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-12">
+      <h1><%= t('.adding_label') %></h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <% flash.each do |name, msg| %>
+        <%= content_tag :div, msg.join('<br>').html_safe, class: "alert-#{name}" %>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <%= render partial: 'form', locals: { label: @label, button_name: t('button.add') } %>
+    </div>
+  </div>
+</div>

--- a/yo_task_manager/app/views/layouts/_header.html.erb
+++ b/yo_task_manager/app/views/layouts/_header.html.erb
@@ -8,6 +8,9 @@
       <li class="nav-item">
         <%= link_to t('tasks.index.task_list'), tasks_path, class: "nav-link #{active_path?(tasks_path)}" %>
       </li>
+      <li class="nav-item">
+        <%= link_to t('labels.index.label_list'), labels_path, class: "nav-link #{active_path?(labels_path)}" %>
+      </li>
       <% if current_user&.admin? %>
         <li clas="nav-item">
           <%= link_to t('admin.users.index.user_list'), admin_users_path, class: "nav-link #{active_path?(admin_users_path)}" %>

--- a/yo_task_manager/app/views/tasks/_form.html.erb
+++ b/yo_task_manager/app/views/tasks/_form.html.erb
@@ -34,6 +34,17 @@
         </td>
       </tr>
       <tr>
+        <th scope="col">
+          <%= f.label t('tasks.task_label') %>
+        </th>
+        <td>
+          <%= f.collection_check_boxes(:label_ids, Label.all, :id, :name) do |l| %>
+            <%= l.label { l.check_box(class: 'check_box') } %>
+            <%= l.label(class: 'badge badge-pill badge-primary mr-3') { l.object.name } %>
+          <% end %>
+        </td>
+      </tr>
+      <tr>
         <td colspan="2">
           <div class="d-flex justify-content-around">
             <%= f.submit button_name, class: 'btn btn-primary' %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -1,15 +1,24 @@
 <div class="container-fluid">
   <div class="row search-form mt-1">
-    <div class="col-9">
+    <div class="col-12">
       <%= search_form_for @q do |f| %>
         <div class="row">
-          <div class="col-6">
+          <div class="col-6 col-lg-4">
             <%= f.label t('tasks.task_name') %>:
             <%= f.search_field :title_cont, class: 'form-control' %>
           </div>
-          <div class="col-6">
+          <div class="col-6 col-lg-4">
             <%= f.label t('tasks.task_state') %>:
             <%= f.select :aasm_state_eq, aasm_states_option, {}, { class: 'form-control' } %>
+          </div>
+          <div class="col-6 col-lg-4">
+            <%= f.label t('tasks.task_label') %>:
+            <div class="form-control" style="border: none;">
+              <%= f.collection_check_boxes(:labels_id_in, Label.all, :id, :name) do |l| %>
+                <%= l.label { l.check_box(class: 'check_box') } %>
+                <%= l.label(class: 'badge badge-pill badge-primary mr-3') { l.object.name } %>
+              <% end %>
+            </div>
           </div>
         </div>
         <div class="row justify-content-between mt-3">
@@ -19,7 +28,9 @@
         </div>
       <% end %>
     </div>
-    <div class="col-3 align-self-end d-flex justify-content-end">
+  </div>
+  <div class="row">
+    <div class="col-12 align-self-end d-flex justify-content-end">
       <%= button_to t('.add_task'), new_task_path, method: :get, class: 'btn btn-primary' %>
     </div>
   </div>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -83,9 +83,7 @@
                 <td class="task-limit"><%= l(t.task_limit, format: :long, default: '-') %></td>
                 <td><%= Task.human_attribute_name("aasm_state.#{t.aasm_state}") %></td>
                 <td>
-                  <% t.labels&.each do |l| %>
-                    <%= label_tag l.name, nil, class: 'badge badge-pill badge-primary' %>
-                  <% end %>
+                  <%= render partial: 'labels/label', collection: t.labels %>
                 </td>
                 <td>
                   <%= button_to t('button.detail'), task_path(t), method: :get, class: 'btn btn-info', form: { style: 'display: inline-block;' } %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -11,9 +11,11 @@
             <%= f.label t('tasks.task_state') %>:
             <%= f.select :aasm_state_eq, aasm_states_option, {}, { class: 'form-control' } %>
           </div>
-          <div class="col-6 col-lg-4">
+        </div>
+        <div class="row">
+          <div class="col-12">
             <%= f.label t('tasks.task_label') %>:
-            <div class="form-control" style="border: none;">
+            <div>
               <%= f.collection_check_boxes(:labels_id_in, Label.all, :id, :name) do |l| %>
                 <%= l.label { l.check_box(class: 'check_box') } %>
                 <%= l.label(class: 'badge badge-pill badge-primary mr-3') { l.object.name } %>

--- a/yo_task_manager/app/views/tasks/index.html.erb
+++ b/yo_task_manager/app/views/tasks/index.html.erb
@@ -56,6 +56,7 @@
               <th><%= sort_link(@q, :body, t('tasks.task_detail')) %></th>
               <th><%= sort_link(@q, :task_limit, t('tasks.task_limit')) %></th>
               <th><%= sort_link(@q, :aasm_state, t('tasks.task_state')) %></th>
+              <th><%= sort_link(@q, :label, t('tasks.task_label')) %></th>
               <th><%= t('action') %></th>
             </tr>
           </thead>
@@ -68,6 +69,11 @@
                 <td><%= t.body %></td>
                 <td class="task-limit"><%= l(t.task_limit, format: :long, default: '-') %></td>
                 <td><%= Task.human_attribute_name("aasm_state.#{t.aasm_state}") %></td>
+                <td>
+                  <% t.labels&.each do |l| %>
+                    <%= label_tag l.name, nil, class: 'badge badge-pill badge-primary' %>
+                  <% end %>
+                </td>
                 <td>
                   <%= button_to t('button.detail'), task_path(t), method: :get, class: 'btn btn-info', form: { style: 'display: inline-block;' } %>
                   <%= button_to t('button.edit'), edit_task_path(t), method: :get, class: 'btn btn-warning', form: { style: 'display: inline-block;' } %>

--- a/yo_task_manager/app/views/tasks/show.html.erb
+++ b/yo_task_manager/app/views/tasks/show.html.erb
@@ -38,9 +38,7 @@
           <tr>
             <th><%= t('tasks.task_label') %></th>
             <td>
-              <% @task.labels&.each do |l| %>
-                <%= label_tag l.name, nil, class: 'badge badge-pill badge-primary' %>
-              <% end %>
+              <%= render partial: 'labels/label', collection: @task.labels %>
             </td>
           </tr>
         </tbody>

--- a/yo_task_manager/app/views/tasks/show.html.erb
+++ b/yo_task_manager/app/views/tasks/show.html.erb
@@ -35,6 +35,14 @@
             <th><%= t('tasks.task_state') %></th>
             <td><%= Task.human_attribute_name("aasm_state.#{@task.aasm_state}") %></td>
           </tr>
+          <tr>
+            <th><%= t('tasks.task_label') %></th>
+            <td>
+              <% @task.labels&.each do |l| %>
+                <%= label_tag l.name, nil, class: 'badge badge-pill badge-primary' %>
+              <% end %>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
     task_detail: Task Detail
     task_limit: Task Limit
     task_state: Task Status
+    task_label: Task Label
     task_not_found: The task is not owned by this user!
     task_is_not_saved: The task is not saved.
     task_is_not_updated: The task is not updated.

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -14,6 +14,24 @@ en:
   not_admin: Access denied. Not Admin.
 
   #models
+  labels:
+    label_name: Label Name
+    label_is_not_saved: The label is not saved.
+    label_is_not_updated: The label is not updated.
+    label_is_not_destroyed: The label is not destroyed.
+    index:
+      label_list: Label List
+      add_label: Add Label
+    new:
+      adding_label: Adding Label
+    create:
+      label_saved: Label is saved.
+    edit:
+      updating_label: Updating Label
+    update:
+      label_updated: Label is updated.
+    destroy:
+      label_deleted: Label is deleted.
   tasks:
     task_user: Task's User
     task_name: Task Name

--- a/yo_task_manager/config/locales/en.yml
+++ b/yo_task_manager/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
   #models
   labels:
     label_name: Label Name
+    label_not_found: The label is not exist!
     label_is_not_saved: The label is not saved.
     label_is_not_updated: The label is not updated.
     label_is_not_destroyed: The label is not destroyed.

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -16,6 +16,7 @@ ja:
   # models
   labels:
     label_name: ラベル名
+    label_not_found: アクセスしようとしているラベルは存在してません！
     label_is_not_saved: ラベルが保存されていません。
     label_is_not_updated: ラベルが更新されていません。
     label_is_not_destroyed: ラベルが削除されていません。

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -14,6 +14,24 @@ ja:
   not_admin: アドミンではないので、アクセスできません。
 
   # models
+  labels:
+    label_name: ラベル名
+    label_is_not_saved: ラベルが保存されていません。
+    label_is_not_updated: ラベルが更新されていません。
+    label_is_not_destroyed: ラベルが削除されていません。
+    index:
+      label_list: ラベル一覧
+      add_label: ラベル追加
+    new:
+      adding_label: ラベル追加
+    create:
+      label_saved: ラベルが保存されました。
+    edit:
+      updating_label: ラベル編集
+    update:
+      label_updated: ラベルが更新されました。
+    destroy:
+      label_deleted: ラベルが削除されました。
   tasks:
     task_user: 所有ユーザー名
     task_name: タスク名

--- a/yo_task_manager/config/locales/ja.yml
+++ b/yo_task_manager/config/locales/ja.yml
@@ -38,6 +38,7 @@ ja:
     task_detail: 詳細
     task_limit: 終了期限
     task_state: ステータス
+    task_label: タスクラベル
     task_not_found: アクセスしようとしているタスクはこのユーザーのタスクではありません!
     task_is_not_saved: タスクが保存されていません。
     task_is_not_updated: タスクが更新されていません。

--- a/yo_task_manager/config/routes.rb
+++ b/yo_task_manager/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   scope '/:locale', locale: /ja|en/ do
     resources :tasks
+    resources :labels, only: %i[index new create destroy edit update]
     resources :sessions, only: %i[new create destroy]
 
     get 'login', to: 'sessions#new', as: 'login'

--- a/yo_task_manager/config/webpacker.yml
+++ b/yo_task_manager/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg
@@ -81,6 +81,9 @@ test:
 
   # Compile test packs to a separate directory
   public_output_path: packs-test
+
+  # set to false for test.
+  extract_css: false
 
 production:
   <<: *default

--- a/yo_task_manager/db/migrate/20191016043859_create_labels.rb
+++ b/yo_task_manager/db/migrate/20191016043859_create_labels.rb
@@ -1,0 +1,9 @@
+class CreateLabels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :labels do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/yo_task_manager/db/migrate/20191016043859_create_labels.rb
+++ b/yo_task_manager/db/migrate/20191016043859_create_labels.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateLabels < ActiveRecord::Migration[6.0]
   def change
     create_table :labels do |t|

--- a/yo_task_manager/db/migrate/20191016044036_create_labelings.rb
+++ b/yo_task_manager/db/migrate/20191016044036_create_labelings.rb
@@ -1,0 +1,10 @@
+class CreateLabelings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :labelings do |t|
+      t.references :task, null: false, foreign_key: true
+      t.references :label, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/yo_task_manager/db/migrate/20191016044036_create_labelings.rb
+++ b/yo_task_manager/db/migrate/20191016044036_create_labelings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateLabelings < ActiveRecord::Migration[6.0]
   def change
     create_table :labelings do |t|

--- a/yo_task_manager/db/schema.rb
+++ b/yo_task_manager/db/schema.rb
@@ -10,7 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_15_070752) do
+ActiveRecord::Schema.define(version: 2019_10_16_044036) do
+
+  create_table "labelings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "label_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["label_id"], name: "index_labelings_on_label_id"
+    t.index ["task_id"], name: "index_labelings_on_task_id"
+  end
+
+  create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -33,5 +48,7 @@ ActiveRecord::Schema.define(version: 2019_10_15_070752) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "labelings", "labels"
+  add_foreign_key "labelings", "tasks"
   add_foreign_key "tasks", "users"
 end

--- a/yo_task_manager/db/seeds.rb
+++ b/yo_task_manager/db/seeds.rb
@@ -8,6 +8,7 @@ FactoryBot.reload
 
 table_names = %w[
   users
+  labels
   tasks
 ]
 table_names.each do |table_name|

--- a/yo_task_manager/db/seeds/development/labels_seed.rb
+++ b/yo_task_manager/db/seeds/development/labels_seed.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+6.times { create(:label) }

--- a/yo_task_manager/db/seeds/development/tasks_seed.rb
+++ b/yo_task_manager/db/seeds/development/tasks_seed.rb
@@ -2,5 +2,5 @@
 
 users = User.all
 users.each do |user|
-  6.times { create(:task, user: user) }
+  6.times { create(:task, user: user, labels: Label.all.sample(2)) }
 end

--- a/yo_task_manager/spec/controllers/admin/users_controller_spec.rb
+++ b/yo_task_manager/spec/controllers/admin/users_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Admin::UsersController, type: :controller do
       expect(response).to have_http_status(:ok)
     end
     it 'assigns @users' do
-      expect(assigns(:users)).to match_array [user]
+      expect(assigns(:users)).to contain_exactly(user)
     end
     it 'renders index template' do
       expect(response).to render_template('index')

--- a/yo_task_manager/spec/controllers/labels_controller_spec.rb
+++ b/yo_task_manager/spec/controllers/labels_controller_spec.rb
@@ -38,11 +38,22 @@ RSpec.describe LabelsController, type: :controller do
   end
 
   context '#edit' do
-    it 'renders edit template' do
-      get :edit, params: { id: label, locale: 'ja' }
-      expect(response).to render_template('edit')
-      expect(response).to have_http_status(:ok)
-      expect(assigns(:label)).to eq label
+    context 'with existing label' do
+      it 'should have status 200 and renders edit template' do
+        get :edit, params: { id: label, locale: 'ja' }
+        expect(response).to render_template('edit')
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:label)).to eq label
+      end
+    end
+
+    context 'without existing label' do
+      it 'should redirect to labels_path and display warning msg' do
+        get :edit, params: { id: '99999999999', locale: 'ja' }
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(labels_path)
+        expect(flash[:danger]).to match [I18n.t('labels.label_not_found')]
+      end
     end
   end
 

--- a/yo_task_manager/spec/controllers/labels_controller_spec.rb
+++ b/yo_task_manager/spec/controllers/labels_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LabelsController, type: :controller do
+  let!(:user) { create(:user) }
+  let!(:label) { create(:label, name: '初期ラベル') }
+  before do
+    login(user)
+  end
+  context '#index' do
+    before { get :index, params: { locale: 'ja' } }
+    it 'has 200 status code' do
+      expect(response).to have_http_status(:ok)
+    end
+    it 'assigns @labels' do
+      expect(assigns(:labels)).to match_array [label]
+    end
+    it 'renders index template' do
+      expect(response).to render_template('index')
+    end
+  end
+
+  context '#new' do
+    it 'renders new template' do
+      get :new, params: { locale: 'ja' }
+      expect(response).to render_template('new')
+    end
+  end
+
+  context '#create' do
+    let(:label_params) { { name: 'ラベル名' } }
+    it 'save as new label and redirect_to labels_path with flash msg' do
+      post :create, params: { label: label_params, locale: 'ja' }
+      expect(Label.last.name).to eq 'ラベル名'
+      expect(response).to redirect_to(labels_path)
+      expect(flash[:success]).to match [I18n.t('labels.create.label_saved')]
+    end
+  end
+
+  context '#edit' do
+    it 'renders edit template' do
+      get :edit, params: { id: label, locale: 'ja' }
+      expect(response).to render_template('edit')
+      expect(response).to have_http_status(:ok)
+      expect(assigns(:label)).to eq label
+    end
+  end
+
+  context '#update' do
+    let(:new_params) { { name: '新しいラベル名' } }
+    it 'update the original label name and redirect_to labels_path with flash msg' do
+      patch :update, params: { id: label, label: new_params, locale: 'ja' }
+      updated_label = Label.find(label.id)
+      expect(updated_label.name).to eq '新しいラベル名'
+      expect(response).to redirect_to(labels_path)
+      expect(flash[:success]).to match [I18n.t('labels.update.label_updated')]
+    end
+  end
+
+  context '#destroy' do
+    it 'should delete the label and redirect_to labels_path with flash msg' do
+      delete :destroy, params: { id: label.id, locale: 'ja' }
+      expect { Label.find(label.id) }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect(response).to redirect_to(labels_path)
+      expect(flash[:success]).to match [I18n.t('labels.destroy.label_deleted')]
+    end
+  end
+end

--- a/yo_task_manager/spec/controllers/labels_controller_spec.rb
+++ b/yo_task_manager/spec/controllers/labels_controller_spec.rb
@@ -9,15 +9,14 @@ RSpec.describe LabelsController, type: :controller do
     login(user)
   end
   context '#index' do
-    before { get :index, params: { locale: 'ja' } }
-    it 'has 200 status code' do
-      expect(response).to have_http_status(:ok)
+    subject { get :index, params: { locale: 'ja' } }
+    it 'has 200 status code and renders index template' do
+      expect(subject).to have_http_status(:ok)
+      expect(subject).to render_template('index')
     end
     it 'assigns @labels' do
-      expect(assigns(:labels)).to match_array [label]
-    end
-    it 'renders index template' do
-      expect(response).to render_template('index')
+      get :index, params: { locale: 'ja' }
+      expect(assigns(:labels)).to contain_exactly(label)
     end
   end
 

--- a/yo_task_manager/spec/controllers/tasks_controller_spec.rb
+++ b/yo_task_manager/spec/controllers/tasks_controller_spec.rb
@@ -9,15 +9,14 @@ RSpec.describe TasksController, type: :controller do
     login(user)
   end
   context '#index' do
-    before { get :index, params: { locale: 'ja' } }
-    it 'has 200 status code' do
-      expect(response).to have_http_status(:ok)
+    subject { get :index, params: { locale: 'ja' } }
+    it 'has 200 status code and renders index template' do
+      expect(subject).to have_http_status(:ok)
+      expect(subject).to render_template('index')
     end
     it 'assigns @tasks' do
-      expect(assigns(:tasks)).to match_array [task]
-    end
-    it 'renders index template' do
-      expect(response).to render_template('index')
+      get :index, params: { locale: 'ja' }
+      expect(assigns(:tasks)).to contain_exactly(task)
     end
   end
 

--- a/yo_task_manager/spec/controllers/tasks_controller_spec.rb
+++ b/yo_task_manager/spec/controllers/tasks_controller_spec.rb
@@ -48,11 +48,22 @@ RSpec.describe TasksController, type: :controller do
   end
 
   context '#edit' do
-    it 'renders edit template' do
-      get :edit, params: { id: task, locale: 'ja' }
-      expect(response).to render_template('edit')
-      expect(response).to have_http_status(:ok)
-      expect(assigns(:task)).to eq task
+    context 'with existing task' do
+      it 'should have status 200 and renders edit template' do
+        get :edit, params: { id: task, locale: 'ja' }
+        expect(response).to render_template('edit')
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:task)).to eq task
+      end
+    end
+
+    context 'without existing task' do
+      it 'should redirect to tasks_path and display warning msg' do
+        get :edit, params: { id: '999999999', locale: 'ja' }
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(tasks_path)
+        expect(flash[:danger]).to match [I18n.t('tasks.task_not_found')]
+      end
     end
   end
 

--- a/yo_task_manager/spec/factories/labels.rb
+++ b/yo_task_manager/spec/factories/labels.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :label do
+    sequence(:name) { |n| "label#{n}" }
+  end
+end

--- a/yo_task_manager/spec/factories/users.rb
+++ b/yo_task_manager/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:login_id) { |n| "user_#{n}" }
     password { 'dummy1234' }
     display_name { "#{login_id}の名前" }
+    role { User.roles.keys.sample }
   end
 end

--- a/yo_task_manager/spec/models/label_spec.rb
+++ b/yo_task_manager/spec/models/label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/yo_task_manager/spec/models/label_spec.rb
+++ b/yo_task_manager/spec/models/label_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Label, type: :model do

--- a/yo_task_manager/spec/models/label_spec.rb
+++ b/yo_task_manager/spec/models/label_spec.rb
@@ -3,5 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Label, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:label) { create(:label) }
+  let!(:task) { create(:task, user: user, labels: [label]) }
+  let!(:labeling) { Labeling.find_by(label_id: label) }
+  describe 'dependent destroy on labeling' do
+    it 'when label get destroyed' do
+      label.destroy
+      expect { label.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { labeling.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
 end

--- a/yo_task_manager/spec/models/labeling_spec.rb
+++ b/yo_task_manager/spec/models/labeling_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Labeling, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/yo_task_manager/spec/models/labeling_spec.rb
+++ b/yo_task_manager/spec/models/labeling_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Labeling, type: :model do

--- a/yo_task_manager/spec/models/labeling_spec.rb
+++ b/yo_task_manager/spec/models/labeling_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe Labeling, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/yo_task_manager/spec/models/task_spec.rb
+++ b/yo_task_manager/spec/models/task_spec.rb
@@ -45,4 +45,16 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe 'dependent destroy on labeling' do
+    let(:user) { create(:user) }
+    let(:label) { create(:label) }
+    let!(:task) { create(:task, user: user, labels: [label]) }
+    let!(:labeling) { Labeling.find_by(label_id: label) }
+    it 'when task get destroyed' do
+      task.destroy
+      expect { task.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { labeling.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
 end


### PR DESCRIPTION
## 関連URL
- [ステップ20: タスクにラベルをつけられるようにしよう](https://github.com/Fablic/training#ステップ20-タスクにラベルをつけられるようにしよう)
  - タスクに複数のラベルをつけられるようにしてみましょう
  - つけたラベルで検索できるようにしてみましょう

## 実装内容
- labelsとlabelingsテーブル追加
- labelsとlabelingsモデルのassociateを追記
- labelsのCRUDsアクションとviewsを実装
- tasksのページ内にlabelsを表示、追加出来るように修正
- tasksのページ内でlabelsをransack検索出来るように修正
- specs追加

## レビューアーに伝えたいこと
- seedsも用意してあるので、ローカルで試したい場合はseed実行すればある程度試せるデータは入ります。

## Screenshot
ラベル一覧：
![image](https://user-images.githubusercontent.com/10822260/66970959-47ca2180-f0ca-11e9-8891-37a803bf5995.png)

タスク追加でラベルを複数つけられる：
![image](https://user-images.githubusercontent.com/10822260/66970981-5ca6b500-f0ca-11e9-8eff-ae06b53291a7.png)

タスク一覧にラベルの表示＆検索：
![image](https://user-images.githubusercontent.com/10822260/66970995-6fb98500-f0ca-11e9-9cb5-b75475c84102.png)
