### PR TITLE
Jaeya_ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/todoApp/app/controllers/tasks_controller.rb
+++ b/todoApp/app/controllers/tasks_controller.rb
@@ -50,6 +50,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :description, :due_date)
+    params.require(:task).permit(:title, :description, :due_date, :status)
   end
 end

--- a/todoApp/app/controllers/tasks_controller.rb
+++ b/todoApp/app/controllers/tasks_controller.rb
@@ -2,11 +2,9 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    if params[:sort].blank?
-      @tasks = Task.order({ created_at: :desc })
-    else
-      @tasks = Task.order_by_due_date(params[:sort])
-    end
+    @tasks = Task.filter_by_ids_or_all(params[:filtered_ids])
+                 .search_result(params[:title_keyword], params[:current_status])
+                 .order_by_due_date_or_default(params[:due_date_direction])
   end
 
   def show

--- a/todoApp/app/controllers/tasks_controller.rb
+++ b/todoApp/app/controllers/tasks_controller.rb
@@ -2,8 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.filter_by_ids_or_all(params[:filtered_ids])
-                 .search_result(params[:title_keyword], params[:current_status])
+    @tasks = Task.search_result(params[:title_keyword], params[:current_status])
                  .order_by_due_date_or_default(params[:due_date_direction])
   end
 

--- a/todoApp/app/models/task.rb
+++ b/todoApp/app/models/task.rb
@@ -28,5 +28,4 @@ class Task < ApplicationRecord
       order(created_at: :desc)
     end
   end
-
 end

--- a/todoApp/app/models/task.rb
+++ b/todoApp/app/models/task.rb
@@ -17,10 +17,6 @@ class Task < ApplicationRecord
     current_status.presence ? where(status: current_status) : all
   end
 
-  def self.filter_by_ids_or_all(filtered_ids)
-    filtered_ids.presence ? where(id: filtered_ids) : all
-  end
-
   def self.order_by_due_date_or_default(due_date_direction)
     if due_date_direction == 'DESC' || due_date_direction == 'ASC'
       order(due_date: due_date_direction.to_sym)

--- a/todoApp/app/models/task.rb
+++ b/todoApp/app/models/task.rb
@@ -14,7 +14,8 @@ class Task < ApplicationRecord
   end
 
   def self.search_by_status(current_status)
-    current_status.presence ? where("status = ?", current_status) : all
+    # current_status.presence ? where("status = ?", current_status) : all
+    current_status.presence ? where(status: current_status) : all
   end
 
   def self.filter_by_ids_or_all(filtered_ids)

--- a/todoApp/app/models/task.rb
+++ b/todoApp/app/models/task.rb
@@ -1,15 +1,32 @@
 class Task < ApplicationRecord
   enum status: { todo: 0, ongoing: 1, done: 2 }
   validates :title, presence: true, length: { maximum: 50 }
-  validates :status, inclusion: { in: status }
+  validates :status, inclusion: { in: statuses }
 
-  def self.order_by_due_date(direction)
-    if direction == 'due_date_desc'
-      Task.order({ due_date: :desc })
-    elsif direction == 'due_date_asc'
-      Task.order({ due_date: :asc })
+
+  def self.search_result(title_keyword, current_status)
+    search_by_title(title_keyword)
+        .search_by_status(current_status)
+  end
+
+  def self.search_by_title(title_keyword)
+    title_keyword.presence ? where("title Like ?", "%#{sanitize_sql_like(title_keyword)}%") : all
+  end
+
+  def self.search_by_status(current_status)
+    current_status.presence ? where("status = ?", current_status) : all
+  end
+
+  def self.filter_by_ids_or_all(filtered_ids)
+    filtered_ids.presence ? where(id: filtered_ids) : all
+  end
+
+  def self.order_by_due_date_or_default(due_date_direction)
+    if due_date_direction == 'DESC' || due_date_direction == 'ASC'
+      order("due_date #{due_date_direction}")
     else
-      Task.order({ created_at: :desc })
+      order(created_at: :desc)
     end
   end
+
 end

--- a/todoApp/app/models/task.rb
+++ b/todoApp/app/models/task.rb
@@ -14,7 +14,6 @@ class Task < ApplicationRecord
   end
 
   def self.search_by_status(current_status)
-    # current_status.presence ? where("status = ?", current_status) : all
     current_status.presence ? where(status: current_status) : all
   end
 

