### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/pivote/app/controllers/application_controller.rb
+++ b/pivote/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user
   before_action :login_required
+  before_action :render_maintenance_page, if: :maintenance?
 
   private
 
@@ -12,5 +13,17 @@ class ApplicationController < ActionController::Base
 
   def login_required
     redirect_to login_url unless current_user
+  end
+
+  def maintenance?
+    File.exist?(MAINTENANCE_FILE_PATH)
+  end
+
+  def render_maintenance_page
+    render(
+        file: Rails.public_path.join('maintenance.html'),
+        content_type: 'text/html',
+        layout: false,
+    )
   end
 end

--- a/pivote/config/application.rb
+++ b/pivote/config/application.rb
@@ -14,6 +14,7 @@ module Pivote
     config.i18n.default_locale = :ja
     # 複数のロケールファイルが読み込まれるようにpathを通す
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.autoload_paths += Dir["#{config.root}/lib"]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/pivote/config/initializers/constants.rb
+++ b/pivote/config/initializers/constants.rb
@@ -1,1 +1,1 @@
-MAINTENANCE_FILE_PATH = 'config/tmp/maintenance.yml'
+MAINTENANCE_FILE_PATH = 'tmp/maintenance.yml'

--- a/pivote/config/initializers/constants.rb
+++ b/pivote/config/initializers/constants.rb
@@ -1,0 +1,1 @@
+MAINTENANCE_FILE_PATH = 'config/tmp/maintenance.yml'

--- a/pivote/lib/batch/batch_logger.rb
+++ b/pivote/lib/batch/batch_logger.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Batch
+  module BatchLogger
+    class << self
+      delegate(
+          :debug,
+          :info,
+          :warn,
+          :error,
+          :fatal,
+          to: :logger,
+      )
+
+      def logger
+        @logger ||= begin
+          # 標準出力とログファイルの両方に出力する、バッチ用のLoggerオブジェクトを作成
+          logger = ActiveSupport::Logger.new(Rails.root.join('log', "batch_#{Rails.env}.log"))
+          logger.formatter = Logger::Formatter.new
+          logger.datetime_format = '%Y-%m-%d %H:%M:%S'
+
+          stdout_logger = ActiveSupport::Logger.new(STDOUT)
+          multiple_loggers = ActiveSupport::Logger.broadcast(stdout_logger)
+          logger.extend(multiple_loggers)
+
+          logger
+        end
+      end
+    end
+  end
+end

--- a/pivote/lib/batch/maintenance_batch.rb
+++ b/pivote/lib/batch/maintenance_batch.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Batch
+  class MaintenanceBatch
+    def self.start
+      return BatchLogger.error('既にメンテナンス中です。') if File.exist?(MAINTENANCE_FILE_PATH)
+
+      data = { start_time: Time.current }
+      YAML.dump(data, File.open(MAINTENANCE_FILE_PATH, 'w'))
+    end
+
+    def self.end
+      return BatchLogger.error('メンテナンス中ではありません。') unless File.exist?(MAINTENANCE_FILE_PATH)
+
+      FileUtils.rm(MAINTENANCE_FILE_PATH)
+    end
+  end
+end

--- a/pivote/public/maintenance.html
+++ b/pivote/public/maintenance.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Maintenance</title>
+</head>
+
+<body>
+    <h1>現在メンテナンス中です</h1>
+</body>
+</html>

--- a/pivote/spec/system/maintenance_spec.rb
+++ b/pivote/spec/system/maintenance_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'メンテナンス機能', type: :system do
+  before do
+    Batch::MaintenanceBatch.start
+  end
+
+  context 'メンテナンス中のとき' do
+    it 'メンテナンスページに遷移する' do
+      visit root_path
+      expect(page).to have_content '現在メンテナンス中です'
+    end
+  end
+
+  context 'メンテナンスが終了したとき' do
+    it 'ログインページに遷移する' do
+      Batch::MaintenanceBatch.end
+      visit root_path
+      expect(page).to have_content User.human_attribute_name(:email)
+      expect(page).to have_content User.human_attribute_name(:password)
+    end
+  end
+end


### PR DESCRIPTION
## 課題
- [ステップ21: メンテナンス機能を作ろう](https://github.com/Fablic/training/tree/shunshunsuke#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)

## 変更内容
-  メンテナンスを開始/終了するバッチを作成
- メンテナンス中はメンテナンスページに遷移させる

## コメント
- Rails runnerを利用した
- 「config/tmp/maintenance.yml」が存在すればメンテナンス中と判定している
- メンテナンス開始方法(maintenance.ymlが生成される)
  - `bin/rails runner Batch::MaintenanceBatch.start`
- メンテナンス終了方法(maintenance.ymlが削除される)
  - `bin/rails runner Batch::MaintenanceBatch.end`

## スクリーンショット
![maintenance](https://user-images.githubusercontent.com/61672778/78355283-6a081b00-75e8-11ea-825f-87fb07083b48.png)