### PR TITLE
Rails研修 ステップ９ (2/3)

### DIFF
--- a/training/app/controllers/application_controller.rb
+++ b/training/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
 class ApplicationController < ActionController::Base
-  # class Forbidden < ActionController::ActionControllerError; end
-
   include ErrorHandlers
 end

--- a/training/app/controllers/application_controller.rb
+++ b/training/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  include ErrorHandlers unless Rails.env.production?
+  include ErrorHandlers if Rails.env.production?
 end

--- a/training/app/controllers/application_controller.rb
+++ b/training/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+  # class Forbidden < ActionController::ActionControllerError; end
+
+  include ErrorHandlers
 end

--- a/training/app/controllers/application_controller.rb
+++ b/training/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  include ErrorHandlers
+  include ErrorHandlers unless Rails.env.production?
 end

--- a/training/app/controllers/concerns/error_handlers.rb
+++ b/training/app/controllers/concerns/error_handlers.rb
@@ -1,10 +1,10 @@
 module ErrorHandlers
   extend ActiveSupport::Concern
 
-  included do
-    class Forbidden < ActionController::ActionControllerError; end
-    class IpAddressRejected < ActionController::ActionControllerError; end
+  class Forbidden < ActionController::ActionControllerError; end
+  class IpAddressRejected < ActionController::ActionControllerError; end
 
+  included do
     rescue_from Exception, with: :rescue500
     rescue_from ActiveRecord::RecordNotFound, with: :rescue404
     rescue_from Forbidden, with: :rescue403

--- a/training/app/controllers/concerns/error_handlers.rb
+++ b/training/app/controllers/concerns/error_handlers.rb
@@ -1,0 +1,19 @@
+module ErrorHandlers
+  extend ActiveSupport::Concern
+
+  included do
+    class Forbidden < ActionController::ActionControllerError; end
+    # rescue_from Exception, with: :rescue500
+    rescue_from Forbidden, with: :rescue403
+  end
+
+  private
+
+  def rescue403
+    render 'errors/forbidden', status: 403
+  end
+
+  def rescue500
+    render 'errors/internal_server_error', status: 500
+  end
+end

--- a/training/app/controllers/concerns/error_handlers.rb
+++ b/training/app/controllers/concerns/error_handlers.rb
@@ -3,14 +3,20 @@ module ErrorHandlers
 
   included do
     class Forbidden < ActionController::ActionControllerError; end
-    # rescue_from Exception, with: :rescue500
-    rescue_from Forbidden, with: :rescue403
-  end
+    class IpAddressRejected < ActionController::ActionControllerError; end
 
-  private
+    rescue_from Exception, with: :rescue500
+    rescue_from ActiveRecord::RecordNotFound, with: :rescue404
+    rescue_from Forbidden, with: :rescue403
+    rescue_from IpAddressRejected, with: :rescue403
+  end
 
   def rescue403
     render 'errors/forbidden', status: 403
+  end
+
+  def rescue404
+    render 'errors/not_found', status: 404
   end
 
   def rescue500

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -2,7 +2,6 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    raise Forbidden
     @tasks = Task.all
   end
 

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
+    raise Forbidden
     @tasks = Task.all
   end
 

--- a/training/app/views/errors/forbidden.html.erb
+++ b/training/app/views/errors/forbidden.html.erb
@@ -1,0 +1,1 @@
+forbidden dao

--- a/training/app/views/errors/forbidden.html.erb
+++ b/training/app/views/errors/forbidden.html.erb
@@ -1,1 +1,3 @@
-forbidden dao
+<h1>Forbidden</h1>
+
+<p>閲覧がブロックされました</p>

--- a/training/app/views/errors/internal_server_error.html.erb
+++ b/training/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,1 @@
+500 error dao

--- a/training/app/views/errors/internal_server_error.html.erb
+++ b/training/app/views/errors/internal_server_error.html.erb
@@ -1,1 +1,3 @@
-500 error dao
+<h1>Internal Server Error</h1>
+
+<p>システムエラーが発生しました。時間を置いてお試しください</p>

