### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/pivote/app/controllers/tasks_controller.rb
+++ b/pivote/app/controllers/tasks_controller.rb
@@ -4,12 +4,8 @@ class TasksController < ApplicationController
   before_action :find_task, only: %i[show edit update destroy]
 
   def index
-    # ソートするカラムのリンクを踏む度に、「desc → asc → デフォルト(作成日時の降順) → desc …」と並び変わる
-    if !params[:sort_column] || params[:direction] == 'asc'
-      @tasks = Task.all.order(created_at: :desc)
-    else
-      sort_tasks
-    end
+    @search_form = TaskSearchForm.new(search_params)
+    @tasks = @search_form.search
   end
 
   def show
@@ -49,10 +45,8 @@ class TasksController < ApplicationController
 
   private
 
-  def sort_tasks
-    @sorted_column = params[:sort_column]
-    @direction = params[:direction] ? 'asc' : 'desc'
-    @tasks = Task.all.order(@sorted_column.to_s + ' ' + @direction)
+  def search_params
+    params.require(:search).permit(:title, :priority, :status, :sort_column, :direction) unless params[:search].nil?
   end
 
   def task_params

--- a/pivote/app/helpers/tasks_helper.rb
+++ b/pivote/app/helpers/tasks_helper.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
 module TasksHelper
-  # 表示するべきソート用アイコンを返す
-  # === 引数
-  # * self_column - このカラムにソートアイコンを表示する
-  # * sorted_column - 現在このカラムでソートされている
-  # * direction - 現在この順番でソートされている
-  def sort_icon(self_column, sorted_column, direction)
-    if direction && self_column == sorted_column.to_sym
-      if direction == 'asc'
+  def sort_icon(self_column, search_form)
+    if search_form.direction && self_column == search_form.sort_column.to_sym
+      if search_form.direction == 'asc'
         '▲'
       else
         '▼'

--- a/pivote/app/helpers/tasks_helper.rb
+++ b/pivote/app/helpers/tasks_helper.rb
@@ -12,4 +12,21 @@ module TasksHelper
       ''
     end
   end
+
+  def sort_params(search_form_hash, next_sort_column)
+    # ソートするカラムのリンクを踏む度に、「desc → asc → デフォルト(作成日時の降順) → desc …」と並び変わる
+    if search_form_hash['sort_column'] == next_sort_column.to_s
+      if search_form_hash['direction'] == 'asc'
+        search_form_hash['sort_column'] = nil
+        search_form_hash['direction'] = nil
+      else
+        search_form_hash['sort_column'] = next_sort_column
+        search_form_hash['direction'] = 'asc'
+      end
+    else
+      search_form_hash['sort_column'] = next_sort_column
+      search_form_hash['direction'] = 'desc'
+    end
+    search_form_hash
+  end
 end

--- a/pivote/app/helpers/tasks_helper.rb
+++ b/pivote/app/helpers/tasks_helper.rb
@@ -15,17 +15,18 @@ module TasksHelper
 
   def sort_params(search_form_hash, next_sort_column)
     # ソートするカラムのリンクを踏む度に、「desc → asc → デフォルト(作成日時の降順) → desc …」と並び変わる
-    if search_form_hash['sort_column'] == next_sort_column.to_s
-      if search_form_hash['direction'] == 'asc'
-        search_form_hash['sort_column'] = nil
-        search_form_hash['direction'] = nil
-      else
-        search_form_hash['sort_column'] = next_sort_column
-        search_form_hash['direction'] = 'asc'
-      end
-    else
+    unless search_form_hash['sort_column'] == next_sort_column.to_s
       search_form_hash['sort_column'] = next_sort_column
       search_form_hash['direction'] = 'desc'
+      return search_form_hash
+    end
+
+    if search_form_hash['direction'] == 'asc'
+      search_form_hash['sort_column'] = nil
+      search_form_hash['direction'] = nil
+    else
+      search_form_hash['sort_column'] = next_sort_column
+      search_form_hash['direction'] = 'asc'
     end
     search_form_hash
   end