--- a/todoApp/app/models/task.rb
+++ b/todoApp/app/models/task.rb
@@ -1,5 +1,7 @@
 class Task < ApplicationRecord
+  enum status: { todo: 0, ongoing: 1, done: 2 }
   validates :title, presence: true, length: { maximum: 50 }
+  validates :status, inclusion: { in: status }
 
   def self.order_by_due_date(direction)
     if direction == 'due_date_desc'

--- a/todoApp/app/views/tasks/_form.html.erb
+++ b/todoApp/app/views/tasks/_form.html.erb
@@ -22,6 +22,11 @@
   </div>
 
   <div class="field">
+    <%= form.label :status %>
+    <%= form.select :status, Task.statuses.keys %>
+  </div>
+
+  <div class="field">
     <%= form.label :due_date %>
     <%= form.datetime_select :due_date %>
   </div>

--- a/todoApp/app/views/tasks/_search.html.erb
+++ b/todoApp/app/views/tasks/_search.html.erb
@@ -1,0 +1,10 @@
+<fieldset>
+  <legend>Search</legend>
+  <%= form_tag(tasks_path, method: :get) do %>
+    <%= label_tag(:title_keyword, t('.title_keyword')) %>:
+    <%= text_field_tag(:title_keyword) %>
+    <%= label_tag(:current_status, t('.current_status')) %>:
+    <%= select_tag(:current_status, options_for_select(Task.statuses), include_blank: 'All') %>
+    <%= submit_tag(t('.search')) %>
+  <% end %>
+</fieldset>

--- a/todoApp/app/views/tasks/_search.html.erb
+++ b/todoApp/app/views/tasks/_search.html.erb
@@ -2,9 +2,11 @@
   <legend>Search</legend>
   <%= form_tag(tasks_path, method: :get) do %>
     <%= label_tag(:title_keyword, t('.title_keyword')) %>:
-    <%= text_field_tag(:title_keyword) %>
+    <%= text_field_tag(:title_keyword, params[:title_keyword]) %>
     <%= label_tag(:current_status, t('.current_status')) %>:
-    <%= select_tag(:current_status, options_for_select(Task.statuses), include_blank: 'All') %>
+    <%= select_tag(:current_status, options_for_select(Task.statuses, params[:current_status]), include_blank: 'All') %>
+    <%= label_tag(:due_date_direction, t('.due_date')) %>:
+    <%= select_tag(:due_date_direction, options_for_select(['DESC', 'ASC'], params[:due_date_direction]), include_blank: 'Default') %>
     <%= submit_tag(t('.search')) %>
   <% end %>
 </fieldset>

--- a/todoApp/app/views/tasks/index.html.erb
+++ b/todoApp/app/views/tasks/index.html.erb
@@ -10,8 +10,8 @@
     <th><%= Task.human_attribute_name(:description) %></th>
     <th><%= Task.human_attribute_name(:status) %></th>
     <th><%= Task.human_attribute_name(:due_date) %>
-      <%= link_to '▼', controller: :tasks, due_date_direction: :'DESC' %>
-      <%= link_to '▲', controller: :tasks, due_date_direction: :'ASC' %>
+      <%= link_to '▼', controller: :tasks, due_date_direction: :'DESC', :filtered_ids => @tasks.pluck(:id) %>
+      <%= link_to '▲', controller: :tasks, due_date_direction: :'ASC', :filtered_ids => @tasks.pluck(:id) %>
     </th>
     <th><%= Task.human_attribute_name(:created_at) %></th>
     <th colspan="3"></th>

--- a/todoApp/app/views/tasks/index.html.erb
+++ b/todoApp/app/views/tasks/index.html.erb
@@ -9,10 +9,7 @@
     <th><%= Task.human_attribute_name(:title) %></th>
     <th><%= Task.human_attribute_name(:description) %></th>
     <th><%= Task.human_attribute_name(:status) %></th>
-    <th><%= Task.human_attribute_name(:due_date) %>
-      <%= link_to '▼', controller: :tasks, due_date_direction: :'DESC', :filtered_ids => @tasks.pluck(:id) %>
-      <%= link_to '▲', controller: :tasks, due_date_direction: :'ASC', :filtered_ids => @tasks.pluck(:id) %>
-    </th>
+    <th><%= Task.human_attribute_name(:due_date) %></th>
     <th><%= Task.human_attribute_name(:created_at) %></th>
     <th colspan="3"></th>
   </tr>