--- a/training/app/views/errors/not_found.html.erb
+++ b/training/app/views/errors/not_found.html.erb
@@ -1,0 +1,4 @@
+<h1>Page Not Found</h1>
+
+<p>お探しのページが存在しません</p>
+<p><%= request.url %></p>

--- a/training/config/routes.rb
+++ b/training/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   root to: 'tasks#index'
   resources :tasks
+
+  # どのルーティングにもマッチしなかったら、404ページにリダイレクト
+  get '*path', controller: 'application', action: 'rescue404'
 end

--- a/training/spec/system/errors_spec.rb
+++ b/training/spec/system/errors_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Errors", type: :system do
+  before do
+    Rails.env = 'production'
+  end
+
+  scenario 'activerecord record not found' do
+    visit task_path(id: 'xxx')
+
+    expect(page).to have_content 'Page Not Found'
+    expect(page).to have_content 'お探しのページが存在しません'
+    expect(page.status_code).to eq 404
+  end
+
+  scenario 'page not found' do
+    visit '/tasks/404test'
+
+    expect(page).to have_content 'Page Not Found'
+    expect(page).to have_content 'お探しのページが存在しません'
+    expect(page.status_code).to eq 404
+  end
+
+  scenario 'internal server error' do
+    allow_any_instance_of(TasksController).to receive(:index).and_throw(Exception)
+    visit tasks_path
+
+    expect(page).to have_content 'Internal Server Error'
+    expect(page).to have_content 'システムエラーが発生しました。時間を置いてお試しください'
+    expect(page.status_code).to eq 500
+  end
+end

--- a/training/spec/system/errors_spec.rb
+++ b/training/spec/system/errors_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe "Errors", type: :system do
     Rails.env = 'production'
   end
 
+  scenario 'forbidden' do
+    allow(Task).to receive(:all).and_raise(ErrorHandlers::Forbidden)
+
+    visit tasks_path
+
+    expect(page).to have_content 'Forbidden'
+    expect(page).to have_content '閲覧がブロックされました'
+    expect(page.status_code).to eq 403
+  end
+
   scenario 'activerecord record not found' do
     visit task_path(id: 'xxx')
 
@@ -22,7 +32,7 @@ RSpec.describe "Errors", type: :system do
   end
 
   scenario 'internal server error' do
-    allow_any_instance_of(TasksController).to receive(:index).and_throw(Exception)
+    allow(Task).to receive(:all).and_raise(Exception)
     visit tasks_path
 
     expect(page).to have_content 'Internal Server Error'


### PR DESCRIPTION
# 概要
[ステップ９](https://github.com/Fablic/training/tree/feature/tatsumi#%E3%82%B9%E3%83%86%E3%83%83%E3%83%979-%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E5%90%84%E7%A8%AE%E8%A8%AD%E5%AE%9A%E3%82%92%E8%A1%8C%E3%81%84%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)

# やったこと
- カスタムエラーページの追加

# 備考
PRが大きくなるので、３つに分割します。

第１段: タイムゾーン and i18n
第２段: エラーページの設定
第３段: 第１段で日本語化したので、step8で作成したsystem specの確認項目の修正

# 実装上の補足

URLが存在しない場合にApplicationController側のrescue_fromでキャッチして404ページにリダイレクトさせたかったのですが、そもそもルーティングが存在しない場合はApplicationControllerに到達する前にエラーが発生するようです。
なので、route.rbの末尾にどのルートにもマッチしなかった用のルートを置いて、404ページにリダイレクトするようにしました。

https://joe41203.hatenablog.com/entry/2018/07/11/003242

# 画面イメージ

エラーページの表示のさせ方

コントローラで`raise 発生させたいエラーのタイプ`

403
<img width="254" alt="403" src="https://user-images.githubusercontent.com/64940424/82623125-67a26480-9c1a-11ea-8b95-5e210c2392c3.png">

404
<img width="484" alt="404" src="https://user-images.githubusercontent.com/64940424/82623139-6cffaf00-9c1a-11ea-9dfc-d4704f4d6772.png">

500
<img width="467" alt="500" src="https://user-images.githubusercontent.com/64940424/82623145-72f59000-9c1a-11ea-9ad5-03bfc86b37b7.png">
