### PR TITLE
Step_21: add rake task for maintenance.

### DIFF
--- a/yo_task_manager/app/controllers/application_controller.rb
+++ b/yo_task_manager/app/controllers/application_controller.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :render_maintenance_page, if: :maintenance_mode?
   around_action :switch_locale
   helper_method :current_user
+
+  def maintenance_mode?
+    File.exist?('tmp/maintenance.yml')
+  end
+
+  def render_maintenance_page
+    maintenance = YAML.load(File.read('tmp/maintenance.yml'))
+    @reason = maintenance['reason']
+    render 'errors/unavailable', layout: false
+  end
 
   def switch_locale(&action)
     locale = (params[:locale] if I18n.available_locales.include? params[:locale]&.to_sym) || I18n.default_locale

--- a/yo_task_manager/app/controllers/application_controller.rb
+++ b/yo_task_manager/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   def render_maintenance_page
     maintenance = YAML.load(File.read('tmp/maintenance.yml'))
     @reason = maintenance['reason']
-    render 'errors/unavailable', layout: false
+    render 'errors/unavailable', layout: false, status: :service_unavailable
   end
 
   def switch_locale(&action)

--- a/yo_task_manager/app/views/errors/unavailable.html.erb
+++ b/yo_task_manager/app/views/errors/unavailable.html.erb
@@ -1,0 +1,2 @@
+<h1>Maintenance now! メンテナンス中！</h1>
+<p><%= @reason %></p>

--- a/yo_task_manager/lib/tasks/maintenance.rake
+++ b/yo_task_manager/lib/tasks/maintenance.rake
@@ -1,5 +1,5 @@
 namespace :maintenance do
-  desc "start maintenance mode. usage: rake maintenance:start[{reason}]"
+  desc "start maintenance mode, usage: rake maintenance:start[{reason}]"
   task :start, [:reason] do |t, args|
     reason = args[:reason]
     reason = 'no reason provided.' if reason.blank?

--- a/yo_task_manager/lib/tasks/maintenance.rake
+++ b/yo_task_manager/lib/tasks/maintenance.rake
@@ -1,0 +1,20 @@
+namespace :maintenance do
+  desc "start maintenance mode. usage: rake maintenance:start[{reason}]"
+  task :start, [:reason] do |t, args|
+    reason = args[:reason]
+    reason = 'no reason provided.' if reason.blank?
+    FileUtils.mkdir('tmp') unless Dir.exists?('tmp')
+    unless File.exists?('tmp/maintenance.yml')
+      File.open('tmp/maintenance.yml', 'w+') do |f|
+        f.write("reason: #{reason}")
+      end
+    end
+  end
+
+  desc "stop maintenance mode"
+  task :stop do
+    if File.exists?('tmp/maintenance.yml')
+      File.delete('tmp/maintenance.yml')
+    end
+  end
+end


### PR DESCRIPTION
## 関連URL
- [ステップ21: メンテナンス機能を作ろう](https://github.com/Fablic/training#ステップ21-メンテナンス機能を作ろう)
  - メンテナンスを開始／終了するバッチを作ってみましょう
  - メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
  - 追加のGemを使わず、自分で実装してみましょう

## 実装内容
- rake taskの実装
- views/errors/unavailable.html.erb を追加
- application_controller.rbに before_actionを追加して、 `tmp/maintenance.yml`の存在チェック
  - 存在する場合は `render 'errors/unavailable'`させる。

## Screenshot
maintenance:start:
![image](https://user-images.githubusercontent.com/10822260/66978005-19a50b80-f0e3-11e9-8cf9-ce6b148a6f34.png)

status 503:
![image](https://user-images.githubusercontent.com/10822260/66978048-478a5000-f0e3-11e9-95c9-085aedfe54a1.png)

maintenance:stop:
![image](https://user-images.githubusercontent.com/10822260/66978023-317c8f80-f0e3-11e9-8240-855142102fe8.png)
