### PR TITLE
ステップ18, 19: ユーザの管理画面を実装しよう / ユーザにロールを追加しよう

### DIFF
--- a/pivote/.rubocop.yml
+++ b/pivote/.rubocop.yml
@@ -6,6 +6,9 @@ inherit_gem:
     # uncomment if use rspec cops
     # - "config/rspec.yml"
 
+Style/YodaCondition:
+  Enabled: false
+
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:

--- a/pivote/app/assets/javascripts/admin/users.coffee
+++ b/pivote/app/assets/javascripts/admin/users.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/pivote/app/assets/javascripts/admin/users.coffee
+++ b/pivote/app/assets/javascripts/admin/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/pivote/app/assets/stylesheets/admin/users.scss
+++ b/pivote/app/assets/stylesheets/admin/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Admin::Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/pivote/app/assets/stylesheets/admin/users.scss
+++ b/pivote/app/assets/stylesheets/admin/users.scss
@@ -1,3 +1,7 @@
 // Place all the styles related to the Admin::Users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+body {
+  background-color: pink;
+}

--- a/pivote/app/controllers/admin/users_controller.rb
+++ b/pivote/app/controllers/admin/users_controller.rb
@@ -1,0 +1,13 @@
+class Admin::UsersController < ApplicationController
+  def new
+  end
+
+  def edit
+  end
+
+  def show
+  end
+
+  def index
+  end
+end

--- a/pivote/app/controllers/admin/users_controller.rb
+++ b/pivote/app/controllers/admin/users_controller.rb
@@ -1,13 +1,61 @@
-class Admin::UsersController < ApplicationController
-  def new
-  end
+# frozen_string_literal: true
 
-  def edit
-  end
+module Admin
+  class UsersController < ApplicationController
+    before_action :require_admin
+    before_action :find_user, only: %i[show edit update destroy]
 
-  def show
-  end
+    def index
+      @users = User.includes(:tasks).all
+    end
 
-  def index
+    def show
+    end
+
+    def new
+      @user = User.new
+    end
+
+    def create
+      @user = User.new(user_params)
+      if @user.save
+        redirect_to admin_users_url, notice: t('flash.create', target: @user.name)
+      else
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @user.update(user_params)
+        redirect_to admin_users_url, notice: t('flash.update', target: @user.name)
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      if @user.destroy
+        redirect_to admin_users_url, notice: t('flash.delete', target: @user.name)
+      else
+        render :index
+      end
+    end
+
+    private
+
+    def require_admin
+      redirect_to root_url unless current_user.is_admin
+    end
+
+    def user_params
+      params.require(:user).permit(:name, :email, :is_admin, :password, :password_confirmation)
+    end
+
+    def find_user
+      @user = User.find(params[:id])
+    end
   end
 end

--- a/pivote/app/controllers/admin/users_controller.rb
+++ b/pivote/app/controllers/admin/users_controller.rb
@@ -44,6 +44,11 @@ module Admin
       end
     end
 
+    def tasks
+      @user = User.find(params[:user_id])
+      @tasks = @user.tasks.page(params[:page])
+    end
+
     private
 
     def require_admin

--- a/pivote/app/controllers/admin/users_controller.rb
+++ b/pivote/app/controllers/admin/users_controller.rb
@@ -40,7 +40,7 @@ module Admin
       if @user.destroy
         redirect_to admin_users_url, notice: t('flash.delete', target: @user.name)
       else
-        render :index
+        render :show
       end
     end
 

--- a/pivote/app/controllers/admin/users_controller.rb
+++ b/pivote/app/controllers/admin/users_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action :find_user, only: %i[show edit update destroy]
 
     def index
-      @users = User.includes(:tasks).all
+      @users = User.includes(:tasks).all.page(params[:page])
     end
 
     def show

--- a/pivote/app/controllers/sessions_controller.rb
+++ b/pivote/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: session_params[:email])
     if user&.authenticate(session_params[:password])
       session[:user_id] = user.id
-      redirect_to root_url, notice: t('flash.task.login')
+      redirect_to root_url, notice: t('flash.login')
     else
       @error = true
       render :new
@@ -19,7 +19,7 @@ class SessionsController < ApplicationController
 
   def destroy
     reset_session
-    redirect_to root_url, notice: t('flash.task.logout')
+    redirect_to root_url, notice: t('flash.logout')
   end
 
   private

--- a/pivote/app/controllers/tasks_controller.rb
+++ b/pivote/app/controllers/tasks_controller.rb
@@ -18,7 +18,7 @@ class TasksController < ApplicationController
   def create
     @task = Task.new(task_params.merge(user_id: current_user.id))
     if @task.save
-      redirect_to tasks_url, notice: t('flash.task.create', task: @task.title)
+      redirect_to tasks_url, notice: t('flash.create', target: @task.title)
     else
       render :new
     end
@@ -29,7 +29,7 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to tasks_url, notice: t('flash.task.update', task: @task.title)
+      redirect_to tasks_url, notice: t('flash.update', target: @task.title)
     else
       render :edit
     end
@@ -37,7 +37,7 @@ class TasksController < ApplicationController
 
   def destroy
     if @task.destroy
-      redirect_to tasks_url, notice: t('flash.task.delete', task: @task.title)
+      redirect_to tasks_url, notice: t('flash.delete', target: @task.title)
     else
       render :index
     end

--- a/pivote/app/helpers/admin/users_helper.rb
+++ b/pivote/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/pivote/app/helpers/admin/users_helper.rb
+++ b/pivote/app/helpers/admin/users_helper.rb
@@ -1,2 +1,6 @@
-module Admin::UsersHelper
+# frozen_string_literal: true
+
+module Admin
+  class UsersHelper
+  end
 end

--- a/pivote/app/helpers/admin/users_helper.rb
+++ b/pivote/app/helpers/admin/users_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Admin
-  class UsersHelper
+  module UsersHelper
   end
 end

--- a/pivote/app/helpers/admin/users_helper.rb
+++ b/pivote/app/helpers/admin/users_helper.rb
@@ -2,5 +2,8 @@
 
 module Admin
   module UsersHelper
+    def admin_icon(is_admin)
+      is_admin ? '○' : '×'
+    end
   end
 end

--- a/pivote/app/models/user.rb
+++ b/pivote/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   private
 
   def validate_admin
-    return if User.where(is_admin: true).count != 1
+    return if 1 < User.where(is_admin: true).count
     errors.add(:base, I18n.t('alert.admin_error'))
     throw :abort
   end

--- a/pivote/app/models/user.rb
+++ b/pivote/app/models/user.rb
@@ -17,10 +17,9 @@ class User < ApplicationRecord
   private
 
   def validate_admin
-    if User.where(is_admin: true).count == 1
-      errors.add(:base, I18n.t('alert.admin_error'))
-      throw :abort
-    end
+    return if User.where(is_admin: true).count != 1
+    errors.add(:base, I18n.t('alert.admin_error'))
+    throw :abort
   end
 
   def validate_admin_for_destroy

--- a/pivote/app/models/user.rb
+++ b/pivote/app/models/user.rb
@@ -9,5 +9,27 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :password, presence: true, length: { minimum: 4 }
 
