### PR TITLE
Rails研修17 (2/2)

### DIFF
--- a/training/app/controllers/application_controller.rb
+++ b/training/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
 class ApplicationController < ActionController::Base
-  include ErrorHandlers if Rails.env.production?
+  include ErrorHandlers if Rails.env.production? || Rails.env.test?
   include Sessions
 end

--- a/training/app/controllers/application_controller.rb
+++ b/training/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  # テスト環境でも本番同様にエラー画面を表示させたいためにRails.env.test?を追加
   include ErrorHandlers if Rails.env.production? || Rails.env.test?
   include Sessions
 end

--- a/training/app/controllers/sessions_controller.rb
+++ b/training/app/controllers/sessions_controller.rb
@@ -1,7 +1,11 @@
 class SessionsController < ApplicationController
   skip_before_action :authorize
 
-  def new; end
+  def new
+    if current_user
+      redirect_to root_path
+    end
+  end
 
   def create
     user = User.find_by(email: params[:email])

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -62,8 +62,7 @@ class TasksController < ApplicationController
 
   def restrict_own_task
     task_user_id = Task.find(params[:id]).user_id
-    unless current_user.id == task_user_id
-      redirect_to root_path, alert: t('tasks.flash.restrict_own_task')
-    end
+    return if current_user.id == task_user_id
+    redirect_to root_path, alert: t('tasks.flash.restrict_own_task')
   end
 end

--- a/training/app/controllers/tasks_controller.rb
+++ b/training/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
+  before_action :restrict_own_task, only: %i[show edit update destroy]
 
   def index
     @tasks = current_user.tasks.order(created_at: :desc).page(params[:page])
@@ -57,5 +58,12 @@ class TasksController < ApplicationController
   def set_task
     @task = Task.find(params[:id])
     @title ||= @task.title
+  end
+
+  def restrict_own_task
+    task_user_id = Task.find(params[:id]).user_id
+    unless current_user.id == task_user_id
+      redirect_to root_path, alert: t('tasks.flash.restrict_own_task')
+    end
   end
 end

--- a/training/app/views/sessions/new.html.erb
+++ b/training/app/views/sessions/new.html.erb
@@ -2,11 +2,11 @@
 
 <%= form_with url: sessions_path, local: true, method: :post, class: 'form-group' do |f| %>
   <div class="form-group">
-    <%= f.label :email %>
+    <%= f.label t('.email') %>
     <%= f.email_field :email, class: 'form-control col-4' %>
   </div>
   <div class="form-group">
-    <%= f.label :password %>
+    <%= f.label t('.password') %>
     <%= f.password_field :password, class: 'form-control col-4' %>
   </div>
   <%= f.submit t('.login_button'), class: 'btn btn-primary' %>

--- a/training/config/locales/views/sessions/ja.yml
+++ b/training/config/locales/views/sessions/ja.yml
@@ -2,6 +2,8 @@ ja:
   sessions:
     new:
       title: ログインフォーム
+      email: メールアドレス
+      password: パスワード
       login_button: ログイン
     flash:
       create: ログインに成功しました

--- a/training/config/locales/views/tasks/ja.yml
+++ b/training/config/locales/views/tasks/ja.yml
@@ -27,5 +27,6 @@ ja:
       create: タスクが作成されました
       update: タスクが更新されました
       delete: タスクが削除されました
+      restrict_own_task: 他のユーザのタスクは更新できません
     confirm:
       delete: 削除しますか？

--- a/training/spec/factories/tasks.rb
+++ b/training/spec/factories/tasks.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     priority { 'low' }
     status { 'waiting' }
     due_date { Time.now + 1.day }
+    association :user
 
     trait :with_order_by_created_at do
       now = Time.now

--- a/training/spec/factories/users.rb
+++ b/training/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Movies::StarWars.character }
+    email { Faker::Internet.email }
+    password { 'password' }
+    is_admin { true }
+  end
+end

--- a/training/spec/rails_helper.rb
+++ b/training/spec/rails_helper.rb
@@ -61,6 +61,7 @@ RSpec.configure do |config|
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
+  config.include LoginSupport
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end

