### PR TITLE
Rails研修ステップ18(3/3)

### DIFF
--- a/training/spec/models/user_spec.rb
+++ b/training/spec/models/user_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'validation' do
+    describe 'name presence' do
+      subject { FactoryBot.build(:user, name: name) }
+
+      context 'is valid' do
+        let(:name) { 'name' }
+        it { is_expected.to be_valid }
+      end
+
+      context 'is invalid' do
+        let(:name) { '' }
+        it { is_expected.to be_invalid }
+        it 'display enter message' do
+          subject.valid?
+          expect(subject.errors[:name][0]).to eq I18n.t('errors.messages.blank')
+        end
+      end
+    end
+
+    describe 'name uniqueness' do
+      subject { FactoryBot.build(:user, name: name) }
+      before do
+        FactoryBot.create(:user, name: 'other_name')
+      end
+
+      context 'is valid' do
+        let(:name) { 'name' }
+        it { is_expected.to be_valid }
+      end
+
+      context 'is invalid' do
+        let(:name) { 'other_name' }
+        it { is_expected.to be_invalid }
+        it 'display taken message' do
+          subject.valid?
+          expect(subject.errors[:name][0]).to eq I18n.t('errors.messages.taken')
+        end
+
+        context 'case sensitive' do
+          let(:name) { 'OTHER_NAME' }
+          it { is_expected.to be_invalid }
+          it 'display taken message' do
+            subject.valid?
+            expect(subject.errors[:name][0]).to eq I18n.t('errors.messages.taken')
+          end
+        end
+      end
+    end
+
+    describe 'email presence' do
+      subject { FactoryBot.build(:user, email: email) }
+
+      context 'is valid' do
+        let(:email) { 'test@test.com' }
+        it { is_expected.to be_valid }
+      end
+
+      context 'is invalid' do
+        let(:email) { '' }
+        it { is_expected.to be_invalid }
+        it 'display enter message' do
+          subject.valid?
+          expect(subject.errors[:email][0]).to eq I18n.t('errors.messages.blank')
+        end
+      end
+    end
+
+    describe 'email uniqueness' do
+      subject { FactoryBot.build(:user, email: email) }
+      before do
+        FactoryBot.create(:user, email: 'other_test@test.com')
+      end
+
+      context 'is valid' do
+        let(:email) { 'test@test.com' }
+        it { is_expected.to be_valid }
+      end
+
+      context 'is invalid' do
+        let(:email) { 'other_test@test.com' }
+        it { is_expected.to be_invalid }
+        it 'display taken message' do
+          subject.valid?
+          expect(subject.errors[:email][0]).to eq I18n.t('errors.messages.taken')
+        end
+
+        context 'case sensitive' do
+          let(:email) { 'OTHER_TEST@TEST.COM' }
+          it { is_expected.to be_invalid }
+          it 'display taken message' do
+            subject.valid?
+            expect(subject.errors[:email][0]).to eq I18n.t('errors.messages.taken')
+          end
+        end
+      end
+    end
+
+    describe 'password presence' do
+      subject { FactoryBot.build(:user, password: password) }
+
+      context 'is valid' do
+        let(:password) { 'password' }
+        it { is_expected.to be_valid }
+      end
+
+      context 'is invalid' do
+        let(:password) { '' }
+        it { is_expected.to be_invalid }
+        it 'display enter message' do
+          subject.valid?
+          expect(subject.errors[:password][0]).to eq I18n.t('errors.messages.blank')
+        end
+      end
+    end
+  end
+
+  describe 'tasks dependent destroy' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:tasks) { FactoryBot.create_list(:task, 5, user: user) }
+
+    it 'task destroyed' do
+      user.destroy!
+      expect(Task.count).to eq(0)
+    end
+  end
+end

--- a/training/spec/requests/admin/sessions_spec.rb
+++ b/training/spec/requests/admin/sessions_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe "Admin::Sessions", type: :request do
   let(:admin) { FactoryBot.create(:user) }
   let(:not_admin) { FactoryBot.create(:user, is_admin: false) }
 
-  describe 'not login' do
+  context 'not logged in' do
     it 'can not access to tasks page' do
       get admin_users_path
       expect(response).to redirect_to(new_admin_sessions_path)
     end
   end
 
-  context 'admin' do
+  context 'login as admin' do
     describe 'new' do
       it 'access ok' do
         get new_admin_sessions_path

