### PR TITLE
Rails研修ステップ18(1/3)

### DIFF
--- a/training/app/controllers/admin/base.rb
+++ b/training/app/controllers/admin/base.rb
@@ -1,0 +1,3 @@
+class Admin::Base < ApplicationController
+  layout 'admin'
+end

--- a/training/app/controllers/admin/base.rb
+++ b/training/app/controllers/admin/base.rb
@@ -1,3 +1,6 @@
-class Admin::Base < ApplicationController
+class Admin::Base < ActionController::Base
+  include ErrorHandlers if Rails.env.production? || Rails.env.test?
+  include Admin::Sessions
+
   layout 'admin'
 end

--- a/training/app/controllers/admin/sessions_controller.rb
+++ b/training/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,24 @@
+class Admin::SessionsController < Admin::Base
+  skip_before_action :authorize
+
+  def new
+    if current_user
+      redirect_to admin_users_path
+    end
+  end
+
+  def create
+    user = User.find_by(email: params[:email], is_admin: true)
+    if user && user.authenticate(params[:password])
+      session[:user_id] = user.id
+      redirect_to admin_users_path, notice: t('sessions.flash.create')
+    else
+      redirect_to new_admin_sessions_path, alert: t('sessions.flash.create_fail')
+    end
+  end
+
+  def destroy
+    session[:user_id] = nil
+    redirect_to new_admin_sessions_path, alert: t('sessions.flash.destroy')
+  end
+end

--- a/training/app/controllers/admin/sessions_controller.rb
+++ b/training/app/controllers/admin/sessions_controller.rb
@@ -2,15 +2,15 @@ class Admin::SessionsController < Admin::Base
   skip_before_action :authorize
 
   def new
-    if current_user
+    if current_admin
       redirect_to admin_users_path
     end
   end
 
   def create
-    user = User.find_by(email: params[:email], is_admin: true)
-    if user && user.authenticate(params[:password])
-      session[:user_id] = user.id
+    admin = User.find_by(email: params[:email], is_admin: true)
+    if admin && admin.authenticate(params[:password])
+      session[:admin_id] = admin.id
       redirect_to admin_users_path, notice: t('sessions.flash.create')
     else
       redirect_to new_admin_sessions_path, alert: t('sessions.flash.create_fail')
@@ -18,7 +18,7 @@ class Admin::SessionsController < Admin::Base
   end
 
   def destroy
-    session[:user_id] = nil
+    session[:admin_id] = nil
     redirect_to new_admin_sessions_path, alert: t('sessions.flash.destroy')
   end
 end

--- a/training/app/controllers/concerns/admin/sessions.rb
+++ b/training/app/controllers/concerns/admin/sessions.rb
@@ -1,0 +1,22 @@
+module Admin::Sessions
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authorize
+    helper_method :current_admin, :logged_in?
+  end
+
+  def current_admin
+    @current_admin ||= User.find(session[:admin_id]) if session[:admin_id]
+  end
+
+  def logged_in?
+    current_admin
+  end
+
+  def authorize
+    unless current_admin
+      redirect_to new_admin_sessions_path, alert: t('sessions.flash.not_authrize')
+    end
+  end
+end

--- a/training/app/models/user.rb
+++ b/training/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :email, presence: true, uniqueness: { case_sensitive: false }
+  validates :password, presence: true
 end

--- a/training/app/views/admin/sessions/new.html.erb
+++ b/training/app/views/admin/sessions/new.html.erb
@@ -9,5 +9,5 @@
     <%= f.label t('sessions.new.password') %>
     <%= f.password_field :password, class: 'form-control col-4' %>
   </div>
-  <%= f.submit t('sessions.new.login_button'), class: 'btn btn-primary' %>
+  <%= f.submit t('sessions.new.login_button'), class: 'btn btn-primary col-4' %>
 <% end %>

--- a/training/app/views/admin/sessions/new.html.erb
+++ b/training/app/views/admin/sessions/new.html.erb
@@ -1,0 +1,13 @@
+<h1><%= t 'sessions.admin.title' %></h1>
+
+<%= form_with url: admin_sessions_path, local: true, method: :post, class: 'form-group' do |f| %>
+  <div class="form-group">
+    <%= f.label t('sessions.new.email') %>
+    <%= f.email_field :email, class: 'form-control col-4' %>
+  </div>
+  <div class="form-group">
+    <%= f.label t('sessions.new.password') %>
+    <%= f.password_field :password, class: 'form-control col-4' %>
+  </div>
+  <%= f.submit t('sessions.new.login_button'), class: 'btn btn-primary' %>
+<% end %>

--- a/training/app/views/layouts/admin.html.erb
+++ b/training/app/views/layouts/admin.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>App</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+  </head>
+
+  <body>
+
+    <%= render 'shared/admin/navbar' %>
+    <div class="container-fluid mt-3">
+      <%= render 'shared/flash_messages' %>
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/training/app/views/sessions/new.html.erb
+++ b/training/app/views/sessions/new.html.erb
@@ -9,5 +9,5 @@
     <%= f.label t('.password') %>
     <%= f.password_field :password, class: 'form-control col-4' %>
   </div>
-  <%= f.submit t('.login_button'), class: 'btn btn-primary' %>
+  <%= f.submit t('.login_button'), class: 'btn btn-primary col-4' %>
 <% end %>

