### PR TITLE
Rails研修 ステップ１２

### DIFF
--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -36,7 +36,7 @@ class TasksController < ApplicationController
   end
 
   def search
-    @tasks = Task.all.order(due_date: params[:priority_order].to_sym)
+    @tasks = Task.order_by_priority(params[:priority_order].to_sym)
     render 'index'
   end
 

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -36,7 +36,7 @@ class TasksController < ApplicationController
   end
 
   def search
-    @tasks = Task.order_by_priority(params[:priority_order].to_sym)
+    @tasks = Task.order_by_due_date(params[:due_date_order].to_sym)
     render 'index'
   end
 

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -35,6 +35,11 @@ class TasksController < ApplicationController
     redirect_to tasks_path, notice: t('tasks.flash.delete')
   end
 
+  def search
+    @tasks = Task.all.order(due_date: params[:priority_order].to_sym)
+    render 'index'
+  end
+
   private
 
   def tasks_params

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -12,6 +12,7 @@ class Task < ApplicationRecord
   }
 
   def self.order_by_priority(priority_order)
+    priority_order = :asc if priority_order.blank?
     order(due_date: priority_order)
   end
 end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -11,8 +11,8 @@ class Task < ApplicationRecord
     done: 2,
   }
 
-  def self.order_by_priority(priority_order)
-    priority_order = :asc if priority_order.blank?
-    order(due_date: priority_order)
+  def self.order_by_due_date(due_date_order)
+    due_date_order = :asc if due_date_order.blank?
+    order(due_date: due_date_order)
   end
 end

--- a/training/app/models/task.rb
+++ b/training/app/models/task.rb
@@ -10,4 +10,8 @@ class Task < ApplicationRecord
     working: 1,
     done: 2,
   }
+
+  def self.order_by_priority(priority_order)
+    order(due_date: priority_order)
+  end
 end

--- a/training/app/views/tasks/_search_form.html.erb
+++ b/training/app/views/tasks/_search_form.html.erb
@@ -1,8 +1,8 @@
 <h3><%= t 'tasks.search_form.title' %></h3>
 <%= form_with url: search_tasks_path, local: true, method: :get do |form| %>
   <div>
-    <%= form.label t('tasks.search_form.priority_order') %>
-    <%= form.select :priority_order, [[t('tasks.search_form.priority_order_asc'), 'asc'], [t('tasks.search_form.priority_order_desc'), 'desc']], selected: params[:priority_order] %>
+    <%= form.label t('tasks.search_form.due_date_order') %>
+    <%= form.select :due_date_order, [[t('tasks.search_form.due_date_order_asc'), 'asc'], [t('tasks.search_form.due_date_order_desc'), 'desc']], selected: params[:due_date_order] %>
   </div>
   <div>
     <%= form.submit t('tasks.search_form.button') %>

--- a/training/app/views/tasks/_search_form.html.erb
+++ b/training/app/views/tasks/_search_form.html.erb
@@ -1,0 +1,10 @@
+<h3>検索フォーム</h3>
+<%= form_with url: search_tasks_path, local: true, method: :get do |form| %>
+  <div>
+    <%= form.label '期限で並べ替え' %>
+    <%= form.select :priority_order, [['昇順', 'asc'], ['降順', 'desc']], selected: params[:priority_order] %>
+  </div>
+  <div>
+    <%= form.submit '検索する' %>
+  </div>
+<% end %>

--- a/training/app/views/tasks/_search_form.html.erb
+++ b/training/app/views/tasks/_search_form.html.erb
@@ -1,10 +1,10 @@
-<h3>検索フォーム</h3>
+<h3><%= t 'tasks.search_form.title' %></h3>
 <%= form_with url: search_tasks_path, local: true, method: :get do |form| %>
   <div>
-    <%= form.label '期限で並べ替え' %>
-    <%= form.select :priority_order, [['昇順', 'asc'], ['降順', 'desc']], selected: params[:priority_order] %>
+    <%= form.label t('tasks.search_form.priority_order') %>
+    <%= form.select :priority_order, [[t('tasks.search_form.priority_order_asc'), 'asc'], [t('tasks.search_form.priority_order_desc'), 'desc']], selected: params[:priority_order] %>
   </div>
   <div>
