### PR TITLE
ステップ18: ユーザの管理画面を実装しよう

### DIFF
--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -6,33 +6,38 @@ class Admin::UsersController < ApplicationController
     @users = User.preload(:tasks).page(params[:page]).per(PER)
   end
 
-  def create
+  def show
+    @user = User.preload(:tasks).find(params[:id])
   end
 
   def edit
+    @user = User.find(params[:id])
   end
 
   def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      flash[:success] = t('flash.update.success')
+      redirect_to admin_user_path(@user.id)
+    else
+      flash.now[:danger] = t('flash.update.fail')
+      render :edit
+    end
   end
 
   def destroy
+    @user = User.find(params[:id])
+    if @user.destroy
+      flash[:success] = t('flash.remove.success')
+    else
+      flash[:success] = t('flash.remove.fail')
+    end
+    redirect_to admin_users_path
   end
 
   private
 
-  def task_params
-    params.require(:task).permit(:title, :description, :priority, :status, :due_date)
+  def user_params
+    params.require(:user).permit(:name, :email)
   end
-
-  def task_search_params
-    params.fetch(:search, {}).permit(:title, :status)
-  end
-
-  # def sort_direction
-  #   %w[asc desc].include?(params[:direction]) ? params[:direction] : 'desc'
-  # end
-
-  # def sort_column
-  #   Task.column_names.include?(params[:sort]) ? 'tasks.' + params[:sort] : 'tasks.created_at'
-  # end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ class Admin::UsersController < ApplicationController
     if @user.destroy
       flash[:success] = t('flash.remove.success')
     else
-      flash[:success] = t('flash.remove.fail')
+      flash[:danger] = t('flash.remove.fail')
     end
     redirect_to admin_users_path
   end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,0 +1,38 @@
+class Admin::UsersController < ApplicationController
+  helper_method :sort_column, :sort_direction
+  PER = 20
+
+  def index
+    @users = User.preload(:tasks).page(params[:page]).per(PER)
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  private
+
+  def task_params
+    params.require(:task).permit(:title, :description, :priority, :status, :due_date)
+  end
+
+  def task_search_params
+    params.fetch(:search, {}).permit(:title, :status)
+  end
+
+  # def sort_direction
+  #   %w[asc desc].include?(params[:direction]) ? params[:direction] : 'desc'
+  # end
+
+  # def sort_column
+  #   Task.column_names.include?(params[:sort]) ? 'tasks.' + params[:sort] : 'tasks.created_at'
+  # end
+end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -27,7 +27,7 @@ class TasksController < ApplicationController
       flash[:success] = t('flash.create.success')
       redirect_to task_path(@task.id)
     else
-      flash.now[:fail] = t('flash.create.fail')
+      flash.now[:danger] = t('flash.create.fail')
       render :new
     end
   end
@@ -43,7 +43,7 @@ class TasksController < ApplicationController
       flash[:success] = t('flash.update.success')
       redirect_to task_path(@task.id)
     else
-      flash.now[:fail] = t('flash.update.fail')
+      flash.now[:danger] = t('flash.update.fail')
       render :edit
     end
   end

--- a/myapp/app/helpers/admin/users_helper.rb
+++ b/myapp/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/myapp/app/helpers/admin/users_helper.rb
+++ b/myapp/app/helpers/admin/users_helper.rb
@@ -1,2 +1,0 @@
-module Admin::UsersHelper
-end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,18 +1,21 @@
 class User < ApplicationRecord
-  has_many :tasks
+  enum role: { General: 0, Admin: 1 }
+  has_many :tasks, dependent: :delete_all
+  has_one :user_session, dependent: :destroy
 
   has_secure_password validations: true
+  validates :password, length: { minimum: 2 }, on: :create
+  validates :password, length: { minimum: 2 }, allow_nil: true, on: :update
 
   validates :name,
     presence: true,
     length: { maximum: 32 }
 
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email,
     presence: true,
-    format: { with: VALID_EMAIL_REGEX },
+    format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
     uniqueness: { case_sensitive:  true },