+  validate :validate_admin_for_update, on: :update
+  before_destroy :validate_admin_for_destroy
+
   has_many :tasks, dependent: :destroy
+
+  private
+
+  def validate_admin
+    if User.where(is_admin: true).count == 1
+      errors.add(:base, I18n.t('alert.admin_error'))
+      throw :abort
+    end
+  end
+
+  def validate_admin_for_destroy
+    return unless is_admin
+    validate_admin
+  end
+
+  def validate_admin_for_update
+    return if is_admin
+    validate_admin
+  end
 end

--- a/pivote/app/views/admin/users/_form.html.erb
+++ b/pivote/app/views/admin/users/_form.html.erb
@@ -1,0 +1,33 @@
+<% if user.errors.present? %>
+  <div id="error_explanation" class="alert alert-danger">
+    <ul>
+      <% user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with model: [:admin, user], local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.text_field :email, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :password %>
+    <%= f.password_field :password, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, class: 'form-control' %>
+  </div>
+  <div class="form-check mb-3">
+    <%= f.check_box :is_admin, class: 'form-check-input' %>
+    <%= f.label :is_admin, class: 'form-check-label' %>
+  </div>
+  <%= f.submit class: 'btn btn-primary' %>
+<% end %>

--- a/pivote/app/views/admin/users/edit.html.erb
+++ b/pivote/app/views/admin/users/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#edit</h1>
+<p>Find me in app/views/admin/users/edit.html.erb</p>

--- a/pivote/app/views/admin/users/edit.html.erb
+++ b/pivote/app/views/admin/users/edit.html.erb
@@ -1,2 +1,7 @@
-<h1>Admin::Users#edit</h1>
-<p>Find me in app/views/admin/users/edit.html.erb</p>
+<h1><%= t('headline.user.edit') %></h1>
+
+<div class="nav justify-content-end">
+  <%= link_to t('link.all'), admin_users_path, class: 'nav-link' %>
+</div>
+
+<%= render partial: 'form', locals: { user: @user } %>

--- a/pivote/app/views/admin/users/edit.html.erb
+++ b/pivote/app/views/admin/users/edit.html.erb
@@ -1,3 +1,5 @@
+<%= stylesheet_link_tag 'admin/users' %>
+
 <h1><%= t('headline.user.edit') %></h1>
 
 <div class="nav justify-content-end">

--- a/pivote/app/views/admin/users/index.html.erb
+++ b/pivote/app/views/admin/users/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#index</h1>
+<p>Find me in app/views/admin/users/index.html.erb</p>

--- a/pivote/app/views/admin/users/index.html.erb
+++ b/pivote/app/views/admin/users/index.html.erb
@@ -1,2 +1,31 @@
-<h1>Admin::Users#index</h1>
-<p>Find me in app/views/admin/users/index.html.erb</p>
+<h1><%= t('headline.user.index') %></h1>
+
+<div class="mb-3">
+  <%= link_to t('crud.create'), new_admin_user_path, class: 'btn btn-primary' %>
+</div>
+
+<table class="table table-hover">
+  <thead class="thead-default">
+    <tr>
+      <th><%= User.human_attribute_name(:name) %></th>
+      <th><%= User.human_attribute_name(:email) %></th>
+      <th class="text-center"><%= User.human_attribute_name(:is_admin) %></th>
+      <th><%= t('column.number_of_tasks') %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= link_to user.name, [:admin, user] %></td>
+        <td><%= user.email %></td>
+        <td class="text-center"><%= user.is_admin ? '○' : '×' %></td>
+        <td><%= user.tasks.length %></td>
+        <td>
+          <%= link_to t('crud.update'), edit_admin_user_path(user), class: 'btn btn-primary mr-3' %>
+          <%= link_to t('crud.delete'), admin_user_path(user), method: :delete, data: { confirm: t('alert.confirm', target: user.name) }, class: 'btn btn-danger' %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/pivote/app/views/admin/users/index.html.erb
+++ b/pivote/app/views/admin/users/index.html.erb
@@ -26,7 +26,7 @@
       <tr>
         <td><%= link_to user.name, [:admin, user] %></td>
         <td><%= user.email %></td>
-        <td class="text-center"><%= user.is_admin ? '○' : '×' %></td>
+        <td class="text-center"><%= admin_icon(user.is_admin) %></td>
         <td><%= link_to_if user.tasks.length > 0, user.tasks.length, admin_user_tasks_path(user) %></td>
         <td>
           <%= link_to t('crud.update'), edit_admin_user_path(user), class: 'btn btn-primary mr-3' %>

--- a/pivote/app/views/admin/users/index.html.erb
+++ b/pivote/app/views/admin/users/index.html.erb
@@ -20,7 +20,7 @@
         <td><%= link_to user.name, [:admin, user] %></td>
         <td><%= user.email %></td>
         <td class="text-center"><%= user.is_admin ? '○' : '×' %></td>
-        <td><%= user.tasks.length %></td>
+        <td><%= link_to_if user.tasks.length > 0, user.tasks.length, admin_user_tasks_path(user) %></td>
         <td>
           <%= link_to t('crud.update'), edit_admin_user_path(user), class: 'btn btn-primary mr-3' %>
           <%= link_to t('crud.delete'), admin_user_path(user), method: :delete, data: { confirm: t('alert.confirm', target: user.name) }, class: 'btn btn-danger' %>

--- a/pivote/app/views/admin/users/index.html.erb
+++ b/pivote/app/views/admin/users/index.html.erb
@@ -4,6 +4,11 @@
   <%= link_to t('crud.create'), new_admin_user_path, class: 'btn btn-primary' %>
 </div>
 
+<div class="mb-3">
+  <%= paginate @users %>
+  <%= page_entries_info @users %>
+</div>
+
 <table class="table table-hover">
   <thead class="thead-default">
     <tr>

--- a/pivote/app/views/admin/users/index.html.erb
+++ b/pivote/app/views/admin/users/index.html.erb
@@ -1,3 +1,5 @@
+<%= stylesheet_link_tag 'admin/users' %>
+
 <h1><%= t('headline.user.index') %></h1>
 
 <div class="mb-3">

--- a/pivote/app/views/admin/users/new.html.erb
+++ b/pivote/app/views/admin/users/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#new</h1>
+<p>Find me in app/views/admin/users/new.html.erb</p>

--- a/pivote/app/views/admin/users/new.html.erb
+++ b/pivote/app/views/admin/users/new.html.erb
@@ -1,2 +1,7 @@
-<h1>Admin::Users#new</h1>
-<p>Find me in app/views/admin/users/new.html.erb</p>
+<h1><%= t('headline.user.new') %></h1>
+
+<div class="nav justify-content-end">
+  <%= link_to t('link.all'), admin_users_path, class: 'nav-link' %>
+</div>
+
+<%= render partial: 'form', locals: { user: @user } %>

--- a/pivote/app/views/admin/users/new.html.erb
+++ b/pivote/app/views/admin/users/new.html.erb
@@ -1,3 +1,5 @@
+<%= stylesheet_link_tag 'admin/users' %>
+
 <h1><%= t('headline.user.new') %></h1>
 
 <div class="nav justify-content-end">

