### PR TITLE
[New]Jaeya_ステップ10：タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/todoApp/app/controllers/tasks_controller.rb
+++ b/todoApp/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.order({ created_at: :desc })
   end
 
   def show

--- a/todoApp/app/controllers/tasks_controller.rb
+++ b/todoApp/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.order({ created_at: :desc })
+    @tasks = Task.order(created_at: :desc)
   end
 
   def show

--- a/todoApp/app/views/tasks/index.html.erb
+++ b/todoApp/app/views/tasks/index.html.erb
@@ -7,6 +7,7 @@
   <tr>
     <th><%= t('tasks.column.title') %></th>
     <th><%= t('tasks.column.description') %></th>
+    <th><%= t('created_at') %></th>
     <th colspan="3"></th>
   </tr>
   </thead>
@@ -16,6 +17,7 @@
     <tr>
       <td><%= task.title %></td>
       <td><%= task.description %></td>
+      <td><%= l(task.created_at, format: :short) %></td>
       <td><%= link_to t('show'), task %></td>
       <td><%= link_to t('edit'), edit_task_path(task) %></td>
       <td><%= link_to t('destroy'), task, method: :delete, data: { confirm: t('flash_message.delete_confirm') } %></td>

--- a/todoApp/app/views/tasks/index.html.erb
+++ b/todoApp/app/views/tasks/index.html.erb
@@ -7,7 +7,7 @@
   <tr>
     <th><%= Task.human_attribute_name(:title) %></th>
     <th><%= Task.human_attribute_name(:description) %></th>
-    <th><%= t('created_at') %></th>
+    <th><%= Task.human_attribute_name(:created_at) %></th>
     <th colspan="3"></th>
   </tr>
   </thead>

--- a/todoApp/app/views/tasks/index.html.erb
+++ b/todoApp/app/views/tasks/index.html.erb
@@ -5,8 +5,8 @@
 <table>
   <thead>
   <tr>
-    <th><%= t('tasks.column.title') %></th>
-    <th><%= t('tasks.column.description') %></th>
+    <th><%= Task.human_attribute_name(:title) %></th>
+    <th><%= Task.human_attribute_name(:description) %></th>
     <th><%= t('created_at') %></th>
     <th colspan="3"></th>
   </tr>

--- a/todoApp/app/views/tasks/show.html.erb
+++ b/todoApp/app/views/tasks/show.html.erb
@@ -1,12 +1,12 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong><%= t('tasks.column.title') %> : </strong>
+  <strong><%= Task.human_attribute_name(:title) %> : </strong>
   <%= @task.title %>
 </p>
 
 <p>
-  <strong><%= t('tasks.column.description') %> : </strong>
+  <strong><%= Task.human_attribute_name(:description) %> : </strong>
   <%= @task.description %>
 </p>
 

--- a/todoApp/config/locales/en.yml
+++ b/todoApp/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   edit: 'Edit'
   destroy: 'Destroy'
   back: 'Back'
+  created_at: 'Created At'
 
   tasks:
     new_task: 'New Task'

--- a/todoApp/config/locales/en.yml
+++ b/todoApp/config/locales/en.yml
@@ -17,10 +17,6 @@ en:
     edit:
       head_title: 'Editing Task'
 
-    column:
-      title: 'Title'
-      description: 'Description'
-
   flash_message:
     create_complete: 'Task was successfully created.'
     update_complete: 'Task was successfully updated.'

--- a/todoApp/config/locales/en.yml
+++ b/todoApp/config/locales/en.yml
@@ -23,6 +23,9 @@ en:
     delete_fail: 'Destroy Failed. Please check again.'
     delete_confirm: 'Are you sure?'
 
+  attributes:
+    created_at: 'Created At'
+
   activerecord:
     model:
       task: 'task'
@@ -31,4 +34,3 @@ en:
       task:
         title: 'Title'
         description: 'Description'
-        created_at: 'Created At'

--- a/todoApp/config/locales/en.yml
+++ b/todoApp/config/locales/en.yml
@@ -3,7 +3,6 @@ en:
   edit: 'Edit'
   destroy: 'Destroy'
   back: 'Back'
-  created_at: 'Created At'
 
   tasks:
     new_task: 'New Task'
@@ -32,3 +31,4 @@ en:
       task:
         title: 'Title'
         description: 'Description'