--- a/training/spec/requests/admin/sessions_spec.rb
+++ b/training/spec/requests/admin/sessions_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Sessions", type: :request do
+  let(:admin) { FactoryBot.create(:user) }
+  let(:not_admin) { FactoryBot.create(:user, is_admin: false) }
+
+  describe 'not login' do
+    it 'can not access to tasks page' do
+      get admin_users_path
+      expect(response).to redirect_to(new_admin_sessions_path)
+    end
+  end
+
+  context 'admin' do
+    describe 'new' do
+      it 'access ok' do
+        get new_admin_sessions_path
+        expect(response).to be_successful
+      end
+
+      it 'login and redirect to root path' do
+        post admin_sessions_path, params: { email: admin.email, password: admin.password }
+        get new_admin_sessions_path
+        expect(response).to redirect_to(admin_users_path)
+      end
+    end
+
+    describe 'create' do
+      context 'login success' do
+        before do
+          post admin_sessions_path, params: { email: admin.email, password: admin.password }
+        end
+
+        it 'redirect to root path' do
+          expect(response).to redirect_to(admin_users_path)
+        end
+
+        it 'access tasks page' do
+          get admin_root_path
+          expect(response).to be_successful
+        end
+      end
+
+      context 'login fail' do
+        context 'wrong email' do
+          before do
+            post admin_sessions_path, params: { email: 'wrong_email@test.com', password: admin.password }
+          end
+
+          it 'redirect to new_session_path' do
+            expect(response).to redirect_to(new_admin_sessions_path)
+          end
+
+          it 'can not access to tasks page' do
+            get admin_users_path
+            expect(response).to redirect_to(new_admin_sessions_path)
+          end
+        end
+
+        context 'wrong password' do
+          before do
+            post admin_sessions_path, params: { email: admin.email, password: 'wrong_password' }
+          end
+
+          it 'redirect to new_session_path' do
+            expect(response).to redirect_to(new_admin_sessions_path)
+          end
+
+          it 'can not access to tasks page' do
+            get admin_users_path
+            expect(response).to redirect_to(new_admin_sessions_path)
+          end
+        end
+      end
+    end
+
+    describe 'destroy' do
+      before do
+        post admin_sessions_path, params: { email: admin.email, password: admin.password }
+        delete admin_sessions_path
+      end
+
+      it 'logout success' do
+        expect(response).to redirect_to(new_admin_sessions_path)
+      end
+
+      it 'can not access to tasks page' do
+        get admin_users_path
+        expect(response).to redirect_to(new_admin_sessions_path)
+      end
+    end
+  end
+
+  context 'not admin' do
+    describe 'create' do
+      it 'can not login' do
+        post admin_sessions_path, params: { email: not_admin.email, password: not_admin.password }
+        expect(response).to redirect_to(new_admin_sessions_path)
+      end
+    end
+  end
+end

--- a/training/spec/requests/admin/sessions_spec.rb
+++ b/training/spec/requests/admin/sessions_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Admin::Sessions", type: :request do
   let(:not_admin) { FactoryBot.create(:user, is_admin: false) }
 
   context 'not logged in' do
-    it 'can not access to tasks page' do
+    it 'can not access to admin users list page' do
       get admin_users_path
       expect(response).to redirect_to(new_admin_sessions_path)
     end
@@ -35,8 +35,8 @@ RSpec.describe "Admin::Sessions", type: :request do
           expect(response).to redirect_to(admin_users_path)
         end
 
-        it 'access tasks page' do
-          get admin_root_path
+        it 'access admin users list page' do
+          get admin_users_path
           expect(response).to be_successful
         end
       end
@@ -51,7 +51,7 @@ RSpec.describe "Admin::Sessions", type: :request do
             expect(response).to redirect_to(new_admin_sessions_path)
           end
 
-          it 'can not access to tasks page' do
+          it 'can not access to admin users list page' do
             get admin_users_path
             expect(response).to redirect_to(new_admin_sessions_path)
           end
@@ -66,7 +66,7 @@ RSpec.describe "Admin::Sessions", type: :request do
             expect(response).to redirect_to(new_admin_sessions_path)
           end
 
-          it 'can not access to tasks page' do
+          it 'can not access to admin users list page' do
             get admin_users_path
             expect(response).to redirect_to(new_admin_sessions_path)
           end
@@ -84,7 +84,7 @@ RSpec.describe "Admin::Sessions", type: :request do
         expect(response).to redirect_to(new_admin_sessions_path)
       end
 
-      it 'can not access to tasks page' do
+      it 'can not access to admin users list page' do
         get admin_users_path
         expect(response).to redirect_to(new_admin_sessions_path)
       end

--- a/training/spec/requests/admin/users_spec.rb
+++ b/training/spec/requests/admin/users_spec.rb
@@ -64,6 +64,4 @@ RSpec.describe 'Admin::Users', type: :request do
       expect(response).to be_successful
     end
   end
-
-# validation
 end

--- a/training/spec/requests/admin/users_spec.rb
+++ b/training/spec/requests/admin/users_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::Users', type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  before do
+    post admin_sessions_path, params: { email: user.email, password: user.password }
+  end
+
+  describe 'index' do
+    it 'access ok' do
+      get admin_users_path
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'show' do
+    it 'access ok' do
+      get admin_user_path(user)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'new' do
+    it 'access ok' do
+      get new_admin_user_path
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'create' do
+    it 'create 1 record' do
+      expect {
+        post admin_users_path, params: { user: FactoryBot.attributes_for(:user) }
+      }.to change { User.count }.by(1)
+    end
+  end
+
+  describe 'edit' do
+    it 'access ok' do
+      get edit_admin_user_path(user)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'update' do
+    it 'title change' do
+      put admin_user_path(user), params: { user: { name: 'edit name' } }
+      user.reload
+      expect(user.name).to eq('edit name')
+    end
+  end
+
+  describe 'delete' do
+    it 'delete 1 record' do
+      expect {
+        delete admin_user_path(user)
+      }.to change { User.count }.by(-1)
+    end
+  end
+
+  describe 'task' do
+    it 'access ok' do
+      get admin_user_tasks_path(user)
+      expect(response).to be_successful
+    end
+  end
+
+# validation
+end


### PR DESCRIPTION
# 概要
[ステップ18](https://github.com/Fablic/training/tree/feature/tatsumi#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

# やったこと
specファイルの追加
- admin/sessionsのテスト
- usersのバリデーションテスト
- tasksのdependent destroyテスト
- admin/usersのCRUD処理テスト