--- a/training/spec/requests/sessions_spec.rb
+++ b/training/spec/requests/sessions_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe 'Sessions', type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'not login' do
+    it 'can not access to tasks page' do
+      get tasks_path
+      expect(response).to redirect_to(new_sessions_path)
+    end
+  end
+
+  describe 'sessions#new' do
+    it 'access ok' do
+      get new_sessions_path
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'sessions#create' do
+    context 'login success' do
+      before do
+        post sessions_path, params: { email: user.email, password: user.password }
+      end
+
+      it 'redirect to root path' do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it 'access tasks page' do
+        get tasks_path
+        expect(response).to be_successful
+      end
+    end
+
+    context 'login fail' do
+      context 'wrong email' do
+        before do
+          post sessions_path, params: { email: 'wrong_password@test.com', password: user.password }
+        end
+
+        it 'redirect to new_session_path' do
+          expect(response).to redirect_to(new_sessions_path)
+        end
+
+        it 'can not access to tasks page' do
+          get tasks_path
+          expect(response).to redirect_to(new_sessions_path)
+        end
+      end
+
+      context 'wrong password' do
+        before do
+          post sessions_path, params: { email: user.email, password: 'wrong_password' }
+        end
+
+        it 'redirect to new_session_path' do
+          expect(response).to redirect_to(new_sessions_path)
+        end
+
+        it 'can not access to tasks page' do
+          get tasks_path
+          expect(response).to redirect_to(new_sessions_path)
+        end
+      end
+    end
+
+    describe 'sessions#destroy' do
+      before do
+        post sessions_path, params: { email: user.email, password: user.password }
+        delete sessions_path
+      end
+
+      it 'logout success' do
+        expect(response).to redirect_to(new_sessions_path)
+      end
+
+      it 'can not access to tasks page' do
+        get tasks_path
+        expect(response).to redirect_to(new_sessions_path)
+      end
+    end
+  end
+end

--- a/training/spec/requests/sessions_spec.rb
+++ b/training/spec/requests/sessions_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe 'Sessions', type: :request do
       get new_sessions_path
       expect(response).to be_successful
     end
+
+    it 'login and redirect to root path' do
+      post sessions_path, params: { email: user.email, password: user.password }
+      get new_sessions_path
+      expect(response).to redirect_to(root_path)
+    end
   end
 
   describe 'sessions#create' do
@@ -36,7 +42,7 @@ RSpec.describe 'Sessions', type: :request do
     context 'login fail' do
       context 'wrong email' do
         before do
-          post sessions_path, params: { email: 'wrong_password@test.com', password: user.password }
+          post sessions_path, params: { email: 'wrong_email@test.com', password: user.password }
         end
 
         it 'redirect to new_session_path' do

--- a/training/spec/requests/sessions_spec.rb
+++ b/training/spec/requests/sessions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Sessions', type: :request do
     end
   end
 
-  describe 'sessions#new' do
+  describe 'new' do
     it 'access ok' do
       get new_sessions_path
       expect(response).to be_successful
@@ -23,7 +23,7 @@ RSpec.describe 'Sessions', type: :request do
     end
   end
 
-  describe 'sessions#create' do
+  describe 'create' do
     context 'login success' do
       before do
         post sessions_path, params: { email: user.email, password: user.password }
@@ -71,7 +71,7 @@ RSpec.describe 'Sessions', type: :request do
       end
     end
 
-    describe 'sessions#destroy' do
+    describe 'destroy' do
       before do
         post sessions_path, params: { email: user.email, password: user.password }
         delete sessions_path