-    length: { maximum: 128 }
+    length: { maximum: 124 }
 
   validates :role,
     presence: true

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -11,9 +11,10 @@ class User < ApplicationRecord
     presence: true,
     length: { maximum: 32 }
 
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email,
     presence: true,
-    format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
+    format: { with: VALID_EMAIL_REGEX },
     uniqueness: { case_sensitive:  true },
     length: { maximum: 124 }
 

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  enum role: { General: 0, Admin: 1 }
+  enum role: { general: 0, admin: 1 }
   has_many :tasks, dependent: :delete_all
   has_one :user_session, dependent: :destroy
 

--- a/myapp/app/models/user_session.rb
+++ b/myapp/app/models/user_session.rb
@@ -1,4 +1,6 @@
 class UserSession < ApplicationRecord
+  belongs_to :user
+
   def self.new_remember_token
     SecureRandom.urlsafe_base64
   end

--- a/myapp/app/views/admin/users/_form.html.erb
+++ b/myapp/app/views/admin/users/_form.html.erb
@@ -1,0 +1,21 @@
+<%= render 'shared/error_messages', model: f.object %>
+<div class="form-group row">
+  <%= f.label :name, class: 'col-sm-2 col-form-label' %>
+  <div class="col-sm-10">
+    <%= f.text_field :name, size: 32, class: 'form-control' %>
+  </div>
+</div>
+<div class="form-group row">
+  <%= f.label :email, class: 'col-sm-2 col-form-label' %>
+  <div class="col-sm-10">
+    <%= f.text_field :email, size: 124, class: 'form-control' %>
+  </div>
+</div>
+<div class="form-group row">
+  <%= f.label :role, class: 'col-sm-2 col-form-label' %>
+  <div class="col-sm-10">
+    <%= f.select :role, User.roles.keys, class: 'form-control' %>
+  </div>
+</div>
+
+<%= f.submit :class => 'btn btn-primary pull-right' %>

--- a/myapp/app/views/admin/users/_form.html.erb
+++ b/myapp/app/views/admin/users/_form.html.erb
@@ -14,7 +14,7 @@
 <div class="form-group row">
   <%= f.label :role, class: 'col-sm-2 col-form-label' %>
   <div class="col-sm-10">
-    <%= f.select :role, User.roles.keys, class: 'form-control' %>
+    <%= f.select :role, User.roles.map { |k, v| [t("enums.user.role.#{k}"), v] }, class: 'form-control' %>
   </div>
 </div>
 

--- a/myapp/app/views/admin/users/edit.html.erb
+++ b/myapp/app/views/admin/users/edit.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, 'User Edit') %>
+<div class="page-header">
+  <h1>Update User Information</h1>
+</div>
+<div class="row">
+  <%= form_for @user, url: admin_user_path(@user.id) do |f| %>
+    <%= render "form", { f: f } %>
+  <% end %>
+  <%= link_to admin_users_path do %>
+    <span class="glyphicon glyphicon-menu-left"></span><%= t('header.back') %>
+  <% end %>
+</div>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -6,8 +6,8 @@
   <thead>
     <tr>
       <th>#</th>
-      <th class="sorting_asc:after"><%= t('header.user_name') %></th>
-      <th><%= t('header.email') %></th>
+      <th class="sorting_asc:after"><%= t('activerecord.attributes.user.name') %></th>
+      <th><%= t('activerecord.attributes.user.email') %></th>
       <th><%= t('header.task_count') %></th>
       <th></th>
       <th></th>
@@ -21,9 +21,9 @@
       <th class="name"><%= user.name %></th>
       <td class="email"><%= user.email %></td>
       <td><span class="badge"><%= user.tasks.to_a.count %></span></td>
