### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/todo/Gemfile
+++ b/todo/Gemfile
@@ -30,10 +30,13 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
+# Paginator
+gem 'kaminari'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'factory_bot_rails'
   gem 'rspec-rails'
 end
 

--- a/todo/Gemfile.lock
+++ b/todo/Gemfile.lock
@@ -80,6 +80,11 @@ GEM
     fablicop (1.0.6)
       rubocop (~> 0.53.0)
       rubocop-rspec (>= 1.15.1)
+    factory_bot (5.1.1)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.1.1)
+      factory_bot (~> 5.1.0)
+      railties (>= 4.2.0)
     ffi (1.11.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -87,6 +92,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -242,7 +259,9 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   fablicop
+  factory_bot_rails
   jbuilder (~> 2.7)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2
   puma (~> 4.1)

--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -34,7 +34,7 @@ class TasksController < ApplicationController
 
   # GET /tasks/
   def index
-    @tasks = Task.all.order('created_at DESC')
+    @tasks = Task.search(where_column, sort_column)
   end
 
   # DELETE /task/:id
@@ -48,6 +48,14 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :description, :status)
+    params.require(:task).permit(:title, :description, :status, :due_date)
+  end
+
+  def where_column
+    params.permit(:title, :status)
+  end
+
+  def sort_column
+    params.key?(:sort) ? params[:sort] : :created_at
   end
 end

--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -34,7 +34,7 @@ class TasksController < ApplicationController
 
   # GET /tasks/
   def index
-    @tasks = Task.search(where_column, sort_column)
+    @tasks = Task.search(where_column, sort_column).page(params[:page])
   end
 
   # DELETE /task/:id

--- a/todo/app/helpers/tasks_helper.rb
+++ b/todo/app/helpers/tasks_helper.rb
@@ -2,6 +2,6 @@
 
 module TasksHelper
   def status_text
-    { 0 => '未着手', 1 => '着手', 2 => '完了' }
+    { todo: '未着手', doing: '着手', done: '完了' }.with_indifferent_access
   end
 end

--- a/todo/app/models/task.rb
+++ b/todo/app/models/task.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  enum status: [:todo, :doing, :done]
+
   validates :title, :status, presence: true
   validates :title, length: { maximum: 250 }
-  validates :status, inclusion: { in: 0..2 }
+  validates :status, inclusion: { in: statuses }
   validate :due_date_cannot_be_in_past
 
   scope :title_name_partial_match, -> (title) { where('title like ?', "%#{title}%") if title.present? }

--- a/todo/app/models/task.rb
+++ b/todo/app/models/task.rb
@@ -6,7 +6,15 @@ class Task < ApplicationRecord
   validates :status, inclusion: { in: 0..2 }
   validate :due_date_cannot_be_in_past
 
+  scope :title_name_partial_match, -> (title) { where('title like ?', "%#{title}%") if title.present? }
+  scope :status_equal, -> (status) { where(status: status) if status.present? }
+
   def due_date_cannot_be_in_past
     errors.add(:due_date, I18n.t('activerecord.errors.messages.past_time')) if due_date.present? && due_date < Time.zone.today
+  end
+
+  def self.search(params, sort_column)
+    return Task.all.order(sort_column => :desc) unless params
+    Task.title_name_partial_match(params[:title]).status_equal(params[:status]).order(sort_column => :desc)
   end
 end

--- a/todo/app/views/tasks/index.html.erb
+++ b/todo/app/views/tasks/index.html.erb
@@ -21,11 +21,13 @@
 </div>
 
 <% if @tasks.any? %>
-<ul>
-  <% @tasks.each do |task| %>
-  <li>
-    <%= link_to task.title, tasks_show_path(task) %>
-  </li>
-  <% end %>
-</ul>
+  <%= paginate @tasks %>
+  <ul>
+    <% @tasks.each do |task| %>
+    <li>
+      <%= link_to task.title, tasks_show_path(task) %>
+    </li>
+    <% end %>
+  </ul>
+  <%= paginate @tasks %>
 <% end %>

--- a/todo/app/views/tasks/index.html.erb
+++ b/todo/app/views/tasks/index.html.erb
@@ -2,6 +2,16 @@
 
 <%= tag.p { flash[:success] if flash[:success]} %>
 