--- a/pivote/app/models/task.rb
+++ b/pivote/app/models/task.rb
@@ -5,8 +5,14 @@ class Task < ApplicationRecord
   validates :description, length: { maximum: 1000 }
 
   # 間に差込で追加したいという要望に応えられるよう、値を10の倍数としている
-  enum priority: { high: 10, middle: 20, low: 30 }
-  enum status: { waiting: 10, doing: 20, done: 30 }
+  enum priority: { low: 10, middle: 20, high: 30 }
+  enum status: { done: 10, doing: 20, waiting: 30 }
+
+  scope :search_with_priority, -> (priority) { where(priority: priority) }
+  scope :search_with_status, -> (status) { where(status: status) }
+  scope :match_with_title, -> (title) { where(:title.to_s + ' LIKE ?', "%#{title}%") }
+  scope :by_default, -> { order(created_at: :desc) }
+  scope :by_custom, -> (column, direction) { order(column + ' ' + direction) }
 
   def format_deadline
     I18n.l self.deadline, format: :date if self.deadline

--- a/pivote/app/models/task.rb
+++ b/pivote/app/models/task.rb
@@ -8,11 +8,10 @@ class Task < ApplicationRecord
   enum priority: { low: 10, middle: 20, high: 30 }
   enum status: { done: 10, doing: 20, waiting: 30 }
 
-  scope :search_with_priority, -> (priority) { where(priority: priority) }
-  scope :search_with_status, -> (status) { where(status: status) }
-  scope :match_with_title, -> (title) { where(:title.to_s + ' LIKE ?', "%#{title}%") }
-  scope :by_default, -> { order(created_at: :desc) }
-  scope :by_custom, -> (column, direction) { order(column + ' ' + direction) }
+  scope :search_with_priority, -> (priority) { where(priority: priority) if priority.present? }
+  scope :search_with_status, -> (status) { where(status: status) if status.present? }
+  scope :match_with_title, -> (title) { where(:title.to_s + ' LIKE ?', "%#{title}%") if title.present? }
+  scope :sort_by_column, ->(column, sort) { order((column.presence || 'created_at').to_sym => (sort.presence || 'desc').to_sym) }
 
   def format_deadline
     I18n.l self.deadline, format: :date if self.deadline

--- a/pivote/app/models/task_search_form.rb
+++ b/pivote/app/models/task_search_form.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class TaskSearchForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :title, :string
+  attribute :priority, :string
+  attribute :status, :string
+  attribute :sort_column, :string
+  attribute :direction, :string
+
+  def search
+    scope = Task.all
+    scope = scope.search_with_priority(priority) if priority.present?
+    scope = scope.search_with_status(status) if status.present?
+    scope = scope.match_with_title(title) if title.present?
+    sort(scope)
+  end
+
+  def sort(scope)
+    # ソートするカラムのリンクを踏む度に、「desc → asc → デフォルト(作成日時の降順) → desc …」と並び変わる
+    if !sort_column || direction == 'asc'
+      self.direction = nil
+      scope.by_default
+    else
+      self.direction = direction.present? ? 'asc' : 'desc'
+      scope.by_custom(sort_column, direction)
+    end
+  end
+end

--- a/pivote/app/models/task_search_form.rb
+++ b/pivote/app/models/task_search_form.rb
@@ -19,12 +19,9 @@ class TaskSearchForm
   end
 
   def sort(scope)
-    # ソートするカラムのリンクを踏む度に、「desc → asc → デフォルト(作成日時の降順) → desc …」と並び変わる
-    if !sort_column || direction == 'asc'
-      self.direction = nil
+    if sort_column.blank?
       scope.by_default
     else
-      self.direction = direction.present? ? 'asc' : 'desc'
       scope.by_custom(sort_column, direction)
     end
   end

--- a/pivote/app/models/task_search_form.rb
+++ b/pivote/app/models/task_search_form.rb
@@ -11,14 +11,9 @@ class TaskSearchForm
   attribute :direction, :string
 
   def search
-    scope = Task.all
-    scope = scope.search_with_priority(priority)
-    scope = scope.search_with_status(status)
-    scope = scope.match_with_title(title)
-    sort(scope)
-  end
-
-  def sort(scope)
-    scope.sort_by_column(sort_column, direction)
+    Task.search_with_priority(priority)
+        .search_with_status(status)
+        .match_with_title(title)
+        .sort_by_column(sort_column, direction)
   end
 end

