### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/myapp/app/assets/stylesheets/custom.scss
+++ b/myapp/app/assets/stylesheets/custom.scss
@@ -122,3 +122,7 @@ footer {
 .off {
   color: gray;
 }
+
+.label-status {
+  margin: 10px;
+}

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   helper_method :sort_column, :sort_direction
 
   def index
-    @tasks = Task.all.order(sort_column + ' ' + sort_direction)
+    @tasks = Task.all.search(params[:search]).order(sort_column + ' ' + sort_direction)
   end
 
   def show

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,8 @@ class TasksController < ApplicationController
   helper_method :sort_column, :sort_direction
 
   def index
-    @tasks = Task.all.search(params[:search]).order(sort_column + ' ' + sort_direction)
+    @search_params = task_search_params
+    @tasks = Task.all.search(@search_params).order(sort_column + ' ' + sort_direction)
   end
 
   def show
@@ -55,6 +56,10 @@ class TasksController < ApplicationController
 
     def task_params
       params.require(:task).permit(:title, :description, :priority, :status, :due_date)
+    end
+
+    def task_search_params
+      params.fetch(:search, {}).permit(:title, :status)
     end
 
     def sort_direction

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -15,11 +15,12 @@ class Task < ApplicationRecord
   validates :status,
     presence: true
 
-  def self.search(title)
-    if title
-      where(['title LIKE ?', "%#{title}%"])
-    else
-      all
-    end
+  scope :search, -> (search_params) do
+    return if search_params.blank?
+
+    title_like(search_params[:title])
+      .status_is(search_params[:status])
   end
+  scope :title_like, -> (title) { where('title LIKE ?', "%#{title}%") if title.present? }
+  scope :status_is, -> (status) { where(status: status) if status.present? }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -14,4 +14,12 @@ class Task < ApplicationRecord
 
   validates :status,
     presence: true
+
+  def self.search(title)
+    if title
+      where(['title LIKE ?', "%#{title}%"])
+    else
+      all
+    end
+  end
 end

--- a/myapp/app/views/tasks/_search.html.erb
+++ b/myapp/app/views/tasks/_search.html.erb
@@ -1,0 +1,14 @@
+<%= form_tag(tasks_path, method: :get) do %>
+  <div class="input-group" style="margin: 10px;">
+    <%= text_field_tag 'search[title]', @search_params[:title], class: 'form-control', placeholder: t('placeholder.search') %>
+    <span class="input-group-btn">
+      <%= submit_tag t('operation.search'), name: nil, class: 'btn btn-default' %>
+    </span>
+  </div>
+
+  <h4>ステータス</h4>
+  <% Task.statuses.each do |k, v| %>
+    <%= radio_button_tag('search[status]', k, false) %>
+    <%= label_tag(k, k, class: 'label-status') %>
+  <% end %>
+<% end %>

--- a/myapp/app/views/tasks/_search.html.erb
+++ b/myapp/app/views/tasks/_search.html.erb
@@ -8,7 +8,7 @@
 
   <h4>ステータス</h4>
   <% Task.statuses.each do |k, v| %>
-    <%= radio_button_tag('search[status]', k, false) %>
+    <%= radio_button_tag('search[status]', k, @search_params[:status] == k) %>
     <%= label_tag(k, k, class: 'label-status') %>
   <% end %>
 <% end %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -45,7 +45,7 @@
       <th><%= task.id %></th>
       <th class="title"><%= task.title %></th>
       <td class="priority"><span class="label label-default"><%= task.priority %></span></td>
-      <td><span class="label label-success"><%= task.status %></span></td>
+      <td class="status"><span class="label label-success"><%= task.status %></span></td>
       <td class="due_date"><%= task.due_date %></td>
       <td class="created_at"><%= I18n.l(task.created_at, format: :default) %></td>
       <td><%= link_to t('operation.detail'), task_path(task.id) %></td>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,49 +1,36 @@
 <div class="center jumbotron">
   <h1>All tasks</h1>
   <p class="lead"><%= t('message.lead') %></p>
-  <%= form_tag(tasks_path, :method => 'get') do %>
-  <div class="input-group" style="margin: 10px;">
-    <%= text_field_tag :search, params[:search], class: 'form-control', placeholder: t('placeholder.search') %>
-    <span class="input-group-btn">
-        <%= submit_tag t('operation.search'), name: nil, class: 'btn btn-default' %>
-    </span>
-  </div>
-  <h4>ステータス</h4>
-  <div class="input-group" style="margin: 10px;">
-  <% Task.statuses.each do |k, v| %>
-    <%= radio_button_tag('status', k, false) %>
-    <%= label_tag(k, k, class: 'label-status') %>
-  <% end %>
-  </div>
-<% end %>
+  <%= render 'search' %>
 </div>
+
 <table class="table table-striped">
   <thead>
     <tr>
       <th>#</th>
       <th class="sorting_asc:after"><%= t('header.title') %></th>
       <th><%= t('header.priority') %>
-        <%= link_to ({sort: 'priority', direction: 'desc', search: params[:search]}), class: is_sorted('priority', 'desc'), id: 'priority_desc' do %>
+        <%= link_to ({sort: 'priority', direction: 'desc', search: @search_params}), class: is_sorted('priority', 'desc'), id: 'priority_desc' do %>
           <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
         <% end %>
-        <%= link_to ({sort: 'priority', direction: 'asc', search: params[:search]}), class: is_sorted('priority', 'asc'), id: 'priority_asc' do %>
+        <%= link_to ({sort: 'priority', direction: 'asc', search: @search_params}), class: is_sorted('priority', 'asc'), id: 'priority_asc' do %>
           <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
         <% end %>
       </th>
       <th><%= t('header.status') %></th>
       <th><%= t('header.due_date') %>
-        <%= link_to ({sort: 'due_date', direction: 'desc', search: params[:search]}), class: is_sorted('due_date', 'desc'), id: 'due_date_desc' do %>
+        <%= link_to ({sort: 'due_date', direction: 'desc', search: @search_params}), class: is_sorted('due_date', 'desc'), id: 'due_date_desc' do %>
           <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
         <% end %>
-        <%= link_to ({sort: 'due_date', direction: 'asc', search: params[:search]}), class: is_sorted('due_date', 'asc'), id: 'due_date_asc' do %>
+        <%= link_to ({sort: 'due_date', direction: 'asc', search: @search_params}), class: is_sorted('due_date', 'asc'), id: 'due_date_asc' do %>
           <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
         <% end %>
       </th>
       <th><%= t('header.created_at') %>
-        <%= link_to ({sort: 'created_at', direction: 'desc', search: params[:search]}), class: is_sorted('created_at', 'desc'), id: 'created_at_desc' do %>
+        <%= link_to ({sort: 'created_at', direction: 'desc', search: @search_params}), class: is_sorted('created_at', 'desc'), id: 'created_at_desc' do %>
           <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
         <% end %>
-        <%= link_to ({sort: 'created_at', direction: 'asc', search: params[:search]}), class: is_sorted('created_at', 'asc'), id: 'created_at_asc' do %>
+        <%= link_to ({sort: 'created_at', direction: 'asc', search: @search_params}), class: is_sorted('created_at', 'asc'), id: 'created_at_asc' do %>
           <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
         <% end %>
       </th>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,6 +1,21 @@
 <div class="center jumbotron">
   <h1>All tasks</h1>
-  <p class="lead">This is all tasks you created.</p>
+  <p class="lead"><%= t('message.lead') %></p>
+  <%= form_tag(tasks_path, :method => 'get') do %>
+  <div class="input-group" style="margin: 10px;">
+    <%= text_field_tag :search, params[:search], class: 'form-control', placeholder: t('placeholder.search') %>
+    <span class="input-group-btn">
+        <%= submit_tag t('operation.search'), name: nil, class: 'btn btn-default' %>
+    </span>
+  </div>
+  <h4>ステータス</h4>
+  <div class="input-group" style="margin: 10px;">
+  <% Task.statuses.each do |k, v| %>
+    <%= radio_button_tag('status', k, false) %>
+    <%= label_tag(k, k, class: 'label-status') %>
+  <% end %>
+  </div>
+<% end %>
 </div>
 <table class="table table-striped">
   <thead>
@@ -8,27 +23,27 @@
       <th>#</th>
       <th class="sorting_asc:after"><%= t('header.title') %></th>
       <th><%= t('header.priority') %>
-        <%= link_to ({sort: 'priority', direction: 'desc'}), class: is_sorted('priority', 'desc'), id: 'priority_desc' do %>
+        <%= link_to ({sort: 'priority', direction: 'desc', search: params[:search]}), class: is_sorted('priority', 'desc'), id: 'priority_desc' do %>
           <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
         <% end %>
-        <%= link_to ({sort: 'priority', direction: 'asc'}), class: is_sorted('priority', 'asc'), id: 'priority_asc' do %>
+        <%= link_to ({sort: 'priority', direction: 'asc', search: params[:search]}), class: is_sorted('priority', 'asc'), id: 'priority_asc' do %>
           <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
         <% end %>
       </th>
       <th><%= t('header.status') %></th>
       <th><%= t('header.due_date') %>
-        <%= link_to ({sort: 'due_date', direction: 'desc'}), class: is_sorted('due_date', 'desc'), id: 'due_date_desc' do %>
+        <%= link_to ({sort: 'due_date', direction: 'desc', search: params[:search]}), class: is_sorted('due_date', 'desc'), id: 'due_date_desc' do %>
           <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
         <% end %>
-        <%= link_to ({sort: 'due_date', direction: 'asc'}), class: is_sorted('due_date', 'asc'), id: 'due_date_asc' do %>
+        <%= link_to ({sort: 'due_date', direction: 'asc', search: params[:search]}), class: is_sorted('due_date', 'asc'), id: 'due_date_asc' do %>
           <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
         <% end %>
       </th>
       <th><%= t('header.created_at') %>
-        <%= link_to ({sort: 'created_at', direction: 'desc'}), class: is_sorted('created_at', 'desc'), id: 'created_at_desc' do %>
+        <%= link_to ({sort: 'created_at', direction: 'desc', search: params[:search]}), class: is_sorted('created_at', 'desc'), id: 'created_at_desc' do %>
           <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
         <% end %>
-        <%= link_to ({sort: 'created_at', direction: 'asc'}), class: is_sorted('created_at', 'asc'), id: 'created_at_asc' do %>
+        <%= link_to ({sort: 'created_at', direction: 'asc', search: params[:search]}), class: is_sorted('created_at', 'asc'), id: 'created_at_asc' do %>
           <span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span>
         <% end %>
       </th>

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
     update: 'Update'
     remove: 'Remove'
     detail: 'Detail'
+    search: 'Search'
   header:
     title: 'Title'
     priority: 'Priority'
@@ -24,6 +25,10 @@ en:
     remove:
       success: 'Task is deleted successfully.'
       fail: 'Failed to delete task. Please try again.'
+  placeholder:
+    search: 'Search with title.'
+  message:
+    lead: "Let's search task."
   error:
     count: 'The form contains %{count}.'
   date:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
     update: '更新'
     remove: '削除'
     detail: '詳細'
+    search: '検索'
   header:
     title: 'タスク名'
     priority: '優先度'
@@ -24,6 +25,10 @@ ja:
     remove:
       success: 'タスクを削除しました。'
       fail: 'タスクの削除に失敗しました。もう一度お試しください。'
+  placeholder:
+    search: 'タスク名で検索'
+  message:
+    lead: 'タスク検索はこちらから'
   error:
     count: '%{count}件のエラーがあります。'
   date:

--- a/myapp/db/migrate/20191029043544_add_index_to_tasks_status.rb
+++ b/myapp/db/migrate/20191029043544_add_index_to_tasks_status.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasksStatus < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_07_060050) do
+ActiveRecord::Schema.define(version: 2019_10_29_043544) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", limit: 16, null: false
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2019_10_07_060050) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["due_date"], name: "index_tasks_on_due_date"
+    t.index ["status"], name: "index_tasks_on_status"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -63,4 +63,18 @@ RSpec.describe Task, type: :model do
       expect(task.errors[:description]).to be_present
     end
   end
