### PR TITLE
ステップ19: ユーザにロールを追加しよう

### DIFF
--- a/todo/app/controllers/admin/users_controller.rb
+++ b/todo/app/controllers/admin/users_controller.rb
@@ -49,7 +49,7 @@ module Admin
         flash[:success] = 'Deleted'
         redirect_to admin_users_path
       else
-        flash[:error] = 'Delete Failed'
+        flash[:error] = @user.errors.full_messages.join("\n")
         @tasks = @user.tasks.page(params[:page])
         render :show
       end

--- a/todo/app/controllers/admin/users_controller.rb
+++ b/todo/app/controllers/admin/users_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   class UsersController < ApplicationController
     before_action :require_login
+    before_action :require_admin_role
 
     # GET /admin/users
     def index
@@ -53,6 +54,12 @@ module Admin
 
     def user_params
       params.require(:user).permit(:name, :password, :password_confirmation, :role)
+    end
+
+    def require_admin_role
+      return if current_user.role == "admin"
+      flash[:error] = 'You cannot access this section'
+      redirect_to tasks_path
     end
   end
 end

--- a/todo/app/controllers/admin/users_controller.rb
+++ b/todo/app/controllers/admin/users_controller.rb
@@ -45,9 +45,14 @@ module Admin
     # DELETE /admin/users/:id
     def destroy
       @user = User.find(params[:id])
-      return :show unless @user.destroy
-      flash[:success] = 'Deleted'
-      redirect_to admin_users_path
+      if @user.destroy
+        flash[:success] = 'Deleted'
+        redirect_to admin_users_path
+      else
+        flash[:error] = 'Delete Failed'
+        @tasks = @user.tasks.page(params[:page])
+        render :show
+      end
     end
 
     private
@@ -57,7 +62,7 @@ module Admin
     end
 
     def require_admin_role
-      return if current_user.role == "admin"
+      return if current_user.admin?
       flash[:error] = 'You cannot access this section'
       redirect_to tasks_path
     end

--- a/todo/app/controllers/admin/users_controller.rb
+++ b/todo/app/controllers/admin/users_controller.rb
@@ -52,7 +52,7 @@ module Admin
     private
 
     def user_params
-      params.require(:user).permit(:name, :password, :password_confirmation)
+      params.require(:user).permit(:name, :password, :password_confirmation, :role)
     end
   end
 end

--- a/todo/app/helpers/admin/users_helper.rb
+++ b/todo/app/helpers/admin/users_helper.rb
@@ -3,7 +3,7 @@
 module Admin
   module UsersHelper
     def user_roles
-      { '一般' => 'general', '管理者' => 'admin' }
+      { 'general' => '一般', 'admin' => '管理者'}
     end
   end
 end

--- a/todo/app/helpers/admin/users_helper.rb
+++ b/todo/app/helpers/admin/users_helper.rb
@@ -2,5 +2,8 @@
 
 module Admin
   module UsersHelper
+    def user_roles
+      { '一般' => 'general', '管理者' => 'admin' }
+    end
   end
 end

--- a/todo/app/helpers/admin/users_helper.rb
+++ b/todo/app/helpers/admin/users_helper.rb
@@ -3,7 +3,7 @@
 module Admin
   module UsersHelper
     def user_roles
-      { 'general' => '一般', 'admin' => '管理者'}
+      { 'general' => '一般', 'admin' => '管理者' }
     end
   end
 end

--- a/todo/app/helpers/application_helper.rb
+++ b/todo/app/helpers/application_helper.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def admin?
+    logged_in? && current_user.admin?
+  end
 end

--- a/todo/app/models/user.rb
+++ b/todo/app/models/user.rb
@@ -2,9 +2,11 @@
 
 class User < ApplicationRecord
   has_secure_password
+  enum role: %i[general admin]
 
   has_many :tasks, dependent: :destroy
 
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false }
+  validates :role, inclusion: { in: roles }
 end

--- a/todo/app/models/user.rb
+++ b/todo/app/models/user.rb
@@ -2,7 +2,7 @@
 
 class User < ApplicationRecord
   has_secure_password
-  enum role: %i[general admin]
+  enum role: { general: 0, admin: 1 }
 
   has_many :tasks, dependent: :destroy
 

--- a/todo/app/models/user.rb
+++ b/todo/app/models/user.rb
@@ -9,4 +9,15 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false }
   validates :role, inclusion: { in: roles }
+
+  before_destroy :not_to_delete_all_admin
+
+  private
+
+  def not_to_delete_all_admin
+    return if general?
+    return unless User.admin.count == 1
+    errors.add :base, '最後の管理者のため削除できません'
+    throw :abort
+  end
 end

--- a/todo/app/views/admin/users/show.html.erb
+++ b/todo/app/views/admin/users/show.html.erb
@@ -1,5 +1,6 @@
 <div class="card">
   <div class="card-body">
