### PR TITLE
Rails研修 ステップ１１

### DIFF
--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -43,5 +43,6 @@ class TasksController < ApplicationController
 
   def set_task
     @task = Task.find(params[:id])
+    @title ||= @task.title
   end
 end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
+  validates :title, :priority, :status, presence: true
+
   enum priority: {
     low: 0,
     medium: 1,

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -1,5 +1,7 @@
 class Task < ApplicationRecord
+  validates :title, length: { maximum: 50 }
   validates :title, :priority, :status, presence: true
+  validate  :due_date_not_before_today
 
   enum priority: {
     low: 0,
@@ -12,4 +14,8 @@ class Task < ApplicationRecord
     working: 1,
     done: 2,
   }
+
+  def due_date_not_before_today
+    errors.add(:due_date, I18n.t('errors.messages.due_date_is_past')) if due_date.present? && due_date < Date.today
+  end
 end

--- a/training/app/views/shared/_error_messages.html.erb
+++ b/training/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,7 @@
+<% if model.errors.any? %>
+  <ul>
+    <% model.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/training/app/views/tasks/_form.html.erb
+++ b/training/app/views/tasks/_form.html.erb
@@ -1,3 +1,4 @@
+<%= render 'shared/error_messages', model: task %>
 <%= form_with model: task, local: true do |f| %>
   <div>
     <%= f.label :title %>

--- a/training/app/views/tasks/edit.html.erb
+++ b/training/app/views/tasks/edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t '.title', title: @task.title %></h1>
+<h1><%= t '.title', title: @title %></h1>
 
 <%= link_to t('tasks.link.back'), tasks_path %>
 

--- a/training/app/views/tasks/show.html.erb
+++ b/training/app/views/tasks/show.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t '.title', title: @task.title %></h1>
+<h1><%= t '.title', title: @title %></h1>
 
 <table>
   <tr>

--- a/training/config/locales/models/tasks/ja.yml
+++ b/training/config/locales/models/tasks/ja.yml
@@ -19,3 +19,6 @@ ja:
         waiting: 未着手
         working: 着手中
         done: 完了
+  errors:
+    messages:
+      due_date_is_past: は今日以降のものを選択してください

--- a/training/db/migrate/20200526001612_change_title_limit_to_tasks.rb
+++ b/training/db/migrate/20200526001612_change_title_limit_to_tasks.rb
@@ -1,0 +1,9 @@
+class ChangeTitleLimitToTasks < ActiveRecord::Migration[6.0]
+  def up
+    change_column :tasks, :title, :string, null: false, limit: 50
+  end
+
+  def down
+    change_column :tasks, :title, :string, null: false
+  end
+end

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_18_075938) do
+ActiveRecord::Schema.define(version: 2020_05_26_001612) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "title", null: false
+    t.string "title", limit: 50, null: false
     t.text "description"
     t.integer "priority", limit: 1, null: false
     t.integer "status", limit: 1, null: false

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     description { 'task description' }
     priority { 'low' }
     status { 'waiting' }
-    due_date { '2019-04-14' }
+    due_date { Time.now + 1.day }
   end
 end

--- a/training/spec/models/task_spec.rb
+++ b/training/spec/models/task_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  describe 'validation' do
+    describe 'title' do
+      subject { FactoryBot.build(:task, title: title) }
+      context 'valid' do
+        context 'title is 49 characters' do
+          let(:title) { 'a' * 49 }
+          it { is_expected.to be_valid }
+        end
+
+        context 'title is 50 characters' do
+          let(:title) { 'a' * 50 }
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context 'invalid' do
+        context 'title is blank' do
+          let(:title) { '' }
+          it { is_expected.to be_invalid }
+        end
+        context 'title is 51 characters' do
+          let(:title) { 'a' * 51 }
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+
+    describe 'priority' do
+      subject { FactoryBot.build(:task, priority: priority) }
+      context 'valid' do
+        context 'title is present' do
+          let(:priority) { 'low' }
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context 'invalid' do
+        context 'title is blank' do
+          let(:priority) { '' }
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+
+    describe 'status' do
+      subject { FactoryBot.build(:task, status: status) }
+      context 'valid' do
+        context 'title is present' do
+          let(:status) { 'waiting' }
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context 'invalid' do
+        context 'title is blank' do
+          let(:status) { '' }
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+
+    describe 'due_date' do
+      subject { FactoryBot.build(:task, due_date: due_date) }
+      context 'valid' do
+        context 'due_date is blank' do
+          let(:due_date) { '' }
+          it { is_expected.to be_valid }
+        end
+
+        context 'due_date is future' do
+          let(:due_date) { Time.now + 1.day }
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context 'invalid' do
+        context 'due_date is past' do
+          let(:due_date) { Time.now - 1.day }
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end

