### PR TITLE
Jaeya_ステップ12: 終了期限を追加しよう

### DIFF
--- a/todoApp/app/controllers/tasks_controller.rb
+++ b/todoApp/app/controllers/tasks_controller.rb
@@ -2,7 +2,11 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.order({ created_at: :desc })
+    if params[:sort].blank?
+      @tasks = Task.order({ created_at: :desc })
+    else
+      @tasks = Task.order_by_due_date(params[:sort])
+    end
   end
 
   def show
@@ -48,6 +52,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :description)
+    params.require(:task).permit(:title, :description, :due_date)
   end
 end

--- a/todoApp/app/models/task.rb
+++ b/todoApp/app/models/task.rb
@@ -1,3 +1,13 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
+
+  def self.order_by_due_date(direction)
+    if direction == 'due_date_desc'
+      Task.order({ due_date: :desc })
+    elsif direction == 'due_date_asc'
+      Task.order({ due_date: :asc })
+    else
+      Task.order({ created_at: :desc })
+    end
+  end
 end

--- a/todoApp/app/models/task.rb
+++ b/todoApp/app/models/task.rb
@@ -3,7 +3,7 @@ class Task < ApplicationRecord
 
   def self.order_by_due_date_or_default(due_date_direction)
     if due_date_direction == 'DESC' || due_date_direction == 'ASC'
-      order("due_date #{due_date_direction}")
+      order(due_date: due_date_direction.to_sym)
     else
       order(created_at: :desc)
     end

--- a/todoApp/app/views/tasks/_form.html.erb
+++ b/todoApp/app/views/tasks/_form.html.erb
@@ -21,6 +21,11 @@
     <%= form.text_area :description %>
   </div>
 
+  <div class="field">
+    <%= form.label :due_date %>
+    <%= form.datetime_select :due_date %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/todoApp/app/views/tasks/index.html.erb
+++ b/todoApp/app/views/tasks/index.html.erb
@@ -7,6 +7,10 @@
   <tr>
     <th><%= t('tasks.column.title') %></th>
     <th><%= t('tasks.column.description') %></th>
+    <th><%= t('tasks.column.due_date') %>
+      <%= link_to '▼', :controller => 'tasks', :sort => 'due_date_desc' %>
+      <%= link_to '▲', :controller => 'tasks', :sort => 'due_date_asc' %>
+    </th>
     <th><%= t('created_at') %></th>
     <th colspan="3"></th>
   </tr>
@@ -17,6 +21,7 @@
     <tr>
       <td><%= task.title %></td>
       <td><%= task.description %></td>
+      <td><%= l(task.due_date, format: :short) if task.due_date %></td>
       <td><%= l(task.created_at, format: :short) %></td>
       <td><%= link_to t('show'), task %></td>
       <td><%= link_to t('edit'), edit_task_path(task) %></td>

--- a/todoApp/app/views/tasks/index.html.erb
+++ b/todoApp/app/views/tasks/index.html.erb
@@ -8,8 +8,8 @@
     <th><%= Task.human_attribute_name(:title) %></th>
     <th><%= Task.human_attribute_name(:description) %></th>
     <th><%= Task.human_attribute_name(:due_date) %>
-      <%= link_to '▼', :controller => 'tasks', :due_date_direction => 'DESC' %>
-      <%= link_to '▲', :controller => 'tasks', :due_date_direction => 'ASC' %>
+      <%= link_to '▼', controller: :tasks, due_date_direction: :'DESC' %>
+      <%= link_to '▲', controller: :tasks, due_date_direction: :'ASC' %>
     </th>
     <th><%= Task.human_attribute_name(:created_at) %></th>
     <th colspan="3"></th>

--- a/todoApp/app/views/tasks/show.html.erb
+++ b/todoApp/app/views/tasks/show.html.erb
@@ -10,5 +10,15 @@
   <%= @task.description %>
 </p>
 
+<p>
+  <strong><%= t('tasks.column.due_date') %> : </strong>
+  <%= l(@task.due_date, format: :short) if @task.due_date %>
+</p>
+
+<p>
+  <strong><%= t('tasks.column.created_at') %> : </strong>
+  <%= l(@task.created_at, format: :short) %>
+</p>
+
 <%= link_to t('edit'), edit_task_path(@task) %> |
 <%= link_to t('back'), tasks_path %>

--- a/todoApp/config/locales/en.yml
+++ b/todoApp/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
     column:
       title: 'Title'
       description: 'Description'
+      due_date: 'Due Date'
 
   flash_message:
     create_complete: 'Task was successfully created.'
@@ -38,3 +39,4 @@ en:
       task:
         title: 'Title'
         description: 'Description'
+        due_date: 'Due Date'

--- a/todoApp/config/locales/en.yml
+++ b/todoApp/config/locales/en.yml
@@ -3,6 +3,8 @@ en:
   edit: 'Edit'
   destroy: 'Destroy'
   back: 'Back'
+  error_unit: 'error'
+  error_message: 'prohibited this task from being saved:'
 
   tasks:
     new_task: 'New Task'

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -22,6 +22,7 @@ ja:
     column:
       title: 'タスク名'
       description: 'タスク詳細'
+      due_date: '終了期限'
 
   flash_message:
     create_complete: 'タスク作成を完了しました。'
@@ -38,3 +39,4 @@ ja:
       task:
         title: 'タスク名'
         description: 'タスク詳細'
+        due_date: '終了期限'

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -4,7 +4,7 @@ ja:
   destroy: '削除'
   back: '戻る'
   error_unit: '個'