-      <td><%= link_to admin_user_path(user.id) do %><span class="glyphicon glyphicon-user"></span><% end %></td>
-      <td><%= link_to edit_admin_user_path(user.id) do %><span class="glyphicon glyphicon-pencil"></span><% end %></td>
-      <td><%= link_to admin_user_path(user.id), method: 'delete', data: { confirm: t('message.confirm') } do %><span class="glyphicon glyphicon-remove"></span><% end %></td>
+      <td><%= link_to admin_user_path(user.id), id: 'user_show' do %><span class="glyphicon glyphicon-user"></span><% end %></td>
+      <td><%= link_to edit_admin_user_path(user.id), id: 'user_edit' do %><span class="glyphicon glyphicon-pencil"></span><% end %></td>
+      <td><%= link_to admin_user_path(user.id), id: 'user_delete', method: 'delete', data: { confirm: t('message.confirm') } do %><span class="glyphicon glyphicon-remove"></span><% end %></td>
     </tr>
     <% end %>
   </tbody>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,7 +1,5 @@
 <div class="center jumbotron">
   <h1>User List</h1>
-  <%# <p class="lead"><%= t('message.lead', name: @user.name) %></p> %>
-  <%# <%= render 'search' %> %>
 </div>
 
 <table class="table table-striped">

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -21,9 +21,9 @@
       <th class="name"><%= user.name %></th>
       <td class="email"><%= user.email %></td>
       <td><span class="badge"><%= user.tasks.to_a.count %></span></td>
-      <td><%= link_to t('operation.detail'), admin_user_path(user.id) %></td>
-      <td><%= link_to t('operation.update'), edit_admin_user_path(user.id) %></td>
-      <td><%= link_to t('operation.remove'), admin_user_path(user.id), method: 'delete', data: { confirm: t('message.confirm') } %></td>
+      <td><%= link_to admin_user_path(user.id) do %><span class="glyphicon glyphicon-user"></span><% end %></td>
+      <td><%= link_to edit_admin_user_path(user.id) do %><span class="glyphicon glyphicon-pencil"></span><% end %></td>
+      <td><%= link_to admin_user_path(user.id), method: 'delete', data: { confirm: t('message.confirm') } do %><span class="glyphicon glyphicon-remove"></span><% end %></td>
     </tr>
     <% end %>
   </tbody>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,0 +1,33 @@
+<div class="center jumbotron">
+  <h1>User List</h1>
+  <%# <p class="lead"><%= t('message.lead', name: @user.name) %></p> %>
+  <%# <%= render 'search' %> %>
+</div>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>#</th>
+      <th class="sorting_asc:after"><%= t('header.user_name') %></th>
+      <th><%= t('header.email') %></th>
+      <th><%= t('header.task_count') %></th>
+      <th></th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+    <tr>
+      <th><%= user.id %></th>
+      <th class="name"><%= user.name %></th>
+      <td class="email"><%= user.email %></td>
+      <td><%= user.tasks.to_a.count %></td>
+      <td><%= link_to t('operation.detail'), user_path(user.id) %></td>
+      <td><%= link_to t('operation.update'), edit_user_path(user.id) %></td>
+      <td><%= link_to t('operation.remove'), user_path(user.id), method: 'delete' %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate @users %>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -22,10 +22,10 @@
       <th><%= user.id %></th>
       <th class="name"><%= user.name %></th>
       <td class="email"><%= user.email %></td>
-      <td><%= user.tasks.to_a.count %></td>
-      <td><%= link_to t('operation.detail'), user_path(user.id) %></td>
-      <td><%= link_to t('operation.update'), edit_user_path(user.id) %></td>
-      <td><%= link_to t('operation.remove'), user_path(user.id), method: 'delete' %></td>
+      <td><span class="badge"><%= user.tasks.to_a.count %></span></td>
+      <td><%= link_to t('operation.detail'), admin_user_path(user.id) %></td>
+      <td><%= link_to t('operation.update'), edit_admin_user_path(user.id) %></td>
+      <td><%= link_to t('operation.remove'), admin_user_path(user.id), method: 'delete', data: { confirm: t('message.confirm') } %></td>
     </tr>
     <% end %>
   </tbody>

--- a/myapp/app/views/admin/users/show.html.erb
+++ b/myapp/app/views/admin/users/show.html.erb
@@ -6,13 +6,13 @@
   <table class="table table-striped table-bordered">
     <tbody>
       <tr>
