### PR TITLE
ステップ11: バリデーションを設定してみよう

### DIFF
--- a/todo/README.md
+++ b/todo/README.md
@@ -5,15 +5,30 @@
 
 * Ruby version
 
+2.6.5
+
 * System dependencies
 
 * Configuration
+
+* Setup
+
+```cassandraql
+docker-compose up -d
+rails db:create 
+rails db:migrate
+rails s
+```
 
 * Database creation
 
 * Database initialization
 
 * How to run the test suite
+
+```cassandraql
+rails spec
+```
 
 * Services (job queues, cache servers, search engines, etc.)
 

--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -9,12 +9,9 @@ class TasksController < ApplicationController
   # POST /tasks/create
   def create
     @task = Task.new(task_params)
-    if @task.save
-      flash[:success] = 'Success!'
-      redirect_to tasks_path
-    else
-      render 'tasks/new'
-    end
+    return render :new unless @task.save
+    flash[:success] = 'Success!'
+    redirect_to tasks_path
   end
 
   # GET /tasks/:id/edit/
@@ -25,12 +22,9 @@ class TasksController < ApplicationController
   # PATCH /tasks/:id
   def update
     @task = Task.find(params[:id])
-    if @task.update(task_params)
-      flash[:success] = 'Success!'
-      redirect_to tasks_path
-    else
-      render 'tasks/edit'
-    end
+    return render :edit unless @task.update(task_params)
+    flash[:success] = 'Success!'
+    redirect_to tasks_path
   end
 
   # GET /tasks/:id

--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -9,9 +9,12 @@ class TasksController < ApplicationController
   # POST /tasks/create
   def create
     @task = Task.new(task_params)
-    return unless @task.save
-    flash[:success] = 'Success!'
-    redirect_to tasks_path
+    if @task.save
+      flash[:success] = 'Success!'
+      redirect_to tasks_path
+    else
+      render 'tasks/new'
+    end
   end
 
   # GET /tasks/:id/edit/
@@ -22,9 +25,12 @@ class TasksController < ApplicationController
   # PATCH /tasks/:id
   def update
     @task = Task.find(params[:id])
-    return unless @task.update(task_params)
-    flash[:success] = 'Success!'
-    redirect_to tasks_path
+    if @task.update(task_params)
+      flash[:success] = 'Success!'
+      redirect_to tasks_path
+    else
+      render 'tasks/edit'
+    end
   end
 
   # GET /tasks/:id

--- a/todo/app/models/task.rb
+++ b/todo/app/models/task.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  validates :title, :status, presence: true
+  validates :title, length: { maximum: 250 }
+  validates :status, inclusion: { in: 0..2 }
 end

--- a/todo/app/views/tasks/_error_message.html.erb
+++ b/todo/app/views/tasks/_error_message.html.erb
@@ -1,0 +1,9 @@
+<% if task.errors.any? %>
+  <div>
+    <ul>
+    <% task.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/todo/app/views/tasks/edit.html.erb
+++ b/todo/app/views/tasks/edit.html.erb
@@ -1,3 +1,5 @@
 <h1>Edit Task</h1>
 
+<%= render partial: 'error_message', locals: { task: @task } %>
+
 <%= render partial: 'form', locals: { task: @task, form_path: tasks_update_path(@task), button_name: t('button.edit')} %>

--- a/todo/app/views/tasks/new.html.erb
+++ b/todo/app/views/tasks/new.html.erb
@@ -1,3 +1,5 @@
 <h1>New Task</h1>
 
+<%= render partial: 'error_message', locals: { task: @task } %>
+
 <%= render partial: 'form', locals: { task: @task, form_path: tasks_create_path, button_name: t('button.add')} %>

--- a/todo/config/locales/ja.yml
+++ b/todo/config/locales/ja.yml
@@ -6,3 +6,16 @@ ja:
     back: 戻る
     edit: 編集
     delete: 削除
+  activerecord:
+    errors:
+      messages:
+        blank: を入力してください
+        too_long: が長すぎます
+        inclusion: は対象外の値です
+    models:
+      task: タスク
+    attributes:
+      task:
+        title: タスク名
+        description: 詳細
+        status: ステータス

--- a/todo/db/migrate/20191122060314_change_title_and_status_to_tasks.rb
+++ b/todo/db/migrate/20191122060314_change_title_and_status_to_tasks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ChangeTitleAndStatusToTasks < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :tasks, :title, false
+    change_column_null :tasks, :status, false
+    change_column_default :tasks, :status, from: nil, to: 0
+  end
+end

--- a/todo/db/schema.rb
+++ b/todo/db/schema.rb
@@ -12,11 +12,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_115_061_829) do
+ActiveRecord::Schema.define(version: 20_191_122_060_314) do
   create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'title'
+    t.string 'title', null: false
     t.text 'description'
-    t.integer 'status'
+    t.integer 'status', default: 0, null: false
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
   end

--- a/todo/spec/models/task_spec.rb
+++ b/todo/spec/models/task_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  let(:title) { 'title' }
+  let(:status) { 0 }
+  let(:description) { 'a' * 250 }
+  subject { Task.new(title: title, description: description, status: status) }
+
+  describe 'when valid' do
+    context 'with valid attributes' do
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with a max-length title' do
+      let(:title) { 'a' * 250 }
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with a valid status' do
+      let(:status) { 2 }
+      it { expect(subject).to be_valid }
+    end
+  end
+
+  describe 'when not valid' do
+    context 'without a title' do
+      let(:title) { nil }
+      it { expect(subject).to_not be_valid }
+    end
+
+    context 'without a status' do
+      let(:status) { nil }
+      it { expect(subject).to_not be_valid }
+
+      let(:status) { 4 }
+      it { expect(subject).to_not be_valid }
+    end
+
+    context 'with a title over max length' do
+      let(:title) { 'a' * 251 }
+      it { expect(subject).to_not be_valid }
+    end
+  end
+end