--- a/pivote/app/models/task_search_form.rb
+++ b/pivote/app/models/task_search_form.rb
@@ -12,17 +12,13 @@ class TaskSearchForm
 
   def search
     scope = Task.all
-    scope = scope.search_with_priority(priority) if priority.present?
-    scope = scope.search_with_status(status) if status.present?
-    scope = scope.match_with_title(title) if title.present?
+    scope = scope.search_with_priority(priority)
+    scope = scope.search_with_status(status)
+    scope = scope.match_with_title(title)
     sort(scope)
   end
 
   def sort(scope)
-    if sort_column.blank?
-      scope.by_default
-    else
-      scope.by_custom(sort_column, direction)
-    end
+    scope.sort_by_column(sort_column, direction)
   end
 end

--- a/pivote/app/views/tasks/index.html.erb
+++ b/pivote/app/views/tasks/index.html.erb
@@ -1,13 +1,34 @@
 <h1><%= t('headline.task.index') %></h1>
 
+<hr>
+<%= form_with url: tasks_path, method: :get, local: true do |f| %>
+  <div>
+    <%= f.label Task.human_attribute_name(:priority) + '：' %>
+    <%= f.select 'search[priority]', Task.enum_options_for_select(:priority), { include_blank: true, selected: @search_form.priority } %>
+  </div>
+  <div>
+    <%= f.label Task.human_attribute_name(:status) + '：' %>
+    <%= f.select 'search[status]', Task.enum_options_for_select(:status), { include_blank: true, selected: @search_form.status } %>
+  </div>
+  <div>
+    <%= f.label Task.human_attribute_name(:title) + '：' %>
+    <%= f.text_field 'search[title]', value: @search_form.title %>
+  </div>
+  <%= f.submit t('button.search') %>
+<% end %>
+<%= form_with url: tasks_path, method: :get, local: true do |f| %>
+  <%= f.submit t('button.reset') %>
+<% end %>
+<hr>
+
 <%= link_to t('crud.create'), new_task_path %>
 
 <table>
   <tr>
     <th><%= Task.human_attribute_name(:title) %></th>
-    <th><%= Task.human_attribute_name(:priority) %></th>
-    <th><%= Task.human_attribute_name(:status) %></th>
-    <th><%= link_to Task.human_attribute_name(:deadline) + sort_icon(:deadline, @sorted_column, @direction), tasks_path(sort_column: :deadline, direction: @direction) %></th>
+    <th><%= link_to Task.human_attribute_name(:priority) + sort_icon(:priority, @search_form), tasks_path(search: @search_form.attributes, 'search[sort_column]' => :priority, 'search[direction]' => @search_form.direction) %></th>
+    <th><%= link_to Task.human_attribute_name(:status) + sort_icon(:status, @search_form), tasks_path(search: @search_form.attributes, 'search[sort_column]' => :status, 'search[direction]' => @search_form.direction) %></th>
+    <th><%= link_to Task.human_attribute_name(:deadline) + sort_icon(:deadline, @search_form), tasks_path(search: @search_form.attributes, 'search[sort_column]' => :deadline, 'search[direction]' => @search_form.direction) %></th>
     <th></th>
   </tr>
   <% @tasks.each do |task| %>

--- a/pivote/app/views/tasks/index.html.erb
+++ b/pivote/app/views/tasks/index.html.erb
@@ -26,9 +26,9 @@
 <table>
   <tr>
     <th><%= Task.human_attribute_name(:title) %></th>