--- a/pivote/app/views/admin/users/show.html.erb
+++ b/pivote/app/views/admin/users/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#show</h1>
+<p>Find me in app/views/admin/users/show.html.erb</p>

--- a/pivote/app/views/admin/users/show.html.erb
+++ b/pivote/app/views/admin/users/show.html.erb
@@ -6,6 +6,16 @@
   <%= link_to t('link.all'), admin_users_path, class: 'nav-link' %>
 </div>
 
+<% if @user.errors.present? %>
+  <div id="error_explanation" class="alert alert-danger">
+    <ul>
+      <% @user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <table class="table table-hover">
   <tbody>
     <tr>

--- a/pivote/app/views/admin/users/show.html.erb
+++ b/pivote/app/views/admin/users/show.html.erb
@@ -1,3 +1,5 @@
+<%= stylesheet_link_tag 'admin/users' %>
+
 <h1><%= t('headline.user.show') %></h1>
 
 <div class="nav justify-content-end">

--- a/pivote/app/views/admin/users/show.html.erb
+++ b/pivote/app/views/admin/users/show.html.erb
@@ -32,7 +32,7 @@
     </tr>
     <tr>
       <th><%= User.human_attribute_name(:is_admin) %></th>
-      <td><%= @user.is_admin ? '○' : '×' %></td>
+      <td><%= admin_icon(@user.is_admin) %></td>
     </tr>
     <tr>
       <th><%= User.human_attribute_name(:created_at) %></th>

--- a/pivote/app/views/admin/users/show.html.erb
+++ b/pivote/app/views/admin/users/show.html.erb
@@ -1,2 +1,37 @@
-<h1>Admin::Users#show</h1>
-<p>Find me in app/views/admin/users/show.html.erb</p>
+<h1><%= t('headline.user.show') %></h1>
+
+<div class="nav justify-content-end">
+  <%= link_to t('link.all'), admin_users_path, class: 'nav-link' %>
+</div>
+
+<table class="table table-hover">
+  <tbody>
+    <tr>
+      <th><%= User.human_attribute_name(:id) %></th>
+      <td><%= @user.id %></td>
+    </tr>
+    <tr>
+      <th><%= User.human_attribute_name(:name) %></th>
+      <td><%= @user.name %></td>
+    </tr>
+    <tr>
+      <th><%= User.human_attribute_name(:email) %></th>
+      <td><%= @user.email %></td>
+    </tr>
+    <tr>
+      <th><%= User.human_attribute_name(:is_admin) %></th>
+      <td><%= @user.is_admin ? '○' : '×' %></td>
+    </tr>
+    <tr>
+      <th><%= User.human_attribute_name(:created_at) %></th>
+      <td><%= l @user.created_at %></td>
+    </tr>
+    <tr>
+      <th><%= User.human_attribute_name(:updated_at) %></th>
+      <td><%= l @user.updated_at %></td>
+    </tr>
+  </tbody>
+</table>
+
+<%= link_to t('crud.update'), edit_admin_user_path(@user), class: 'btn btn-primary mr-3' %>
+<%= link_to t('crud.delete'), admin_user_path(@user), method: :delete, data: { confirm: t('alert.confirm', target: @user.name) }, class: 'btn btn-danger' %>

--- a/pivote/app/views/admin/users/tasks.html.erb
+++ b/pivote/app/views/admin/users/tasks.html.erb
@@ -1,0 +1,27 @@
+<h1><%= t('headline.user.tasks', name: @user.name) %></h1>
+
+<div class="mb-3">
+  <%= paginate @tasks %>
+  <%= page_entries_info @tasks %>
+</div>
+
+<table class="table table-hover">
+  <thead class="thead-default">
+    <tr>
+      <th><%= Task.human_attribute_name(:title) %></th>
+      <th><%= Task.human_attribute_name(:priority) %></th>
+      <th><%= Task.human_attribute_name(:status) %></th>
+      <th><%= Task.human_attribute_name(:deadline) %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= task.title %></td>
+        <td><%= task.human_attribute_enum(:priority) %></td>
+        <td><%= task.human_attribute_enum(:status) %></td>
+        <td><%= task.format_deadline %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/pivote/app/views/admin/users/tasks.html.erb
+++ b/pivote/app/views/admin/users/tasks.html.erb
@@ -1,4 +1,10 @@
+<%= stylesheet_link_tag 'admin/users' %>
+
 <h1><%= t('headline.user.tasks', name: @user.name) %></h1>
+
+<div class="nav justify-content-end">
+  <%= link_to t('link.all'), admin_users_path, class: 'nav-link' %>
+</div>
 
 <div class="mb-3">
   <%= paginate @tasks %>

--- a/pivote/app/views/layouts/application.html.erb
+++ b/pivote/app/views/layouts/application.html.erb
@@ -15,6 +15,9 @@
       <ul class="navbar-nav ml-auto">
         <% if current_user %>
           <li class="nav-item"><%= link_to t('link.tasks'), tasks_path, class: 'nav-link' %></li>
+          <% if current_user.is_admin %>
+            <li class="nav-item"><%= link_to t('link.users'), admin_users_path, class: 'nav-link' %></li>
+          <% end %>
           <li class="nav-item"><%= link_to t('link.logout'), logout_path, method: :delete, class: 'nav-link' %></li>
         <% else %>
           <li class="nav-item"><%= link_to t('link.login'), login_path %></li>

--- a/pivote/app/views/tasks/index.html.erb
+++ b/pivote/app/views/tasks/index.html.erb
@@ -32,30 +32,28 @@
   <%= page_entries_info @tasks %>
 </div>
 
-<div class="mb-3">
-  <table class="table table-hover">
-    <thead class="thead-default">
+<table class="table table-hover">
+  <thead class="thead-default">
+    <tr>
+      <th><%= Task.human_attribute_name(:title) %></th>
+      <th><%= link_to Task.human_attribute_name(:priority) + sort_icon(:priority, @search_form), tasks_path(search: sort_params(@search_form.attributes, :priority)) %></th>
+      <th><%= link_to Task.human_attribute_name(:status) + sort_icon(:status, @search_form), tasks_path(search: sort_params(@search_form.attributes, :status)) %></th>
+      <th><%= link_to Task.human_attribute_name(:deadline) + sort_icon(:deadline, @search_form), tasks_path(search: sort_params(@search_form.attributes, :deadline)) %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tasks.each do |task| %>
       <tr>