+    <%= render partial: 'shared/flash_message' %>
     <h1 class="card-title"><%= @user.name %></h1>
     <div class="card-body">
       権限：<%= user_roles[@user.role] %>

--- a/todo/app/views/admin/users/show.html.erb
+++ b/todo/app/views/admin/users/show.html.erb
@@ -1,6 +1,9 @@
 <div class="card">
   <div class="card-body">
     <h1 class="card-title"><%= @user.name %></h1>
+    <div class="card-body">
+      権限：<%= user_roles[@user.role] %>
+    </div>
     <% if @tasks.any? %>
       <%= paginate @tasks %>
       <table class="table">

--- a/todo/app/views/layouts/application.html.erb
+++ b/todo/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
       <a class="navbar-brand" href="#">todo</a>
       <div class="navbar-collapse">
       <ul class="navbar-nav mr-auto">
-        <li class="nav-link"><%= link_to "Admin", admin_users_path, class: 'nav-link' if logged_in? && current_user.admin? %></li>
+        <li class="nav-link"><%= link_to "Admin", admin_users_path, class: 'nav-link' if admin? %></li>
         <li class="nav-link"><%= link_to "Log out", logout_path, class: 'nav-link', method: :delete if logged_in? %></li>
         <li class="nav-link"><%= link_to "Log in", login_path, class: 'nav-link' unless logged_in? %></li>
       </ul>

--- a/todo/app/views/layouts/application.html.erb
+++ b/todo/app/views/layouts/application.html.erb
@@ -10,10 +10,15 @@
   </head>
 
   <body>
-    <header class="navbar navbar-dark bg-dark">
+    <header class="navbar navbar-expand-lg navbar-dark bg-dark">
       <a class="navbar-brand" href="#">todo</a>
-      <%= link_to "Log out", logout_path, method: :delete if logged_in?%>
-      <%= link_to "Log in", login_path unless logged_in? %>
+      <div class="navbar-collapse">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-link"><%= link_to "Admin", admin_users_path, class: 'nav-link' if logged_in? && current_user.admin? %></li>
+        <li class="nav-link"><%= link_to "Log out", logout_path, class: 'nav-link', method: :delete if logged_in? %></li>
+        <li class="nav-link"><%= link_to "Log in", login_path, class: 'nav-link' unless logged_in? %></li>
+      </ul>
+      </div>
     </header>
     <div class="container">
     <%= yield %>

--- a/todo/app/views/shared/_flash_message.html.erb
+++ b/todo/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,5 @@
 <% if flash[:success] %>
   <p class="alert alert-success"><%= flash[:success] %></p>
+<% elsif flash[:error] %>
+  <p class="alert alert-danger"><%= flash[:error] %></p>
 <% end %>

--- a/todo/app/views/shared/users/_form.html.erb
+++ b/todo/app/views/shared/users/_form.html.erb
@@ -14,7 +14,7 @@
     <%= f.password_field :password_confirmation, class: 'form-control' %>
   </div>
 
-  <% if logged_in? && current_user.role == "admin" %>
+  <% if logged_in? && current_user.admin? %>
     <div class="form-group row">
       <%= f.label :role %>
       <%= f.select :role, user_roles.invert, {}, class: 'form-control' %>

--- a/todo/app/views/shared/users/_form.html.erb
+++ b/todo/app/views/shared/users/_form.html.erb
@@ -17,7 +17,7 @@
   <% if logged_in? && current_user.role == "admin" %>
     <div class="form-group row">
       <%= f.label :role %>
-      <%= f.select :role, user_roles, {}, class: 'form-control' %>
+      <%= f.select :role, user_roles.invert, {}, class: 'form-control' %>
     </div>
   <% end %>
 

--- a/todo/app/views/shared/users/_form.html.erb
+++ b/todo/app/views/shared/users/_form.html.erb
@@ -14,7 +14,7 @@
     <%= f.password_field :password_confirmation, class: 'form-control' %>
   </div>
 
-  <% if logged_in? && current_user.admin? %>
+  <% if admin? %>
     <div class="form-group row">
       <%= f.label :role %>
       <%= f.select :role, user_roles.invert, {}, class: 'form-control' %>

--- a/todo/app/views/shared/users/_form.html.erb
+++ b/todo/app/views/shared/users/_form.html.erb
@@ -14,6 +14,13 @@
     <%= f.password_field :password_confirmation, class: 'form-control' %>
   </div>
 
+  <% if logged_in? && current_user.role == "admin" %>
+    <div class="form-group row">
+      <%= f.label :role %>
+      <%= f.select :role, user_roles, {}, class: 'form-control' %>
+    </div>
+  <% end %>
+
   <div class="form-group row">
     <%= f.submit button_name, class: 'btn btn-primary' %>
   </div>