-    <%= form.submit '検索する' %>
+    <%= form.submit t('tasks.search_form.button') %>
   </div>
 <% end %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -2,6 +2,8 @@
 
 <%= link_to t('.new_task'), new_task_path %>
 
+<%= render 'search_form' %>
+
 <table>
   <tr>
     <th><%= Task.human_attribute_name(:title) %></th>

--- a/training/config/locales/views/tasks/ja.yml
+++ b/training/config/locales/views/tasks/ja.yml
@@ -9,6 +9,12 @@ ja:
       title: '%{title}のタスク更新'
     new:
       title: 新しいタスクの作成
+    search_form:
+      title: 検索フォーム
+      priority_order: 期限で並べ替え
+      priority_order_asc: 昇順
+      priority_order_desc: 降順
+      button: 検索する
     link:
       show: 詳細
       edit: 編集
@@ -20,4 +26,3 @@ ja:
       delete: タスクが削除されました
     confirm:
       delete: 削除しますか？
-

--- a/training/config/locales/views/tasks/ja.yml
+++ b/training/config/locales/views/tasks/ja.yml
@@ -11,9 +11,9 @@ ja:
       title: 新しいタスクの作成
     search_form:
       title: 検索フォーム
-      priority_order: 期限で並べ替え
-      priority_order_asc: 昇順
-      priority_order_desc: 降順
+      due_date_order: 期限で並べ替え
+      due_date_order_asc: 昇順
+      due_date_order_desc: 降順
       button: 検索する
     link:
       show: 詳細

--- a/training/config/routes.rb
+++ b/training/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   root to: 'tasks#index'
-  resources :tasks
+  resources :tasks do
+    collection do
+      get :search
+    end
+  end
 
   # どのルーティングにもマッチしなかったら、404ページにリダイレクト
   get '*path', controller: 'application', action: 'rescue404'

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     priority { 'low' }
     status { 'waiting' }
     due_date { '2019-04-14' }
+
+    trait :with_order_by_due_date do
+      now = Time.now
+      sequence(:title) { |n| "task title-#{n}" }
+      sequence(:due_date) { |n| now - n.days }
+    end
   end
 end

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
 
     trait :with_order_by_due_date do
       now = Time.now
-      sequence(:title) { |n| "task title-#{n}" }
       sequence(:due_date) { |n| now - n.days }
     end
   end

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
 
     trait :with_order_by_due_date do
       now = Time.now
-      sequence(:due_date) { |n| now - n.days }
+      sequence(:due_date) { |n| now + n.days }
     end
   end
 end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Tasks", type: :system do
     tasks = FactoryBot.create_list(:task, 5, :with_order_by_due_date)
 
     visit tasks_path
