### PR TITLE
uzushino_ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/training_app/Gemfile
+++ b/training_app/Gemfile
@@ -27,6 +27,8 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
+gem 'ransack'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/training_app/Gemfile
+++ b/training_app/Gemfile
@@ -37,6 +37,8 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 
   gem 'rspec-rails', '~> 3.9'
+
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/training_app/Gemfile.lock
+++ b/training_app/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
+    polyamorous (2.3.2)
+      activerecord (>= 5.2.1)
     powerpack (0.1.2)
     public_suffix (4.0.3)
     puma (4.3.1)
@@ -154,6 +156,11 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    ransack (2.3.2)
+      activerecord (>= 5.2.1)
+      activesupport (>= 5.2.1)
+      i18n
+      polyamorous (= 2.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -255,6 +262,7 @@ DEPENDENCIES
   mysql2
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.1)
+  ransack
   rspec-rails (~> 3.9)
   sass-rails (>= 6)
   selenium-webdriver

--- a/training_app/Gemfile.lock
+++ b/training_app/Gemfile.lock
@@ -83,6 +83,11 @@ GEM
     fablicop (1.0.6)
       rubocop (~> 0.53.0)
       rubocop-rspec (>= 1.15.1)
+    factory_bot (5.1.1)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.1.1)
+      factory_bot (~> 5.1.0)
+      railties (>= 4.2.0)
     ffi (1.12.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -256,6 +261,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   fablicop
+  factory_bot_rails
   i18n_generators
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/training_app/app/controllers/tasks_controller.rb
+++ b/training_app/app/controllers/tasks_controller.rb
@@ -9,7 +9,7 @@ class TasksController < ApplicationController
     @q = Task.ransack(params[:q])
 
     @tasks = @q
-      .result()
+      .result
       .order(created_at: :desc)
   end
 

--- a/training_app/app/controllers/tasks_controller.rb
+++ b/training_app/app/controllers/tasks_controller.rb
@@ -6,7 +6,10 @@ class TasksController < ApplicationController
   # GET /tasks
   # GET /tasks.json
   def index
-    @tasks = Task
+    @q = Task.ransack(params[:q])
+
+    @tasks = @q
+      .result(distinct: true)
       .order(created_at: :desc)
   end
 
@@ -73,6 +76,6 @@ class TasksController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def task_params
-    params.require(:task).permit(:title, :body)
+    params.require(:task).permit(:title, :body, :status)
   end
 end

--- a/training_app/app/controllers/tasks_controller.rb
+++ b/training_app/app/controllers/tasks_controller.rb
@@ -9,6 +9,7 @@ class TasksController < ApplicationController
     @q = Task.ransack(params[:q])
 
     @tasks = @q
+      .result()
       .order(created_at: :desc)
   end
 

--- a/training_app/app/controllers/tasks_controller.rb
+++ b/training_app/app/controllers/tasks_controller.rb
@@ -9,7 +9,6 @@ class TasksController < ApplicationController
     @q = Task.ransack(params[:q])
 
     @tasks = @q
-      .result(distinct: true)
       .order(created_at: :desc)
   end
 

--- a/training_app/app/models/task.rb
+++ b/training_app/app/models/task.rb
@@ -6,13 +6,24 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text(65535)      not null
+#  status     :integer          default("todo"), not null
 #  title      :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  user_id    :integer
 #
+# Indexes
+#
+#  index_tasks_on_status  (status)
+#
 
 class Task < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
+
+  enum status: {
+    todo: 0,
+    progress: 1,
+    done: 2,
+  }
 end

--- a/training_app/app/views/tasks/_form.html.erb
+++ b/training_app/app/views/tasks/_form.html.erb
@@ -23,7 +23,7 @@
   
   <div class="field">
     <%= form.label :status %>
-    <%= form.select :status, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), k] } -%>
+    <%= form.select :status, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), k] } %>
   </div>
 
   <div class="actions">

--- a/training_app/app/views/tasks/_form.html.erb
+++ b/training_app/app/views/tasks/_form.html.erb
@@ -20,6 +20,11 @@
     <%= form.label :body %>
     <%= form.text_area :body %>
   </div>
+  
+  <div class="field">
+    <%= form.label :status %>
+    <%= form.select :status, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), v] } -%>
+  </div>
 
   <div class="actions">
     <%= form.submit %>

--- a/training_app/app/views/tasks/_form.html.erb
+++ b/training_app/app/views/tasks/_form.html.erb
@@ -23,7 +23,7 @@
   
   <div class="field">
     <%= form.label :status %>
-    <%= form.select :status, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), v] } -%>
+    <%= form.select :status, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), k] } -%>
   </div>
 
   <div class="actions">