-        <th><%= Task.human_attribute_name(:title) %></th>
-        <th><%= link_to Task.human_attribute_name(:priority) + sort_icon(:priority, @search_form), tasks_path(search: sort_params(@search_form.attributes, :priority)) %></th>
-        <th><%= link_to Task.human_attribute_name(:status) + sort_icon(:status, @search_form), tasks_path(search: sort_params(@search_form.attributes, :status)) %></th>
-        <th><%= link_to Task.human_attribute_name(:deadline) + sort_icon(:deadline, @search_form), tasks_path(search: sort_params(@search_form.attributes, :deadline)) %></th>
-        <th></th>
+        <td><%= link_to task.title, task_path(task) %></td>
+        <td><%= task.human_attribute_enum(:priority) %></td>
+        <td><%= task.human_attribute_enum(:status) %></td>
+        <td><%= task.format_deadline %></td>
+        <td>
+          <%= link_to t('crud.update'), edit_task_path(task), class: 'btn btn-primary mr-3' %>
+          <%= link_to t('crud.delete'), task_path(task), method: :delete, data: {confirm: t('alert.confirm', target: task.title)}, class: 'btn btn-danger' %>
+        </td>
       </tr>
-    </thead>
-    <tbody>
-      <% @tasks.each do |task| %>
-        <tr>
-          <td><%= link_to task.title, task_path(task) %></td>
-          <td><%= task.human_attribute_enum(:priority) %></td>
-          <td><%= task.human_attribute_enum(:status) %></td>
-          <td><%= task.format_deadline %></td>
-          <td>
-            <%= link_to t('crud.update'), edit_task_path(task), class: 'btn btn-primary mr-3' %>
-            <%= link_to t('crud.delete'), task_path(task), method: :delete, data: {confirm: t('alert.confirm', target: task.title)}, class: 'btn btn-danger' %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-</div>
+    <% end %>
+  </tbody>
+</table>

--- a/pivote/app/views/tasks/index.html.erb
+++ b/pivote/app/views/tasks/index.html.erb
@@ -52,7 +52,7 @@
           <td><%= task.format_deadline %></td>
           <td>
             <%= link_to t('crud.update'), edit_task_path(task), class: 'btn btn-primary mr-3' %>
-            <%= link_to t('crud.delete'), task_path(task), method: :delete, data: {confirm: t('alert.confirm', task: task.title)}, class: 'btn btn-danger' %>
+            <%= link_to t('crud.delete'), task_path(task), method: :delete, data: {confirm: t('alert.confirm', target: task.title)}, class: 'btn btn-danger' %>
           </td>
         </tr>
       <% end %>

--- a/pivote/app/views/tasks/show.html.erb
+++ b/pivote/app/views/tasks/show.html.erb
@@ -42,4 +42,4 @@
 </table>
 
 <%= link_to t('crud.update'), edit_task_path, class: 'btn btn-primary mr-3' %>
-<%= link_to t('crud.delete'), task_path(@task), method: :delete, data: {confirm: t('alert.confirm', task: @task.title)}, class: 'btn btn-danger' %>
+<%= link_to t('crud.delete'), task_path(@task), method: :delete, data: {confirm: t('alert.confirm', target: @task.title)}, class: 'btn btn-danger' %>

--- a/pivote/config/initializers/assets.rb
+++ b/pivote/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( admin/users.css )

--- a/pivote/config/locales/en.yml
+++ b/pivote/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
       new: Create user
       show: User detail
       edit: Edit user
+      tasks: 「%{name}」 tasks
   crud:
     create: Create
     update: Update

--- a/pivote/config/locales/en.yml
+++ b/pivote/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
     login: Logged in.
     logout: Logged out.
   alert:
-    confirm: Delete 「%{task}」?
+    confirm: Delete 「%{target}」?
     login_error: error
   link:
     all: all

--- a/pivote/config/locales/en.yml
+++ b/pivote/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
   alert:
     confirm: Delete 「%{target}」?
     login_error: error
+    admin_error: error
   link:
     all: all
     tasks: tasks

--- a/pivote/config/locales/en.yml
+++ b/pivote/config/locales/en.yml
@@ -1,34 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   headline:
     task:
@@ -38,6 +7,11 @@ en:
       edit: Edit task
     session:
       new: Login
+    user:
+      index: All users
+      new: Create user
+      show: User detail
+      edit: Edit user
   crud:
     create: Create
     update: Update
@@ -47,20 +21,22 @@ en:
     reset: Reset
     login: Login
   flash:
-    task:
-      create: Created 「%{task}」.
-      update: Updated 「%{task}」.
-      delete: Deleted 「%{task}」.
-      login: Logged in.
-      logout: Logged out.
+    create: Created 「%{target}」.
+    update: Updated 「%{target}」.
+    delete: Deleted 「%{target}」.
+    login: Logged in.
+    logout: Logged out.
   alert:
     confirm: Delete 「%{task}」?
     login_error: error
   link:
     all: all
     tasks: tasks
+    users: users
     login: login
     logout: logout
+  column:
+    number_of_tasks: Number of tasks
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"

--- a/pivote/config/locales/ja.yml
+++ b/pivote/config/locales/ja.yml
@@ -30,6 +30,7 @@ ja:
   alert:
     confirm: 「%{target}」を削除します。よろしいですか？
     login_error: メールアドレス、またはパスワードが正しくありません。
+    admin_error: 管理者が存在しなくなるため実行できません。
   link:
     all: 一覧
     tasks: タスク一覧

--- a/pivote/config/locales/ja.yml
+++ b/pivote/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
       new: ユーザーの新規登録
       show: ユーザーの詳細
       edit: ユーザーの編集
+      tasks: 「%{name}」のタスク一覧
   crud:
     create: 登録
     update: 編集

--- a/pivote/config/locales/ja.yml
+++ b/pivote/config/locales/ja.yml
@@ -7,6 +7,11 @@ ja:
       edit: タスクの編集
     session:
       new: ログイン
+    user:
+      index: ユーザー一覧
+      new: ユーザーの新規登録
+      show: ユーザーの詳細
+      edit: ユーザーの編集
   crud:
     create: 登録
     update: 編集
@@ -16,20 +21,22 @@ ja:
     reset: リセット
     login: ログイン
   flash:
-    task:
-      create: タスク「%{task}」を登録しました。
-      update: タスク「%{task}」を更新しました。
-      delete: タスク「%{task}」を削除しました。
-      login: ログインしました。
-      logout: ログアウトしました。
+    create: 「%{target}」を登録しました。
+    update: 「%{target}」を更新しました。
+    delete: 「%{target}」を削除しました。
+    login: ログインしました。
+    logout: ログアウトしました。
   alert:
-    confirm: タスク「%{task}」を削除します。よろしいですか？
+    confirm: 「%{target}」を削除します。よろしいですか？
     login_error: メールアドレス、またはパスワードが正しくありません。
   link:
     all: 一覧
     tasks: タスク一覧
+    users: ユーザー一覧
     login: ログイン
     logout: ログアウト
+  column:
+    number_of_tasks: タスク数
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"

--- a/pivote/config/locales/models.ja.yml
+++ b/pivote/config/locales/models.ja.yml
@@ -23,4 +23,7 @@ ja:
         name: 名前
         email: メールアドレス
         password: パスワード
+        password_confirmation: パスワード(確認)
         is_admin: 管理者
+        created_at: 作成日時
+        updated_at: 更新日時

--- a/pivote/config/routes.rb
+++ b/pivote/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
+
+  namespace :admin do
+    resources :users
+  end
+
   root to: 'tasks#index'
   resources :tasks
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/pivote/config/routes.rb
+++ b/pivote/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
 
   namespace :admin do
