### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替えましょう 

### DIFF
--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -34,7 +34,7 @@ class TasksController < ApplicationController
 
   # GET /tasks/
   def index
-    @tasks = Task.all.order('created_at DESC')
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   # DELETE /task/:id

--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -34,7 +34,7 @@ class TasksController < ApplicationController
 
   # GET /tasks/
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order('created_at DESC')
   end
 
   # DELETE /task/:id

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -5,6 +5,20 @@ require 'rails_helper'
 RSpec.describe 'Tasks', type: :system do
   let(:task) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: 0) }
 
+  it 'show tasks ordered by latest dates' do
+    visit tasks_new_path
+    fill_in 'task_title', with: 'first'
+    click_button '追加'
+
+    visit tasks_new_path
+    fill_in 'task_title', with: 'second'
+    click_button '追加'
+
+    within('ul') do
+      expect(page.text).to match(/second\nfirst/)
+    end
+  end
+
   it 'show task detail' do
     visit tasks_show_path(task)
 


### PR DESCRIPTION
### ステップ10: タスク一覧を作成日時の順番で並び替えましょう

### 概要
[ステップ10: タスク一覧を作成日時の順番で並び替えましょう](https://github.com/Fablic/training/#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

### 対応内容

- タスクが作成日時順に並ぶよう、tasks_controllerを修正
- 新しい順番になっているか確認するテストを追加

### 備考