-    <th><%= link_to Task.human_attribute_name(:priority) + sort_icon(:priority, @search_form), tasks_path(search: @search_form.attributes, 'search[sort_column]' => :priority, 'search[direction]' => @search_form.direction) %></th>
-    <th><%= link_to Task.human_attribute_name(:status) + sort_icon(:status, @search_form), tasks_path(search: @search_form.attributes, 'search[sort_column]' => :status, 'search[direction]' => @search_form.direction) %></th>
-    <th><%= link_to Task.human_attribute_name(:deadline) + sort_icon(:deadline, @search_form), tasks_path(search: @search_form.attributes, 'search[sort_column]' => :deadline, 'search[direction]' => @search_form.direction) %></th>
+    <th><%= link_to Task.human_attribute_name(:priority) + sort_icon(:priority, @search_form), tasks_path(search: sort_params(@search_form.attributes, :priority)) %></th>
+    <th><%= link_to Task.human_attribute_name(:status) + sort_icon(:status, @search_form), tasks_path(search: sort_params(@search_form.attributes, :status)) %></th>
+    <th><%= link_to Task.human_attribute_name(:deadline) + sort_icon(:deadline, @search_form), tasks_path(search: sort_params(@search_form.attributes, :deadline)) %></th>
     <th></th>
   </tr>
   <% @tasks.each do |task| %>

--- a/pivote/config/locales/en.yml
+++ b/pivote/config/locales/en.yml
@@ -40,6 +40,9 @@ en:
     create: Create
     update: Update
     delete: Delete
+  button:
+    search: Search
+    reset: Reset
   flash:
     task:
       create: Created 「%{task}」.
@@ -49,3 +52,7 @@ en:
     confirm: Delete 「%{task}」?
   link:
     all: all
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      date: "%Y/%m/%d"

--- a/pivote/config/locales/ja.yml
+++ b/pivote/config/locales/ja.yml
@@ -9,6 +9,9 @@ ja:
     create: 登録
     update: 編集
     delete: 削除
+  button:
+    search: 検索
+    reset: リセット
   flash:
     task:
       create: タスク「%{task}」を登録しました。

--- a/pivote/db/migrate/20200321113928_add_index_tasks.rb
+++ b/pivote/db/migrate/20200321113928_add_index_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIndexTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :priority
+    add_index :tasks, :status
+  end
+end

--- a/pivote/db/schema.rb
+++ b/pivote/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_17_064217) do
+ActiveRecord::Schema.define(version: 2020_03_21_113928) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", limit: 30, null: false
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2020_03_17_064217) do
     t.datetime "deadline"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["priority"], name: "index_tasks_on_priority"
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/pivote/spec/system/tasks_spec.rb
+++ b/pivote/spec/system/tasks_spec.rb
@@ -3,70 +3,205 @@
 require 'rails_helper'
 
 describe 'タスク管理機能', type: :system do
-  let(:test_task) { FactoryBot.create(:task) }
+  let(:single_task) { FactoryBot.create(:task) }
+  let(:tasks_1) {
+    FactoryBot.create(:task, title: task1_title, priority: :high, status: :waiting, deadline: Time.zone.now, created_at: Time.zone.now)
+    FactoryBot.create(:task, title: task2_title, priority: :middle, status: :doing, deadline: 1.day.ago, created_at: 1.day.ago)
+    FactoryBot.create(:task, title: task3_title, priority: :low, status: :done, deadline: 2.days.ago, created_at: 2.days.ago)
+  }
+  let(:task1_title) { '1st' }
+  let(:task2_title) { '2nd' }
+  let(:task3_title) { '3rd' }
+  let(:task1_i) { page.body.index(task1_title) }
+  let(:task2_i) { page.body.index(task2_title) }
+  let(:task3_i) { page.body.index(task3_title) }
+  let(:tasks_2) {
+    FactoryBot.create(:task, title: task4_title, priority: :high, status: :done, deadline: 4.days.ago, created_at: 4.days.ago)
+    FactoryBot.create(:task, title: task5_title, priority: :middle, status: :doing, deadline: 5.days.ago, created_at: 5.days.ago)
+    FactoryBot.create(:task, title: task6_title, priority: :low, status: :waiting, deadline: 6.days.ago, created_at: 6.days.ago)
+  }
+  let(:task4_title) { '4th' }
+  let(:task5_title) { '5th' }
+  let(:task6_title) { '6th' }
+  let(:task4_i) { page.body.index(task4_title) }
+  let(:task5_i) { page.body.index(task5_title) }
+  let(:task6_i) { page.body.index(task6_title) }
 
-  describe '一覧表示' do
+  describe 'ソート機能' do
     before do