--- a/training/spec/requests/tasks_spec.rb
+++ b/training/spec/requests/tasks_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe "Tasks", type: :request do
+  describe 'restrict_own_task' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:task) { FactoryBot.create(:task, user: user) }
+
+    context 'user who created task is same as login user' do
+      before do
+        post sessions_path, params: { email: user.email, password: user.password }
+      end
+
+      context 'edit' do
+        it 'access edit page' do
+          get edit_task_path(task)
+          expect(response).to be_successful
+        end
+      end
+
+      context 'show' do
+        it 'access show page' do
+          get task_path(task)
+          expect(response).to be_successful
+        end
+      end
+
+      context 'update' do
+        it 'title updated' do
+          put task_path(task), params: { task: { title: 'edit title' } }
+          task.reload
+          expect(task.title).to eq('edit title')
+        end
+      end
+
+      context 'delete' do
+        let!(:task) { FactoryBot.create(:task, user: user) }
+
+        it 'delete 1 record' do
+          expect {
+            delete task_path(task)
+          }.to change { Task.count }.by(-1)
+        end
+      end
+    end
+
+    context 'user who created task is different from login user' do
+      before do
+        post sessions_path, params: { email: user2.email, password: user2.password }
+      end
+
+      let(:user2) { FactoryBot.create(:user) }
+
+      context 'edit' do
+        it 'redirect to root path' do
+          get edit_task_path(task)
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context 'show' do
+        it 'redirect to root path' do
+          get task_path(task)
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context 'update' do
+        it 'title not updated' do
+          put task_path(task), params: { task: { title: 'edit title' } }
+          task.reload
+          expect(task.title).not_to eq('edit title')
+        end
+
+        it 'redirect to root path' do
+          put task_path(task), params: { task: { title: 'edit title' } }
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context 'delete' do
+        let!(:task) { FactoryBot.create(:task, user: user) }
+
+        it 'no record deleted' do
+          expect {
+            delete task_path(task)
+          }.to change { Task.count }.by(0)
+        end
+
+        it 'redirect to root path' do
+          delete task_path(task)
+          expect(response).to redirect_to(root_path)
+        end
+      end
+    end
+  end
+end

--- a/training/spec/support/login_support.rb
+++ b/training/spec/support/login_support.rb
@@ -1,0 +1,12 @@
+module LoginSupport
+  def login(user)
+    visit new_sessions_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: user.password
+    click_button 'ログイン'
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/training/spec/support/login_support.rb
+++ b/training/spec/support/login_support.rb
@@ -3,7 +3,7 @@ module LoginSupport
     visit new_sessions_path
     fill_in 'email', with: user.email
     fill_in 'password', with: user.password
-    click_button 'ログイン'
+    click_button I18n.t('sessions.new.login_button')
   end
 end
 

--- a/training/spec/support/login_support.rb
+++ b/training/spec/support/login_support.rb
@@ -6,7 +6,3 @@ module LoginSupport
     click_button I18n.t('sessions.new.login_button')
   end
 end
-
-RSpec.configure do |config|
-  config.include LoginSupport
-end

--- a/training/spec/system/errors_spec.rb
+++ b/training/spec/system/errors_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe "Errors", type: :system do
-  include LoginSupport
-
   before do
     login(user)
   end

--- a/training/spec/system/errors_spec.rb
+++ b/training/spec/system/errors_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe "Errors", type: :system do
+  include LoginSupport
+
   before do
-    Rails.env = 'production'
+    login(user)
   end
+
+  let(:user) { FactoryBot.create(:user) }
 
   scenario 'forbidden' do
     allow(Task).to receive(:all).and_raise(ErrorHandlers::Forbidden)

--- a/training/spec/system/sessions_spec.rb
+++ b/training/spec/system/sessions_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :system do
+  include LoginSupport
+
+  let(:user) { FactoryBot.create(:user) }
+
+  context 'not login' do
+    scenario 'can not access to tasks page' do
+      visit tasks_path
+      expect(current_path).to eq(new_sessions_path)
+      expect(page).to have_content I18n.t('sessions.flash.not_authrize')
+    end
+
+    scenario 'navbar content' do
+      visit tasks_path
+      expect(find('.navbar')).not_to have_content "#{user.name}#{I18n.t('navbar.Mr')}"
+      expect(find('.navbar')).to have_content I18n.t('navbar.login')
+    end
+  end
+
+  describe 'login' do
+    scenario 'success' do
+      login(user)
+      expect(current_path).to eq(root_path)
+      expect(page).to have_content I18n.t('sessions.flash.create')
+    end
+
+    scenario 'failed' do
+      user.email = 'wrong_email@test.com'
+      login(user)
+      expect(current_path).to eq(new_sessions_path)
+      expect(page).to have_content I18n.t('sessions.flash.create_fail')
+    end
+
+    scenario 'navbar content' do
+      login(user)
+      expect(find('.navbar')).to have_content "#{user.name}#{I18n.t('navbar.Mr')}"
+      expect(find('.navbar')).to have_content I18n.t('navbar.logout')
+    end
+  end
+
+  scenario 'logout' do
+    login(user)
+    click_link I18n.t('navbar.logout')
+    expect(current_path).to eq(new_sessions_path)
+    expect(page).to have_content I18n.t('sessions.flash.destroy')
+  end
+end

