### PR TITLE
ステップ11: バリデーションを設定してみよう

### DIFF
--- a/pivote/app/models/task.rb
+++ b/pivote/app/models/task.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :description, length: { maximum: 1000 }
+
   # 間に差込で追加したいという要望に応えられるよう、値を10の倍数としている
   enum priority: { high: 10, middle: 20, low: 30 }
   enum status: { waiting: 10, doing: 20, done: 30 }

--- a/pivote/app/views/tasks/_form.html.erb
+++ b/pivote/app/views/tasks/_form.html.erb
@@ -1,3 +1,13 @@
+<% if task.errors.present? %>
+  <div id="error_explanation" class="alert alert-danger">
+    <ul>
+      <% task.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <%= form_with model: task, local: true do |f| %>
   <div><%= f.label :title %></div>
   <div><%= f.text_field :title, id: 'task_title' %></div>

--- a/pivote/db/migrate/20200317064217_change_tasks_title_and_description_limit.rb
+++ b/pivote/db/migrate/20200317064217_change_tasks_title_and_description_limit.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ChangeTasksTitleAndDescriptionLimit < ActiveRecord::Migration[5.2]
+  def up
+    change_column :tasks, :title, :string, limit: 30
+    change_column :tasks, :description, :text, limit: 1000
+  end
+
+  def down
+    change_column :tasks, :title, :string
+    change_column :tasks, :description, :text
+  end
+end

--- a/pivote/db/schema.rb
+++ b/pivote/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_09_064900) do
+ActiveRecord::Schema.define(version: 2020_03_17_064217) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "title", null: false
+    t.string "title", limit: 30, null: false
     t.text "description"
     t.integer "priority", limit: 1, null: false
     t.integer "status", limit: 1, null: false

--- a/pivote/spec/models/task_spec.rb
+++ b/pivote/spec/models/task_spec.rb
@@ -8,6 +8,11 @@ describe Task, type: :model do
       let(:task) { FactoryBot.build(:task, title: title) }
       subject { task }
 
+      context '0文字の場合' do
+        let(:title) { '' }
+        it { is_expected.to be_invalid }
+      end
+
       context '30文字の場合' do
         let(:title) { 'a' * 30 }
         it { is_expected.to be_valid }

--- a/pivote/spec/models/task_spec.rb
+++ b/pivote/spec/models/task_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Task, type: :model do
+  describe 'バリデーション' do
+    describe '名称' do
+      let(:task) { FactoryBot.build(:task, title: title) }
+      subject { task }
+
+      context '30文字の場合' do
+        let(:title) { 'a' * 30 }
+        it { is_expected.to be_valid }
+      end
+
+      context '31文字の場合' do
+        let(:title) { 'a' * 31 }
+        it { is_expected.to be_invalid }
+      end
+    end
+
+    describe '説明' do
+      let(:task) { FactoryBot.build(:task, description: description) }
+      subject { task }
+
+      context '1000文字の場合' do
+        let(:description) { 'a' * 1000 }
+        it { is_expected.to be_valid }
+      end
+
+      context '1001文字の場合' do
+        let(:description) { 'a' * 1001 }
+        it { is_expected.to be_invalid }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 課題
[ステップ11: バリデーションを設定してみよう](https://github.com/Fablic/training/tree/shunshunsuke#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)

## 変更内容
- タスクの名称と説明に文字数制限を設定した(DBとモデル両方)
  - spec実装
- 名称に空文字は禁止した