-        <th><%= t('header.user_name') %></th><td><%= @user.name %></td>
+        <th><%= t('activerecord.attributes.user.name') %></th><td><%= @user.name %></td>
       </tr>
       <tr>
-        <th><%= t('header.email') %></th><td><%= @user.email %></td>
+        <th><%= t('activerecord.attributes.user.email') %></th><td><%= @user.email %></td>
       </tr>
       <tr>
-        <th><%= t('header.created_at') %></th><td><%= I18n.l(@user.created_at, format: :default) %></td>
+        <th><%= t('activerecord.attributes.user.created_at') %></th><td><%= I18n.l(@user.created_at, format: :default) %></td>
       </tr>
     </tbody>
   </table>
@@ -22,11 +22,11 @@
 <% end %>
 
 <div class="pull-right">
-  <%= link_to edit_admin_user_path(@user.id), class: 'btn btn-primary' do %>
-    <%= t('operation.update') %> <span class="glyphicon glyphicon-pencil"></span>
+  <%= link_to edit_admin_user_path(@user.id), class: 'btn btn-primary', id: 'user_edit' do %>
+    <span class="glyphicon glyphicon-pencil"></span>
   <% end %>
-  <%= link_to admin_user_path(@user.id), method: 'delete', class: 'btn btn-danger', data: { confirm: t('message.confirm') } do %>
-    <%= t('operation.remove') %> <span class="glyphicon glyphicon-remove"></span>
+  <%= link_to admin_user_path(@user.id), id: 'user_delete', method: 'delete', class: 'btn btn-danger', data: { confirm: t('message.confirm') } do %>
+    <span class="glyphicon glyphicon-remove"></span>
   <% end %>
 </div>
 
@@ -38,11 +38,11 @@
   <thead>
     <tr>
       <th>#</th>
-      <th class="sorting_asc:after"><%= t('header.title') %></th>
-      <th><%= t('header.priority') %></th>
-      <th><%= t('header.status') %></th>
-      <th><%= t('header.due_date') %></th>
-      <th><%= t('header.created_at') %></th>
+      <th class="sorting_asc:after"><%= t('activerecord.attributes.task.title') %></th>
+      <th><%= t('activerecord.attributes.task.priority') %></th>
+      <th><%= t('activerecord.attributes.task.status') %></th>
+      <th><%= t('activerecord.attributes.task.due_date') %></th>
+      <th><%= t('activerecord.attributes.task.created_at') %></th>
     </tr>
   </thead>
   <tbody>

--- a/myapp/app/views/admin/users/show.html.erb
+++ b/myapp/app/views/admin/users/show.html.erb
@@ -1,0 +1,60 @@
+<% provide(:title, 'Task Registration') %>
+<div class="page-header">
+  <h1>User Profile</h1>
+</div>
+<div class="panel panel-default">
+  <table class="table table-striped table-bordered">
+    <tbody>
+      <tr>
+        <th><%= t('header.user_name') %></th><td><%= @user.name %></td>
+      </tr>
+      <tr>
+        <th><%= t('header.email') %></th><td><%= @user.email %></td>
+      </tr>
+      <tr>
+        <th><%= t('header.created_at') %></th><td><%= I18n.l(@user.created_at, format: :default) %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<%= link_to root_path do %>
+  <span class="glyphicon glyphicon-menu-left"></span><%= t('header.back') %>
+<% end %>
+
+<div class="pull-right">
+  <%= link_to edit_admin_user_path(@user.id), class: 'btn btn-primary' do %>
+    <%= t('operation.update') %> <span class="glyphicon glyphicon-pencil"></span>
+  <% end %>
+  <%= link_to admin_user_path(@user.id), method: 'delete', class: 'btn btn-danger', data: { confirm: t('message.confirm') } do %>
+    <%= t('operation.remove') %> <span class="glyphicon glyphicon-remove"></span>
+  <% end %>
+</div>
+
+<div class="page-header">
+  <h1>Task</h1>
+</div>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>#</th>
+      <th class="sorting_asc:after"><%= t('header.title') %></th>
+      <th><%= t('header.priority') %></th>
+      <th><%= t('header.status') %></th>
+      <th><%= t('header.due_date') %></th>
+      <th><%= t('header.created_at') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @user.tasks.each do |task| %>
+    <tr>
+      <th><%= task.id %></th>
+      <th class="title"><%= task.title %></th>
+      <td class="priority"><span class="label label-default"><%= task.priority %></span></td>
+      <td class="status"><span class="label label-success"><%= task.status %></span></td>
+      <td class="due_date"><%= task.due_date %></td>
+      <td class="created_at"><%= I18n.l(task.created_at, format: :default) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/myapp/app/views/layouts/_header.html.erb
+++ b/myapp/app/views/layouts/_header.html.erb
@@ -5,6 +5,7 @@
       <ul class="nav navbar-nav navbar-right">
         <% if signed_in? %>
           <li><%= link_to new_task_path do %><%= t('operation.create') %> <span class="glyphicon glyphicon-plus"></span><% end %></li>