--- a/training/app/views/shared/admin/_navbar.html.erb
+++ b/training/app/views/shared/admin/_navbar.html.erb
@@ -1,0 +1,28 @@
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <%= link_to t('navbar.admin.title'), root_path, class: 'navbar-brand' %>
+
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item">
+        <%= link_to t('admin.users.index'), tasks_path, class: 'nav-link' %>
+      </li>
+    </ul>
+
+    <ul class="navbar-nav">
+      <% if logged_in? %>
+        <li class="nav-item">
+          <span class="nav-link text-light"><%= current_user.name %><%= t 'navbar.Mr' %></span>
+        </li>
+      <% end %>
+      <li class="nav-item">
+        <%=
+          if session[:user_id]
+            link_to t('navbar.logout'), sessions_path, method: :delete, class: 'nav-link'
+          else
+            link_to t('navbar.login'), new_sessions_path, class: 'nav-link'
+          end
+        %>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/training/app/views/shared/admin/_navbar.html.erb
+++ b/training/app/views/shared/admin/_navbar.html.erb
@@ -11,12 +11,12 @@
     <ul class="navbar-nav">
       <% if logged_in? %>
         <li class="nav-item">
-          <span class="nav-link text-light"><%= current_user.name %><%= t 'navbar.Mr' %></span>
+          <span class="nav-link text-light"><%= current_admin.name %><%= t 'navbar.Mr' %></span>
         </li>
       <% end %>
       <li class="nav-item">
         <%=
-          if session[:user_id]
+          if session[:admin_id]
             link_to t('navbar.logout'), sessions_path, method: :delete, class: 'nav-link'
           else
             link_to t('navbar.login'), new_sessions_path, class: 'nav-link'

--- a/training/config/locales/views/navbar/ja.yml
+++ b/training/config/locales/views/navbar/ja.yml
@@ -4,3 +4,5 @@ ja:
     login: ログイン
     logout: ログアウト
     Mr: さん
+    admin:
+      title: 管理者画面

--- a/training/config/locales/views/sessions/ja.yml
+++ b/training/config/locales/views/sessions/ja.yml
@@ -5,6 +5,8 @@ ja:
       email: メールアドレス
       password: パスワード
       login_button: ログイン
+    admin:
+      title: 管理者ログインフォーム
     flash:
       create: ログインに成功しました
       create_fail: ログインに失敗しました、メールアドレスかパスワードが間違っております

--- a/training/config/locales/views/users/ja.yml
+++ b/training/config/locales/views/users/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  admin:
+    users:
+      index: ユーザ一覧

--- a/training/config/routes.rb
+++ b/training/config/routes.rb
@@ -7,6 +7,14 @@ Rails.application.routes.draw do
   end
   resource :sessions, only: [:new, :create, :destroy]
 
+  namespace :admin do
+    root to: 'users#index'
+    resource :sessions, only: [:new, :create, :destroy]
+    resources :users do
+      resources :tasks, only: [:index]
+    end
+  end
+
   # どのルーティングにもマッチしなかったら、404ページにリダイレクト
   get '*path', controller: 'application', action: 'rescue404'
 end

--- a/training/config/routes.rb
+++ b/training/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resource :sessions, only: [:new, :create, :destroy]
 
   namespace :admin do
-    root to: 'users#index'
+    root to: 'admin/users#index'
     resource :sessions, only: [:new, :create, :destroy]
     resources :users do
       resources :tasks, only: [:index]

--- a/training/config/routes.rb
+++ b/training/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     end
   end
 
-  # どのルーティングにもマッチしなかったら、404ページにリダイレクト
-  get '*path', controller: 'application', action: 'rescue404'
+  if Rails.env.production? || Rails.env.test?
+    # どのルーティングにもマッチしなかったら、404ページにリダイレクト
+    get '*path', controller: 'application', action: 'rescue404'
+  end
 end

--- a/training/db/migrate/20200608061050_add_index_to_users.rb
+++ b/training/db/migrate/20200608061050_add_index_to_users.rb
@@ -1,0 +1,6 @@
+class AddIndexToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_index :users, :name, unique: true
+    add_index :users, :email, unique: true
+  end
+end

--- a/training/db/schema.rb
+++ b/training/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_03_062234) do
+ActiveRecord::Schema.define(version: 2020_06_08_061050) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 50, null: false
@@ -33,6 +33,8 @@ ActiveRecord::Schema.define(version: 2020_06_03_062234) do
     t.boolean "is_admin", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["name"], name: "index_users_on_name", unique: true
   end
 
   add_foreign_key "tasks", "users"

--- a/training/spec/factories/users.rb
+++ b/training/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    name { Faker::Movies::StarWars.character }
-    email { Faker::Internet.email }
+    sequence(:name) {|n| "#{n}-#{Faker::Movies::StarWars.character}" }
+    sequence(:email) {|n| "#{n}-#{Faker::Internet.email}" }
     password { 'password' }
     is_admin { true }
   end


### PR DESCRIPTION
# 概要
[ステップ18](https://github.com/Fablic/training/tree/feature/tatsumi#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

# やったこと
- adminパス作成
- adminログイン機能実装
- adminログインフォーム作成
- userモデルの変更
- userテーブルの変更
- userにuniqueバリデーションを追加したので、一意になるようにfactorybotの修正

# 備考
結構、重い内容なので、３部に分けて実装する予定です

第1部: admin/ログイン周りの実装
第2部: admin/usersのCRUD実装
第3部: テスト追加

# 画面イメージ

### 管理者ログインフォーム

<img width="1804" alt="Screen Shot 2020-06-08 at 16 24 32" src="https://user-images.githubusercontent.com/64940424/84003211-9ce1dd00-a9a4-11ea-80e8-da4c3bbde0cc.png">