+        created_at: 'Created At'

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
   edit: '修正'
   destroy: '削除'
   back: '戻る'
+  created_at: '作成日時'
 
   tasks:
     new_task: '新タスク'

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -23,6 +23,9 @@ ja:
     delete_fail: '削除が無事に完了できませんでした。もう一度お願いします。'
     delete_confirm: '本当に削除しますか？'
 
+  attributes:
+    created_at: '作成日時'
+
   activerecord:
     model:
       task: 'タスク'
@@ -31,4 +34,3 @@ ja:
       task:
         title: 'タスク名'
         description: 'タスク詳細'
-        created_at: '作成日時'

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -17,10 +17,6 @@ ja:
     edit:
       head_title: 'タスク修正'
 
-    column:
-      title: 'タスク名'
-      description: 'タスク詳細'
-
   flash_message:
     create_complete: 'タスク作成を完了しました。'
     update_complete: 'タスク更新を完了しました。'

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -3,7 +3,6 @@ ja:
   edit: '修正'
   destroy: '削除'
   back: '戻る'
-  created_at: '作成日時'
 
   tasks:
     new_task: '新タスク'
@@ -32,3 +31,4 @@ ja:
       task:
         title: 'タスク名'
         description: 'タスク詳細'
+        created_at: '作成日時'

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Task management', type: :system, js: true do
+RSpec.describe 'Task management', type: :system do
   before do
     %w(first second).each do |nth|
       Task.create!(title: "rspec #{nth} task", description: 'rspec Description')

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -1,43 +1,50 @@
 require 'rails_helper'
 
-RSpec.describe 'Task management', type: :system do
-  before do
-    Task.create!(title: 'rspec first task', description: 'rspec Description')
-  end
-
-  scenario 'When user visit the tasks_path it shows the task list order by created recently.' do
-    Task.create!(title: 'rspec second task', description: 'rspec Description')
-    visit tasks_path
-    recent_title = find(:xpath, ".//table/tbody/tr[1]/td[1]").text
-    old_title = find(:xpath, ".//table/tbody/tr[2]/td[1]").text
-    expect(recent_title).to have_content 'rspec second task'
-    expect(old_title).to have_content 'rspec first task'
-  end
-
-  scenario 'When user click New Task link it creates new task.' do
-    visit tasks_path
-    click_link 'New Task'
-    fill_in 'Title', :with => 'My Task'
-    fill_in 'Description', :with => 'My Task Description'
-    click_button 'Create Task'
-    expect(page).to have_content 'Task was successfully created.'
-  end
-
-  scenario 'When user click Edit link it updates the selected task.' do
-    visit tasks_path
-    click_link 'Edit'
-    fill_in 'Title', :with => 'My Edited Task'
-    fill_in 'Description', :with => 'Edit My Task Description'
-    click_button 'Update Task'
-    expect(page).to have_content 'Task was successfully updated.'
-  end
-
-  scenario 'When user click Destroy link it deletes the selected task.' do
-    visit tasks_path
-    accept_alert do
-      click_link 'Destroy'
+RSpec.describe 'Task', type: :system do
+  context 'visit the tasks_path' do
+    before do
+      Task.create!(title: 'rspec first task', description: 'rspec Description')
+      Task.create!(title: 'rspec second task', description: 'rspec Description')
     end
-    expect(page).to have_content 'Task was successfully destroyed.'
+
+    it 'shows the task list order by created recently.' do
+      visit tasks_path
+      recent_title = find(:xpath, ".//table/tbody/tr[1]/td[1]").text
+      old_title = find(:xpath, ".//table/tbody/tr[2]/td[1]").text
+      expect(recent_title).to have_content 'rspec second task'
+      expect(old_title).to have_content 'rspec first task'
+    end
   end
 