--- a/training/spec/system/sessions_spec.rb
+++ b/training/spec/system/sessions_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe "Sessions", type: :system do
-  include LoginSupport
-
   let(:user) { FactoryBot.create(:user) }
 
   context 'not login' do

--- a/training/spec/system/sessions_spec.rb
+++ b/training/spec/system/sessions_spec.rb
@@ -46,4 +46,13 @@ RSpec.describe "Sessions", type: :system do
     expect(current_path).to eq(new_sessions_path)
     expect(page).to have_content I18n.t('sessions.flash.destroy')
   end
+
+  scenario 'restrict_own_task' do
+    task = FactoryBot.create(:task)
+    login(user)
+
+    visit edit_task_path(task)
+    expect(current_path).to eq(root_path)
+    expect(page).to have_content I18n.t('tasks.flash.restrict_own_task')
+  end
 end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "Tasks", type: :system do
         click_button I18n.t('tasks.search_form.button')
 
         expect(current_path).to eq(tasks_path)
-        expect(page).to have_content '検索でエラーが発生しました。時間を置いて再度お試しください'
+        expect(page).to have_content I18n.t('tasks.search_form.search_error')
       end
     end
   end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :system do
-  include LoginSupport
-
   before do
     login(user)
   end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Tasks", type: :system do
   include LoginSupport
+
   before do
     login(user)
   end

--- a/training/spec/system/tasks_spec.rb
+++ b/training/spec/system/tasks_spec.rb
@@ -1,71 +1,78 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :system do
+  include LoginSupport
+  before do
+    login(user)
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+
   scenario '#create' do
     visit new_task_path
 
-    fill_in 'タイトル', with: 'title test'
-    fill_in '詳細', with: 'description test'
-    select '中', from: '優先度'
-    select '着手中', from: 'ステータス'
+    fill_in 'task_title', with: 'title test'
+    fill_in 'task_description', with: 'description test'
+    select Task.priorities_i18n['medium'], from: 'task_priority'
+    select Task.statuses_i18n['working'], from: 'task_status'
     select Time.now.year, from: 'task_due_date_1i'
     select Time.now.month + 1, from: 'task_due_date_2i'
     select Time.now.day, from: 'task_due_date_3i'
-    click_button '登録する'
+    click_button I18n.t('helpers.submit.create')
 
     expect(current_path).to eq(tasks_path)
-    expect(page).to have_content 'タスクが作成されました'
+    expect(page).to have_content I18n.t('tasks.flash.create')
     expect(page).to have_content 'title test'
   end
 
   scenario '#update' do
-    task = FactoryBot.create(:task)
+    task = FactoryBot.create(:task, user: user)
 
     visit edit_task_path(task)
 
-    fill_in 'タイトル', with: 'edit title test'
-    fill_in '詳細', with: 'edit description test'
-    select '高', from: '優先度'
-    select '未着手', from: 'ステータス'
-    select '2020', from: 'task_due_date_1i'
-    select '6月', from: 'task_due_date_2i'
-    select '2', from: 'task_due_date_3i'
-    click_button '更新する'
+    fill_in 'task_title', with: 'edit title test'
+    fill_in 'task_description', with: 'edit description test'
+    select Task.priorities_i18n['hight'], from: 'task_priority'
+    select Task.statuses_i18n['waiting'], from: 'task_status'
+    select Time.now.year, from: 'task_due_date_1i'
+    select Time.now.month + 1, from: 'task_due_date_2i'
+    select Time.now.day, from: 'task_due_date_3i'
+    click_button I18n.t('helpers.submit.update')
 
     expect(current_path).to eq(tasks_path)
-    expect(page).to have_content 'タスクが更新されました'
+    expect(page).to have_content I18n.t('tasks.flash.update')
     expect(page).to have_content 'edit title test'
   end
 
   scenario '#show' do
-    task = FactoryBot.create(:task)
+    task = FactoryBot.create(:task, user: user)
 
     visit tasks_path
 
-    click_link '詳細'
+    click_link I18n.t('tasks.link.show')
 
     expect(current_path).to eq(task_path(task))
     expect(page).to have_content 'task title'
     expect(page).to have_content 'task description'