--- a/training_app/app/views/tasks/index.html.erb
+++ b/training_app/app/views/tasks/index.html.erb
@@ -7,7 +7,7 @@
   <%= f.search_field :title_cont %>
 
   <%= f.label :status %>
-  <%= f.select :status_eq, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), v] }, include_blank: true -%>
+  <%= f.select :status_eq, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), v] }, include_blank: true %>
 
   <%= f.submit t('helpers.submit.search') %>
 <% end %>

--- a/training_app/app/views/tasks/index.html.erb
+++ b/training_app/app/views/tasks/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1><%= Task.model_name.human -%></h1>
+<h1><%= Task.model_name.human %></h1>
 
 <%= search_form_for(@q) do |f| %>
   <%= f.label :title %>

--- a/training_app/app/views/tasks/index.html.erb
+++ b/training_app/app/views/tasks/index.html.erb
@@ -7,15 +7,16 @@
   <%= f.search_field :title_cont %>
 
   <%= f.label :status %>
-  <%= f.select :status_eq, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), v] } -%>
+  <%= f.select :status_eq, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), v] }, include_blank: true -%>
 
-  <%= f.submit %>
+  <%= f.submit t('helpers.submit.search') %>
 <% end %>
 
 <table>
   <thead>
     <tr>
       <th><%= Task.human_attribute_name(:title) %></th>
+      <th><%= Task.human_attribute_name(:status) %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -24,6 +25,7 @@
     <% @tasks.each do |task| %>
       <tr>
         <td class="task-title"><%= task.title %></td>
+        <td><%= t("activerecord.enums.task.status.#{task.status}") %></td>
         <td><%= link_to t('show'), task %></td>
         <td><%= link_to t('edit'), edit_task_path(task) %></td>
         <td><%= link_to t('destroy'), task, { 

--- a/training_app/app/views/tasks/index.html.erb
+++ b/training_app/app/views/tasks/index.html.erb
@@ -2,6 +2,16 @@
 
 <h1><%= Task.model_name.human -%></h1>
 
+<%= search_form_for(@q) do |f| %>
+  <%= f.label :title %>
+  <%= f.search_field :title_cont %>
+
+  <%= f.label :status %>
+  <%= f.select :status_eq, Task.statuses.map { |k, v| [t("activerecord.enums.task.status.#{k}"), v] } -%>
+
+  <%= f.submit %>
+<% end %>
+
 <table>
   <thead>
     <tr>

--- a/training_app/config/locales/ja.yml
+++ b/training_app/config/locales/ja.yml
@@ -145,6 +145,7 @@ ja:
       create: 登録する
       submit: 保存する
       update: 更新する
+      search: 検索する
   number:
     currency:
       format:

--- a/training_app/config/locales/translation_ja.yml
+++ b/training_app/config/locales/translation_ja.yml
@@ -31,4 +31,4 @@ ja:
         status:
           todo: 未着手
           progress: 進行中
-          done: 終了
+          done: 完了

--- a/training_app/config/locales/translation_ja.yml
+++ b/training_app/config/locales/translation_ja.yml
@@ -24,3 +24,11 @@ ja:
       task:
         body: 本文 #g
         title: 題名  #g
+        status: 状態
+
+    enums:
+      task:
+        status:
+          todo: 未着手
+          progress: 進行中
+          done: 終了

--- a/training_app/db/migrate/20200122004916_change_column_on_tasks.rb
+++ b/training_app/db/migrate/20200122004916_change_column_on_tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeColumnOnTasks < ActiveRecord::Migration[6.0]
   def change
     change_column_null :tasks, :title, false

--- a/training_app/db/migrate/20200122043856_add_column_status_on_tasks.rb
+++ b/training_app/db/migrate/20200122043856_add_column_status_on_tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddColumnStatusOnTasks < ActiveRecord::Migration[6.0]
   def change
     add_column :tasks, :status, :integer, null: false, default: 0

--- a/training_app/db/migrate/20200122043856_add_column_status_on_tasks.rb
+++ b/training_app/db/migrate/20200122043856_add_column_status_on_tasks.rb
@@ -1,0 +1,6 @@
+class AddColumnStatusOnTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :status, :integer, null: false, default: 0
+    add_index :tasks, :status
+  end
+end

--- a/training_app/db/schema.rb
+++ b/training_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_22_004916) do
+ActiveRecord::Schema.define(version: 2020_01_22_043856) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
@@ -18,6 +18,8 @@ ActiveRecord::Schema.define(version: 2020_01_22_004916) do
     t.integer "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/training_app/spec/factories/task.rb
