### PR TITLE
ステップ12: 終了期限を追加しよう

### DIFF
--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -54,6 +54,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :description, :status)
+    params.require(:task).permit(:title, :description, :status, :due_date)
   end
 end

--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -40,7 +40,7 @@ class TasksController < ApplicationController
 
   # GET /tasks/
   def index
-    @tasks = Task.all.order('created_at DESC')
+    @tasks = Task.all.order(sort_column => :desc)
   end
 
   # DELETE /task/:id
@@ -55,5 +55,9 @@ class TasksController < ApplicationController
 
   def task_params
     params.require(:task).permit(:title, :description, :status, :due_date)
+  end
+
+  def sort_column
+    params.key?(:sort) ? params[:sort] : :created_at
   end
 end

--- a/todo/app/models/task.rb
+++ b/todo/app/models/task.rb
@@ -4,4 +4,9 @@ class Task < ApplicationRecord
   validates :title, :status, presence: true
   validates :title, length: { maximum: 250 }
   validates :status, inclusion: { in: 0..2 }
+  validate :due_date_cannot_be_in_past
+
+  def due_date_cannot_be_in_past
+    errors.add(:due_date, I18n.t('activerecord.errors.messages.past_time')) if due_date.present? && due_date < Time.zone.today
+  end
 end

--- a/todo/app/views/tasks/_form.html.erb
+++ b/todo/app/views/tasks/_form.html.erb
@@ -9,6 +9,9 @@
   <%= f.label :status %>
   <%= f.select :status, status_text.invert, {} %>
 
+  <%= f.label :due_date %>
+  <%= f.datetime_field :due_date %>
+
   <%= f.submit button_name %>
 
 <% end %>

--- a/todo/app/views/tasks/index.html.erb
+++ b/todo/app/views/tasks/index.html.erb
@@ -4,10 +4,18 @@
 
 <%= link_to 'Create New Task', tasks_new_path %>
 
+<div>
+  Sort by
+  <%= link_to t('activerecord.attributes.task.due_date'), sort: 'due_date' %> /
+  <%= link_to t('activerecord.attributes.task.created_at'), sort: 'created_at' %>
+</div>
+
 <% if @tasks.any? %>
 <ul>
   <% @tasks.each do |task| %>
-  <li><%= link_to task.title, tasks_show_path(task) %></li>
+  <li>
+    <%= link_to task.title, tasks_show_path(task) %>
+  </li>
   <% end %>
 </ul>
 <% end %>

--- a/todo/app/views/tasks/show.html.erb
+++ b/todo/app/views/tasks/show.html.erb
@@ -1,10 +1,12 @@
 <h1><%= @task.title %></h1>
 
 <dl>
-  <dt>説明</dt>
+  <dt><%= t('activerecord.attributes.task.description') %></dt>
   <dd><%= @task.description %></dd>
-  <dt>ステータス</dt>
+  <dt><%= t('activerecord.attributes.task.status') %></dt>
   <dd><%= status_text[@task.status] %></dd>
+  <dt><%= t('activerecord.attributes.task.due_date') %></dt>
+  <dd><%= @task.due_date %></dd>
 </dl>
 
 <%= link_to t('link.back'), tasks_path %>

--- a/todo/config/locales/en.yml
+++ b/todo/config/locales/en.yml
@@ -30,6 +30,10 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  activerecord:
+    errors:
+      messages:
+        past_time: Cannot be in the past
   button:
     add: Add
     edit: Update

--- a/todo/config/locales/ja.yml
+++ b/todo/config/locales/ja.yml
@@ -20,3 +20,6 @@ ja:
         title: タスク名
         description: 詳細
         status: ステータス
+        due_date: 終了期限
+        created_at: 作成日
+        modified_at: 更新日

--- a/todo/config/locales/ja.yml
+++ b/todo/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
         blank: を入力してください
         too_long: が長すぎます
         inclusion: は対象外の値です
+        past_time: 過去の日付は使えません
     models:
       task: タスク
     attributes:

--- a/todo/db/migrate/20191125051149_add_due_date_to_tasks.rb
+++ b/todo/db/migrate/20191125051149_add_due_date_to_tasks.rb
@@ -2,6 +2,6 @@
 
 class AddDueDateToTasks < ActiveRecord::Migration[6.0]
   def change
-    add_column :tasks, :due_date, :datetime
+    add_column :tasks, :due_date, :datetime, after: :status
   end
 end

--- a/todo/db/migrate/20191125051149_add_due_date_to_tasks.rb
+++ b/todo/db/migrate/20191125051149_add_due_date_to_tasks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDueDateToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :due_date, :datetime
+  end
+end

--- a/todo/db/schema.rb
+++ b/todo/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,13 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_125_051_149) do
-  create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'title', null: false
-    t.text 'description'
-    t.integer 'status', default: 0, null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.datetime 'due_date'
+ActiveRecord::Schema.define(version: 2019_11_25_051149) do
+
+  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description"
+    t.integer "status", default: 0, null: false
+    t.datetime "due_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
+
 end