-      FactoryBot.create(:task, title: '1st', deadline: Time.zone.now, created_at: Time.zone.now)
-      FactoryBot.create(:task, title: '2nd', deadline: 1.day.ago, created_at: 1.day.ago)
-      FactoryBot.create(:task, title: '3rd', deadline: 2.days.ago, created_at: 2.days.ago)
+      tasks_1
       visit tasks_path
     end
 
-    it '作成日時の降順で表示される' do
-      trs = all('table tr')
-      tds = trs[1].all('td')
-      expect(tds[0]).to have_content '1st'
-      tds = trs[2].all('td')
-      expect(tds[0]).to have_content '2nd'
-      tds = trs[3].all('td')
-      expect(tds[0]).to have_content '3rd'
+    context '何も指定していないとき' do
+      it '作成日時の降順で表示される' do
+        expect(task1_i).to be < task2_i
+        expect(task2_i).to be < task3_i
+      end
     end
 
-    it '期限のリンクを1回踏むと、降順で表示される' do
-      click_link '期限'
-      # DOMが生成されるまで待つ
-      sleep 0.1
-      trs = all('table tr')
-      tds = trs[1].all('td')
-      expect(tds[0]).to have_content '1st'
-      tds = trs[2].all('td')
-      expect(tds[0]).to have_content '2nd'
-      tds = trs[3].all('td')
-      expect(tds[0]).to have_content '3rd'
+    context '優先度のリンクを1回踏んだとき' do
+      it '優先度の降順で表示される' do
+        click_link '優先度'
+        sleep 0.1
+        expect(task1_i).to be < task2_i
+        expect(task2_i).to be < task3_i
+      end
     end
 
-    it '期限のリンクを2回踏むと、昇順で表示される' do
-      click_link '期限'
-      click_link '期限'
-      sleep 0.1
-      trs = all('table tr')
-      tds = trs[1].all('td')
-      expect(tds[0]).to have_content '3rd'
-      tds = trs[2].all('td')
-      expect(tds[0]).to have_content '2nd'
-      tds = trs[3].all('td')
-      expect(tds[0]).to have_content '1st'
+    context '優先度のリンクを2回踏んだとき' do
+      it '優先度の昇順で表示される' do
+        click_link '優先度'
+        click_link '優先度'
+        sleep 0.1
+        expect(task3_i).to be < task2_i
+        expect(task2_i).to be < task1_i
+      end
     end
 