+          <li><%= link_to 'Admin', admin_users_path %>
           <li><%= link_to 'Home', root_path %></li>
           <li><%= link_to 'Logout', login_path, method: :delete %></li>
         <% else %>

--- a/myapp/app/views/layouts/_header.html.erb
+++ b/myapp/app/views/layouts/_header.html.erb
@@ -4,7 +4,7 @@
     <nav>
       <ul class="nav navbar-nav navbar-right">
         <% if signed_in? %>
-          <li><%= link_to t('operation.create'), new_task_path %></li>
+          <li><%= link_to new_task_path do %><%= t('operation.create') %> <span class="glyphicon glyphicon-plus"></span><% end %></li>
           <li><%= link_to 'Home', root_path %></li>
           <li><%= link_to 'Logout', login_path, method: :delete %></li>
         <% else %>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -13,7 +13,9 @@
     <%= render 'layouts/header' %>
     <div class="container">
       <% flash.each do |message_type, message| %>
-        <div class="alert alert-<%= message_type %>"><%= message %></div>
+        <div class="alert alert-<%= message_type %>">
+          <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span><%= message %>
+        </div>
       <% end %>
       <%= yield %>
       <%= render 'layouts/footer' %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,36 +1,36 @@
 <%= render 'shared/error_messages', model: f.object %>
 <div class="form-group row">
   <%= f.label :title, class: 'col-sm-2 col-form-label' %>
-  <span class="label label-danger">Required</span>
-  <div class="col-sm-5">
+  <span class="label label-danger col-sm-1">Required</span>
+  <div class="col-sm-9">
     <%= f.text_field :title, size: 124, class: 'form-control' %>
   </div>
 </div>
 <div class="form-group row">
-  <%= f.label :description, class: 'col-sm-2 col-form-label' %>
-  <div class="col-sm-5">
+  <%= f.label :description, class: 'col-sm-3 col-form-label' %>
+  <div class="col-sm-9">
     <%= f.text_area :description, class: 'form-control', rows: 3 %>
   </div>
 </div>
 <div class="form-group row">
   <%= f.label :priority, class: 'col-sm-2 col-form-label' %>
-  <span class="label label-danger">Required</span>
-  <div class="col-sm-5">
+  <span class="label label-danger col-sm-1">Required</span>
+  <div class="col-sm-9">
     <%= f.select :priority, Task.priorities.keys, class: 'form-control' %>
   </div>
 </div>
 <div class="form-group row">
   <%= f.label :status, class: 'col-sm-2 col-form-label' %>
-  <span class="label label-danger">Required</span>
-  <div class="col-sm-5">
+  <span class="label label-danger col-sm-1">Required</span>
+  <div class="col-sm-8">
     <%= f.select :status, Task.statuses.keys, class: 'form-control' %>
   </div>
 </div>
 <div class="form-group row">
-  <%= f.label :due_date, class: 'col-sm-2 col-form-label' %>
-  <div class="col-sm-5">
+  <%= f.label :due_date, class: 'col-sm-3 col-form-label' %>
+  <div class="col-sm-9">
     <%= f.date_field :due_date, class: 'form-control' %>
   </div>
 </div>
 