+  context 'user click the link' do
+    before do
+      Task.create!(title: 'rspec first task', description: 'rspec Description')
+    end
+
+    it 'creates new task when click New Task' do
+      visit tasks_path
+      click_link 'New Task'
+      fill_in 'Title', :with => 'My Task'
+      fill_in 'Description', :with => 'My Task Description'
+      click_button 'Create Task'
+      expect(page).to have_content 'Task was successfully created.'
+    end
+
+    it 'updates the selected task when click Edit' do
+      visit tasks_path
+      click_link 'Edit'
+      fill_in 'Title', :with => 'My Edited Task'
+      fill_in 'Description', :with => 'Edit My Task Description'
+      click_button 'Update Task'
+      expect(page).to have_content 'Task was successfully updated.'
+    end
+
+    it 'deletes the selected task when click Destroy' do
+      visit tasks_path
+      accept_alert do
+        click_link 'Destroy'
+      end
+      expect(page).to have_content 'Task was successfully destroyed.'
+    end
+  end
 end

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -2,12 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Task management', type: :system do
   before do
-    %w(first second).each do |nth|
-      Task.create!(title: "rspec #{nth} task", description: 'rspec Description')
-    end
+    Task.create!(title: 'rspec first task', description: 'rspec Description')
   end
 
   scenario 'When user visit the tasks_path it shows the task list order by created recently.' do
+    Task.create!(title: 'rspec second task', description: 'rspec Description')
     visit tasks_path
     recent_title = find(:xpath, ".//table/tbody/tr[1]/td[1]").text
     old_title = find(:xpath, ".//table/tbody/tr[2]/td[1]").text
@@ -26,7 +25,7 @@ RSpec.describe 'Task management', type: :system do
 
   scenario 'When user click Edit link it updates the selected task.' do
     visit tasks_path
-    first(:link, 'Edit').click
+    click_link 'Edit'
     fill_in 'Title', :with => 'My Edited Task'
     fill_in 'Description', :with => 'Edit My Task Description'
     click_button 'Update Task'
@@ -36,7 +35,7 @@ RSpec.describe 'Task management', type: :system do
   scenario 'When user click Destroy link it deletes the selected task.' do
     visit tasks_path
     accept_alert do
-      first(:link, 'Destroy').click
+      click_link 'Destroy'
     end
     expect(page).to have_content 'Task was successfully destroyed.'
   end

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -2,12 +2,17 @@ require 'rails_helper'
 
 RSpec.describe 'Task management', type: :system, js: true do
   before do
-    Task.create!(title: 'rspec Test', description: 'rspec Description')
+    %w(first second).each do |nth|
+      Task.create!(title: "rspec #{nth} task", description: 'rspec Description')
+    end
   end
 
-  scenario 'When user visit the tasks_path it shows the task list.' do
+  scenario 'When user visit the tasks_path it shows the task list order by created recently.' do
     visit tasks_path
-    expect(page).to have_content 'rspec Description'
+    recent_title = find(:xpath, ".//table/tbody/tr[1]/td[1]").text
+    old_title = find(:xpath, ".//table/tbody/tr[2]/td[1]").text
+    expect(recent_title).to have_content 'rspec second task'
+    expect(old_title).to have_content 'rspec first task'
   end
 
   scenario 'When user click New Task link it creates new task.' do
@@ -21,7 +26,7 @@ RSpec.describe 'Task management', type: :system, js: true do
 
   scenario 'When user click Edit link it updates the selected task.' do
     visit tasks_path
-    click_link 'Edit'
+    first(:link, 'Edit').click
     fill_in 'Title', :with => 'My Edited Task'
     fill_in 'Description', :with => 'Edit My Task Description'
     click_button 'Update Task'
@@ -31,7 +36,7 @@ RSpec.describe 'Task management', type: :system, js: true do
   scenario 'When user click Destroy link it deletes the selected task.' do
     visit tasks_path
     accept_alert do
-      click_link 'Destroy'
+      first(:link, 'Destroy').click
     end
     expect(page).to have_content 'Task was successfully destroyed.'
   end


### PR DESCRIPTION
## 実装内容
- タスク一覧にソート適応
- テスト作成

## 課題
https://github.com/Fablic/training#ステップ10-タスク一覧を作成日時の順番で並び替えましょう--スキップ可能

## 参考
rails capybara : https://github.com/teamcapybara/capybara#xpath-css-and-selectors
i18n Datetime format : https://guides.rubyonrails.org/i18n.html#adding-date-time-formats

## 動作確認結果
![Screen Shot 2019-12-24 at 10 09 39](https://user-images.githubusercontent.com/58239688/71387119-94375d80-2635-11ea-8aa7-c1b02d3e15b4.png)

宜しくお願い致します。