### PR TITLE
Rails研修 ステップ９ (3/3)

### DIFF
--- a/training/app/views/tasks/show.html.erb
+++ b/training/app/views/tasks/show.html.erb
@@ -11,11 +11,11 @@
   </tr>
   <tr>
   <th><%= Task.human_attribute_name(:priority) %></th>
-    <td><%= @task.priority %></td>
+    <td><%= @task.priority_i18n %></td>
   </tr>
   <tr>
   <th><%= Task.human_attribute_name(:status) %></th>
-    <td><%= @task.status %></td>
+    <td><%= @task.status_i18n %></td>
   </tr>
   <tr>
   <th><%= Task.human_attribute_name(:due_date) %></th>

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe "Tasks", type: :system do
   scenario '#create' do
     visit new_task_path
 
-    fill_in 'Title', with: 'title test'
-    fill_in 'Description', with: 'description test'
-    select 'medium', from: 'Priority'
-    select 'working', from: 'Status'
+    fill_in 'タイトル', with: 'title test'
+    fill_in '詳細', with: 'description test'
+    select '中', from: '優先度'
+    select '着手中', from: 'ステータス'
     select '2019', from: 'task_due_date_1i'
-    select 'January', from: 'task_due_date_2i'
+    select '1月', from: 'task_due_date_2i'
     select '1', from: 'task_due_date_3i'
-    click_button '送信'
+    click_button '登録する'
 
     expect(current_path).to eq(tasks_path)
     expect(page).to have_content 'タスクが作成されました'
@@ -23,14 +23,14 @@ RSpec.describe "Tasks", type: :system do
 
     visit edit_task_path(task)
 
-    fill_in 'Title', with: 'edit title test'
-    fill_in 'Description', with: 'edit description test'
-    select 'high', from: 'Priority'
-    select 'waiting', from: 'Status'
+    fill_in 'タイトル', with: 'edit title test'
+    fill_in '詳細', with: 'edit description test'
+    select '高', from: '優先度'
+    select '未着手', from: 'ステータス'
     select '2020', from: 'task_due_date_1i'
-    select 'July', from: 'task_due_date_2i'
+    select '6月', from: 'task_due_date_2i'
     select '2', from: 'task_due_date_3i'
-    click_button '送信'
+    click_button '更新する'
 
     expect(current_path).to eq(tasks_path)
     expect(page).to have_content 'タスクが更新されました'
@@ -42,14 +42,14 @@ RSpec.describe "Tasks", type: :system do
 
     visit tasks_path
 
-    click_link 'show'
+    click_link '詳細'
 
     expect(current_path).to eq(task_path(task))
     expect(page).to have_content 'task title'
     expect(page).to have_content 'task description'
-    expect(page).to have_content 'low'
-    expect(page).to have_content 'waiting'
-    expect(page).to have_content '2019年04月14日'
+    expect(page).to have_content '低'
+    expect(page).to have_content '未着手'
+    expect(page).to have_content '04/14'
   end
 
   scenario '#delete' do
@@ -57,7 +57,7 @@ RSpec.describe "Tasks", type: :system do
 
     visit tasks_path
 
-    click_link 'delete'
+    click_link '削除'
 
     expect(current_path).to eq(tasks_path)
     expect(page).to have_content 'タスクが削除されました'


### PR DESCRIPTION
# 概要
[ステップ９](https://github.com/Fablic/training/tree/feature/tatsumi#%E3%82%B9%E3%83%86%E3%83%83%E3%83%979-%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E5%90%84%E7%A8%AE%E8%A8%AD%E5%AE%9A%E3%82%92%E8%A1%8C%E3%81%84%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)

# やったこと
- tasks system specの日本語化対応

# 備考
PRが大きくなるので、３つに分割します。

第１段: タイムゾーン and i18n
第２段: エラーページの設定
第３段: 第１段で日本語化したので、step8で作成したsystem specの確認項目の修正