### PR TITLE
Feature/tatsumi 15 (2/2)

### DIFF
--- a/training/app/views/kaminari/_first_page.html.erb
+++ b/training/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% unless current_page.first? %>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :class => 'page-link', :remote => remote %>
+</li>
+<% end %>

--- a/training/app/views/kaminari/_gap.html.erb
+++ b/training/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="page-item disabled"><a href="#" onclick="return false;" class="page-link"><%= raw(t 'views.pagination.truncate') %></a></li>

--- a/training/app/views/kaminari/_last_page.html.erb
+++ b/training/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% unless current_page.last? %>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :class => 'page-link', :remote => remote %>
+</li>
+<% end %>

--- a/training/app/views/kaminari/_next_page.html.erb
+++ b/training/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% unless current_page.last? %>
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :class => 'page-link', :rel => 'next', :remote => remote %>
+</li>
+<% end %>

--- a/training/app/views/kaminari/_page.html.erb
+++ b/training/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="page-item<%= ' active' if page.current? %>">
+  <%= link_to page, url, opts = {:remote => remote, :class => 'page-link', :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+</li>

--- a/training/app/views/kaminari/_paginator.html.erb
+++ b/training/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,27 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%- pagination_class ||= '' %>
+<%- nav_class ||= '' %>
+<%= paginator.render do -%>
+<nav class="<%= nav_class %>">
+  <ul class="pagination <%= pagination_class %>">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </ul>
+</nav>
+<% end -%>

--- a/training/app/views/kaminari/_prev_page.html.erb
+++ b/training/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% unless current_page.first? %>
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :class => 'page-link' %>
+</li>
+<% end %>

--- a/training/app/views/layouts/application.html.erb
+++ b/training/app/views/layouts/application.html.erb
@@ -10,9 +10,8 @@
   </head>
 
   <body>
-    <%= notice %>
-    <%= alert %>
     <div class="container-fluid">
+      <%= render 'shared/flash_messages' %>
       <%= yield %>
     </div>
   </body>

--- a/training/app/views/layouts/application.html.erb
+++ b/training/app/views/layouts/application.html.erb
@@ -12,6 +12,8 @@
   <body>
     <%= notice %>
     <%= alert %>
-    <%= yield %>
+    <div class="container-fluid">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/training/app/views/shared/_flash_messages.html.erb
+++ b/training/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,8 @@
+<% if flash.any? %>
+  <div class="alert alert-success" role="alert">
+    <%= notice %>
+  </div>
+  <div class="alert alert-danger" role="alert">
+    <%= alert %>
+  </div>
+<% end %>

--- a/training/app/views/shared/_flash_messages.html.erb
+++ b/training/app/views/shared/_flash_messages.html.erb
@@ -1,8 +1,9 @@
 <% if flash.any? %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <div class="alert alert-danger" role="alert">
-    <%= alert %>
-  </div>
+  <% flash.each do |key, value| %>
+    <% type = 'success' if key == 'notice' %>
+    <% type = 'danger' if key == 'alert' %>
+    <div class="alert alert-<%= type %>" role="alert">
+      <%= value %>
+    </div>
+  <% end %>
 <% end %>

--- a/training/app/views/tasks/_form.html.erb
+++ b/training/app/views/tasks/_form.html.erb
@@ -1,26 +1,24 @@
 <%= render 'shared/error_messages', model: task %>
-<%= form_with model: task, local: true do |f| %>
-  <div>
+<%= form_with model: task, local: true, class: 'form-group' do |f| %>
+  <div class="form-group">
     <%= f.label :title %>
-    <%= f.text_field :title %>
+    <%= f.text_field :title, class: 'form-control col-4' %>
   </div>
-  <div>
+  <div class="form-group">
     <%= f.label :description %>
-    <%= f.text_area :description %>
+    <%= f.text_area :description, class: 'form-control col-4', rows: 6 %>
   </div>
-  <div>
+  <div class="form-group">
     <%= f.label :priority %>
-    <%= f.select :priority, Task.priorities_i18n.invert %>
+    <%= f.select :priority, Task.priorities_i18n.invert, {}, class: 'custom-select col-1 ml-1' %>
   </div>
-  <div>
+  <div class="form-group">
     <%= f.label :status %>
-    <%= f.select :status, Task.statuses_i18n.invert %>
+    <%= f.select :status, Task.statuses_i18n.invert, {}, class: 'custom-select col-1 ml-1' %>
   </div>
-  <div>
+  <div class="form-group">
     <%= f.label :due_date %>
     <%= f.date_select :due_date %>
   </div>
-  <div>
-    <%= f.submit %>
-  </div>
+  <%= f.submit class: 'btn btn-primary' %>
 <% end %>

--- a/training/app/views/tasks/_form.html.erb
+++ b/training/app/views/tasks/_form.html.erb
@@ -18,7 +18,7 @@
   </div>
   <div class="form-group">
     <%= f.label :due_date %>
-    <%= f.date_select :due_date %>
+    <%= f.date_select :due_date, {date_separator: '/ '}, class: 'custom-select col-1' %>
   </div>
   <%= f.submit class: 'btn btn-primary' %>
 <% end %>

--- a/training/app/views/tasks/_search_form.html.erb
+++ b/training/app/views/tasks/_search_form.html.erb
@@ -1,10 +1,14 @@
-<h3><%= t 'tasks.search_form.title' %></h3>
-<%= form_with url: search_tasks_path, local: true, method: :get do |form| %>
-  <div>
-    <%= form.label t('tasks.search_form.due_date_order') %>
-    <%= form.select :due_date_order, [[t('tasks.search_form.due_date_order_asc'), 'asc'], [t('tasks.search_form.due_date_order_desc'), 'desc']], selected: params[:due_date_order] %>
+<div class="card border-secondary mb-3" style="max-width: 30rem;">
+  <div class="card-header"><%= t 'tasks.search_form.title' %></div>
+  <div class="card-body text-secondary">
+  <%= form_with url: search_tasks_path, local: true, method: :get, class: 'form-group' do |form| %>
+    <div class="form-group">
+      <%= form.label t('tasks.search_form.due_date_order') %>
+      <%= form.select :due_date_order, [[t('tasks.search_form.due_date_order_asc'), 'asc'], [t('tasks.search_form.due_date_order_desc'), 'desc']], {selected: params[:due_date_order]}, {class: 'custom-select col-5'} %>
+    </div>
+    <div>
+      <%= form.submit t('tasks.search_form.button'), class: 'btn btn-primary' %>
+    </div>
+  <% end %>
   </div>
-  <div>
-    <%= form.submit t('tasks.search_form.button') %>
-  </div>
-<% end %>
+</div>

--- a/training/app/views/tasks/_search_form.html.erb
+++ b/training/app/views/tasks/_search_form.html.erb
@@ -1,21 +1,20 @@
 <div class="card border-secondary mb-3" style="max-width: 30rem;">
   <div class="card-header"><%= t 'tasks.search_form.title' %></div>
   <div class="card-body text-secondary">
-  <%= form_with url: search_tasks_path, local: true, method: :get, class: 'form-group' do |form| %>
-    <div>
-      <%= form.label t('tasks.search_form.search_for_title') %>
-      <%= form.text_field :title, value: params[:title], placeholder: t('tasks.search_form.search_for_title') %>
-    </div>
-    <div>
-      <%= form.label t('tasks.search_form.search_for_status') %>
-      <%= form.select :status, Task.statuses_i18n.invert, selected: params[:status], include_blank: t('tasks.search_form.search_for_status') %>
-    </div>
-    <div class="form-group">
-      <%= form.label t('tasks.search_form.due_date_order') %>
-      <%= form.select :due_date_order, [[t('tasks.search_form.due_date_order_asc'), 'asc'], [t('tasks.search_form.due_date_order_desc'), 'desc']], {selected: params[:due_date_order]}, {class: 'custom-select col-5'} %>
-    </div>
-    <div>
+    <%= form_with url: search_tasks_path, local: true, method: :get, class: 'form-group' do |form| %>
+      <div class="form-group">
+        <%= form.label t('tasks.search_form.search_for_title') %>
+        <%= form.text_field :title, value: params[:title], placeholder: t('tasks.search_form.search_for_title'), class: 'form-control col-9' %>
+      </div>
+      <div class="form-group">
+        <%= form.label t('tasks.search_form.search_for_status') %>
+        <%= form.select :status, Task.statuses_i18n.invert, {selected: params[:status], include_blank: t('tasks.search_form.search_for_status')}, {class: 'custom-select col-5'} %>
+      </div>
+      <div class="form-group">
+        <%= form.label t('tasks.search_form.due_date_order') %>
+        <%= form.select :due_date_order, [[t('tasks.search_form.due_date_order_asc'), 'asc'], [t('tasks.search_form.due_date_order_desc'), 'desc']], {selected: params[:due_date_order]}, {class: 'custom-select col-5'} %>
+      </div>
       <%= form.submit t('tasks.search_form.button'), class: 'btn btn-primary' %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -11,6 +11,7 @@
     <th><%= Task.human_attribute_name(:priority) %></th>
     <th><%= Task.human_attribute_name(:status) %></th>
     <th><%= Task.human_attribute_name(:due_date) %></th>
+    <th><%= Task.human_attribute_name(:created_at) %></th>
     <th></th>
   </tr>
   <% @tasks.each do |task| %>
@@ -20,6 +21,7 @@
       <td><%= task.priority_i18n %></td>
       <td><%= task.status_i18n %></td>
       <td><%= task.due_date.presence && l(task.due_date, format: :short) %></td>
+      <td><%= l task.created_at, format: :long %></td>
       <td>
         <%= link_to t('tasks.link.show'), task_path(task) %>
         <%= link_to t('tasks.link.edit'), edit_task_path(task) %>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -16,7 +16,7 @@
   <% @tasks.each do |task| %>
     <tr>
       <td><%= task.title %></td>
-      <td><%= task.description %></td>
+      <td><%= truncate(task.description, length: 50) %></td>
       <td><%= task.priority_i18n %></td>
       <td><%= task.status_i18n %></td>
       <td><%= task.due_date.presence && l(task.due_date, format: :short) %></td>

--- a/training/app/views/tasks/index.html.erb
+++ b/training/app/views/tasks/index.html.erb
@@ -1,18 +1,17 @@
 <h1><%= t '.title' %></h1>
 
-<%= link_to t('.new_task'), new_task_path %>
-
 <%= render 'search_form' %>
 
-<table>
+<%= link_to t('.new_task'), new_task_path %>
+
+<table class="table table-striped">
   <tr>
     <th><%= Task.human_attribute_name(:title) %></th>
     <th><%= Task.human_attribute_name(:description) %></th>
     <th><%= Task.human_attribute_name(:priority) %></th>
     <th><%= Task.human_attribute_name(:status) %></th>
     <th><%= Task.human_attribute_name(:due_date) %></th>
-    <th><%= Task.human_attribute_name(:created_at) %></th>
-    <th><%= Task.human_attribute_name(:updated_at) %></th>
+    <th></th>
   </tr>
   <% @tasks.each do |task| %>
     <tr>
@@ -21,8 +20,6 @@
       <td><%= task.priority_i18n %></td>
       <td><%= task.status_i18n %></td>
       <td><%= task.due_date.presence && l(task.due_date, format: :short) %></td>
-      <td><%= l task.created_at, format: :long %></td>
-      <td><%= l task.updated_at, format: :long %></td>
       <td>
         <%= link_to t('tasks.link.show'), task_path(task) %>
         <%= link_to t('tasks.link.edit'), edit_task_path(task) %>
@@ -31,3 +28,4 @@
     </tr>
   <% end %>
 </table>
+

--- a/training/app/views/tasks/show.html.erb
+++ b/training/app/views/tasks/show.html.erb
@@ -1,40 +1,39 @@
 <h1><%= t '.title', title: @title %></h1>
 
-<table>
+<table class="table table-striped">
   <tr>
-  <th><%= Task.human_attribute_name(:title) %></th>
-    <td><%= @task.title %></td>
-  </tr>
+      <th><%= Task.human_attribute_name(:title) %></th>
+      <td><%= @task.title %></td>
+    </tr>
   <tr>
-  <th><%= Task.human_attribute_name(:description) %></th>
-    <td><%= @task.description %></td>
-  </tr>
+      <th><%= Task.human_attribute_name(:description) %></th>
+      <td><%= @task.description %></td>
+    </tr>
   <tr>
-  <th><%= Task.human_attribute_name(:priority) %></th>
+    <th><%= Task.human_attribute_name(:priority) %></th>
     <td><%= @task.priority_i18n %></td>
   </tr>
   <tr>
-  <th><%= Task.human_attribute_name(:status) %></th>
+    <th><%= Task.human_attribute_name(:status) %></th>
     <td><%= @task.status_i18n %></td>
   </tr>
   <tr>
-  <th><%= Task.human_attribute_name(:due_date) %></th>
+    <th><%= Task.human_attribute_name(:due_date) %></th>
     <td><%= l @task.due_date, format: :short %></td>
   </tr>
   <tr>
-  <th><%= Task.human_attribute_name(:created_at) %></th>
+    <th><%= Task.human_attribute_name(:created_at) %></th>
     <td><%= l @task.created_at, format: :long %></td>
   </tr>
   <tr>
-  <th><%= Task.human_attribute_name(:updated_at) %></th>
+    <th><%= Task.human_attribute_name(:updated_at) %></th>
     <td><%= l @task.updated_at, format: :long %></td>
   </tr>
   <tr>
     <td colspan="2">
-      <%= link_to t('tasks.link.edit'), edit_task_path(@task) %>
-      <%= link_to t('tasks.link.delete'), task_path(@task), method: :delete %>
+      <%= link_to t('tasks.link.edit'), edit_task_path(@task), class: 'btn btn-outline-primary mr-2' %>
+      <%= link_to t('tasks.link.delete'), task_path(@task), method: :delete, class: 'btn btn-outline-danger mr-2' %>
+      <%= link_to t('tasks.link.back'), tasks_path, class: 'btn btn-outline-dark' %>
     </td>
   </tr>
 </table>
-
-<%= link_to t('tasks.link.back'), tasks_path %>

--- a/training/docker-compose.yml
+++ b/training/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   web:
     build: .
-    command: /bin/sh -c "rm -rf ./tmp/pids/server.pid && bundle exec rails s -p 3000 -b 0.0.0.0"
+    command: /bin/sh -c "rm -rf ./tmp/pids/server.pid && yarn install && bundle exec rails s -p 3000 -b 0.0.0.0"
     tty: true
     stdin_open: true
     depends_on:


### PR DESCRIPTION
# 概要
[ステップ１５](https://github.com/Fablic/training/tree/feature/tatsumi#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

# やったこと
- bootstrapによるデザイン当て

# 画面イメージ

### index

<img width="1804" alt="Screen Shot 2020-06-02 at 17 38 56" src="https://user-images.githubusercontent.com/64940424/83499266-0cb11d00-a4f8-11ea-854d-379a52efcc40.png">

### show

<img width="1006" alt="Screen Shot 2020-06-02 at 17 39 12" src="https://user-images.githubusercontent.com/64940424/83499304-25213780-a4f8-11ea-86dc-64154dad24fe.png">

### new

<img width="628" alt="Screen Shot 2020-06-02 at 17 39 34" src="https://user-images.githubusercontent.com/64940424/83499348-34a08080-a4f8-11ea-9d0f-65a70b683b54.png">


### edit

<img width="634" alt="Screen Shot 2020-06-02 at 17 39 21" src="https://user-images.githubusercontent.com/64940424/83499372-3c602500-a4f8-11ea-8b5b-77cefa4ba237.png">

# 備考
yarnでbootstrapを導入したせいか、kaminari-bootstrapを入れてもkaminariのページ部分のデザインが変わらなかったので、手動でkaminariのviewsにbootstrapを当て込みました。

https://github.com/KamilDzierbicki/bootstrap4-kaminari-views

<img width="593" alt="Screen Shot 2020-06-03 at 10 31 02" src="https://user-images.githubusercontent.com/64940424/83586296-0322c600-a587-11ea-8b0c-995d4c4366e6.png">