--- a/todoApp/app/views/tasks/index.html.erb
+++ b/todoApp/app/views/tasks/index.html.erb
@@ -1,15 +1,17 @@
 <p id="notice"><%= notice %></p>
 
 <h1><%= t('.head_title') %></h1>
+<%= render 'search' %>
 
-<table>
+<table id="task table">
   <thead>
   <tr>
     <th><%= t('tasks.column.title') %></th>
     <th><%= t('tasks.column.description') %></th>
+    <th><%= t('tasks.column.status') %></th>
     <th><%= t('tasks.column.due_date') %>
-      <%= link_to '▼', :controller => 'tasks', :sort => 'due_date_desc' %>
-      <%= link_to '▲', :controller => 'tasks', :sort => 'due_date_asc' %>
+      <%= link_to '▼', :controller => 'tasks', :due_date_direction => 'DESC', :filtered_ids => @tasks.pluck(:id) %>
+      <%= link_to '▲', :controller => 'tasks', :due_date_direction => 'ASC', :filtered_ids => @tasks.pluck(:id) %>
     </th>
     <th><%= t('created_at') %></th>
     <th colspan="3"></th>
@@ -21,6 +23,7 @@
     <tr>
       <td><%= task.title %></td>
       <td><%= task.description %></td>
+      <td><%= task.status %></td>
       <td><%= l(task.due_date, format: :short) if task.due_date %></td>
       <td><%= l(task.created_at, format: :short) %></td>
       <td><%= link_to t('show'), task %></td>

--- a/todoApp/app/views/tasks/show.html.erb
+++ b/todoApp/app/views/tasks/show.html.erb
@@ -11,6 +11,11 @@
 </p>
 
 <p>
+  <strong><%= t('tasks.column.status') %> : </strong>
+  <%= @task.status %>
+</p>
+
+<p>
   <strong><%= t('tasks.column.due_date') %> : </strong>
   <%= l(@task.due_date, format: :short) if @task.due_date %>
 </p>

--- a/todoApp/config/locales/en.yml
+++ b/todoApp/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
     search:
       title_keyword: 'Title Keyword'
       current_status: 'Current Status'
+      due_date: 'Due Date'
       search: 'Search'
 
   flash_message:

--- a/todoApp/config/locales/en.yml
+++ b/todoApp/config/locales/en.yml
@@ -18,10 +18,15 @@ en:
       head_title: 'New List'
     edit:
       head_title: 'Editing Task'
+    search:
+      title_keyword: 'Title Keyword'
+      current_status: 'Current Status'
+      search: 'Search'
 
     column:
       title: 'Title'
       description: 'Description'
+      status: 'Status'
       due_date: 'Due Date'
 
   flash_message:
@@ -39,4 +44,5 @@ en:
       task:
         title: 'Title'
         description: 'Description'
+        status: 'Status'
         due_date: 'Due Date'

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -20,6 +20,7 @@ ja:
     search:
       title_keyword: 'タイトル・キーワード'
       current_status: '現状態'
+      due_date: '終了期限'
       search: '検索'
 
   flash_message:

--- a/todoApp/config/locales/ja.yml
+++ b/todoApp/config/locales/ja.yml
@@ -18,10 +18,15 @@ ja:
       head_title: 'タスク作成'
     edit:
       head_title: 'タスク修正'
+    search:
+      title_keyword: 'タイトル・キーワード'
+      current_status: '現状態'
+      search: '検索'
 
     column:
       title: 'タスク名'
       description: 'タスク詳細'
+      status: '進捗'
       due_date: '終了期限'
 
   flash_message:
@@ -39,4 +44,5 @@ ja:
       task:
         title: 'タスク名'
         description: 'タスク詳細'
+        status: '進捗'
         due_date: '終了期限'

--- a/todoApp/db/migrate/20191225075308_add_task_status_to_tasks.rb
+++ b/todoApp/db/migrate/20191225075308_add_task_status_to_tasks.rb
@@ -1,5 +1,9 @@
 class AddTaskStatusToTasks < ActiveRecord::Migration[6.0]
