### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/guild/app/models/logic_board.rb
+++ b/guild/app/models/logic_board.rb
@@ -6,15 +6,14 @@ class LogicBoard
 
   def self.index(user_id)
     {
-      'task_list'     => Task.where(user_id: user_id),
       'state_list'    => get_state_list,
       'priority_list' => get_priority_list,
       'label_list'    => get_label_list,
-    }
+    }.merge(get_task_all(user_id))
   end
 
   def self.get_task_all(user_id)
-    {'task_list' => Task.where(user_id: user_id)}
+    {'task_list' => Task.where(user_id: user_id).order(created_at: "DESC")}
   end
 
   def self.get_task_by_id(user_id, id)

--- a/guild/spec/app/models/logic_board_spec.rb
+++ b/guild/spec/app/models/logic_board_spec.rb
@@ -6,6 +6,8 @@ require 'value_objects/label'
 
 describe LogicBoard , type: :model do
   let!(:task_a) { create(:task1) }
+  let!(:task_b) { create(:task2) }
+  let!(:task_new) { create(:task_new) }
   let(:user_id) {1}
   let(:ng_user_id) {999999}
   let(:expected) {
@@ -18,9 +20,10 @@ describe LogicBoard , type: :model do
 
   describe '#index' do
     context 'Valid user' do
-      it 'task is found' do
+      it 'Task is found' do
         result = LogicBoard.index(user_id)
-        expect(result['task_list'].count).to eq 1
+        expect(result['task_list'].count).to eq 3
+        expect(result['task_list'][0].id).to eq task_new.id
         result['task_list'].each do | task |
           expect(task).to be_an_instance_of(Task)
           expect(task.user_id).to eq user_id
@@ -40,8 +43,10 @@ describe LogicBoard , type: :model do
 
   describe '#get_task_all' do
     context 'Valid user' do
-      it 'task is found' do
+      it 'Task is found' do
         result = LogicBoard.get_task_all(user_id)
+        expect(result['task_list'].count).to eq 3
+        expect(result['task_list'][0].id).to eq task_new.id
         result['task_list'].each do | task |
           expect(task).to be_an_instance_of(Task)
           expect(task.user_id).to eq user_id
@@ -58,7 +63,7 @@ describe LogicBoard , type: :model do
 
   describe '#get_task_by_id' do
     context 'Valid user' do
-      it 'task is found' do
+      it 'Task is found' do
         result = LogicBoard.get_task_by_id(user_id, task_a.id)
         expect(result['task']).to be_an_instance_of(Task)
         expect(result['task'].id).to eq task_a.id

--- a/guild/spec/app/models/logic_board_spec.rb
+++ b/guild/spec/app/models/logic_board_spec.rb
@@ -5,9 +5,27 @@ require 'value_objects/priority'
 require 'value_objects/label'
 
 describe LogicBoard , type: :model do
+
   let!(:task_a) { create(:task1) }
-  let!(:task_b) { create(:task2) }
-  let!(:task_new) { create(:task_new) }
+  let!(:task_b) {
+    create(:task1,
+      id: 2,
+      subject: 'test subject 2nd',
+      description: 'test description 2nd',
+      state: 2,
+      label: 2
+    )
+  }
+  let!(:task_new) {
+    create(:task1,
+      id: 3,
+      subject: 'new test subject',
+      description: 'new test description',
+      state: 3,
+      label: 3,
+      created_at: Time.current.tomorrow,
+      updated_at: Time.current.tomorrow)
+  }
   let(:user_id) {1}
   let(:ng_user_id) {999999}
   let(:expected) {

--- a/guild/spec/factories/task.rb
+++ b/guild/spec/factories/task.rb
@@ -1,31 +1,11 @@
 FactoryBot.define do
   factory :task1, class: Task do
-    id {1}
-    user_id {1}
-    subject {'test subject 1st'}
-    description {'test description'}
-    state {1}
-    priority {1}
-    label {1}
-  end
-  factory :task2, class: Task do
-    id {2}
-    user_id {1}
-    subject {'test subject 2nd'}
-    description {'test description 2nd'}
-    state {2}
-    priority {2}
-    label {2}
-  end
-  factory :task_new, class: Task do
-    id {3}
-    user_id {1}
-    subject {'new test subject'}
-    description {'new test description'}
-    state {1}
-    priority {3}
-    label {3}
-    created_at {Time.current.tomorrow}
-    updated_at {Time.current.tomorrow}
+    id { 1 }
+    user_id { 1 }
+    subject { 'test subject 1st' }
+    description { 'test description' }
+    state { 1 }
+    priority { 1 }
+    label { 1 }
   end
 end

--- a/guild/spec/factories/task.rb
+++ b/guild/spec/factories/task.rb
@@ -2,10 +2,30 @@ FactoryBot.define do
   factory :task1, class: Task do
     id {1}
     user_id {1}
-    subject {'test subject'}
+    subject {'test subject 1st'}
     description {'test description'}
     state {1}
     priority {1}
     label {1}
+  end
+  factory :task2, class: Task do
+    id {2}
+    user_id {1}
+    subject {'test subject 2nd'}
+    description {'test description 2nd'}
+    state {2}
+    priority {2}
+    label {2}
+  end
+  factory :task_new, class: Task do
+    id {3}
+    user_id {1}
+    subject {'new test subject'}
+    description {'new test description'}
+    state {1}
+    priority {3}
+    label {3}
+    created_at {Time.current.tomorrow}
+    updated_at {Time.current.tomorrow}
   end
 end


### PR DESCRIPTION
## 課題
[STEP10](https://github.com/fablic/training/#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

## 内容
- 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
- 並び替えがうまく行っていることをfeature specで書いてみましょう