-<%= f.submit :class => 'btn btn-primary' %>
+<%= f.submit :class => 'btn btn-primary pull-right' %>

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -4,5 +4,7 @@
   <%= form_for @task, url: task_path(@task.id) do |f| %>
     <%= render "form", { f: f } %>
   <% end %>
+  <%= link_to tasks_path do %>
+  <span class="glyphicon glyphicon-menu-left"></span><%= t('header.back') %>
+<% end %>
 </div>
-<%= link_to sprintf("<< %s", t('header.back')), tasks_path %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -50,7 +50,7 @@
       <td class="created_at"><%= I18n.l(task.created_at, format: :default) %></td>
       <td><%= link_to t('operation.detail'), task_path(task.id) %></td>
       <td><%= link_to t('operation.update'), edit_task_path(task.id) %></td>
-      <td><%= link_to t('operation.remove'), task_path(task.id), method: 'delete' %></td>
+      <td><%= link_to t('operation.remove'), task_path(task.id), method: 'delete', data: { confirm: t('message.confirm') } %></td>
     </tr>
     <% end %>
   </tbody>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -30,8 +30,14 @@
       <thead><tr><th><%= t('header.description') %></th></tr></thead>
       <tbody><tr><td><%= @task.description %></td><tr></tbody>
     </table>
-    <%= link_to t('operation.update'), edit_task_path(@task.id), class: 'btn btn-primary' %>
-    <%= link_to t('operation.remove'), task_path(@task.id), method: 'delete', class: 'btn btn-danger' %>
+    <%= link_to edit_task_path(@task.id), class: 'btn btn-primary' do %>
+      <%= t('operation.update') %> <span class="glyphicon glyphicon-pencil"></span>
+    <% end %>
+    <%= link_to task_path(@task.id), method: 'delete', class: 'btn btn-danger', data: { confirm: t('message.confirm') } do %>
+      <%= t('operation.remove') %> <span class="glyphicon glyphicon-remove"></span>
+    <% end %>
   </div>
 </div>
-<%= link_to sprintf("<< %s", t('header.list')), root_path %>
+<%= link_to root_path do %>
+  <span class="glyphicon glyphicon-menu-left"></span><%= t('header.back') %>
+<% end %>

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -15,6 +15,8 @@ en:
     updated_at: 'Updated Date'
     description: 'Description'
     list: 'Task List'
+    email: 'Email'
+    task_count: 'Tasks'
     back: 'Back'
   flash:
     create:

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
     search: 'Search with title.'
   message:
     lead: 'Hello, %{name}.'
+    confirm: 'Are you sure to delete?'
   error:
     count: 'The form contains %{count} error(s).'
   date:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -1,6 +1,6 @@
 ja:
   operation:
-    create: '新規作成'
+    create: '作成'
     update: '更新'
     remove: '削除'
     detail: '詳細'
@@ -17,17 +17,17 @@ ja:
     list: 'タスク一覧'
     email: 'メールアドレス'
     task_count: 'タスク数'
-    back: '戻る'
+    back: '一覧に戻る'
   flash:
     create:
       success: 'タスクを作成しました。'
       fail: 'タスクの新規登録に失敗しました。もう一度お試しください。'
     update:
-      success: 'タスクを更新しました。'
-      fail: 'タスクの更新に失敗しました。もう一度お試しください。'
+      success: '更新しました。'
+      fail: '更新に失敗しました。もう一度お試しください。'
     remove:
-      success: 'タスクを削除しました。'
-      fail: 'タスクの削除に失敗しました。もう一度お試しください。'
+      success: '削除しました。'
+      fail: '削除に失敗しました。もう一度お試しください。'
     login:
       fail: 'メールアドレス、またはパスワードが無効です。'
     user:
@@ -36,6 +36,7 @@ ja:
     search: 'タスク名で検索'
   message:
     lead: '%{name}さん、こんにちは！'
+    confirm: '削除してよろしいですか？'
   error:
     count: '%{count}件のエラーがあります。'
   date:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -15,6 +15,8 @@ ja:
     updated_at: '更新日'
     description: '内容'
     list: 'タスク一覧'