-  def change
-    add_column :tasks, :status, :integer, { :null => false, :default => 0 }
+  def up
+    add_column :tasks, :status, :integer, null: false, default: 0
+  end
+
+  def down
+    remove_column :tasks, :status, :integer
   end
 end

--- a/todoApp/db/migrate/20191225075308_add_task_status_to_tasks.rb
+++ b/todoApp/db/migrate/20191225075308_add_task_status_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddTaskStatusToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :status, :integer, { :null => false, :default => 0 }
+  end
+end

--- a/todoApp/db/migrate/20191227065128_add_index_to_tasks.rb
+++ b/todoApp/db/migrate/20191227065128_add_index_to_tasks.rb
@@ -1,0 +1,9 @@
+class AddIndexToTasks < ActiveRecord::Migration[6.0]
+  def up
+    add_index :tasks, :status
+  end
+
+  def down
+    remove_index :tasks, :status
+  end
+end

--- a/todoApp/db/schema.rb
+++ b/todoApp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_24_051519) do
+ActiveRecord::Schema.define(version: 2019_12_25_075308) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 50, null: false
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2019_12_24_051519) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "due_date"
+    t.integer "status", default: 0, null: false
   end
 
 end

--- a/todoApp/db/schema.rb
+++ b/todoApp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_25_075308) do
+ActiveRecord::Schema.define(version: 2019_12_27_065128) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 50, null: false
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2019_12_25_075308) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "due_date"
     t.integer "status", default: 0, null: false
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/todoApp/spec/models/task_spec.rb
+++ b/todoApp/spec/models/task_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Task, :type => :model do
     let!(:task4) { Task.create(title: 'title too but done', status: 'done') }
 
     context 'only return searched by title' do
-        it {
-          expect(Task.search_result('I am title', nil)).to eq([task1])
-        }
+      it {
+        expect(Task.search_result('I am title', nil)).to eq([task1])
+      }
     end
 
     context 'only return searched by status' do

--- a/todoApp/spec/models/task_spec.rb
+++ b/todoApp/spec/models/task_spec.rb
@@ -1,19 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe Task, :type => :model do
-  context 'When user searching' do
-    before do
-      Task.create!(title: 'title keyword', status: 'todo')
-      Task.create!(title: 'i am not', status: 'ongoing')
+  describe '#searching' do
+    let!(:task1) { Task.create(title: 'title keyword', status: 0) }
+    let!(:task2) { Task.create(title: 'still doing', status: 1) }
+
+    context 'only return searched title' do
+        it {
+          puts Task.search_by_title('title keyword').inspect
+          expect(Task.search_by_title('title keyword').pluck(:title)).to eq(task1.title)
+        }
     end
 
-    it 'should return only searched title when searched by title' do
-      expect(Task.search_by_title('title keyword').pluck(:title)).to eq(['title keyword'])
+    context 'only return searched status' do
+      it {
+        puts task2.status
+        puts Task.search_by_status(task2.status).inspect
+        # puts Task.where('status = ?', task2.status).inspect
+        expect(Task.search_by_status(task2.status).pluck(:title)).to eq(task2.title)
+      }
     end
 
-    it 'should return only searched status when searched by status' do
-
-    end
   end
+
+  # context 'When user searching' do
+  #   before do
+  #     task1 = Task.create!(title: 'title keyword', status: 'todo')
+  #     task2 = Task.create!()
+  #   end
+  #
+  #   it 'should return only searched title when searched by title' do
+  #     expect(Task.search_by_title('title keyword').title).to eq(task1.title)
+  #   end
+  #
+  #   it 'should return only searched status when searched by status' do
+  #     expect(Task.search_by_status(task2.status).title).to eq(task2.title)
+  #   end
+  # end
 
 end

--- a/todoApp/spec/models/task_spec.rb
+++ b/todoApp/spec/models/task_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Task, :type => :model do
+  context 'When user searching' do
+    before do
+      Task.create!(title: 'title keyword', status: 'todo')
+      Task.create!(title: 'i am not', status: 'ongoing')
+    end
+
+    it 'should return only searched title when searched by title' do
+      expect(Task.search_by_title('title keyword').pluck(:title)).to eq(['title keyword'])
+    end
+
+    it 'should return only searched status when searched by status' do
+
+    end
+  end
+
+end

--- a/todoApp/spec/models/task_spec.rb
+++ b/todoApp/spec/models/task_spec.rb
@@ -2,40 +2,29 @@ require 'rails_helper'
 
 RSpec.describe Task, :type => :model do
   describe '#searching' do
