### PR TITLE
Rails研修 ステップ１０

### DIFF
--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def show; end

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     priority { 'low' }
     status { 'waiting' }
     due_date { '2019-04-14' }
+
+    trait :with_order_by_created_at do
+      now = Time.now
+      sequence(:title) { |n| "task title-#{n}" }
+      sequence(:created_at) { |n| now - n.days }
+    end
   end
 end

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
 
     trait :with_order_by_created_at do
       now = Time.now
-      sequence(:title) { |n| "task title-#{n}" }
       sequence(:created_at) { |n| now - n.days }
     end
   end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe "Tasks", type: :system do
 
     visit tasks_path
 
-    expect(page.body.index(tasks[0].title)).to be < page.body.index(tasks[1].title)
-    expect(page.body.index(tasks[1].title)).to be < page.body.index(tasks[2].title)
-    expect(page.body.index(tasks[2].title)).to be < page.body.index(tasks[3].title)
-    expect(page.body.index(tasks[3].title)).to be < page.body.index(tasks[4].title)
+    expect(page.body.index(I18n.l(tasks[0].created_at, format: :long))).to be < page.body.index(I18n.l(tasks[1].created_at, format: :long))
+    expect(page.body.index(I18n.l(tasks[1].created_at, format: :long))).to be < page.body.index(I18n.l(tasks[2].created_at, format: :long))
+    expect(page.body.index(I18n.l(tasks[2].created_at, format: :long))).to be < page.body.index(I18n.l(tasks[3].created_at, format: :long))
+    expect(page.body.index(I18n.l(tasks[3].created_at, format: :long))).to be < page.body.index(I18n.l(tasks[4].created_at, format: :long))
   end
 end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -63,4 +63,15 @@ RSpec.describe "Tasks", type: :system do
     expect(page).to have_content 'タスクが削除されました'
     expect(page).not_to have_content 'task title'
   end
+
+  scenario 'in descending order of created_at' do
+    tasks = FactoryBot.create_list(:task, 5, :with_order_by_created_at)
+
+    visit tasks_path
+
+    expect(page.body.index(tasks[0].title)).to be < page.body.index(tasks[1].title)
+    expect(page.body.index(tasks[1].title)).to be < page.body.index(tasks[2].title)
+    expect(page.body.index(tasks[2].title)).to be < page.body.index(tasks[3].title)
+    expect(page.body.index(tasks[3].title)).to be < page.body.index(tasks[4].title)
+  end
 end


### PR DESCRIPTION
# 概要
[ステップ１０](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

# やったこと
- task一覧取得処理にorderを追加
- tasks_specにorderを追加

# 実装ポイント
作成日に降順に並んでいるかを確認するために、
`page.body.index`を使用しています。

https://qiita.com/color_box/items/0dea8842b81d2ce3c5f3