+    email: 'メールアドレス'
+    task_count: 'タスク数'
     back: '戻る'
   flash:
     create:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -7,7 +7,6 @@ ja:
     search: '検索'
   header:
     title: 'タスク名'
-    user_name: 'ユーザ'
     priority: '優先度'
     status: 'ステータス'
     due_date: '期限'
@@ -15,7 +14,6 @@ ja:
     updated_at: '更新日'
     description: '内容'
     list: 'タスク一覧'
-    email: 'メールアドレス'
     task_count: 'タスク数'
     back: '一覧に戻る'
   flash:

--- a/myapp/config/locales/models/ja.yml
+++ b/myapp/config/locales/models/ja.yml
@@ -1,15 +1,27 @@
 ja:
   activerecord:
     models:
-      task: 'Task'
+      task: Task
+      user: User
     attributes:
       task:
-        id: 'ID'
-        title: 'タスク名'
-        description: '内容'
-        user_id: 'ユーザID'
-        priority: '優先度'
-        status: 'ステータス'
-        due_date: '期限'
-        created_at: '作成日'
-        updated_at: '更新日'
+        id: ID
+        title: タスク名
+        description: 内容
+        user_id: ユーザID
+        priority: 優先度
+        status: ステータス
+        due_date: 期限
+        created_at: 登録日
+        updated_at: 更新日
+      user:
+        id: ID
+        name: ユーザ名
+        email: メールアドレス
+        role: 権限
+        created_at: 登録日
+  enums:
+    user:
+      role:
+        general: 一般
+        admin: 管理者

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -7,4 +7,8 @@ Rails.application.routes.draw do
   post   'login', to: 'sessions#create'
   delete 'login', to: 'sessions#destroy'
   get    'signup', to: 'users#new'
+
+  namespace :admin do
+    resources :users
+  end
 end

--- a/myapp/spec/system/admin/users_spec.rb
+++ b/myapp/spec/system/admin/users_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  before do
+    driven_by(:rack_test)
+    @user = create(:user)
+    @task = create_list(:task, 10, user_id: @user.id)
+    login(@user)
+  end
+
+  context 'When a user opens user list' do
+    it 'Success to show an user list' do
+      visit admin_users_path
+
+      expect(page).to have_content @user.name
+      expect(page).to have_content @user.email
+      expect(page).to have_content 10
+      expect(page).to have_link 'user_show', href: admin_user_path(@user.id)
+      expect(page).to have_link 'user_edit', href: edit_admin_user_path(@user.id)
+      expect(page).to have_link 'user_delete', href: admin_user_path(@user.id)
+    end
+  end
+
+  context 'When a user opens detail user information page' do
+    it 'Show user name, email, created_at and tasks' do
+      visit admin_user_path(@user.id)
+
+      expect(page).to have_content @user.name
+      expect(page).to have_content @user.email
+      expect(page).to have_content @user.created_at.strftime("%Y-%m-%d %H:%M")
+      expect(page).to have_link 'user_edit', href: edit_admin_user_path(@user.id)
+      expect(page).to have_link 'user_delete', href: admin_user_path(@user.id)
+    end
+  end
+
+  context 'When a user tries to edit an user information' do
+    it 'Success to update an user information' do
+      visit edit_admin_user_path(@user.id)
+      fill_in 'user[name]', with: 'テスト太郎'
+      fill_in 'user[email]', with: 'test.taro@example.com'
+      click_on '更新する'
+
+      expect(page).to have_content '更新しました。'
+    end
+  end
+
+  context 'When a user deletes the other user on user list page' do
+    it 'Success to delete user' do
+      visit admin_users_path
+      click_on 'user_delete'
+
+      expect(page).to have_content '削除しました。'
+    end
+  end
+
+  context 'When a user deletes the other user on user detail page' do
+    it 'Success to delete user' do
+      visit admin_user_path(@user.id)
+      click_on 'user_delete'
+
+      expect(page).to have_content '削除しました。'
+    end
+  end
+
+  context 'When there is validation error' do
+    it 'Fail to update a user because of the length of name' do
+      visit edit_admin_user_path(@user.id)
+      fill_in 'user[name]', with: 'テ' * 33
+      fill_in 'user[email]', with: 'test.taro@example.com'
+      click_on '更新する'
+
+      expect(page).to have_content '更新に失敗しました。もう一度お試しください。'
+      expect(page).to have_content '1件のエラーがあります。'
+      expect(page).to have_content 'ユーザ名は32文字以内で入力してください'
+    end
+
+    it 'Fail to update a user because empty name' do
+      visit edit_admin_user_path(@user.id)
+      fill_in 'user[name]', with: ''
+      fill_in 'user[email]', with: 'test.taro@example.com'
+      click_on '更新する'
+
+      expect(page).to have_content '更新に失敗しました。もう一度お試しください。'
+      expect(page).to have_content '1件のエラーがあります。'
+      expect(page).to have_content 'ユーザ名を入力してください'
+    end
+
+    it 'Fail to update a user because of the format of email' do
+      visit edit_admin_user_path(@user.id)
+      fill_in 'user[name]', with: 'テスト'
+      fill_in 'user[email]', with: 'test'
+      click_on '更新する'
+
+      expect(page).to have_content '更新に失敗しました。もう一度お試しください。'
+      expect(page).to have_content '1件のエラーがあります。'
+      expect(page).to have_content 'メールアドレスは不正な値です'
+    end
+
+    it 'Fail to update a user because empty email' do
+      visit edit_admin_user_path(@user.id)
+      fill_in 'user[name]', with: 'テスト'
+      fill_in 'user[email]', with: ''
+      click_on '更新する'
+
+      expect(page).to have_content '更新に失敗しました。もう一度お試しください。'
+      expect(page).to have_content '2件のエラーがあります。'
+      expect(page).to have_content 'メールアドレスを入力してください'
+    end
+  end
+end