-    let!(:task1) { Task.create(title: 'title keyword', status: 0) }
-    let!(:task2) { Task.create(title: 'still doing', status: 1) }
+    let!(:task1) { Task.create(title: 'I am title', status: 'todo') }
+    let!(:task2) { Task.create(title: 'still doing', status: 'ongoing') }
+    let!(:task3) { Task.create(title: 'already done', status: 'done') }
+    let!(:task4) { Task.create(title: 'title too but done', status: 'done') }
 
-    context 'only return searched title' do
+    context 'only return searched by title' do
         it {
-          puts Task.search_by_title('title keyword').inspect
-          expect(Task.search_by_title('title keyword').pluck(:title)).to eq(task1.title)
+          expect(Task.search_result('I am title', nil)).to eq([task1])
         }
     end
 
-    context 'only return searched status' do
+    context 'only return searched by status' do
       it {
-        puts task2.status
-        puts Task.search_by_status(task2.status).inspect
-        # puts Task.where('status = ?', task2.status).inspect
-        expect(Task.search_by_status(task2.status).pluck(:title)).to eq(task2.title)
+        expect(Task.search_result(nil, 'ongoing')).to eq([task2])
+      }
+    end
+
+    context 'only return searched by title and status' do
+      it {
+        expect(Task.search_result('title', 'done')).to eq([task4])
       }
     end
 
   end
-
-  # context 'When user searching' do
-  #   before do
-  #     task1 = Task.create!(title: 'title keyword', status: 'todo')
-  #     task2 = Task.create!()
-  #   end
-  #
-  #   it 'should return only searched title when searched by title' do
-  #     expect(Task.search_by_title('title keyword').title).to eq(task1.title)
-  #   end
-  #
-  #   it 'should return only searched status when searched by status' do
-  #     expect(Task.search_by_status(task2.status).title).to eq(task2.title)
-  #   end
-  # end
 
 end

--- a/todoApp/spec/models/task_spec.rb
+++ b/todoApp/spec/models/task_spec.rb
@@ -81,4 +81,28 @@ RSpec.describe Task, :type => :model do
       }
     end
   end
+
+  describe '#sorting' do
+    let!(:task1) { Task.create(title: 'I am title', due_date: 1.day.from_now) }
+    let!(:task2) { Task.create(title: 'still doing', due_date: 3.days.from_now) }
+    let!(:task3) { Task.create(title: 'already done', due_date: 2.days.from_now) }
+
+    context 'should order by created at desc' do
+      it {
+        expect(Task.order_by_due_date_or_default(nil)).to eq([task3, task2, task1])
+      }
+    end
+
+    context 'should order by due date asc' do
+      it {
+        expect(Task.order_by_due_date_or_default('ASC')).to eq([task1, task3, task2])
+      }
+    end
+
+    context 'should order by due date desc' do
+      it {
+        expect(Task.order_by_due_date_or_default('DESC')).to eq([task2, task3, task1])
+      }
+    end
+  end
 end

--- a/todoApp/spec/models/task_spec.rb
+++ b/todoApp/spec/models/task_spec.rb
@@ -80,6 +80,5 @@ RSpec.describe Task, :type => :model do
         expect(Task.search_result('title', 'done')).to eq([task4])
       }
     end
-
   end
 end

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -14,26 +14,6 @@ RSpec.describe 'Task management', type: :system, js: true do
       expect(recent_title).to have_content 'rspec second task'
       expect(old_title).to have_content 'rspec first task'
     end
-
-    it 'should be ascending order by due date when user click on ▲ symbol' do
-      visit tasks_path
-      click_link '▲'
-      expect(page).to have_content 'Due Date'
-      urgent_deadline = find(:xpath, ".//table/tbody/tr[1]/td[2]").text
-      still_have_time = find(:xpath, ".//table/tbody/tr[2]/td[2]").text
-      expect(urgent_deadline).to have_content 'deadline is soon'
-      expect(still_have_time).to have_content 'still have time until deadline'
-    end
-
-    it 'should be descending order by due date when user click on ▼ symbol' do
-      visit tasks_path
-      click_link '▼'
-      expect(page).to have_content 'Due Date'
-      still_have_time = find(:xpath, ".//table/tbody/tr[1]/td[2]").text
-      urgent_deadline = find(:xpath, ".//table/tbody/tr[2]/td[2]").text
-      expect(still_have_time).to have_content 'still have time until deadline'
-      expect(urgent_deadline).to have_content 'deadline is soon'
-    end
   end
 
   context 'user click the link' do

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Task management', type: :system, js: true do
   context 'visit the tasks_path' do
     before do