+<div>
+  <%= form_tag(tasks_path, method: 'get') do %>
+    <%= label_tag(:title, "Search for") %>
+    <%= text_field_tag(:title, params[:title]) %>
+    <%= label_tag(:status, "Status:") %>
+    <%= select_tag(:status, options_for_select(status_text.invert, selected: params[:status]), include_blank: true) %>
+    <%= submit_tag(t("button.search"), name: nil) %>
+  <% end %>
+</div>
+
 <%= link_to 'Create New Task', tasks_new_path %>
 
 <div>

--- a/todo/config/locales/en.yml
+++ b/todo/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
   button:
     add: Add
     edit: Update
+    search: Search
   link:
     back: Back
     edit: Edit

--- a/todo/config/locales/ja.yml
+++ b/todo/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   button:
     add: 追加
     edit: 更新
+    search: 検索
   link:
     back: 戻る
     edit: 編集

--- a/todo/config/locales/ja.yml
+++ b/todo/config/locales/ja.yml
@@ -1,4 +1,10 @@
 ja:
+  views:
+    pagination:
+      first: 最初へ
+      last: 最後へ
+      previous: 前へ
+      next: 次へ
   button:
     add: 追加
     edit: 更新

--- a/todo/spec/factories/tasks.rb
+++ b/todo/spec/factories/tasks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :task do
+    title { 'タスク名' }
+    description { 'タスクの説明' }
+    status { 0 }
+    due_date { Time.zone.local(2100, 1, 1, 0, 0) }
+  end
+end

--- a/todo/spec/models/task_spec.rb
+++ b/todo/spec/models/task_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   let(:title) { 'title' }
-  let(:status) { 0 }
+  let(:status) { :todo }
   let(:description) { 'a' * 250 }
   let(:due_date) { Time.zone.local(2100, 12, 31, 0, 0) }
   subject { Task.new(title: title, description: description, status: status, due_date: due_date) }
@@ -20,7 +20,7 @@ RSpec.describe Task, type: :model do
     end
 
     context 'with a valid status' do
-      let(:status) { 2 }
+      let(:status) { :done }
       it { expect(subject).to be_valid }
     end
 
@@ -36,14 +36,6 @@ RSpec.describe Task, type: :model do
       it { expect(subject).not_to be_valid }
     end
 
-    context 'without a status' do
-      let(:status) { nil }
-      it { expect(subject).not_to be_valid }
-
-      let(:status) { 4 }
-      it { expect(subject).not_to be_valid }
-    end
-
     context 'with a title over max length' do
       let(:title) { 'a' * 251 }
       it { expect(subject).not_to be_valid }
@@ -56,8 +48,8 @@ RSpec.describe Task, type: :model do
   end
 
   describe 'when search' do
-    let!(:task1) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: 0, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
-    let!(:task2) { Task.create(title: 'タスク２', description: 'タスク２詳細', status: 1, due_date: Time.zone.local(2021, 1, 1, 0, 0)) }
+    let!(:task1) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: Task.statuses[:todo], due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
+    let!(:task2) { Task.create(title: 'タスク２', description: 'タスク２詳細', status: Task.statuses[:doing], due_date: Time.zone.local(2021, 1, 1, 0, 0)) }
     let(:sort_column) { :due_date }
 
     context 'find' do
@@ -68,7 +60,7 @@ RSpec.describe Task, type: :model do
       end
 
       it 'with a status' do
-        tasks = Task.search({ title: nil, status: 1 }, sort_column)
+        tasks = Task.search({ title: nil, status: Task.statuses[:doing] }, sort_column)
         expect(tasks.size).to eq(1)
         expect(tasks).to include(task2)
       end
@@ -87,7 +79,7 @@ RSpec.describe Task, type: :model do
       end
 
       it 'with a status' do
-        tasks = Task.search({ title: nil, status: 2 }, sort_column)
+        tasks = Task.search({ title: nil, status: Task.statuses[:done] }, sort_column)
         expect(tasks.size).to eq(0)
       end
     end

--- a/todo/spec/models/task_spec.rb
+++ b/todo/spec/models/task_spec.rb
@@ -54,4 +54,42 @@ RSpec.describe Task, type: :model do
       it { expect(subject).to_not be_valid }
     end
   end