-    resources :users
+    resources :users do
+      get 'tasks'
+    end
   end
 
   root to: 'tasks#index'

--- a/pivote/spec/system/sessions_spec.rb
+++ b/pivote/spec/system/sessions_spec.rb
@@ -18,7 +18,7 @@ describe 'ログイン機能', type: :system do
       let(:password) { user.password }
 
       it 'ログインできる' do
-        expect(page).to have_content I18n.t('flash.task.login')
+        expect(page).to have_content I18n.t('flash.login')
       end
     end
 
@@ -52,7 +52,7 @@ describe 'ログイン機能', type: :system do
 
       it 'ログアウトできる' do
         click_link I18n.t('link.logout')
-        expect(page).to have_content I18n.t('flash.task.logout')
+        expect(page).to have_content I18n.t('flash.logout')
       end
     end
   end

--- a/pivote/spec/system/tasks_spec.rb
+++ b/pivote/spec/system/tasks_spec.rb
@@ -28,278 +28,278 @@ describe 'タスク管理機能', type: :system do
   let(:task5_i) { page.body.index(task5_title) }
   let(:task6_i) { page.body.index(task6_title) }
 
-  before do |example|
-    unless example.metadata[:skip_before]
+  describe 'ログイン前提の処理' do
+    before do
       visit login_path
       fill_in 'session_email', with: user_a.email
       fill_in 'session_password', with: user_a.password
       click_button 'ログイン'
     end
+
+    describe 'ソート機能' do
+      before do
+        tasks_1
+        visit tasks_path
+      end
+
+      context '何も指定していないとき' do
+        it '作成日時の降順で表示される' do
+          expect(task1_i).to be < task2_i
+          expect(task2_i).to be < task3_i
+        end
+      end
+
+      context '優先度のリンクを1回踏んだとき' do
+        it '優先度の降順で表示される' do
+          click_link '優先度'
+          sleep 0.1
+          expect(task1_i).to be < task2_i
+          expect(task2_i).to be < task3_i
+        end
+      end
+
+      context '優先度のリンクを2回踏んだとき' do
+        it '優先度の昇順で表示される' do
+          click_link '優先度'
+          click_link '優先度'
+          sleep 0.1
+          expect(task3_i).to be < task2_i
+          expect(task2_i).to be < task1_i
+        end
+      end
+
+      context '優先度のリンクを3回踏んだとき' do
+        it '作成日時の降順で表示される' do
+          click_link '優先度'
+          click_link '優先度'
+          click_link '優先度'
+          sleep 0.1
+          expect(task1_i).to be < task2_i
+          expect(task2_i).to be < task3_i
+        end
+      end
+
+      context 'ステータスのリンクを1回踏んだとき' do
+        it 'ステータスの降順で表示される' do
+          click_link 'ステータス'
+          sleep 0.1
+          expect(task1_i).to be < task2_i
+          expect(task2_i).to be < task3_i
+        end
+      end
+
+      context 'ステータスのリンクを2回踏んだとき' do
+        it 'ステータスの昇順で表示される' do
+          click_link 'ステータス'
+          click_link 'ステータス'
+          sleep 0.1
+          expect(task3_i).to be < task2_i
+          expect(task2_i).to be < task1_i
+        end
+      end
+
+      context 'ステータスのリンクを3回踏んだとき' do
+        it '作成日時の降順で表示される' do
+          click_link 'ステータス'
+          click_link 'ステータス'
+          click_link 'ステータス'
+          sleep 0.1
+          expect(task1_i).to be < task2_i
+          expect(task2_i).to be < task3_i
+        end
+      end
+
+      context '期限のリンクを1回踏んだとき' do
+        it '期限の降順で表示される' do
+          click_link '期限'
+          sleep 0.1
+          expect(task1_i).to be < task2_i
+          expect(task2_i).to be < task3_i
+        end
+      end
+
+      context '期限のリンクを2回踏んだとき' do
+        it '期限の昇順で表示される' do
+          click_link '期限'
+          click_link '期限'
+          sleep 0.1
+          expect(task3_i).to be < task2_i
+          expect(task2_i).to be < task1_i
+        end
+      end
+
+      context '期限のリンクを3回踏んだとき' do
+        it '作成日時の降順で表示される' do
+          click_link '期限'
+          click_link '期限'
+          click_link '期限'
+          sleep 0.1
+          expect(task1_i).to be < task2_i
+          expect(task2_i).to be < task3_i
+        end
+      end
+    end
+
+    describe '検索機能' do
+      before do
+        tasks_1
+        tasks_2
+        visit tasks_path
+      end
+
+      context '優先度で検索したとき' do
+        it '選択した優先度のタスクが表示される' do
+          select '高', from: 'search[priority]'
+          click_button '検索'
+          expect(page).to have_content task1_title
+          expect(page).to have_no_content task2_title
+          expect(page).to have_no_content task3_title
+        end
+      end
+
+      context 'ステータスで検索したとき' do
+        it '選択したステータスのタスクが表示される' do
+          select '着手', from: 'search[status]'
+          click_button '検索'
+          expect(page).to have_content task2_title
+          expect(page).to have_no_content task1_title
+          expect(page).to have_no_content task3_title
+        end
+      end
+
+      context '名称で検索したとき' do
+        it '選択した名称のタスクが表示される' do
+          fill_in 'search[title]', with: task3_title
+          click_button '検索'
+          expect(page).to have_content task3_title
+          expect(page).to have_no_content task1_title
+          expect(page).to have_no_content task2_title
+        end
+      end
+
+      context '優先度とステータスで検索したとき' do
+        it '選択した優先度とステータスのタスクが表示される' do
+          select '低', from: 'search[priority]'
+          select '未着手', from: 'search[status]'
+          click_button '検索'
+          expect(page).to have_content task6_title
+          expect(page).to have_no_content task3_title
+        end
+      end
+
+      context 'ステータスと名称で検索したとき' do
+        it '選択したステータスと名称のタスクが表示される' do
+          select '完了', from: 'search[status]'
+          fill_in 'search[title]', with: task4_title
+          click_button '検索'
+          expect(page).to have_content task4_title
+          expect(page).to have_no_content task3_title
+        end
+      end
+
+      context '優先度と名称で検索したとき' do
+        it '選択した優先度と名称のタスクが表示される' do
+          select '中', from: 'search[priority]'
+          fill_in 'search[title]', with: task5_title
+          click_button '検索'
+          expect(page).to have_content task5_title
+          expect(page).to have_no_content task2_title
+        end
+      end
+    end
+
+    describe 'ページネーション' do
+      before do
+        (1..100).each { |i|
+          FactoryBot.create(:task, title: "ページネーションタスク#{i}", created_at: i.days.ago, user: user_a)
+        }
+        visit tasks_path
+      end
+
+      context '「2」のリンクを踏んだとき' do
+        it '21番目のタスクが表示される' do
+          click_link '2'
+          expect(page).to have_content 'ページネーションタスク21'
+          expect(page).to have_no_content 'ページネーションタスク20'
+        end
+      end
+
+      context '「最後」のリンクを踏んだとき' do
+        it '100番目のタスクが表示される' do
+          click_link '最後 »'
+          expect(page).to have_content 'ページネーションタスク100'
+          expect(page).to have_no_content 'ページネーションタスク80'
+        end
+      end
+    end
+
+    describe '一覧表示' do
+      before do
+        user_b = FactoryBot.create(:user, name: 'Bさん', email: 'b@example.com')
+        FactoryBot.create(:task, title: 'Bさんのタスク', user: user_b)
+        visit tasks_path
+      end
+
+      it 'Bさんのタスクは表示されない' do
+        expect(page).to have_no_content 'Bさんのタスク'
+      end
+    end
+
+    describe '詳細表示' do
+      before do
+        visit task_path(single_task)
+      end
+
+      it '作成したタスクの詳細が表示される' do
+        expect(page).to have_content 'テストです'
+      end
+    end
+
+    describe '新規作成' do
+      before do
+        visit new_task_path
+        fill_in 'task_title', with: '新規タスク'
+        click_button '登録する'
+      end
+
+      it 'タスクが新規作成される' do
+        expect(page).to have_content '新規タスク'
+        expect(Task.count).to eq 1
+      end
+    end
+
+    describe '編集' do
+      before do
+        visit edit_task_path(single_task)
+        fill_in 'task_title', with: '編集した'
+        click_button '更新する'
+      end
+
+      it 'タスクが編集される' do
+        expect(page).to have_content '編集した'
+      end
+    end
+
+    describe '削除' do
+      before do
+        single_task
+        visit tasks_path
+        click_link '削除'
+        page.driver.browser.switch_to.alert.accept
+      end
+
+      it 'タスクが削除される' do
+        expect(page).to have_no_content single_task[:priority]
+        expect(Task.count).to eq 0
+      end
+    end
   end
 