-      Task.create!(title: 'rspec first task', description: 'deadline is soon', due_date: 1.day.from_now)
-      Task.create!(title: 'rspec second task', description: 'still have time until deadline', due_date: 3.days.from_now)
+      Task.create!(title: 'rspec first task', description: 'first description')
+      Task.create!(title: 'rspec second task', description: 'second description')
     end
 
     it 'shows the task list order by created recently.' do
@@ -85,8 +85,30 @@ RSpec.describe 'Task management', type: :system, js: true do
 
   context 'when user search' do
     before do
-      Task.create!(title: 'first task', description: 'first Description', status: 'todo')
-      Task.create!(title: 'second task', description: 'second Description', status: 'ongoing')
+      Task.create!(title: 'first task', description: 'deadline is soon', status: 'todo', due_date: 1.day.from_now)
+      Task.create!(title: 'second task', description: 'still have time until deadline', status: 'ongoing', due_date: 3.days.from_now)
+    end
+
+    it 'should be ascending order by due date when user search by due_date asc' do
+      visit tasks_path
+      select('ASC', from: 'Due Date')
+      click_button 'Search'
+      expect(page).to have_content 'Due Date'
+      urgent_deadline = find(:xpath, ".//table/tbody/tr[1]/td[2]").text
+      still_have_time = find(:xpath, ".//table/tbody/tr[2]/td[2]").text
+      expect(urgent_deadline).to have_content 'deadline is soon'
+      expect(still_have_time).to have_content 'still have time until deadline'
+    end
+
+    it 'should be descending order by due date when user search by due_date desc' do
+      visit tasks_path
+      select('DESC', from: 'Due Date')
+      click_button 'Search'
+      expect(page).to have_content 'Due Date'
+      still_have_time = find(:xpath, ".//table/tbody/tr[1]/td[2]").text
+      urgent_deadline = find(:xpath, ".//table/tbody/tr[2]/td[2]").text
+      expect(still_have_time).to have_content 'still have time until deadline'
+      expect(urgent_deadline).to have_content 'deadline is soon'
     end
 
     it 'only shows searched task list when user search by title' do

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -1,99 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe 'Task management', type: :system, js: true do
-  before do
-    Task.create!(title: "rspec first task", description: 'deadline is soon', due_date: DateTime.now + 1)
-    Task.create!(title: "rspec second task", description: 'still have time until deadline', due_date: DateTime.now + 3)
-  end
-
-  scenario 'When user visit the tasks_path it shows the task list order by created recently.' do
-    visit tasks_path
-    expect(page).to have_content 'Task List'
-    recent_title = find(:xpath, ".//table/tbody/tr[1]/td[1]").text
-    old_title = find(:xpath, ".//table/tbody/tr[2]/td[1]").text
-    expect(recent_title).to have_content 'rspec second task'
-    expect(old_title).to have_content 'rspec first task'
-  end
-
-  scenario 'Task list should be ascending order by due date when user click on ▲ symbol' do
-    visit tasks_path
-    click_link '▲'
-    expect(page).to have_content 'Due Date'
-    urgent_deadline = find(:xpath, ".//table/tbody/tr[1]/td[2]").text
-    still_have_time = find(:xpath, ".//table/tbody/tr[2]/td[2]").text
-    expect(urgent_deadline).to have_content 'deadline is soon'
-    expect(still_have_time).to have_content 'still have time until deadline'
-  end
-
-  scenario 'Task list should be descending order by due date when user click on ▼ symbol' do
-    visit tasks_path
-    click_link '▼'
-    expect(page).to have_content 'Due Date'
-    still_have_time = find(:xpath, ".//table/tbody/tr[1]/td[2]").text
-    urgent_deadline = find(:xpath, ".//table/tbody/tr[2]/td[2]").text
-    expect(still_have_time).to have_content 'still have time until deadline'
-    expect(urgent_deadline).to have_content 'deadline is soon'
-  end
-
-  scenario 'When user click New Task link it creates new task.' do
-    visit tasks_path
-    click_link 'New Task'
-    fill_in 'Title', :with => 'My Task'
-    fill_in 'Description', :with => 'My Task Description'
-    click_button 'Create Task'
-    expect(page).to have_content 'Task was successfully created.'
-  end
-
-  scenario 'Title must be exist when creates new task.' do
-    visit tasks_path
-    click_link 'New Task'
-    fill_in 'Description', :with => 'My Task Description'
-    click_button 'Create Task'
-    expect(page).to have_content "Title can't be blank"
-  end
-
-  scenario 'Title length must be less than 50 when creates new task' do
-    visit tasks_path
-    click_link 'New Task'
-    fill_in 'Title', :with => 'a' * 51
-    fill_in 'Description', :with => 'My Task Description'
-    click_button 'Create Task'
-    expect(page).to have_content 'Title is too long (maximum is 50 characters)'
-  end
-
-  scenario 'When user click Edit link it updates the selected task.' do
-    visit tasks_path
-    first(:link, 'Edit').click
-    fill_in 'Title', :with => 'My Edited Task'
-    fill_in 'Description', :with => 'Edit My Task Description'
-    click_button 'Update Task'
-    expect(page).to have_content 'Task was successfully updated.'
-  end
-
-  scenario 'Title must be exist when updates task.' do
-    visit tasks_path
-    first(:link, 'Edit').click
-    fill_in 'Title', :with => ''
-    fill_in 'Description', :with => 'Edit My Task Description'
-    click_button 'Update Task'
-    expect(page).to have_content "Title can't be blank"
-  end
-
-  scenario 'Title length must be less than 50 when when updates task.' do
-    visit tasks_path
-    first(:link, 'Edit').click
-    fill_in 'Title', :with => 'a' * 51
-    fill_in 'Description', :with => 'Edit My Task Description'
-    click_button 'Update Task'
-    expect(page).to have_content 'Title is too long (maximum is 50 characters)'
-  end
-
-  scenario 'When user click Destroy link it deletes the selected task.' do
-    visit tasks_path
-    accept_alert do
-      first(:link, 'Destroy').click
+  context 'when user search' do
+    before do
+      Task.create!(title: 'first task', description: 'first Description', status: 'todo')
+      Task.create!(title: 'second task', description: 'second Description', status: 'ongoing')
     end