--- a/todo/spec/models/task_spec.rb
+++ b/todo/spec/models/task_spec.rb
@@ -27,20 +27,20 @@ RSpec.describe Task, type: :model do
   describe 'when not valid' do
     context 'without a title' do
       let(:title) { nil }
-      it { expect(subject).to_not be_valid }
+      it { expect(subject).not_to be_valid }
     end
 
     context 'without a status' do
       let(:status) { nil }
-      it { expect(subject).to_not be_valid }
+      it { expect(subject).not_to be_valid }
 
       let(:status) { 4 }
-      it { expect(subject).to_not be_valid }
+      it { expect(subject).not_to be_valid }
     end
 
     context 'with a title over max length' do
       let(:title) { 'a' * 251 }
-      it { expect(subject).to_not be_valid }
+      it { expect(subject).not_to be_valid }
     end
   end
 end

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -27,36 +27,74 @@ RSpec.describe 'Tasks', type: :system do
     expect(page).to have_content '未着手'
   end
 
-  it 'create new task' do
-    visit tasks_new_path
+  describe 'when create new task' do
+    context 'with valid attributes' do
+      it 'fill all items' do
+        visit tasks_new_path
+        fill_in 'task_title', with: '新規タスク'
+        fill_in 'task_description', with: '新規タスク詳細'
+        select '着手', from: 'task_status'
 
-    fill_in 'task_title', with: '新規タスク'
-    fill_in 'task_description', with: '新規タスク詳細'
-    select '着手', from: 'task_status'
+        click_button '追加'
 
-    click_button '追加'
+        expect(page).to have_content 'Success!'
+        expect(page).to have_content '新規タスク'
+      end
+    end
 
-    expect(page).to have_content 'Success!'
-    expect(page).to have_content '新規タスク'
+    context 'with invalid attributes' do
+      it 'no title' do
+        visit tasks_new_path
+        click_button '追加'
+        expect(page).to have_content 'タスク名 を入力してください'
+      end
+
+      it 'too long title' do
+        visit tasks_new_path
+        fill_in 'task_title', with: 'a' * 251
+        click_button '追加'
+        expect(page).to have_content 'タスク名 が長すぎます'
+      end
+    end
   end
 
-  it 'update task' do
-    visit tasks_edit_path(task)
+  describe 'when update task' do
+    context 'with valid attributes' do
+      it 'fill all items' do
+        visit tasks_edit_path(task)
 
-    expect(page).to have_field 'task_title', with: 'タスク１'
-    expect(page).to have_field 'task_description', with: 'タスク１詳細'
-    expect(page).to have_select 'task_status',
-                                selected: '未着手',
-                                options: %w[未着手 着手 完了]
+        expect(page).to have_field 'task_title', with: 'タスク１'
+        expect(page).to have_field 'task_description', with: 'タスク１詳細'
+        expect(page).to have_select 'task_status',
+                                    selected: '未着手',
+                                    options: %w[未着手 着手 完了]
 
-    fill_in 'task_title', with: 'タスク１修正'
-    fill_in 'task_description', with: 'タスク１詳細修正'
-    select '完了', from: 'task_status'
+        fill_in 'task_title', with: 'タスク１修正'
+        fill_in 'task_description', with: 'タスク１詳細修正'
+        select '完了', from: 'task_status'
 
-    click_button '更新'
+        click_button '更新'
 
-    expect(page).to have_content 'Success!'
-    expect(page).to have_content 'タスク１修正'
+        expect(page).to have_content 'Success!'
+        expect(page).to have_content 'タスク１修正'
+      end
+    end
+
+    context 'with invalid attributes' do
+      it 'no title' do
+        visit tasks_edit_path(task)
+        fill_in 'task_title', with: ''
+        click_button '更新'
+        expect(page).to have_content 'タスク名 を入力してください'
+      end
+
+      it 'too long title' do
+        visit tasks_edit_path(task)
+        fill_in 'task_title', with: 'a' * 251
+        click_button '更新'
+        expect(page).to have_content 'タスク名 が長すぎます'
+      end
+    end
   end
 
   it 'delete task' do


### PR DESCRIPTION
### ステップ11: バリデーションを設定してみよう

### 概要
[ステップ11: バリデーションを設定してみよう
](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)

### 対応内容

- `rails generate migration ChangeTitleAndStatusToTasks`でマイグレーションファイル作成
    - titleとstatusを必須項目に変更
- modelにTaskにバリデーション追加
    - Titleに必須チェックとレングスチェック追加
    - Statusに必須チェックと範囲チェック追加
- 画面にバリデーションエラーを表示

### 備考

[カラムを変更する](https://railsguides.jp/active_record_migrations.html#%E3%82%AB%E3%83%A9%E3%83%A0%E3%82%92%E5%A4%89%E6%9B%B4%E3%81%99%E3%82%8B)
[Active Record バリデーション](https://railsguides.jp/active_record_validations.html)