-  context 'ログインしていない場合' do
-    it 'ログインページに戻される', :skip_before do
+  describe '非ログイン時の処理' do
+    it 'ログインページに戻される' do
       visit tasks_path
       expect(page).to have_content User.human_attribute_name(:password)
       expect(page).to have_no_content I18n.t('headline.task.index')
-    end
-  end
-
-  describe 'ソート機能' do
-    before do
-      tasks_1
-      visit tasks_path
-    end
-
-    context '何も指定していないとき' do
-      it '作成日時の降順で表示される' do
-        expect(task1_i).to be < task2_i
-        expect(task2_i).to be < task3_i
-      end
-    end
-
-    context '優先度のリンクを1回踏んだとき' do
-      it '優先度の降順で表示される' do
-        click_link '優先度'
-        sleep 0.1
-        expect(task1_i).to be < task2_i
-        expect(task2_i).to be < task3_i
-      end
-    end
-
-    context '優先度のリンクを2回踏んだとき' do
-      it '優先度の昇順で表示される' do
-        click_link '優先度'
-        click_link '優先度'
-        sleep 0.1
-        expect(task3_i).to be < task2_i
-        expect(task2_i).to be < task1_i
-      end
-    end
-
-    context '優先度のリンクを3回踏んだとき' do
-      it '作成日時の降順で表示される' do
-        click_link '優先度'
-        click_link '優先度'
-        click_link '優先度'
-        sleep 0.1
-        expect(task1_i).to be < task2_i
-        expect(task2_i).to be < task3_i
-      end
-    end
-
-    context 'ステータスのリンクを1回踏んだとき' do
-      it 'ステータスの降順で表示される' do
-        click_link 'ステータス'
-        sleep 0.1
-        expect(task1_i).to be < task2_i
-        expect(task2_i).to be < task3_i
-      end
-    end
-
-    context 'ステータスのリンクを2回踏んだとき' do
-      it 'ステータスの昇順で表示される' do
-        click_link 'ステータス'
-        click_link 'ステータス'
-        sleep 0.1
-        expect(task3_i).to be < task2_i
-        expect(task2_i).to be < task1_i
-      end
-    end
-
-    context 'ステータスのリンクを3回踏んだとき' do
-      it '作成日時の降順で表示される' do
-        click_link 'ステータス'
-        click_link 'ステータス'
-        click_link 'ステータス'
-        sleep 0.1
-        expect(task1_i).to be < task2_i
-        expect(task2_i).to be < task3_i
-      end
-    end
-
-    context '期限のリンクを1回踏んだとき' do
-      it '期限の降順で表示される' do
-        click_link '期限'
-        sleep 0.1
-        expect(task1_i).to be < task2_i
-        expect(task2_i).to be < task3_i
-      end
-    end
-
-    context '期限のリンクを2回踏んだとき' do
-      it '期限の昇順で表示される' do
-        click_link '期限'
-        click_link '期限'
-        sleep 0.1
-        expect(task3_i).to be < task2_i
-        expect(task2_i).to be < task1_i
-      end
-    end
-
-    context '期限のリンクを3回踏んだとき' do
-      it '作成日時の降順で表示される' do
-        click_link '期限'
-        click_link '期限'
-        click_link '期限'
-        sleep 0.1
-        expect(task1_i).to be < task2_i
-        expect(task2_i).to be < task3_i
-      end
-    end
-  end
-
-  describe '検索機能' do
-    before do
-      tasks_1
-      tasks_2
-      visit tasks_path
-    end
-
-    context '優先度で検索したとき' do
-      it '選択した優先度のタスクが表示される' do
-        select '高', from: 'search[priority]'
-        click_button '検索'
-        expect(page).to have_content task1_title
-        expect(page).to have_no_content task2_title
-        expect(page).to have_no_content task3_title
-      end
-    end
-
-    context 'ステータスで検索したとき' do
-      it '選択したステータスのタスクが表示される' do
-        select '着手', from: 'search[status]'
-        click_button '検索'
-        expect(page).to have_content task2_title
-        expect(page).to have_no_content task1_title
-        expect(page).to have_no_content task3_title
-      end
-    end
-
-    context '名称で検索したとき' do
-      it '選択した名称のタスクが表示される' do
-        fill_in 'search[title]', with: task3_title
-        click_button '検索'
-        expect(page).to have_content task3_title
-        expect(page).to have_no_content task1_title
-        expect(page).to have_no_content task2_title
-      end
-    end
-
-    context '優先度とステータスで検索したとき' do
-      it '選択した優先度とステータスのタスクが表示される' do
-        select '低', from: 'search[priority]'
-        select '未着手', from: 'search[status]'
-        click_button '検索'
-        expect(page).to have_content task6_title
-        expect(page).to have_no_content task3_title
-      end
-    end
-
-    context 'ステータスと名称で検索したとき' do
-      it '選択したステータスと名称のタスクが表示される' do
-        select '完了', from: 'search[status]'
-        fill_in 'search[title]', with: task4_title
-        click_button '検索'
-        expect(page).to have_content task4_title
-        expect(page).to have_no_content task3_title
-      end
-    end
-
-    context '優先度と名称で検索したとき' do
-      it '選択した優先度と名称のタスクが表示される' do
-        select '中', from: 'search[priority]'
-        fill_in 'search[title]', with: task5_title
-        click_button '検索'
-        expect(page).to have_content task5_title
-        expect(page).to have_no_content task2_title
-      end
-    end
-  end
-
-  describe 'ページネーション' do
-    before do
-      (1..100).each { |i|
-        FactoryBot.create(:task, title: "ページネーションタスク#{i}", created_at: i.days.ago, user: user_a)
-      }
-      visit tasks_path
-    end
-
-    context '「2」のリンクを踏んだとき' do
-      it '21番目のタスクが表示される' do
-        click_link '2'
-        expect(page).to have_content 'ページネーションタスク21'
-        expect(page).to have_no_content 'ページネーションタスク20'
-      end
-    end
-
-    context '「最後」のリンクを踏んだとき' do
-      it '100番目のタスクが表示される' do
-        click_link '最後 »'
-        expect(page).to have_content 'ページネーションタスク100'
-        expect(page).to have_no_content 'ページネーションタスク80'
-      end
-    end
-  end
-
-  describe '一覧表示' do
-    before do
-      user_b = FactoryBot.create(:user, name: 'Bさん', email: 'b@example.com')
-      FactoryBot.create(:task, title: 'Bさんのタスク', user: user_b)
-      visit tasks_path
-    end
-
-    it 'Bさんのタスクは表示されない' do
-      expect(page).to have_no_content 'Bさんのタスク'
-    end
-  end
-
-  describe '詳細表示' do
-    before do
-      visit task_path(single_task)
-    end
-
-    it '作成したタスクの詳細が表示される' do
-      expect(page).to have_content 'テストです'
-    end
-  end
-
-  describe '新規作成' do
-    before do
-      visit new_task_path
-      fill_in 'task_title', with: '新規タスク'
-      click_button '登録する'
-    end
-
-    it 'タスクが新規作成される' do
-      expect(page).to have_content '新規タスク'
-      expect(Task.count).to eq 1
-    end
-  end
-
-  describe '編集' do
-    before do
-      visit edit_task_path(single_task)
-      fill_in 'task_title', with: '編集した'
-      click_button '更新する'
-    end
-
-    it 'タスクが編集される' do
-      expect(page).to have_content '編集した'
-    end
-  end
-
-  describe '削除' do
-    before do
-      single_task
-      visit tasks_path
-      click_link '削除'
-      page.driver.browser.switch_to.alert.accept
-    end
-
-    it 'タスクが削除される' do
-      expect(page).to have_no_content single_task[:priority]
-      expect(Task.count).to eq 0
     end
   end
 end