-    expect(page).to have_content 'Task was successfully destroyed.'
+
+    it 'only shows searched task list when user search by title' do
+      visit tasks_path
+      fill_in 'Title Keyword', :with => 'first task'
+      click_button 'Search'
+      expect(page).to have_no_content 'second task'
+    end
+
+    it 'only shows searched task list when user search by status' do
+      visit tasks_path
+      select('todo', from: 'Current Status')
+      click_button 'Search'
+      within_table('task table') do
+        expect(page).to have_no_content 'ongoing'
+      end
+    end
   end
 
 end

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'Task management', type: :system, js: true do
       select('todo', from: 'Current Status')
       click_button 'Search'
       within_table('task table') do
-      expect(page).to have_no_content 'ongoing'
+        expect(page).to have_no_content 'ongoing'
       end
     end
   end

--- a/todoApp/spec/system/task_spec.rb
+++ b/todoApp/spec/system/task_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'Task management', type: :system, js: true do
       select('todo', from: 'Current Status')
       click_button 'Search'
       within_table('task table') do
-        expect(page).to have_no_content 'ongoing'
+      expect(page).to have_no_content 'ongoing'
       end
     end
   end


### PR DESCRIPTION
## 実装内容
- ステータス（未着手・着手中・完了）を追加
- 一覧画面でタイトルとステータスで検索ができるように
- 検索インデックスを追加
- 検索に対してmodel specを追加

## 課題
https://github.com/Fablic/training#ステップ13-ステータスを追加して検索できるようにしよう

## 参考
rails Active Record Query Interface : https://guides.rubyonrails.org/active_record_querying.html
rails Active Record Migrations add_index section : https://edgeguides.rubyonrails.org/active_record_migrations.html

## 動作確認結果
![Screen Shot 2020-01-14 at 10 26 34](https://user-images.githubusercontent.com/58239688/72306211-bf075580-36b9-11ea-96ab-a29b8b45f4a7.png)

宜しくお願い致します。