### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/taskManager/app/controllers/tasks_controller.rb
+++ b/taskManager/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   before_action :task, only: [:destroy, :show, :edit, :update]
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(id: :desc)
   end
 
   def new

--- a/taskManager/app/controllers/tasks_controller.rb
+++ b/taskManager/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   before_action :task, only: [:destroy, :show, :edit, :update]
   def index
-    @tasks = Task.all.order(id: :desc)
+    @tasks = Task.order(id: :desc)
   end
 
   def new

--- a/taskManager/app/views/shared/_error_messages.html.erb
+++ b/taskManager/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,0 @@
-<% if model.errors.any? %>
-  <div class="alert alert-warning">
-    <ul>
-      <% model.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>

--- a/taskManager/app/views/shared/_error_messages.html.erb
+++ b/taskManager/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div class="alert alert-warning">
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/taskManager/app/views/tasks/_form.html.erb
+++ b/taskManager/app/views/tasks/_form.html.erb
@@ -1,4 +1,12 @@
-<%= render 'shared/error_messages', model: form.object %>
+<% if form.object.errors.any? %>
+  <div class="alert alert-warning">
+    <ul>
+      <% form.object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 
 <div class="form-group row">
   <%= form.label :summary, class: 'col-sm-2 col-form-label' %>

--- a/taskManager/app/views/tasks/_form.html.erb
+++ b/taskManager/app/views/tasks/_form.html.erb
@@ -1,0 +1,34 @@
+<%= render 'shared/error_messages', model: form.object %>
+
+<div class="form-group row">
+  <%= form.label :summary, class: 'col-sm-2 col-form-label' %>
+  <div class="col-sm-5">
+    <%= form.text_field :summary %>
+  </div>
+</div>
+<div class="form-group row">
+  <%= form.label :description, class: 'col-sm-2 col-form-label' %>
+  <div class="col-sm-5">
+    <%= form.text_area :description %>
+  </div>
+</div>
+<div class="form-group row">
+  <%= form.label :priority, class: 'col-sm-2 col-form-label' %>
+  <div class="col-sm-5">
+    <%# Todo: model.*.ymlに記述されているpriorityのHashMapをStep12以降で調整 %>
+    <%= form.select :priority, Task.priorities.map { |k,v| [t("tasks.edit.priority.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:priority)) } %>
+  </div>
+</div>
+<div class="form-group row">
+  <%= form.label :status, class: 'col-sm-2 col-form-label' %>
+  <div class="col-sm-5">
+    <%# Todo: model.*.ymlに記述されているstatusのHashMapをStep12以降で調整 %>
+    <%= form.select :status, Task.statuses.map { |k,v| [t("tasks.edit.status.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:status)) } %>
+  </div>
+</div>
+<div class="form-group row">
+  <%= form.label :due, class: 'col-sm-2 col-form-label' %>
+  <div class="col-sm-5">
+    <%= form.text_field :due %>
+  </div>
+</div>

--- a/taskManager/app/views/tasks/edit.html.erb
+++ b/taskManager/app/views/tasks/edit.html.erb
@@ -1,25 +1,35 @@
 <h1><%= t('.title', task_id: @task.id) %></h1>
 <%= form_with(model: @task, local: true) do |form| %>
-
-  <div class="field">
-    <%= form.label :summary %>
-    <%= form.text_field :summary %>
+<%= render 'shared/error_messages', model: form.object %>
+  <div class="form-group row">
+    <%= form.label :summary, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.text_field :summary %>
+    </div>
   </div>
-  <div class="field">
-    <%= form.label :description %>
-    <%= form.text_field :description %>
+  <div class="form-group row">
+    <%= form.label :description, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.text_field :description %>
+    </div>
   </div>
-  <div class="field">
-    <%= form.label :priority %>
-    <%= form.select :priority, Task.priorities.map { |k,v| [t(".priority.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:priority)) } %>
+  <div class="form-group row">
+    <%= form.label :priority, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.select :priority, Task.priorities.map { |k,v| [t(".priority.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:priority)) } %>
+    </div>
   </div>
-  <div class="field">
-    <%= form.label :status %>
-    <%= form.select :status, Task.statuses.map { |k,v| [t(".status.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:status)) } %>
+  <div class="form-group row">
+    <%= form.label :status, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.select :status, Task.statuses.map { |k,v| [t(".status.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:status)) } %>
+    </div>
   </div>
-  <div class="field">
-    <%= form.label :due %>
-    <%= form.text_field :due %>
+  <div class="form-group row">
+    <%= form.label :due, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.text_field :due %>
+    </div>
   </div>
   <div>
     <%= form.submit t('action.update'), class:"btn btn-primary" %>

--- a/taskManager/app/views/tasks/edit.html.erb
+++ b/taskManager/app/views/tasks/edit.html.erb
@@ -1,36 +1,6 @@
 <h1><%= t('.title', task_id: @task.id) %></h1>
 <%= form_with(model: @task, local: true) do |form| %>
-<%= render 'shared/error_messages', model: form.object %>
-  <div class="form-group row">
-    <%= form.label :summary, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.text_field :summary %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= form.label :description, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.text_field :description %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= form.label :priority, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.select :priority, Task.priorities.map { |k,v| [t(".priority.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:priority)) } %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= form.label :status, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.select :status, Task.statuses.map { |k,v| [t(".status.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:status)) } %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= form.label :due, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.text_field :due %>
-    </div>
-  </div>
+  <%= render 'form', { form: form } %>
   <div>
     <%= form.submit t('action.update'), class:"btn btn-primary" %>
     <%= link_to t('action.remove'), task_path(@task), class:"btn btn-primary", method: :delete, data: { confirm: t('flash.remove.confirm') } %>

--- a/taskManager/app/views/tasks/index.html.erb
+++ b/taskManager/app/views/tasks/index.html.erb
@@ -8,6 +8,7 @@
     <th><%= Task.human_attribute_name(:priority) %></th>
     <th><%= Task.human_attribute_name(:status) %></th>
     <th><%= Task.human_attribute_name(:due) %></th>
+    <th><%= Task.human_attribute_name(:created_at) %></th>
     <th></th>
   </tr>
   </thead>
@@ -19,6 +20,7 @@
     <td><%= t(".priority.#{task.priority}") %></td>
     <td><%= t(".status.#{task.status}") %></td>
     <td><%= task.due %></td>
+    <td><%= task.created_at %></td>
     <td>
       <%= link_to t('action.detail'), task_path(task.id), class:"btn btn-primary" %>
       <%= link_to t('action.update'), edit_task_path(task), class:"btn btn-primary" %>

--- a/taskManager/app/views/tasks/new.html.erb
+++ b/taskManager/app/views/tasks/new.html.erb
@@ -1,38 +1,7 @@
 <h1><%= t('.title')  %></h1>
 
 <%= form_with(model: @task, local: true) do |form| %>
-<%= render 'shared/error_messages', model: form.object %>
-
-  <div class="form-group row">
-    <%= form.label :summary, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.text_field :summary %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= form.label :description, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.text_area :description %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= form.label :priority, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.select :priority, Task.priorities.map { |k,v| [t(".priority.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:priority)) } %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= form.label :status, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.select :status, Task.statuses.map { |k,v| [t(".status.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:status)) } %>
-    </div>
-  </div>
-  <div class="form-group row">
-    <%= form.label :due, class: 'col-sm-2 col-form-label' %>
-    <div class="col-sm-5">
-      <%= form.text_field :due %>
-    </div>
-  </div>
+  <%= render 'form', { form: form } %>
   <div>
     <%= form.submit t('action.create'), class:"btn btn-primary" %>
     <%= link_to t('action.back'), root_path, class:"btn btn-primary" %>

--- a/taskManager/app/views/tasks/new.html.erb
+++ b/taskManager/app/views/tasks/new.html.erb
@@ -1,26 +1,37 @@
 <h1><%= t('.title')  %></h1>
 
 <%= form_with(model: @task, local: true) do |form| %>
+<%= render 'shared/error_messages', model: form.object %>
 
-  <div class="field">
-    <%= form.label :summary %>
-    <%= form.text_field :summary %>
+  <div class="form-group row">
+    <%= form.label :summary, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.text_field :summary %>
+    </div>
   </div>
-  <div class="field">
-    <%= form.label :description %>
-    <%= form.text_field :description %>
+  <div class="form-group row">
+    <%= form.label :description, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.text_area :description %>
+    </div>
   </div>
-  <div class="field">
-    <%= form.label :priority %>
-    <%= form.select :priority, Task.priorities.map { |k,v| [t(".priority.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:priority)) } %>
+  <div class="form-group row">
+    <%= form.label :priority, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.select :priority, Task.priorities.map { |k,v| [t(".priority.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:priority)) } %>
+    </div>
   </div>
-  <div class="field">
-    <%= form.label :status %>
-    <%= form.select :status, Task.statuses.map { |k,v| [t(".status.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:status)) } %>
+  <div class="form-group row">
+    <%= form.label :status, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.select :status, Task.statuses.map { |k,v| [t(".status.#{k}"),k] }, { prompt: t('flash.selector', item: Task.human_attribute_name(:status)) } %>
+    </div>
   </div>
-  <div class="field">
-    <%= form.label :due %>
-    <%= form.text_field :due %>
+  <div class="form-group row">
+    <%= form.label :due, class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-5">
+      <%= form.text_field :due %>
+    </div>
   </div>
   <div>
     <%= form.submit t('action.create'), class:"btn btn-primary" %>

--- a/taskManager/spec/system/tasks_spec.rb
+++ b/taskManager/spec/system/tasks_spec.rb
@@ -2,18 +2,16 @@ require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system, js: true  do
 
-  let!(:init_task) { Task.create( summary: 'task1', description: 'first task', priority: 1, status: 1 ) }
-  before do
-    Task.create( summary: 'task2', description: 'second task', priority: 3, status: 3 )
-    Task.create( summary: 'task3', description: 'third task', priority: 5, status: 5 )
-  end
+  let!(:test_task1) { Task.create( summary: 'task1', description: '1st task', priority: 1, status: 1 ) }
+  let!(:test_task2) { Task.create( summary: 'task2', description: '2nd task', priority: 3, status: 3 ) }
+  let!(:test_task3) { Task.create( summary: 'task3', description: '3rd task', priority: 5, status: 5 ) }
 
   describe 'Task List Page' do
     it 'Tests of Layout' do
       visit root_path
       expect(page).to have_content I18n.t('tasks.index.title')
-      expect(page).to have_content init_task.summary
-      expect(page).to have_content init_task.description
+      expect(page).to have_content test_task1.summary
+      expect(page).to have_content test_task1.description
       expect(page).to have_content I18n.t('tasks.index.priority.highest')
       expect(page).to have_content I18n.t('tasks.index.status.open')
     end
@@ -27,16 +25,16 @@ RSpec.describe 'Tasks', type: :system, js: true  do
 
     it 'Test of Click Detail Anchor Link' do
       visit root_path
-      all('tbody tr')[0].click_link I18n.t('action.detail')
-      expect(current_path).to eq task_path(init_task)
-      expect(page).to have_content I18n.t('tasks.show.title', task_id: init_task.id)
+      click_link I18n.t('action.detail'), match: :first
+      expect(current_path).to eq task_path(test_task3)
+      expect(page).to have_content I18n.t('tasks.show.title', task_id: test_task3.id)
     end
 
     it 'Test of Click Edit Anchor Link' do
       visit root_path
-      all('tbody tr')[0].click_link I18n.t('action.update')
-      expect(current_path).to eq edit_task_path(init_task)
-      expect(page).to have_content I18n.t('tasks.edit.title', task_id: init_task.id)
+      click_link I18n.t('action.update'), match: :first
+      expect(current_path).to eq edit_task_path(test_task3)
+      expect(page).to have_content I18n.t('tasks.edit.title', task_id: test_task3.id)
     end
   end
 
@@ -142,44 +140,44 @@ RSpec.describe 'Tasks', type: :system, js: true  do
   end
 
   describe 'Task Detail Page' do
-    it 'displays init_task settings' do
-      visit task_path(init_task)
-      expect(page).to have_content I18n.t('tasks.show.title', task_id: init_task.id)
-      expect(page).to have_content init_task.summary
-      expect(page).to have_content init_task.description
+    it 'displays test_task1 settings' do
+      visit task_path(test_task1)
+      expect(page).to have_content I18n.t('tasks.show.title', task_id: test_task1.id)
+      expect(page).to have_content test_task1.summary
+      expect(page).to have_content test_task1.description
       expect(page).to have_content I18n.t('tasks.index.priority.highest')
       expect(page).to have_content I18n.t('tasks.index.status.open')
     end
 
     it 'is increase when click Edit anchor-link' do
-      visit task_path(init_task)
+      visit task_path(test_task1)
       click_on I18n.t('action.update')
-      expect(current_path).to eq edit_task_path(init_task)
-      expect(page).to have_content I18n.t('tasks.edit.title', task_id: init_task.id)
+      expect(current_path).to eq edit_task_path(test_task1)
+      expect(page).to have_content I18n.t('tasks.edit.title', task_id: test_task1.id)
     end
 
     it 'Test of Click Back Anchor Link' do
-      visit task_path(init_task)
+      visit task_path(test_task1)
       click_on I18n.t('action.back')
       expect(current_path).to eq root_path
       expect(page).to have_content I18n.t('tasks.index.title')
     end
 
     it 'is clicked Delete Anchor Link and Cancel' do
-      visit task_path(init_task)
+      visit task_path(test_task1)
       expect {
         click_on I18n.t('action.remove')
         expect(page.driver.browser.switch_to.alert.text).to eq I18n.t('flash.remove.confirm')
         page.driver.browser.switch_to.alert.dismiss
-        expect(page).to have_content I18n.t('tasks.show.title', task_id: init_task.id)
+        expect(page).to have_content I18n.t('tasks.show.title', task_id: test_task1.id)
       }.to change { Task.count }.by (0)
-      expect(current_path).to eq task_path(init_task)
-      expect(page).to have_content init_task.summary
-      expect(page).to have_content init_task.description
+      expect(current_path).to eq task_path(test_task1)
+      expect(page).to have_content test_task1.summary
+      expect(page).to have_content test_task1.description
     end
 
     it 'is clicked Delete Anchor Link and OK' do
-      visit task_path(init_task)
+      visit task_path(test_task1)
       expect {
         click_on I18n.t('action.remove')
         expect(page.driver.browser.switch_to.alert.text).to eq I18n.t('flash.remove.confirm')
@@ -187,8 +185,8 @@ RSpec.describe 'Tasks', type: :system, js: true  do
         expect(page).to have_content I18n.t('tasks.index.title')
       }.to change { Task.count }.by (-1)
       expect(current_path).to eq tasks_path # root_pathに変更予定
-      expect(page).to have_no_content init_task.summary
-      expect(page).to have_no_content init_task.description
+      expect(page).to have_no_content test_task1.summary
+      expect(page).to have_no_content test_task1.description
     end
   end
 end

--- a/taskManager/spec/system/tasks_spec.rb
+++ b/taskManager/spec/system/tasks_spec.rb
@@ -10,11 +10,21 @@ RSpec.describe 'Tasks', type: :system, js: true  do
     it 'Tests of Layout' do
       visit root_path
       expect(page).to have_content I18n.t('tasks.index.title')
-      expect(page).to have_content test_task1.summary
-      expect(page).to have_content test_task1.description
-      expect(page).to have_content I18n.t('tasks.index.priority.highest')
-      expect(page).to have_content I18n.t('tasks.index.status.open')
+      expect(all('thead tr')[0].text).to have_content Task.human_attribute_name(:summary)
+      expect(all('thead tr')[0].text).to have_content Task.human_attribute_name(:description)
+      expect(all('thead tr')[0].text).to have_content Task.human_attribute_name(:priority)
+      expect(all('thead tr')[0].text).to have_content Task.human_attribute_name(:status)
+      expect(all('thead tr')[0].text).to have_content Task.human_attribute_name(:due)
+      expect(all('thead tr')[0].text).to have_content Task.human_attribute_name(:created_at)
+      expect(all('thead tr')[0].text).to have_no_content Task.human_attribute_name(:updated_at)
     end
+
+    it 'record is sorted by created_at with desc order' do
+      visit root_path
+      expect(all('tbody tr')[0].text).to have_content test_task3.summary
+      expect(all('tbody tr')[1].text).to have_content test_task2.summary
+      expect(all('tbody tr')[2].text).to have_content test_task1.summary
+    end 
 
     it 'Tests of Click Draft Anchor Link' do
       visit root_path


### PR DESCRIPTION
## 要件
[ステップ10: タスク一覧を作成日時の順番で並び替えましょう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

## 対応
- タスク一覧をIDの降順で並び替え（※INDEXが貼ってあるIDでソートしました）
- タスク一覧に項目「作成日」を追加
- タスク一覧が作成順の降順ソートされているかのspecテストを追加

## 検証
- タスク一覧画面を目視確認し、作成日が最新のレコードが上位に表示されること
- RSpecを実施して既存テストがエラーにならないこと
- RSpecを実施して降順ソートテストがエラーにならないこと
```
$ rspec
2020-02-14 10:39:36 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
Capybara starting Puma...
* Version 3.12.2 , codename: Llamas in Pajamas
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:51342
.........

Finished in 7.37 seconds (files took 1.35 seconds to load)
18 examples, 0 failures
```

## 備考
- 前ステップのPRがmerge前なので、PRの `into` は `kazuyoshi_nagano_step9` にしています