-    it '期限のリンクを3回踏むと、作成日時の降順で表示される' do
-      click_link '期限'
-      click_link '期限'
-      click_link '期限'
-      sleep 0.1
-      trs = all('table tr')
-      tds = trs[1].all('td')
-      expect(tds[0]).to have_content '1st'
-      tds = trs[2].all('td')
-      expect(tds[0]).to have_content '2nd'
-      tds = trs[3].all('td')
-      expect(tds[0]).to have_content '3rd'
+    context '優先度のリンクを3回踏んだとき' do
+      it '作成日時の降順で表示される' do
+        click_link '優先度'
+        click_link '優先度'
+        click_link '優先度'
+        sleep 0.1
+        expect(task1_i).to be < task2_i
+        expect(task2_i).to be < task3_i
+      end
+    end
+
+    context 'ステータスのリンクを1回踏んだとき' do
+      it 'ステータスの降順で表示される' do
+        click_link 'ステータス'
+        sleep 0.1
+        expect(task1_i).to be < task2_i
+        expect(task2_i).to be < task3_i
+      end
+    end
+
+    context 'ステータスのリンクを2回踏んだとき' do
+      it 'ステータスの昇順で表示される' do
+        click_link 'ステータス'
+        click_link 'ステータス'
+        sleep 0.1
+        expect(task3_i).to be < task2_i
+        expect(task2_i).to be < task1_i
+      end
+    end
+
+    context 'ステータスのリンクを3回踏んだとき' do
+      it '作成日時の降順で表示される' do
+        click_link 'ステータス'
+        click_link 'ステータス'
+        click_link 'ステータス'
+        sleep 0.1
+        expect(task1_i).to be < task2_i
+        expect(task2_i).to be < task3_i
+      end
+    end
+
+    context '期限のリンクを1回踏んだとき' do
+      it '期限の降順で表示される' do
+        click_link '期限'
+        sleep 0.1
+        expect(task1_i).to be < task2_i
+        expect(task2_i).to be < task3_i
+      end
+    end
+
+    context '期限のリンクを2回踏んだとき' do
+      it '期限の昇順で表示される' do
+        click_link '期限'
+        click_link '期限'
+        sleep 0.1
+        expect(task3_i).to be < task2_i
+        expect(task2_i).to be < task1_i
+      end
+    end
+
+    context '期限のリンクを3回踏んだとき' do
+      it '作成日時の降順で表示される' do
+        click_link '期限'
+        click_link '期限'
+        click_link '期限'
+        sleep 0.1
+        expect(task1_i).to be < task2_i
+        expect(task2_i).to be < task3_i
+      end
+    end
+  end
+
+  describe '検索機能' do
+    before do
+      tasks_1
+      tasks_2
+      visit tasks_path
+    end
+
+    context '優先度で検索したとき' do
+      it '選択した優先度のタスクが表示される' do
+        select '高', from: 'search[priority]'
+        click_button '検索'
+        expect(page).to have_content task1_title
+        expect(page).to have_no_content task2_title
+        expect(page).to have_no_content task3_title
+      end
+    end
+
+    context 'ステータスで検索したとき' do
+      it '選択したステータスのタスクが表示される' do
+        select '着手', from: 'search[status]'
+        click_button '検索'
+        expect(page).to have_content task2_title
+        expect(page).to have_no_content task1_title
+        expect(page).to have_no_content task3_title
+      end
+    end
+
+    context '名称で検索したとき' do
+      it '選択した名称のタスクが表示される' do
+        fill_in 'search[title]', with: task3_title
+        click_button '検索'
+        expect(page).to have_content task3_title
+        expect(page).to have_no_content task1_title
+        expect(page).to have_no_content task2_title
+      end
+    end
+
+    context '優先度とステータスで検索したとき' do
+      it '選択した優先度とステータスのタスクが表示される' do
+        select '低', from: 'search[priority]'
+        select '未着手', from: 'search[status]'
+        click_button '検索'
+        expect(page).to have_content task6_title
+        expect(page).to have_no_content task3_title
+      end
+    end
+
+    context 'ステータスと名称で検索したとき' do
+      it '選択したステータスと名称のタスクが表示される' do
+        select '完了', from: 'search[status]'
+        fill_in 'search[title]', with: task4_title
+        click_button '検索'
+        expect(page).to have_content task4_title
+        expect(page).to have_no_content task3_title
+      end
+    end
+
+    context '優先度と名称で検索したとき' do
+      it '選択した優先度と名称のタスクが表示される' do
+        select '中', from: 'search[priority]'
+        fill_in 'search[title]', with: task5_title
+        click_button '検索'
+        expect(page).to have_content task5_title
+        expect(page).to have_no_content task2_title
+      end
     end
   end
 
   describe '詳細表示' do
     before do
-      visit task_path(test_task)
+      visit task_path(single_task)
     end
 
     it '作成したタスクの詳細が表示される' do
@@ -89,7 +224,7 @@ describe 'タスク管理機能', type: :system do
 
   describe '編集' do
     before do
-      visit edit_task_path(test_task)
+      visit edit_task_path(single_task)
       fill_in 'task_title', with: '編集した'
       click_button '更新する'
     end
@@ -101,14 +236,14 @@ describe 'タスク管理機能', type: :system do
 
   describe '削除' do
     before do
-      test_task
+      single_task
       visit tasks_path
       click_link '削除'
       page.driver.browser.switch_to.alert.accept
     end
 
     it 'タスクが削除される' do
-      expect(page).to have_no_content test_task[:priority]
+      expect(page).to have_no_content single_task[:priority]
       expect(Task.count).to eq 0
     end
   end


### PR DESCRIPTION
## 課題
[ステップ13: ステータスを追加して、検索できるようにしよう](https://github.com/Fablic/training/tree/shunshunsuke#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)

## 変更内容
- タスクの優先度・ステータス・名称で検索できるようにした
- タスクの優先度とステータスでもソートできるようにした
- 検索用のインデックスを追加した
- タスクの検索とソートに関するsystem specを追加した