+
+  describe 'when search' do
+    let!(:task1) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: 0, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
+    let!(:task2) { Task.create(title: 'タスク２', description: 'タスク２詳細', status: 1, due_date: Time.zone.local(2021, 1, 1, 0, 0)) }
+    let(:sort_column) { :due_date }
+
+    context 'find' do
+      it 'with a title' do
+        tasks = Task.search({ title: 'タスク２', status: nil }, sort_column)
+        expect(tasks.size).to eq(1)
+        expect(tasks).to include(task2)
+      end
+
+      it 'with a status' do
+        tasks = Task.search({ title: nil, status: 1 }, sort_column)
+        expect(tasks.size).to eq(1)
+        expect(tasks).to include(task2)
+      end
+
+      it 'with no conditions' do
+        tasks = Task.search({ title: nil, status: nil }, sort_column)
+        expect(tasks.size).to eq(2)
+        expect(tasks).to include(task1, task2)
+      end
+    end
+
+    context 'not find' do
+      it 'with a title' do
+        tasks = Task.search({ title: 'タスク３', status: nil }, sort_column)
+        expect(tasks.size).to eq(0)
+      end
+
+      it 'with a status' do
+        tasks = Task.search({ title: nil, status: 2 }, sort_column)
+        expect(tasks.size).to eq(0)
+      end
+    end
+  end
 end