+++ b/training_app/spec/factories/task.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :task do
+    sequence(:title) { |n| "title #{n}"}
+    sequence(:body) { |n| "body #{n}"}
+
+    status { 0 }
+  end
+end

--- a/training_app/spec/models/tasks_spec.rb
+++ b/training_app/spec/models/tasks_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Task do
+  describe '検索機能について' do
+    let!(:task1) { Task.create(title: 'A', body: 'Hoge', status: :todo) }
+    let!(:task2) { Task.create(title: 'B', body: 'Foo', status: :progress) }
+    let!(:task3) { Task.create(title: 'C', body: 'Bar', status: :done) }
+
+    it '検索を行うことができる' do
+      params = { body_cont: 'O' }
+      expect(Task.search(params).result.count).to eq(2)
+
+      params = { status_eq: 2 }
+      expect(Task.search(params).result.count).to eq(1)
+    end
+  end
+end

--- a/training_app/spec/models/tasks_spec.rb
+++ b/training_app/spec/models/tasks_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 describe Task do
   describe '検索機能について' do
-    let!(:task1) { Task.create(title: 'A', body: 'Hoge', status: :todo) }
-    let!(:task2) { Task.create(title: 'B', body: 'Foo', status: :progress) }
-    let!(:task3) { Task.create(title: 'C', body: 'Bar', status: :done) }
+    let!(:task1) { create(:task, body: 'Hoge') }
+    let!(:task2) { create(:task, body: 'Foo') }
+    let!(:task3) { create(:task, body: 'Bar', status: :done) }
 
     it '検索を行うことができる' do
-      params = { body_cont: 'O' }
+      params = { body_cont: 'o' }
       expect(Task.search(params).result.count).to eq(2)
 
       params = { status_eq: 2 }

--- a/training_app/spec/rails_helper.rb
+++ b/training_app/spec/rails_helper.rb
@@ -62,4 +62,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end

--- a/training_app/spec/system/tasks_spec.rb
+++ b/training_app/spec/system/tasks_spec.rb
@@ -12,8 +12,8 @@ end
 
 RSpec.describe 'Tasks', type: :system do
   feature 'タスク一覧' do
-    given!(:task1) { Task.create!(title: 'ABC', body: 'foo') }
-    given!(:task2) { Task.create!(title: 'DEF', body: 'bar') }
+    given!(:task1) { create(:task) }
+    given!(:task2) { create(:task) }
 
     scenario '一覧に表示される' do
       visit tasks_path
@@ -44,7 +44,7 @@ RSpec.describe 'Tasks', type: :system do
     scenario '検索を行うことができる' do
       visit tasks_path
 
-      fill_in 'q[title_cont]', with: 'A'
+      fill_in 'q[title_cont]', with: task1.title
       click_on I18n.t('helpers.submit.search')
 
       expect(page).to have_content(task1.title)
@@ -53,7 +53,7 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   feature 'タスク詳細' do
-    given!(:task) { Task.create!(title: 'ABC', body: 'hoge') }
+    given!(:task) { create(:task) }
 
     scenario '一覧に表示される' do
       visit task_path(task)
@@ -101,7 +101,7 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   feature 'タスク更新' do
-    given!(:task) { Task.create(title: 'ABC', body: 'DEF') }
+    given!(:task) { create(:task, title: 'ABC', body: 'DEF') }
 
     scenario '登録済のタスクが入力されている' do
       visit edit_task_path(task)

--- a/training_app/spec/system/tasks_spec.rb
+++ b/training_app/spec/system/tasks_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_content I18n.t('tasks.index.destroy')
       expect(Task.count).to eq(1)
     end
+
+    scenario '検索を行うことができる' do
+      visit tasks_path
+
+      fill_in 'q[title_cont]', with: 'A'
+      click_on I18n.t('helpers.submit.search')
+
+      expect(page).to have_content(task1.title)
+      expect(page).to have_no_content(task2.title)
+    end
   end
 
   feature 'タスク詳細' do


### PR DESCRIPTION
### 概要

ステップ13: ステータスを追加して、検索できるようにしよう

### 対応内容

- [x] ステータス（未着手・着手中・完了）を追加してみよう
  - 【オプション要件】初学者ではない場合はstateを管理するGemを導入しても構いません
- [x] 一覧画面でタイトルとステータスで検索ができるようにしよう
  - 【オプション要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構いません
- [x] 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
  - 以降のステップでも必要に応じて確認する癖をつけましょう
- [x] 検索インデックスを貼りましょう
- [x] 検索に対してmodel specを追加してみよう（feature specも拡充しておきましょう

### 備考
```
ステップ12: 終了期限を追加しよう ★ スキップ可
```
はスキップ