-  error_message: 'のエーラーが発生したため保存できません。：'
+  error_message: 'のエラーが発生したため保存できません。：'
 
   tasks:
     new_task: '新タスク'

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -3,6 +3,8 @@ ja:
   edit: '修正'
   destroy: '削除'
   back: '戻る'
+  error_unit: '個'
+  error_message: 'のエーラーが発生したため保存できません。：'
 
   tasks:
     new_task: '新タスク'

--- a/todoApp/db/migrate/20191224051519_add_due_date_to_tasks.rb
+++ b/todoApp/db/migrate/20191224051519_add_due_date_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDueDateToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :due_date, :datetime
+  end
+end

--- a/todoApp/db/migrate/20191224051519_add_due_date_to_tasks.rb
+++ b/todoApp/db/migrate/20191224051519_add_due_date_to_tasks.rb
@@ -1,5 +1,5 @@
 class AddDueDateToTasks < ActiveRecord::Migration[6.0]
   def change
-    add_column :tasks, :due_date, :datetime
+    add_column :tasks, :due_date, :datetime, after: :description
   end
 end

--- a/todoApp/db/schema.rb
+++ b/todoApp/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_24_014552) do
+ActiveRecord::Schema.define(version: 2019_12_24_051519) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 50, null: false
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "due_date"
   end
 
 end

--- a/todoApp/db/schema.rb
+++ b/todoApp/db/schema.rb
@@ -15,9 +15,9 @@ ActiveRecord::Schema.define(version: 2019_12_24_051519) do
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 50, null: false
     t.text "description"
+    t.datetime "due_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.datetime "due_date"
   end
 
 end

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Task management', type: :system, js: true do
   context 'visit the tasks_path' do
     before do
-      Task.create!(title: 'rspec first task', description: 'deadline is soon', due_date: DateTime.now + 1)
-      Task.create!(title: 'rspec second task', description: 'still have time until deadline', due_date: DateTime.now + 3)
+      Task.create!(title: 'rspec first task', description: 'deadline is soon', due_date: 1.day.from_now)
+      Task.create!(title: 'rspec second task', description: 'still have time until deadline', due_date: 3.days.from_now)
     end
 
     it 'shows the task list order by created recently.' do

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -2,17 +2,37 @@ require 'rails_helper'
 
 RSpec.describe 'Task management', type: :system, js: true do
   before do
-    %w(first second).each do |nth|
-      Task.create!(title: "rspec #{nth} task", description: 'rspec Description')
-    end
+    Task.create!(title: "rspec first task", description: 'deadline is soon', due_date: DateTime.now + 1)
+    Task.create!(title: "rspec second task", description: 'still have time until deadline', due_date: DateTime.now + 3)
   end
 
   scenario 'When user visit the tasks_path it shows the task list order by created recently.' do
     visit tasks_path
+    expect(page).to have_content 'Task List'
     recent_title = find(:xpath, ".//table/tbody/tr[1]/td[1]").text
     old_title = find(:xpath, ".//table/tbody/tr[2]/td[1]").text
     expect(recent_title).to have_content 'rspec second task'
     expect(old_title).to have_content 'rspec first task'
+  end
+
+  scenario 'Task list should be ascending order by due date when user click on ▲ マーク' do
+    visit tasks_path
+    click_link '▲'
+    expect(page).to have_content 'Due Date'
+    urgent_deadline = find(:xpath, ".//table/tbody/tr[1]/td[2]").text
+    still_have_time = find(:xpath, ".//table/tbody/tr[2]/td[2]").text
+    expect(urgent_deadline).to have_content 'deadline is soon'
+    expect(still_have_time).to have_content 'still have time until deadline'
+  end
+
+  scenario 'Task list should be descending order by due date when user click on ▼ マーク' do
+    visit tasks_path
+    click_link '▼'
+    expect(page).to have_content 'Due Date'
+    still_have_time = find(:xpath, ".//table/tbody/tr[1]/td[2]").text
+    urgent_deadline = find(:xpath, ".//table/tbody/tr[2]/td[2]").text
+    expect(still_have_time).to have_content 'still have time until deadline'
+    expect(urgent_deadline).to have_content 'deadline is soon'
   end
 
   scenario 'When user click New Task link it creates new task.' do

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Task management', type: :system, js: true do
     expect(old_title).to have_content 'rspec first task'
   end
 
-  scenario 'Task list should be ascending order by due date when user click on ▲ マーク' do
+  scenario 'Task list should be ascending order by due date when user click on ▲ symbol' do
     visit tasks_path
     click_link '▲'
     expect(page).to have_content 'Due Date'
@@ -25,7 +25,7 @@ RSpec.describe 'Task management', type: :system, js: true do
     expect(still_have_time).to have_content 'still have time until deadline'
   end
 
-  scenario 'Task list should be descending order by due date when user click on ▼ マーク' do
+  scenario 'Task list should be descending order by due date when user click on ▼ symbol' do
     visit tasks_path
     click_link '▼'
     expect(page).to have_content 'Due Date'


### PR DESCRIPTION
## 実装内容
-  終了期限を追加
- `rails g migration AddDueDateToTasks` コマンドでマイグレーションファイル作成
- テストファイル作成

## 課題
https://github.com/Fablic/training#ステップ12-終了期限を追加しよう--スキップ可能

## 参考
rails link_to method : https://apidock.com/rails/ActionView/Helpers/UrlHelper/link_to
rails Action View Date Helpers : https://api.rubyonrails.org/classes/ActionView/Helpers/DateHelper.html#method-i-datetime_select

## 動作確認結果
![Screen Shot 2020-01-07 at 17 26 55](https://user-images.githubusercontent.com/58239688/71880124-f97d6980-3172-11ea-8f3a-f83a5363a1df.png)

宜しくお願い致します。