--- a/todo/db/schema.rb
+++ b/todo/db/schema.rb
@@ -12,12 +12,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_122_060_314) do
+ActiveRecord::Schema.define(version: 20_191_125_051_149) do
   create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
     t.string 'title', null: false
     t.text 'description'
     t.integer 'status', default: 0, null: false
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+    t.datetime 'due_date'
   end
 end

--- a/todo/spec/models/task_spec.rb
+++ b/todo/spec/models/task_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Task, type: :model do
   let(:title) { 'title' }
   let(:status) { 0 }
   let(:description) { 'a' * 250 }
-  subject { Task.new(title: title, description: description, status: status) }
+  let(:due_date) { Time.zone.local(2100, 12, 31, 0, 0) }
+  subject { Task.new(title: title, description: description, status: status, due_date: due_date) }
 
   describe 'when valid' do
     context 'with valid attributes' do
@@ -20,6 +21,11 @@ RSpec.describe Task, type: :model do
 
     context 'with a valid status' do
       let(:status) { 2 }
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with a due_date today' do
+      let(:due_date) { Time.zone.now }
       it { expect(subject).to be_valid }
     end
   end
@@ -40,6 +46,11 @@ RSpec.describe Task, type: :model do
 
     context 'with a title over max length' do
       let(:title) { 'a' * 251 }
+      it { expect(subject).to_not be_valid }
+    end
+
+    context 'with a past due_date' do
+      let(:due_date) { Time.zone.now.yesterday }
       it { expect(subject).to_not be_valid }
     end
   end

--- a/todo/spec/rails_helper.rb
+++ b/todo/spec/rails_helper.rb
@@ -62,4 +62,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.before(:each) do |example|
+    if example.metadata[:type] == :system
+      driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+    end
+  end
 end

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -5,15 +5,28 @@ require 'rails_helper'
 RSpec.describe 'Tasks', type: :system do
   let(:task) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: 0, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
 
-  it 'show tasks ordered by latest dates' do
+  it 'show tasks ordered by sort link' do
     visit tasks_new_path
     fill_in 'task_title', with: 'first'
+    fill_in 'task_due_date', with: Time.zone.local(2021, 1, 1, 0, 0)
     click_button '追加'
 
     visit tasks_new_path
     fill_in 'task_title', with: 'second'
+    fill_in 'task_due_date', with: Time.zone.local(2020, 1, 1, 0, 0)
     click_button '追加'
 
+    within('ul') do
+      expect(page.text).to match(/second\nfirst/)
+    end
+
+    click_link '終了期限'
+    within('ul') do
+      expect(page.text).to match(/first\nsecond/)
+    end
+
+    click_link '作成日'
+    sleep(0.5)
     within('ul') do
       expect(page.text).to match(/second\nfirst/)
     end

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
-  let(:task) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: 0) }
+  let(:task) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: 0, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
 
   it 'show tasks ordered by latest dates' do
     visit tasks_new_path
@@ -30,8 +30,10 @@ RSpec.describe 'Tasks', type: :system do
   it 'create new task' do
     visit tasks_new_path
 
+    time = Time.zone.local(2020, 10, 10, 10, 10)
     fill_in 'task_title', with: '新規タスク'
     fill_in 'task_description', with: '新規タスク詳細'
+    fill_in 'task_due_date', with: time
     select '着手', from: 'task_status'
 
     click_button '追加'
@@ -49,8 +51,10 @@ RSpec.describe 'Tasks', type: :system do
                                 selected: '未着手',
                                 options: %w[未着手 着手 完了]
 
+    time = Time.zone.local(2020, 10, 10, 10, 10)
     fill_in 'task_title', with: 'タスク１修正'
     fill_in 'task_description', with: 'タスク１詳細修正'
+    fill_in 'task_due_date', with: time
     select '完了', from: 'task_status'
 
     click_button '更新'

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     click_link '終了期限'
+    sleep(0.5)
     within('ul') do
       expect(page.text).to match(/first\nsecond/)
     end


### PR DESCRIPTION
### ステップ12: 終了期限を追加しよう ★ スキップ可能

### 概要
[ステップ12: 終了期限を追加しよう ★ スキップ可能](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E7%B5%82%E4%BA%86%E6%9C%9F%E9%99%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

### 対応内容

- 新規・編集画面に終了期限の入力スペースを追加
    - 過去の日付は入れられないようにバリデーション追加
- 一覧画面を終了期限でソートできるようにする

### 備考

[単独のマイグレーションを作成する](https://railsguides.jp/active_record_migrations.html#%E5%8D%98%E7%8B%AC%E3%81%AE%E3%83%9E%E3%82%A4%E3%82%B0%E3%83%AC%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B)
[その他のフォームヘルパー（日付）](https://railsguides.jp/form_helpers.html#%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E3%83%98%E3%83%AB%E3%83%91%E3%83%BC)
[カスタムメソッド](https://railsguides.jp/active_record_validations.html#%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%A0%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89)