### PR TITLE
sho_step11

### DIFF
--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,3 +1,3 @@
 class Task < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 50 }
 end

--- a/myapp/db/migrate/20191107095142_add_not_null_and_limit_to_tasks.rb
+++ b/myapp/db/migrate/20191107095142_add_not_null_and_limit_to_tasks.rb
@@ -1,0 +1,9 @@
+class AddNotNullAndLimitToTasks < ActiveRecord::Migration[5.2]
+  def up
+    change_column :tasks, :name, :string, null: false
+  end
+
+  def down
+    change_column :tasks, :name, :string, null: true
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_29_073203) do
+ActiveRecord::Schema.define(version: 2019_11_07_095142) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "priority"
     t.datetime "deadline"
     t.integer "status"
-    t.string "name"
+    t.string "name", null: false
     t.text "description"
     t.bigint "user_id"
     t.datetime "created_at", null: false

--- a/myapp/spec/features/task_spec.rb
+++ b/myapp/spec/features/task_spec.rb
@@ -1,14 +1,34 @@
 require 'rails_helper'
 
 RSpec.feature "Task management", type: :feature do
-  scenario "User creates a new task" do
+  scenario "User creates a new task with name that length is 50" do
     visit new_task_path
 
-    fill_in "名前", with: "My Task"
+    fill_in "名前", with: 'a' * 50
     fill_in "説明", with: "説明"
     click_button "送信"
 
     expect(page).to have_text("新しいタスクが作成されました！")
+  end
+
+  scenario "User can't create a new task with name that length is invalid" do
+    visit new_task_path
+
+    fill_in "名前", with: 'a' * 51
+    fill_in "説明", with: "説明"
+    click_button "送信"
+
+    expect(page).to have_text("名前は50文字以内")
+  end
+
+  scenario "User can't create a new task with empty name" do
+    visit new_task_path
+
+    fill_in "名前", with: ""
+    fill_in "説明", with: "説明"
+    click_button "送信"
+
+    expect(page).to have_text("名前を入力してください")
   end
 
   scenario "User edits a task." do

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  context "with invalid values" do
+    it "blank name" do
+      task = Task.new
+      expect(task.save).to eq(false)
+    end
+
+    it "name too long" do
+      task = Task.new
+      task.name = 'a' * 51
+      expect(task.save).to eq(false)
+    end
+  end
+
+  context "with valid values" do
+    it "name" do
+      task = Task.new
+      task.name = 'a' * 50
+      expect(task.save).to eq(true)
+    end
+  end
+end

--- a/myapp/test/fixtures/tasks.yml
+++ b/myapp/test/fixtures/tasks.yml
@@ -1,17 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  priority: 1
-  deadline: 2019-10-29 07:32:03
-  status: 1
   name: MyString
   description: MyText
-  user_id: 1
 
 two:
-  priority: 2
-  deadline: 2019-10-29 07:32:03
-  status: 1
-  name: MyString2
-  description: MyText2
-  user_id: 1
+  name: MyString
+  description: MyText

--- a/myapp/test/models/task_test.rb
+++ b/myapp/test/models/task_test.rb
@@ -16,4 +16,10 @@ class TaskTest < ActiveSupport::TestCase
                  0123456789"
     assert_not task.save
   end
+
+  test "should save with valid data" do
+    task = Task.new
+    task.name = "valid name."
+    assert task.save
+  end
 end

--- a/myapp/test/models/task_test.rb
+++ b/myapp/test/models/task_test.rb
@@ -8,18 +8,13 @@ class TaskTest < ActiveSupport::TestCase
 
   test "should not save task with name length exceed 50" do
     task = Task.new
-    task.name = "0123456789
-                 0123456789
-                 0123456789
-                 0123456789
-                 0123456789
-                 0123456789"
+    task.name = 'a' * 51
     assert_not task.save
   end
 
-  test "should save with valid data" do
+  test "should save with valid length for name" do
     task = Task.new
-    task.name = "valid name."
+    task.name = 'a' * 50
     assert task.save
   end
 end

--- a/myapp/test/models/task_test.rb
+++ b/myapp/test/models/task_test.rb
@@ -1,7 +1,19 @@
 require 'test_helper'
 
 class TaskTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should not save task without name" do
+    task = Task.new
+    assert_not task.save
+  end
+
+  test "should not save task with name length exceed 50" do
+    task = Task.new
+    task.name = "0123456789
+                 0123456789
+                 0123456789
+                 0123456789
+                 0123456789
+                 0123456789"
+    assert_not task.save
+  end
 end


### PR DESCRIPTION
# Rails研修step11のPRです #
## 概要

- training[step11](https://github.com/Fablic/training/tree/wengtadashi#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)の対応
- 動作確認する際はこちらを[Dockerアプリの起動方法について](https://github.com/Fablic/training/tree/wengtadashi#%E3%82%B9%E3%83%86%E3%83%83%E3%83%974-docker%E3%81%AB%E6%85%A3%E3%82%8C%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)

## 対応内容

- [x] add test for task model
- [x] show messages of validation error.
- [x] nameにdbのnot nullを追加
- [x] nameに文字数制限（50文字）を追加

## 備考
- 時間的制約があるため、スキップ可能のstepはスキップさせて頂いてます
- 一部先読みで付けたattrはfixtureから削除してます

## スクショ
### テスト結果
![Screen Shot 2019-11-08 at 10 41 55](https://user-images.githubusercontent.com/1732022/68442506-89a33f00-0214-11ea-8c20-8a227ac61309.png)

### NOT NULL エラーメッセージ
<img width="366" alt="Screen Shot 2019-11-08 at 10 42 16" src="https://user-images.githubusercontent.com/1732022/68442522-9758c480-0214-11ea-843e-e326ddaba237.png">
### Length over 50 エラーメッセージ
<img width="334" alt="Screen Shot 2019-11-08 at 10 42 27" src="https://user-images.githubusercontent.com/1732022/68442530-a0e22c80-0214-11ea-8fd5-dd66b8a1eb68.png">