--- a/pivote/spec/system/users_spec.rb
+++ b/pivote/spec/system/users_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'ユーザー管理機能', type: :system do
+  let(:admin) { FactoryBot.create(:user, name: 'admin', email: 'admin@example.com', is_admin: true) }
+  let(:admin_task) { FactoryBot.create(:task, title: 'xxxxx', user: admin) }
+  let(:general) { FactoryBot.create(:user, email: 'delete@example.com') }
+  let(:general_task) { FactoryBot.create(:task, user: general) }
+
+  before do |example|
+    unless example.metadata[:skip_before]
+      visit login_path
+      fill_in 'session_email', with: admin.email
+      fill_in 'session_password', with: admin.password
+      click_button I18n.t('link.login')
+      click_link I18n.t('link.users')
+    end
+  end
+
+  describe '一覧表示' do
+    it 'ユーザーが表示される' do
+      expect(page).to have_content 'admin@example.com'
+    end
+
+    it '作成したタスクの数が表示される' do
+      admin_task
+      visit admin_users_path
+      tds = page.all('td')
+      expect(tds[3]).to have_content '1'
+    end
+  end
+
+  describe 'タスク一覧表示' do
+    it '作成したタスクが表示される' do
+      admin_task
+      click_link '1'
+      expect(page).to have_content 'xxxxx'
+    end
+  end
+
+  describe '新規作成' do
+    it 'ユーザーが新規作成される' do
+      visit new_admin_user_path
+      fill_in 'user_name', with: '新規ユーザー'
+      fill_in 'user_email', with: 'new@example.com'
+      fill_in 'user_password', with: 'password'
+      fill_in 'user_password_confirmation', with: 'password'
+      click_button '登録する'
+
+      expect(page).to have_content '新規ユーザー'
+      expect(User.count).to eq 2
+    end
+  end
+
+  describe '編集' do
+    before do
+      visit edit_admin_user_path(admin)
+      fill_in 'user_name', with: '編集ユーザー'
+      fill_in 'user_password', with: 'password'
+      fill_in 'user_password_confirmation', with: 'password'
+    end
+
+    context '編集しても管理ユーザーが存在するとき' do
+      it '編集できる' do
+        check 'user_is_admin'
+        click_button '更新する'
+
+        expect(page).to have_content '編集ユーザー'
+        expect(User.count).to eq 1
+      end
+    end
+
+    context '編集すると管理ユーザーが存在しなくなるとき' do
+      it '編集できない' do
+        uncheck 'user_is_admin'
+        click_button '更新する'
+
+        expect(page).to have_content I18n.t('alert.admin_error')
+        expect(User.count).to eq 1
+      end
+    end
+  end
+
+  describe '削除' do
+    before do
+      general
+      general_task
+    end
+
+    context '削除しても管理ユーザーが存在するとき' do
+      it '削除できる' do
+        visit admin_user_path(general)
+        click_link I18n.t('crud.delete')
+        page.driver.browser.switch_to.alert.accept
+
+        expect(page).to have_no_content 'delete@example.com'
+        expect(User.count).to eq 1
+        expect(Task.count).to eq 0
+      end
+    end
+
+    context '削除すると管理ユーザーが存在しなくなるとき' do
+      it '削除できない' do
+        visit admin_user_path(admin)
+        click_link I18n.t('crud.delete')
+        page.driver.browser.switch_to.alert.accept
+
+        expect(page).to have_content I18n.t('alert.admin_error')
+        expect(User.count).to eq 2
+        expect(Task.count).to eq 1
+      end
+    end
+  end
+
+  describe 'アクセス制限' do
+    it '一般ユーザーはアクセスできない', :skip_before do
+      visit login_path
+      fill_in 'session_email', with: general.email
+      fill_in 'session_password', with: general.password
+      click_button I18n.t('link.login')
+      visit admin_users_path
+      expect(page).to have_no_content I18n.t('headline.user.index')
+      expect(page).to have_content I18n.t('headline.task.index')
+    end
+  end
+end

--- a/pivote/spec/system/users_spec.rb
+++ b/pivote/spec/system/users_spec.rb
@@ -8,113 +8,113 @@ describe 'ユーザー管理機能', type: :system do
   let(:general) { FactoryBot.create(:user, email: 'delete@example.com') }
   let(:general_task) { FactoryBot.create(:task, user: general) }
 
-  before do |example|
-    unless example.metadata[:skip_before]
+  describe 'ログイン前提の処理' do
+    before do
       visit login_path
       fill_in 'session_email', with: admin.email
       fill_in 'session_password', with: admin.password
       click_button I18n.t('link.login')
       click_link I18n.t('link.users')
     end