+
+  context 'When searching with title' do
+    let!(:task) { create(:task, user_id: user.id, title: 'hoge') }
+    it 'the record which has that title is found' do
+      expect(Task.find_by(title: 'hoge')).to have_attributes(title: 'hoge')
+    end
+  end
+
+  context 'When searching with status' do
+    let!(:task) { create(:task, user_id: user.id, status: 1) }
+    it 'the record which has that status is found' do
+      expect(Task.find_by(status: 'InProgress')).to have_attributes(status: 'InProgress')
+    end
+  end
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -188,4 +188,43 @@ RSpec.describe "Tasks", type: :system do
       expect(page).to have_content I18n.t('flash.remove.success')
     end
   end
+
+  context 'When a user searches by title' do
+    let!(:task) { create(:task, title: 'hoge') }
+
+    it 'Find one record' do
+      visit tasks_path
+      fill_in 'search[title]', with: 'hoge'
+      click_on I18n.t('operation.search')
+
+      title = page.all('.title')
+      expect(title[0].text).to eq 'hoge'
+    end
+  end
+
+  context 'When a user searches by status' do
+    let!(:task) { create(:task, status: 2) }
+
+    it 'Find one record' do
+      visit tasks_path
+      choose 'search_status_Closed'
+      click_on I18n.t('operation.search')
+
+      status = page.all('.status')
+      expect(status[0].text).to eq 'Closed'
+    end
+  end
+
+  context 'When a usr searches by title and status' do
+    let!(:task) { create(:task, title: 'fuga', status: 1) }
+    it 'Find one record' do
+      visit tasks_path
+      fill_in 'search[title]', with: 'fuga'
+      choose 'search_status_InProgress'
+      click_on I18n.t('operation.search')
+
+      title = page.all('.title')
+      expect(title[0].text).to eq 'fuga'
+    end
+  end
 end


### PR DESCRIPTION
## 実施内容
- 一覧画面でタイトルとステータスでの検索を実装
- 検索に対してmodel spec, system specを追加
- `tasks.status` カラムにindex追加
- 検索時のログを見て発行されるSQLの変化を確認
```
# タスク一覧表示した時
SELECT `tasks`.* FROM `tasks` ORDER BY created_at desc

# "新規"というワードでタイトル検索した時
SELECT `tasks`.* FROM `tasks` WHERE (title LIKE '%新規%') ORDER BY created_at desc

# "新規"というワードでタイトル検索+ステータスがopenで検索した時
SELECT `tasks`.* FROM `tasks` WHERE (title LIKE '%新規%') AND `tasks`.`status` = 0 ORDER BY created_at desc
```

##  課題
[ステップ13: ステータスを追加して、検索できるようにしよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)