-    expect(page).to have_content '低'
-    expect(page).to have_content '未着手'
+    expect(page).to have_content Task.priorities_i18n['low']
+    expect(page).to have_content Task.statuses_i18n['waiting']
     expect(page).to have_content I18n.l(task.due_date, format: :short)
   end
 
   scenario '#delete' do
-    task = FactoryBot.create(:task)
+    task = FactoryBot.create(:task, user: user)
 
     visit tasks_path
 
-    click_link '削除'
+    click_link I18n.t('tasks.link.delete')
 
     expect(current_path).to eq(tasks_path)
-    expect(page).to have_content 'タスクが削除されました'
+    expect(page).to have_content I18n.t('tasks.flash.delete')
     expect(page).not_to have_content 'task title'
   end
 
   scenario 'in descending order of created_at' do
-    tasks = FactoryBot.create_list(:task, 5, :with_order_by_created_at)
+    tasks = FactoryBot.create_list(:task, 5, :with_order_by_created_at, user: user)
 
     visit tasks_path
 
@@ -76,11 +83,11 @@ RSpec.describe "Tasks", type: :system do
   end
 
   scenario 'in descending order of due_date' do
-    tasks = FactoryBot.create_list(:task, 5, :with_order_by_due_date)
+    tasks = FactoryBot.create_list(:task, 5, :with_order_by_due_date, user: user)
 
     visit tasks_path
