### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/todo/app/controllers/application_controller.rb
+++ b/todo/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   around_action :switch_locale
+  before_action :return_503, if: :maintenance_mode?
   include SessionsHelper
 
   def switch_locale(&action)
@@ -11,6 +12,18 @@ class ApplicationController < ActionController::Base
 
   def default_url_options
     { locale: I18n.locale }
+  end
+
+  def maintenance_mode?
+    ENV['MAINTENANCE_MODE'] == "on"
+  end
+
+  def return_503
+    render(file: Rails.public_path.join("503.html"),
+           content_type: "text/html",
+           layout: false,
+           status: :service_unavailable
+          )
   end
 
   protected

--- a/todo/app/controllers/application_controller.rb
+++ b/todo/app/controllers/application_controller.rb
@@ -15,7 +15,8 @@ class ApplicationController < ActionController::Base
   end
 
   def maintenance_mode?
-    ENV['MAINTENANCE_MODE'] == 'on'
+    site_setting = SiteSetting.first_or_create
+    site_setting.on?
   end
 
   def return_503

--- a/todo/app/controllers/application_controller.rb
+++ b/todo/app/controllers/application_controller.rb
@@ -15,14 +15,14 @@ class ApplicationController < ActionController::Base
   end
 
   def maintenance_mode?
-    ENV['MAINTENANCE_MODE'] == "on"
+    ENV['MAINTENANCE_MODE'] == 'on'
   end
 
   def return_503
-    render(file: Rails.public_path.join("503.html"),
-           content_type: "text/html",
+    render(file: Rails.public_path.join('503.html'),
+           content_type: 'text/html',
            layout: false,
-           status: :service_unavailable
+           status: :service_unavailable,
           )
   end
 

--- a/todo/app/models/site_setting.rb
+++ b/todo/app/models/site_setting.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SiteSetting < ApplicationRecord
+end

--- a/todo/app/models/site_setting.rb
+++ b/todo/app/models/site_setting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class SiteSetting < ApplicationRecord
+  enum maintenance: %i[off on]
 end

--- a/todo/db/migrate/20191216060217_create_site_settings.rb
+++ b/todo/db/migrate/20191216060217_create_site_settings.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateSiteSettings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :site_settings do |t|
+      t.integer :maintenance, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/todo/db/schema.rb
+++ b/todo/db/schema.rb
@@ -13,14 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20_191_216_060_217) do
-  create_table 'labels', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.integer 'content_type'
-    t.bigint 'task_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['task_id'], name: 'index_labels_on_task_id'
-  end
-
   create_table 'site_settings', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
     t.integer 'maintenance', default: 0, null: false
     t.datetime 'created_at', precision: 6, null: false
@@ -46,6 +38,5 @@ ActiveRecord::Schema.define(version: 20_191_216_060_217) do
     t.datetime 'updated_at', precision: 6, null: false
   end
 
-  add_foreign_key 'labels', 'tasks'
   add_foreign_key 'tasks', 'users'
 end

--- a/todo/db/schema.rb
+++ b/todo/db/schema.rb
@@ -12,7 +12,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_212_045_620) do
+ActiveRecord::Schema.define(version: 20_191_216_060_217) do
+  create_table 'labels', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.integer 'content_type'
+    t.bigint 'task_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['task_id'], name: 'index_labels_on_task_id'
+  end
+
+  create_table 'site_settings', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.integer 'maintenance', default: 0, null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+  end
+
   create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
     t.string 'title', null: false
     t.text 'description'
@@ -32,5 +46,6 @@ ActiveRecord::Schema.define(version: 20_191_212_045_620) do
     t.datetime 'updated_at', precision: 6, null: false
   end
 
+  add_foreign_key 'labels', 'tasks'
   add_foreign_key 'tasks', 'users'
 end

--- a/todo/lib/tasks/maintenance.rake
+++ b/todo/lib/tasks/maintenance.rake
@@ -1,2 +1,11 @@
 namespace :maintenance do