--- a/todo/config/locales/ja.yml
+++ b/todo/config/locales/ja.yml
@@ -29,6 +29,7 @@ ja:
         name: 名前
         password: パスワード
         password_confirmation: パスワード確認
+        role: ロール
       task:
         title: タスク名
         description: 詳細

--- a/todo/db/migrate/20191212045620_add_role_to_user.rb
+++ b/todo/db/migrate/20191212045620_add_role_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRoleToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0, after: :password_digest
+  end
+end

--- a/todo/db/schema.rb
+++ b/todo/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_204_045_639) do
+ActiveRecord::Schema.define(version: 20_191_212_045_620) do
   create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
     t.string 'title', null: false
     t.text 'description'
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20_191_204_045_639) do
   create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
     t.string 'name'
     t.string 'password_digest'
+    t.integer 'role', default: 0, null: false
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
   end

--- a/todo/spec/controllers/admin/users_controller_spec.rb
+++ b/todo/spec/controllers/admin/users_controller_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Admin::UsersController, type: :controller do
-  let(:user) { create(:user) }
+  let(:administrator) { create(:administrator) }
 
   describe 'GET #index' do
     it 'returns http success' do
-      add_session user
+      add_session administrator
       get :index
       expect(response).to have_http_status(:success)
     end
@@ -15,7 +15,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
   describe 'GET #new' do
     it 'returns http success' do
-      add_session user
+      add_session administrator
       get :new
       expect(response).to have_http_status(:success)
     end
@@ -23,16 +23,16 @@ RSpec.describe Admin::UsersController, type: :controller do
 
   describe 'GET #edit' do
     it 'returns http success' do
-      add_session user
-      get :edit, params: { id: user.id }
+      add_session administrator
+      get :edit, params: { id: administrator.id }
       expect(response).to have_http_status(:success)
     end
   end
 
   describe 'GET #show' do
     it 'returns http success' do
-      add_session user
-      get :show, params: { id: user.id }
+      add_session administrator
+      get :show, params: { id: administrator.id }
       expect(response).to have_http_status(:success)
     end
   end

--- a/todo/spec/factories/users.rb
+++ b/todo/spec/factories/users.rb
@@ -5,11 +5,13 @@ FactoryBot.define do
     name { 'test_user' }
     password { 'test_password' }
     password_confirmation { 'test_password' }
+    role { :general }
   end
 
   factory :administrator, class: User do
     name { 'administrator' }
     password { 'admin_password' }
     password_confirmation { 'admin_password' }
+    role { :admin }
   end
 end

--- a/todo/spec/system/admin/admin_users_spec.rb
+++ b/todo/spec/system/admin/admin_users_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe 'Admin::Users', type: :system do
         fill_in 'user_name', with: 'test_user'
         fill_in 'user_password', with: 'test_password'
         fill_in 'user_password_confirmation', with: 'test_password'
+        select '管理者', from: 'user_role'
         click_on '登録'
         expect(page.current_path).to eq('/admin/users')
         expect(page).to have_content 'Success!'
@@ -105,6 +106,7 @@ RSpec.describe 'Admin::Users', type: :system do
         fill_in 'user_name', with: 'test_user1'
         fill_in 'user_password', with: 'test_password1'
         fill_in 'user_password_confirmation', with: 'test_password1'
+        select '管理者', from: 'user_role'
         click_on '更新'
         expect(page.current_path).to eq('/admin/users')
         expect(page).to have_content 'Success!'

--- a/todo/spec/system/admin/admin_users_spec.rb
+++ b/todo/spec/system/admin/admin_users_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe 'Admin::Users', type: :system do
         visit admin_user_path administrator
         click_on '削除'
         expect(page.current_path).to eq("/admin/users/#{administrator.id}")
-        expect(page).to have_content 'Delete Failed'
+        expect(page).to have_content '最後の管理者のため削除できません'
       end
     end
   end

--- a/todo/spec/system/admin/admin_users_spec.rb
+++ b/todo/spec/system/admin/admin_users_spec.rb
@@ -159,13 +159,32 @@ RSpec.describe 'Admin::Users', type: :system do
 
   describe 'when delete user' do
     context 'with logged-in administrator' do
-      it 'success' do
+      let(:unnecessary_administrator) { create(:administrator, name: 'unnecessary_user') }
+
+      it 'success to delete a general user' do
         log_in_as administrator
         visit admin_user_path user
         click_on '削除'
         expect(page.current_path).to eq('/admin/users')
         expect(page).to have_content 'Deleted'
         expect(page).not_to have_content 'test_user'