--- a/training/spec/models/task_spec.rb
+++ b/training/spec/models/task_spec.rb
@@ -20,10 +20,18 @@ RSpec.describe Task, type: :model do
         context 'title is blank' do
           let(:title) { '' }
           it { is_expected.to be_invalid }
+          it 'display enter message' do
+            subject.save
+            expect(subject.errors[:title][0]).to eq I18n.t('errors.messages.blank')
+          end
         end
         context 'title is 51 characters' do
           let(:title) { 'a' * 51 }
           it { is_expected.to be_invalid }
+          it 'display to long message' do
+            subject.save
+            expect(subject.errors[:title][0]).to eq I18n.t('errors.messages.too_long', count: 50)
+          end
         end
       end
     end
@@ -31,16 +39,20 @@ RSpec.describe Task, type: :model do
     describe 'priority' do
       subject { FactoryBot.build(:task, priority: priority) }
       context 'valid' do
-        context 'title is present' do
+        context 'priority is present' do
           let(:priority) { 'low' }
           it { is_expected.to be_valid }
         end
       end
 
       context 'invalid' do
-        context 'title is blank' do
+        context 'priority is blank' do
           let(:priority) { '' }
           it { is_expected.to be_invalid }
+          it 'display enter message' do
+            subject.save
+            expect(subject.errors[:priority][0]).to eq I18n.t('errors.messages.blank')
+          end
         end
       end
     end
@@ -48,16 +60,20 @@ RSpec.describe Task, type: :model do
     describe 'status' do
       subject { FactoryBot.build(:task, status: status) }
       context 'valid' do
-        context 'title is present' do
+        context 'status is present' do
           let(:status) { 'waiting' }
           it { is_expected.to be_valid }
         end
       end
 
       context 'invalid' do
-        context 'title is blank' do
+        context 'status is blank' do
           let(:status) { '' }
           it { is_expected.to be_invalid }
+          it 'display enter message' do
+            subject.save
+            expect(subject.errors[:status][0]).to eq I18n.t('errors.messages.blank')
+          end
         end
       end
     end
@@ -80,6 +96,10 @@ RSpec.describe Task, type: :model do
         context 'due_date is past' do
           let(:due_date) { Time.now - 1.day }
           it { is_expected.to be_invalid }
+          it 'display enter future date message' do
+            subject.save
+            expect(subject.errors[:due_date][0]).to eq I18n.t('errors.messages.due_date_is_past')
+          end
         end
       end
     end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "Tasks", type: :system do
     fill_in '詳細', with: 'description test'
     select '中', from: '優先度'
     select '着手中', from: 'ステータス'
-    select '2019', from: 'task_due_date_1i'
-    select '1月', from: 'task_due_date_2i'
-    select '1', from: 'task_due_date_3i'
+    select Time.now.year, from: 'task_due_date_1i'
+    select Time.now.month + 1, from: 'task_due_date_2i'
+    select Time.now.day, from: 'task_due_date_3i'
     click_button '登録する'
 
     expect(current_path).to eq(tasks_path)
@@ -49,7 +49,7 @@ RSpec.describe "Tasks", type: :system do
     expect(page).to have_content 'task description'
     expect(page).to have_content '低'
     expect(page).to have_content '未着手'
-    expect(page).to have_content '04/14'
+    expect(page).to have_content I18n.l(task.due_date, format: :short)
   end
 
   scenario '#delete' do


### PR DESCRIPTION
# 概要
[ステップ１１](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)

# やったこと
- taskモデルにバリデーションを追加
  - taskのタイトル必須入力
  - taskのタイトル５０文字チェック
  - due_dateの過去日チェック
- task_specの作成

# 画面イメージ
<img width="413" alt="Screen Shot 2020-05-26 at 11 30 08" src="https://user-images.githubusercontent.com/64940424/82854738-50c67f80-9f44-11ea-87d6-222c45bfb34a.png">

# 備考
due_dateに過去日チェックを導入したことで、一部テストが失敗していたのでdue_dateに過去日で登録している箇所を未来日に変更しました