+  desc "set maintenance_mode on"
+  task :on do
+    ENV['MAINTENANCE_MODE'] = "on"
+  end
+
+  desc "set maintenance_mode off"
+  task :off do
+    ENV['MAINTENANCE_MODE'] = "off"
+  end
 end

--- a/todo/lib/tasks/maintenance.rake
+++ b/todo/lib/tasks/maintenance.rake
@@ -2,12 +2,14 @@
 
 namespace :maintenance do
   desc 'set maintenance_mode on'
-  task :on do
-    ENV['MAINTENANCE_MODE'] = 'on'
+  task on: :environment do
+    setting = SiteSetting.first_or_create
+    setting.update(maintenance: :on)
   end
 
   desc 'set maintenance_mode off'
-  task :off do
-    ENV['MAINTENANCE_MODE'] = 'off'
+  task off: :environment do
+    setting = SiteSetting.first_or_create
+    setting.update(maintenance: :off)
   end
 end

--- a/todo/lib/tasks/maintenance.rake
+++ b/todo/lib/tasks/maintenance.rake
@@ -1,0 +1,2 @@
+namespace :maintenance do
+end

--- a/todo/lib/tasks/maintenance.rake
+++ b/todo/lib/tasks/maintenance.rake
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 namespace :maintenance do
-  desc "set maintenance_mode on"
+  desc 'set maintenance_mode on'
   task :on do
-    ENV['MAINTENANCE_MODE'] = "on"
+    ENV['MAINTENANCE_MODE'] = 'on'
   end
 
-  desc "set maintenance_mode off"
+  desc 'set maintenance_mode off'
   task :off do
-    ENV['MAINTENANCE_MODE'] = "off"
+    ENV['MAINTENANCE_MODE'] = 'off'
   end
 end

--- a/todo/public/503.html
+++ b/todo/public/503.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Site Maintainance (503)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+
+<body>
+<!-- This file lives in public/500.html -->
+<div>
+    <div>
+        <h1>503</h1>
+    </div>
+    <p>Site Maintenance...</p>
+</div>
+</body>
+</html>
+

--- a/todo/spec/factories/site_settings.rb
+++ b/todo/spec/factories/site_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :site_setting do
+    maintenance { 1 }
+  end
+end

--- a/todo/spec/factories/site_settings.rb
+++ b/todo/spec/factories/site_settings.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :site_setting do
-    maintenance { 1 }
+    maintenance { 0 }
   end
 end

--- a/todo/spec/lib/tasks/maintenance_spec.rb
+++ b/todo/spec/lib/tasks/maintenance_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'maintenance' do
   before(:all) do
     @rake = Rake::Application.new
     Rake.application = @rake
-    Rake.application.rake_require('maintenance', ["#{Rails.root}/lib/tasks"])
+    Rake.application.rake_require('maintenance', [Rails.root.join('lib', 'tasks')])
     Rake::Task.define_task(:environment)
   end
 
@@ -20,7 +20,8 @@ RSpec.describe 'maintenance' do
 
     it 'should success.' do
       @rake[task].invoke
-      expect(ENV['MAINTENANCE_MODE']).to eq 'on'
+      site_setting = SiteSetting.first
+      expect(site_setting.maintenance).to eq 'on'
     end
   end
 
@@ -29,7 +30,8 @@ RSpec.describe 'maintenance' do
 
     it 'should success.' do
       @rake[task].invoke
-      expect(ENV['MAINTENANCE_MODE']).to eq 'off'
+      site_setting = SiteSetting.first
+      expect(site_setting.maintenance).to eq 'off'
     end
   end
 end