### PR DESCRIPTION
## 実施内容
- 画面上に管理メニューを追加（URLは先頭に `/admin` がつく）
- ユーザ一覧・作成・更新・削除を実装
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示
- ユーザが作成したタスクの一覧が見られるようにする
- ユーザを削除したら、そのユーザが抱えているタスクを削除する

ユーザを削除した時のクエリ（関連する `tasks` , `user_sessions` からもレコードが消えていることを確認）
```
  UserSession Load (0.5ms)  SELECT `user_sessions`.* FROM `user_sessions` WHERE `user_sessions`.`session` = 'f7f1103dcb8706286ec69a2740d07f4dfed691c5eff18b5d3c2d4f2bdd12244a' LIMIT 1
  ↳ app/controllers/application_controller.rb:10:in `current_user'
  User Load (0.3ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 9 LIMIT 1
  ↳ app/controllers/admin/users_controller.rb:29:in `destroy'
   (0.2ms)  BEGIN
  ↳ app/controllers/admin/users_controller.rb:30:in `destroy'
  Task Destroy (1.6ms)  DELETE FROM `tasks` WHERE `tasks`.`user_id` = 9
  ↳ app/controllers/admin/users_controller.rb:30:in `destroy'
  UserSession Load (0.3ms)  SELECT `user_sessions`.* FROM `user_sessions` WHERE `user_sessions`.`user_id` = 9 LIMIT 1
  ↳ app/controllers/admin/users_controller.rb:30:in `destroy'
  UserSession Destroy (0.8ms)  DELETE FROM `user_sessions` WHERE `user_sessions`.`id` = 1
  ↳ app/controllers/admin/users_controller.rb:30:in `destroy'
  User Destroy (0.3ms)  DELETE FROM `users` WHERE `users`.`id` = 9
  ↳ app/controllers/admin/users_controller.rb:30:in `destroy'
   (2.1ms)  COMMIT
  ↳ app/controllers/admin/users_controller.rb:30:in `destroy'
```

## 補足
- 次のstepで管理者ユーザを導入するため、今の時点ではログインしていれば誰でも管理画面が閲覧可能です

## 課題
[ステップ18: ユーザの管理画面を実装しよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)