--- a/todo/spec/rails_helper.rb
+++ b/todo/spec/rails_helper.rb
@@ -35,6 +35,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  # Add factory_bot
+  config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
-  let(:task) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: 0, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
-  let(:task2) { Task.create(title: 'タスク２', description: 'タスク２詳細', status: 1, due_date: Time.zone.local(2021, 1, 1, 0, 0)) }
+  let(:task) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: :todo, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
+  let(:task2) { Task.create(title: 'タスク２', description: 'タスク２詳細', status: :doing, due_date: Time.zone.local(2021, 1, 1, 0, 0)) }
 
   describe 'when show tasks' do
     context 'show' do

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
-  let(:task) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: :todo, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
-  let(:task2) { Task.create(title: 'タスク２', description: 'タスク２詳細', status: :doing, due_date: Time.zone.local(2021, 1, 1, 0, 0)) }
+  let(:task1) { create(:task, title: 'タスク１', description: 'タスク１詳細', status: :todo, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
+  let(:task2) { create(:task, title: 'タスク２', description: 'タスク２詳細', status: :doing, due_date: Time.zone.local(2021, 1, 1, 0, 0)) }
 
   describe 'when show tasks' do
-    context 'show' do
-      it 'sort by link' do
+    context 'sort' do
+      it 'by link' do
         visit tasks_new_path
         fill_in 'task_title', with: 'first'
         fill_in 'task_due_date', with: Time.zone.local(2021, 1, 1, 0, 0)
@@ -37,9 +37,37 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
 
+    context 'paginate' do
+      let!(:task_list) { create_list(:task, 60) }
+      it 'go next' do
+        visit tasks_path
+
+        expect(page).to have_content('タスク名', count: 25)
+        click_link '次へ', match: :first
+
+        expect(page).to have_content('タスク名', count: 25)
+        click_link '最後へ', match: :first
+
+        expect(page).to have_content('タスク名', count: 10)
+      end
+
+      it 'go back' do
+        visit tasks_path
+        click_link '最後へ', match: :first
+
+        expect(page).to have_content('タスク名', count: 10)
+        click_link '前へ', match: :first
+
+        expect(page).to have_content('タスク名', count: 25)
+        click_link '最初へ', match: :first
+
+        expect(page).to have_content('タスク名', count: 25)
+      end
+    end
+
     context 'search' do
       it 'by title' do
-        visit tasks_show_path(task)
+        visit tasks_show_path(task1)
         visit tasks_show_path(task2)
         visit tasks_path
 
@@ -51,7 +79,7 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'by status' do
-        visit tasks_show_path(task)
+        visit tasks_show_path(task1)
         visit tasks_show_path(task2)
         visit tasks_path
         select '着手', from: 'status'
@@ -64,7 +92,7 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   it 'show task detail' do
-    visit tasks_show_path(task)
+    visit tasks_show_path(task1)
 
     expect(page).to have_content 'タスク１'
     expect(page).to have_content 'タスク１詳細'
@@ -105,7 +133,7 @@ RSpec.describe 'Tasks', type: :system do
   describe 'when update task' do
     context 'with valid attributes' do
       it 'fill all items' do
-        visit tasks_edit_path(task)
+        visit tasks_edit_path(task1)
 
         expect(page).to have_field 'task_title', with: 'タスク１'
         expect(page).to have_field 'task_description', with: 'タスク１詳細'
@@ -128,14 +156,14 @@ RSpec.describe 'Tasks', type: :system do
 
     context 'with invalid attributes' do
       it 'no title' do
-        visit tasks_edit_path(task)
+        visit tasks_edit_path(task1)
         fill_in 'task_title', with: ''
         click_button '更新'
         expect(page).to have_content 'タスク名 を入力してください'
       end
 
       it 'too long title' do
-        visit tasks_edit_path(task)
+        visit tasks_edit_path(task1)
         fill_in 'task_title', with: 'a' * 251
         click_button '更新'
         expect(page).to have_content 'タスク名 が長すぎます'
@@ -144,7 +172,7 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   it 'delete task' do
-    visit tasks_show_path(task)
+    visit tasks_show_path(task1)
 
     click_link '削除'
 

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -4,32 +4,62 @@ require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
   let(:task) { Task.create(title: 'タスク１', description: 'タスク１詳細', status: 0, due_date: Time.zone.local(2020, 1, 1, 0, 0)) }
+  let(:task2) { Task.create(title: 'タスク２', description: 'タスク２詳細', status: 1, due_date: Time.zone.local(2021, 1, 1, 0, 0)) }
 
-  it 'show tasks ordered by sort link' do
-    visit tasks_new_path
-    fill_in 'task_title', with: 'first'
-    fill_in 'task_due_date', with: Time.zone.local(2021, 1, 1, 0, 0)
-    click_button '追加'
+  describe 'when show tasks' do
+    context 'show' do
+      it 'sort by link' do
+        visit tasks_new_path
+        fill_in 'task_title', with: 'first'
+        fill_in 'task_due_date', with: Time.zone.local(2021, 1, 1, 0, 0)
+        click_button '追加'
 
-    visit tasks_new_path
-    fill_in 'task_title', with: 'second'
-    fill_in 'task_due_date', with: Time.zone.local(2020, 1, 1, 0, 0)
-    click_button '追加'
+        visit tasks_new_path
+        fill_in 'task_title', with: 'second'
+        fill_in 'task_due_date', with: Time.zone.local(2020, 1, 1, 0, 0)
+        click_button '追加'
 
-    within('ul') do
-      expect(page.text).to match(/second\nfirst/)
+        within('ul') do
+          expect(page.text).to match(/second\nfirst/)
+        end
+
+        click_link '終了期限'
+        sleep(0.5)
+        within('ul') do
+          expect(page.text).to match(/first\nsecond/)
+        end
+
+        click_link '作成日'
+        sleep(0.5)
+        within('ul') do
+          expect(page.text).to match(/second\nfirst/)
+        end
+      end
     end
 
-    click_link '終了期限'
-    sleep(0.5)
-    within('ul') do
-      expect(page.text).to match(/first\nsecond/)
-    end
+    context 'search' do
+      it 'by title' do
+        visit tasks_show_path(task)
+        visit tasks_show_path(task2)
+        visit tasks_path
 
-    click_link '作成日'
-    sleep(0.5)
-    within('ul') do
-      expect(page.text).to match(/second\nfirst/)
+        fill_in 'title', with: 'タスク２'
+        click_button '検索'
+
+        expect(page).to have_content 'タスク２'
+        expect(page).not_to have_content 'タスク１'
+      end
+
+      it 'by status' do
+        visit tasks_show_path(task)
+        visit tasks_show_path(task2)
+        visit tasks_path
+        select '着手', from: 'status'
+        click_button '検索'
+
+        expect(page).to have_content 'タスク２'
+        expect(page).not_to have_content 'タスク１'
+      end
     end
   end
 
@@ -83,8 +113,10 @@ RSpec.describe 'Tasks', type: :system do
                                     selected: '未着手',
                                     options: %w[未着手 着手 完了]
 
+        time = Time.zone.local(2020, 10, 10, 10, 10)
         fill_in 'task_title', with: 'タスク１修正'
         fill_in 'task_description', with: 'タスク１詳細修正'
+        fill_in 'task_due_date', with: time
         select '完了', from: 'task_status'
 
         click_button '更新'


### PR DESCRIPTION
### ステップ13: ステータスを追加して、検索できるようにしよう

### 概要
[ステップ13: ステータスを追加して、検索できるようにしよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)

### 対応内容

- Tasksモデルに検索用の処理を追加
- 「タスク名」「ステータス」を検索できるよう画面を修正
    - 合わせてコントローラーやその他を修正

### 備考

[基本的なフォームを作成する](https://railsguides.jp/form_helpers.html#%E5%9F%BA%E6%9C%AC%E7%9A%84%E3%81%AA%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B)
[SelectタグとOptionタグ](https://railsguides.jp/form_helpers.html#select%E3%82%BF%E3%82%B0%E3%81%A8option%E3%82%BF%E3%82%B0)
[クエリインターフェース](https://railsguides.jp/active_record_querying.html)