+      end
+
+      it 'success to delete an administrator' do
+        log_in_as administrator
+        visit admin_user_path unnecessary_administrator
+        click_on '削除'
+        expect(page.current_path).to eq('/admin/users')
+        expect(page).to have_content 'Deleted'
+        expect(page).not_to have_content 'unnecessary_user'
+      end
+
+      it 'failed not to delete all administrators' do
+        log_in_as administrator
+        visit admin_user_path administrator
+        click_on '削除'
+        expect(page.current_path).to eq("/admin/users/#{administrator.id}")
+        expect(page).to have_content 'Delete Failed'
       end
     end
   end

--- a/todo/spec/system/admin/admin_users_spec.rb
+++ b/todo/spec/system/admin/admin_users_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Admin::Users', type: :system do
   let(:user) { create(:user) }
 
   describe 'when access index' do
-    context 'with logged-in user' do
+    context 'with logged-in administrator' do
       let!(:admin_task) { create(:task, user: administrator) }
       it 'success to show admin users page' do
         log_in_as administrator
@@ -25,6 +25,15 @@ RSpec.describe 'Admin::Users', type: :system do
       end
     end
 
+    context 'with logged-in general user' do
+      it 'redirect to tasks page' do
+        log_in_as user
+        visit admin_users_path
+        expect(page.current_path).to eq('/tasks')
+        expect(page).to have_content('You cannot access this section')
+      end
+    end
+
     context 'with logged-out user' do
       it 'failed to access' do
         visit admin_users_path
@@ -36,7 +45,7 @@ RSpec.describe 'Admin::Users', type: :system do
   describe 'when access show' do
     let!(:task) { create_list(:task, 26, user: administrator) }
 
-    context 'with logged-in user' do
+    context 'with logged-in administrator' do
       it 'success to access' do
         log_in_as administrator
         visit admin_user_path(administrator)
@@ -54,6 +63,15 @@ RSpec.describe 'Admin::Users', type: :system do
       end
     end
 
+    context 'with logged-in general user' do
+      it 'redirect to tasks page' do
+        log_in_as user
+        visit admin_users_path
+        expect(page.current_path).to eq('/tasks')
+        expect(page).to have_content('You cannot access this section')
+      end
+    end
+
     context 'with logged-out user' do
       it 'failed to access' do
         visit admin_user_path(administrator)
@@ -63,7 +81,7 @@ RSpec.describe 'Admin::Users', type: :system do
   end
 
   describe 'when access new' do
-    context 'with logged-in user' do
+    context 'with logged-in administrator' do
       it 'success to access' do
         log_in_as administrator
         visit new_admin_user_path
@@ -83,6 +101,15 @@ RSpec.describe 'Admin::Users', type: :system do
       end
     end
 
+    context 'with logged-in general user' do
+      it 'redirect to tasks page' do
+        log_in_as user
+        visit admin_users_path
+        expect(page.current_path).to eq('/tasks')
+        expect(page).to have_content('You cannot access this section')
+      end
+    end
+
     context 'with logged-out user' do
       it 'failed to access' do
         visit new_admin_user_path
@@ -92,7 +119,7 @@ RSpec.describe 'Admin::Users', type: :system do
   end
 
   describe 'when access edit' do
-    context 'with logged-in user' do
+    context 'with logged-in administrator' do
       it 'success to access' do
         log_in_as administrator
         visit edit_admin_user_path user
@@ -113,6 +140,15 @@ RSpec.describe 'Admin::Users', type: :system do
       end
     end
 
+    context 'with logged-in general user' do
+      it 'redirect to tasks page' do
+        log_in_as user
+        visit admin_users_path
+        expect(page.current_path).to eq('/tasks')
+        expect(page).to have_content('You cannot access this section')
+      end
+    end
+
     context 'with logged-out user' do
       it 'failed to access' do
         visit edit_admin_user_path user
@@ -122,7 +158,7 @@ RSpec.describe 'Admin::Users', type: :system do
   end
 
   describe 'when delete user' do
-    context 'with logged-in user' do
+    context 'with logged-in administrator' do
       it 'success' do
         log_in_as administrator
         visit admin_user_path user

--- a/todo/spec/system/users_spec.rb
+++ b/todo/spec/system/users_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'Users', type: :system do
     context 'success' do
       it 'with valid attribute' do
         visit signup_path
+        # ロールが表示されないことを確認する
+        expect(page).not_to have_content 'ロール'
         fill_in 'user_name', with: 'test_user'
         fill_in 'user_password', with: 'test_password'
         fill_in 'user_password_confirmation', with: 'test_password'


### PR DESCRIPTION
### ステップ19: ユーザにロールを追加しよう ★ スキップ可能

### 概要
[ステップ19: ユーザにロールを追加しよう ★ スキップ可能）](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

### 対応内容

- `rails g migration AddRoleToUser role:integer` でユーザにロール追加
- ユーザ登録、変更画面にロールを変更できるよう項目追加
- 管理者ユーザのみadminにアクセス可能に変更
- 管理者が最後の一人の場合、削除しない

### 備考