-    select '降順', from: 'priority_order'
+    select '降順', from: 'due_date_order'
     click_button '検索する'
 
     expect(page.body.index(I18n.l(tasks[0].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[1].due_date, format: :short))
@@ -92,7 +92,7 @@ RSpec.describe "Tasks", type: :system do
     tasks = FactoryBot.create_list(:task, 5, :with_order_by_due_date)
 
     visit tasks_path
-    select '昇順', from: 'priority_order'
+    select '昇順', from: 'due_date_order'
     click_button '検索する'
 
     expect(page.body.index(I18n.l(tasks[4].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[3].due_date, format: :short))

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -63,4 +63,30 @@ RSpec.describe "Tasks", type: :system do
     expect(page).to have_content 'タスクが削除されました'
     expect(page).not_to have_content 'task title'
   end
+
+  scenario 'in descending order of due_date' do
+    tasks = FactoryBot.create_list(:task, 5, :with_order_by_due_date)
+
+    visit tasks_path
+    select '降順', from: 'priority_order'
+    click_button '検索する'
+
+    expect(page.body.index(tasks[0].title)).to be < page.body.index(tasks[1].title)
+    expect(page.body.index(tasks[1].title)).to be < page.body.index(tasks[2].title)
+    expect(page.body.index(tasks[2].title)).to be < page.body.index(tasks[3].title)
+    expect(page.body.index(tasks[3].title)).to be < page.body.index(tasks[4].title)
+  end
+
+  scenario 'in ascending order of due_date' do
+    tasks = FactoryBot.create_list(:task, 5, :with_order_by_due_date)
+
+    visit tasks_path
+    select '昇順', from: 'priority_order'
+    click_button '検索する'
+
+    expect(page.body.index(tasks[4].title)).to be < page.body.index(tasks[3].title)
+    expect(page.body.index(tasks[3].title)).to be < page.body.index(tasks[2].title)
+    expect(page.body.index(tasks[2].title)).to be < page.body.index(tasks[1].title)
+    expect(page.body.index(tasks[1].title)).to be < page.body.index(tasks[0].title)
+  end
 end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -71,10 +71,10 @@ RSpec.describe "Tasks", type: :system do
     select '降順', from: 'priority_order'
     click_button '検索する'
 
-    expect(page.body.index(tasks[0].title)).to be < page.body.index(tasks[1].title)
-    expect(page.body.index(tasks[1].title)).to be < page.body.index(tasks[2].title)
-    expect(page.body.index(tasks[2].title)).to be < page.body.index(tasks[3].title)
-    expect(page.body.index(tasks[3].title)).to be < page.body.index(tasks[4].title)
+    expect(page.body.index(I18n.l(tasks[0].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[1].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[1].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[2].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[2].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[3].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[3].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[4].due_date, format: :short))
   end
 
   scenario 'in ascending order of due_date' do
@@ -84,9 +84,9 @@ RSpec.describe "Tasks", type: :system do
     select '昇順', from: 'priority_order'
     click_button '検索する'
 
-    expect(page.body.index(tasks[4].title)).to be < page.body.index(tasks[3].title)
-    expect(page.body.index(tasks[3].title)).to be < page.body.index(tasks[2].title)
-    expect(page.body.index(tasks[2].title)).to be < page.body.index(tasks[1].title)
-    expect(page.body.index(tasks[1].title)).to be < page.body.index(tasks[0].title)
+    expect(page.body.index(I18n.l(tasks[4].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[3].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[3].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[2].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[2].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[1].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[1].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[0].due_date, format: :short))
   end
 end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe "Tasks", type: :system do
     select '降順', from: 'due_date_order'
     click_button '検索する'
 
-    expect(page.body.index(I18n.l(tasks[0].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[1].due_date, format: :short))
-    expect(page.body.index(I18n.l(tasks[1].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[2].due_date, format: :short))
-    expect(page.body.index(I18n.l(tasks[2].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[3].due_date, format: :short))
-    expect(page.body.index(I18n.l(tasks[3].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[4].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[4].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[3].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[3].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[2].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[2].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[1].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[1].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[0].due_date, format: :short))
   end
 
   scenario 'in ascending order of due_date' do
@@ -95,9 +95,9 @@ RSpec.describe "Tasks", type: :system do
     select '昇順', from: 'due_date_order'
     click_button '検索する'
 
-    expect(page.body.index(I18n.l(tasks[4].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[3].due_date, format: :short))
-    expect(page.body.index(I18n.l(tasks[3].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[2].due_date, format: :short))
-    expect(page.body.index(I18n.l(tasks[2].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[1].due_date, format: :short))
-    expect(page.body.index(I18n.l(tasks[1].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[0].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[0].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[1].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[1].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[2].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[2].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[3].due_date, format: :short))
+    expect(page.body.index(I18n.l(tasks[3].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[4].due_date, format: :short))
   end
 end


### PR DESCRIPTION
# 概要
[ステップ１２](https://github.com/Fablic/training/tree/feature/tatsumi#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E7%B5%82%E4%BA%86%E6%9C%9F%E9%99%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

# やったこと
- due_dateによるソート機能の追加
- 検索フォームの追加
- tasks_system_sepcへソート機能のテストケース追加

# 画面イメージ

<img width="724" alt="Screen Shot 2020-05-27 at 10 54 09" src="https://user-images.githubusercontent.com/64940424/82968522-75842b00-a008-11ea-9eec-78eb3771afdd.png">