--- a/todo/spec/lib/tasks/maintenance_spec.rb
+++ b/todo/spec/lib/tasks/maintenance_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'maintenance' do
+  before(:all) do
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake.application.rake_require('maintenance', ["#{Rails.root}/lib/tasks"])
+    Rake::Task.define_task(:environment)
+  end
+
+  before(:each) do
+    @rake[task].reenable
+  end
+
+  describe 'maintenance:on' do
+    let(:task) { 'maintenance:on' }
+
+    it 'should success.' do
+      @rake[task].invoke
+      expect(ENV['MAINTENANCE_MODE']).to eq "on"
+    end
+  end
+
+  describe 'maintenance:off' do
+    let(:task) { 'maintenance:off' }
+
+    it 'should success.' do
+      @rake[task].invoke
+      expect(ENV['MAINTENANCE_MODE']).to eq "off"
+    end
+  end
+end

--- a/todo/spec/lib/tasks/maintenance_spec.rb
+++ b/todo/spec/lib/tasks/maintenance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'rake'
 
@@ -18,7 +20,7 @@ RSpec.describe 'maintenance' do
 
     it 'should success.' do
       @rake[task].invoke
-      expect(ENV['MAINTENANCE_MODE']).to eq "on"
+      expect(ENV['MAINTENANCE_MODE']).to eq 'on'
     end
   end
 
@@ -27,7 +29,7 @@ RSpec.describe 'maintenance' do
 
     it 'should success.' do
       @rake[task].invoke
-      expect(ENV['MAINTENANCE_MODE']).to eq "off"
+      expect(ENV['MAINTENANCE_MODE']).to eq 'off'
     end
   end
 end

--- a/todo/spec/models/site_setting_spec.rb
+++ b/todo/spec/models/site_setting_spec.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe SiteSetting, type: :model do
-end

--- a/todo/spec/models/site_setting_spec.rb
+++ b/todo/spec/models/site_setting_spec.rb
@@ -3,5 +3,4 @@
 require 'rails_helper'
 
 RSpec.describe SiteSetting, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/todo/spec/models/site_setting_spec.rb
+++ b/todo/spec/models/site_setting_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SiteSetting, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/todo/spec/system/applications_spec.rb
+++ b/todo/spec/system/applications_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Applications', type: :system do
+  let!(:site_setting) { create(:site_setting, maintenance: maintenance) }
+
+  context 'When maintenance mode on' do
+    let(:maintenance) { :on }
+    it 'returns 503' do
+      visit login_path
+      expect(page).to have_content '503'
+    end
+  end
+
+  context 'When maintenance mode off' do
+    let(:maintenance) { :off }
+    it 'returns 200' do
+      visit login_path
+      expect(page).not_to have_content '503'
+    end
+  end
+end

--- a/todo/spec/system/applications_spec.rb
+++ b/todo/spec/system/applications_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe 'Applications', type: :system do
     it 'returns 200' do
       visit login_path
       expect(page).not_to have_content '503'
+      expect(page).to have_content 'ログイン'
+      expect(page).to have_selector '#session_name'
+      expect(page).to have_selector '#session_password'
     end
   end
 end


### PR DESCRIPTION
### ステップ21: メンテナンス機能を作ろう

### 概要
[ステップ21: メンテナンス機能を作ろう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)

### 対応内容

- `rails g task maintenance`で、メンテナンスを切り替えるrake task作成
- `rails g model site_setting` で　管理するためのテーブルを作成
- site_settingテーブルのmaintenance項目が１の時、メンテナンスモードとして503のページを返す

### 確認方法

```
docker-compose up -d
rails db:migrate
# メンテナンスモードをonにする
rails maintenance:on
# メンテナンスモードをoffにする
rails maintenance:off
```

### 備考

当初は、環境変数の切り替えでメンテナンスモードをON /OFFしようと考えていたのですが、
RubyのENVを利用して変更する環境変数は一時的なものであったため、
方針を変更し、DBに値を持つようにしました。

### 参考にした箇所

- [カスタムRakeタスク](https://railsguides.jp/command_line.html#%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%A0rake%E3%82%BF%E3%82%B9%E3%82%AF)