-  end
 
-  describe '一覧表示' do
-    it 'ユーザーが表示される' do
-      expect(page).to have_content 'admin@example.com'
-    end
+    describe '一覧表示' do
+      it 'ユーザーが表示される' do
+        expect(page).to have_content 'admin@example.com'
+      end
 
-    it '作成したタスクの数が表示される' do
-      admin_task
-      visit admin_users_path
-      tds = page.all('td')
-      expect(tds[3]).to have_content '1'
-    end
-  end
-
-  describe 'タスク一覧表示' do
-    it '作成したタスクが表示される' do
-      admin_task
-      click_link '1'
-      expect(page).to have_content 'xxxxx'
-    end
-  end
-
-  describe '新規作成' do
-    it 'ユーザーが新規作成される' do
-      visit new_admin_user_path
-      fill_in 'user_name', with: '新規ユーザー'
-      fill_in 'user_email', with: 'new@example.com'
-      fill_in 'user_password', with: 'password'
-      fill_in 'user_password_confirmation', with: 'password'
-      click_button '登録する'
-
-      expect(page).to have_content '新規ユーザー'
-      expect(User.count).to eq 2
-    end
-  end
-
-  describe '編集' do
-    before do
-      visit edit_admin_user_path(admin)
-      fill_in 'user_name', with: '編集ユーザー'
-      fill_in 'user_password', with: 'password'
-      fill_in 'user_password_confirmation', with: 'password'
-    end
-
-    context '編集しても管理ユーザーが存在するとき' do
-      it '編集できる' do
-        check 'user_is_admin'
-        click_button '更新する'
-
-        expect(page).to have_content '編集ユーザー'
-        expect(User.count).to eq 1
+      it '作成したタスクの数が表示される' do
+        admin_task
+        visit admin_users_path
+        tds = page.all('td')
+        expect(tds[3]).to have_content '1'
       end
     end
 
-    context '編集すると管理ユーザーが存在しなくなるとき' do
-      it '編集できない' do
-        uncheck 'user_is_admin'
-        click_button '更新する'
-
-        expect(page).to have_content I18n.t('alert.admin_error')
-        expect(User.count).to eq 1
-      end
-    end
-  end
-
-  describe '削除' do
-    before do
-      general
-      general_task
-    end
-
-    context '削除しても管理ユーザーが存在するとき' do
-      it '削除できる' do
-        visit admin_user_path(general)
-        click_link I18n.t('crud.delete')
-        page.driver.browser.switch_to.alert.accept
-
-        expect(page).to have_no_content 'delete@example.com'
-        expect(User.count).to eq 1
-        expect(Task.count).to eq 0
+    describe 'タスク一覧表示' do
+      it '作成したタスクが表示される' do
+        admin_task
+        click_link '1'
+        expect(page).to have_content 'xxxxx'
       end
     end
 
-    context '削除すると管理ユーザーが存在しなくなるとき' do
-      it '削除できない' do
-        visit admin_user_path(admin)
-        click_link I18n.t('crud.delete')
-        page.driver.browser.switch_to.alert.accept
+    describe '新規作成' do
+      it 'ユーザーが新規作成される' do
+        visit new_admin_user_path
+        fill_in 'user_name', with: '新規ユーザー'
+        fill_in 'user_email', with: 'new@example.com'
+        fill_in 'user_password', with: 'password'
+        fill_in 'user_password_confirmation', with: 'password'
+        click_button '登録する'
 
-        expect(page).to have_content I18n.t('alert.admin_error')
+        expect(page).to have_content '新規ユーザー'
         expect(User.count).to eq 2
-        expect(Task.count).to eq 1
+      end
+    end
+
+    describe '編集' do
+      before do
+        visit edit_admin_user_path(admin)
+        fill_in 'user_name', with: '編集ユーザー'
+        fill_in 'user_password', with: 'password'
+        fill_in 'user_password_confirmation', with: 'password'
+      end
+
+      context '編集しても管理ユーザーが存在するとき' do
+        it '編集できる' do
+          check 'user_is_admin'
+          click_button '更新する'
+
+          expect(page).to have_content '編集ユーザー'
+          expect(User.count).to eq 1
+        end
+      end
+
+      context '編集すると管理ユーザーが存在しなくなるとき' do
+        it '編集できない' do
+          uncheck 'user_is_admin'
+          click_button '更新する'
+
+          expect(page).to have_content I18n.t('alert.admin_error')
+          expect(User.count).to eq 1
+        end
+      end
+    end
+
+    describe '削除' do
+      before do
+        general
+        general_task
+      end
+
+      context '削除しても管理ユーザーが存在するとき' do
+        it '削除できる' do
+          visit admin_user_path(general)
+          click_link I18n.t('crud.delete')
+          page.driver.browser.switch_to.alert.accept
+
+          expect(page).to have_no_content 'delete@example.com'
+          expect(User.count).to eq 1
+          expect(Task.count).to eq 0
+        end
+      end
+
+      context '削除すると管理ユーザーが存在しなくなるとき' do
+        it '削除できない' do
+          visit admin_user_path(admin)
+          click_link I18n.t('crud.delete')
+          page.driver.browser.switch_to.alert.accept
+
+          expect(page).to have_content I18n.t('alert.admin_error')
+          expect(User.count).to eq 2
+          expect(Task.count).to eq 1
+        end
       end
     end
   end
 
   describe 'アクセス制限' do
-    it '一般ユーザーはアクセスできない', :skip_before do
+    it '一般ユーザーはアクセスできない' do
       visit login_path
       fill_in 'session_email', with: general.email
       fill_in 'session_password', with: general.password


### PR DESCRIPTION
## 課題
- [ステップ18: ユーザの管理画面を実装しよう ★ スキップ可能](https://github.com/Fablic/training/tree/shunshunsuke#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
- [ステップ19: ユーザにロールを追加しよう ★ スキップ可能](https://github.com/Fablic/training/tree/shunshunsuke#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

##  変更内容
- ユーザーの管理画面実装
- ユーザー一覧・作成・更新・削除を実装
- ユーザー一覧ページにタスク数を表示
- ユーザーが作成したタスク一覧を閲覧可能
- 管理ユーザーのみ管理画面にアクセス可能
- 管理ユーザーが一人もいなくならいようにvalidateを設定
- ユーザー管理画面のsystem spec追加

## スクリーンショット
### ユーザー一覧
![index](https://user-images.githubusercontent.com/61672778/77889715-3dcb6200-72a9-11ea-9950-607815537b88.png)
### ユーザー詳細
![show](https://user-images.githubusercontent.com/61672778/77889735-491e8d80-72a9-11ea-96bc-1fbabf9e9226.png)
### ユーザー新規登録
![new](https://user-images.githubusercontent.com/61672778/77889761-53d92280-72a9-11ea-8819-1676eb020e12.png)
### ユーザーのタスク一覧
![tasks](https://user-images.githubusercontent.com/61672778/77889796-66ebf280-72a9-11ea-8202-58e05f8e7512.png)