-    select '降順', from: 'due_date_order'
-    click_button '検索する'
+    select I18n.t('tasks.search_form.due_date_order_desc'), from: 'due_date_order'
+    click_button I18n.t('tasks.search_form.button')
 
     expect(page.body.index(I18n.l(tasks[4].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[3].due_date, format: :short))
     expect(page.body.index(I18n.l(tasks[3].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[2].due_date, format: :short))
@@ -89,11 +96,11 @@ RSpec.describe "Tasks", type: :system do
   end
 
   scenario 'in ascending order of due_date' do
-    tasks = FactoryBot.create_list(:task, 5, :with_order_by_due_date)
+    tasks = FactoryBot.create_list(:task, 5, :with_order_by_due_date, user: user)
 
     visit tasks_path
-    select '昇順', from: 'due_date_order'
-    click_button '検索する'
+    select I18n.t('tasks.search_form.due_date_order_asc'), from: 'due_date_order'
+    click_button I18n.t('tasks.search_form.button')
 
     expect(page.body.index(I18n.l(tasks[0].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[1].due_date, format: :short))
     expect(page.body.index(I18n.l(tasks[1].due_date, format: :short))).to be < page.body.index(I18n.l(tasks[2].due_date, format: :short))
@@ -103,11 +110,11 @@ RSpec.describe "Tasks", type: :system do
 
   describe 'search' do
     before do
-      FactoryBot.create(:task, title: 'tiger elephant gorilla', status: 'working')
-      FactoryBot.create(:task, title: 'rabbit rat', status: 'done')
-      FactoryBot.create(:task, title: 'bear elephant', status: 'working')
-      FactoryBot.create(:task, title: 'monkey', status: 'waiting')
-      FactoryBot.create(:task, title: 'zebra deer', status: 'done')
+      FactoryBot.create(:task, title: 'tiger elephant gorilla', status: 'working', user: user)
+      FactoryBot.create(:task, title: 'rabbit rat', status: 'done', user: user)
+      FactoryBot.create(:task, title: 'bear elephant', status: 'working', user: user)
+      FactoryBot.create(:task, title: 'monkey', status: 'waiting', user: user)
+      FactoryBot.create(:task, title: 'zebra deer', status: 'done', user: user)
     end
 
     # テーブル最上部のラベル行も件数に含むので全レコード - 1
@@ -117,8 +124,8 @@ RSpec.describe "Tasks", type: :system do
         scenario 'all record' do
           visit tasks_path
           fill_in 'title', with: ''
-          select '昇順', from: 'due_date_order'
-          click_button '検索する'
+          select I18n.t('tasks.search_form.due_date_order_asc'), from: 'due_date_order'
+          click_button I18n.t('tasks.search_form.button')
 
           expect(record_count).to eq(5)
         end
@@ -128,8 +135,8 @@ RSpec.describe "Tasks", type: :system do
         scenario 'is 2 records' do
           visit tasks_path
           fill_in 'title', with: 'elephant'
-          select '昇順', from: 'due_date_order'
-          click_button '検索する'
+          select I18n.t('tasks.search_form.due_date_order_asc'), from: 'due_date_order'
+          click_button I18n.t('tasks.search_form.button')
 
           expect(record_count).to eq(2)
           expect(page).to have_content 'tiger elephant gorilla'
@@ -140,12 +147,12 @@ RSpec.describe "Tasks", type: :system do
       context 'title is blank and status is present' do
         scenario 'is 2 records' do
           visit tasks_path
-          select '完了', from: 'status'
-          select '昇順', from: 'due_date_order'
-          click_button '検索する'
+          select Task.statuses_i18n['done'], from: 'status'
+          select I18n.t('tasks.search_form.due_date_order_asc'), from: 'due_date_order'
+          click_button I18n.t('tasks.search_form.button')
 
           expect(record_count).to eq(2)
-          expect(page).to have_content '完了'
+          expect(page).to have_content Task.statuses_i18n['done']
         end
       end
 
@@ -153,14 +160,14 @@ RSpec.describe "Tasks", type: :system do
         scenario 'is 2 records' do
           visit tasks_path
           fill_in 'title', with: 'elephant'
-          select '着手中', from: 'status'
-          select '昇順', from: 'due_date_order'
-          click_button '検索する'
+          select Task.statuses_i18n['working'], from: 'status'
+          select I18n.t('tasks.search_form.due_date_order_asc'), from: 'due_date_order'
+          click_button I18n.t('tasks.search_form.button')
 
           expect(record_count).to eq(2)
           expect(page).to have_content 'tiger elephant gorilla'
           expect(page).to have_content 'bear elephant'
-          expect(page).to have_content '着手中'
+          expect(page).to have_content Task.statuses_i18n['working']
         end
       end
     end
@@ -169,9 +176,9 @@ RSpec.describe "Tasks", type: :system do
       scenario 'is none record' do
         visit tasks_path
         fill_in 'title', with: 'dog'
-        select '着手中', from: 'status'
-        select '昇順', from: 'due_date_order'
-        click_button '検索する'
+        select Task.statuses_i18n['working'], from: 'status'
+        select I18n.t('tasks.search_form.due_date_order_asc'), from: 'due_date_order'
+        click_button I18n.t('tasks.search_form.button')
 
         expect(record_count).to eq(0)
       end
@@ -183,9 +190,9 @@ RSpec.describe "Tasks", type: :system do
 
         visit tasks_path
         fill_in 'title', with: 'elephant'
-        select '着手中', from: 'status'
-        select '昇順', from: 'due_date_order'
-        click_button '検索する'
+        select Task.statuses_i18n['working'], from: 'status'
+        select I18n.t('tasks.search_form.due_date_order_asc'), from: 'due_date_order'
+        click_button I18n.t('tasks.search_form.button')
 
         expect(current_path).to eq(tasks_path)
         expect(page).to have_content '検索でエラーが発生しました。時間を置いて再度お試しください'


### PR DESCRIPTION
# 概要
[ステップ１７](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9717-%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%83%AD%E3%82%B0%E3%82%A2%E3%82%A6%E3%83%88%E6%A9%9F%E8%83%BD%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86)

# やったこと
- rspecのテストケース追加
- 既存specのi18n化
- 以下はテストケース作成時に実装が漏れていることに気付き追加で実装しました
  - ログイン状態でログインフォームに遷移した時に、ルートにリダイレクト
  - 他のユーザが作成したタスクに遷移した時にルートにリダイレクト

# 備考
training/app/controllers/application_controller.rbでErrorHandlersのinclude条件にテスト環境を追加しているのは以下の理由です。
もし、他に解決策をご存知でしたら指摘お願いします

- rspecを実行した場合にデフォルトでtest環境になるので、エラーページが表示されない
- ↑問題を回避するために、training/spec/system/errors_spec.rbでRails.envをproductionに上書きしているが、ログインユーザを作成した時に、どうやらtest環境にレコードが作られるようで、production環境でログインできずにエラーメッセージまで到達できない
- includeにテスト環境を追加したが、テスト環境なので特に問題はないかなと推測している