### PR TITLE
Rails研修課題ステップ21

### DIFF
--- a/training/app/controllers/admin/base.rb
+++ b/training/app/controllers/admin/base.rb
@@ -1,6 +1,7 @@
 class Admin::Base < ActionController::Base
   include ErrorHandlers if Rails.env.production? || Rails.env.test?
   include Admin::Sessions
+  include Maintenance
 
   layout 'admin'
 end

--- a/training/app/controllers/admin/users_controller.rb
+++ b/training/app/controllers/admin/users_controller.rb
@@ -34,6 +34,8 @@ class Admin::UsersController < Admin::Base
   def destroy
     if @user.is_admin? && last_admin_user?
       redirect_to admin_users_path, alert: t('admin.users.flash.last_admin_user')
+    elsif @user == current_admin
+      redirect_to admin_users_path, alert: t('admin.users.flash.current_login_user')
     else
       @user.destroy!
       redirect_to admin_users_path, notice: t('admin.users.flash.delete')

--- a/training/app/controllers/application_controller.rb
+++ b/training/app/controllers/application_controller.rb
@@ -2,4 +2,5 @@ class ApplicationController < ActionController::Base
   # テスト環境でも本番同様にエラー画面を表示させたいためにRails.env.test?を追加
   include ErrorHandlers if Rails.env.production? || Rails.env.test?
   include Sessions
+  include Maintenance
 end

--- a/training/app/controllers/concerns/maintenance.rb
+++ b/training/app/controllers/concerns/maintenance.rb
@@ -1,0 +1,36 @@
+module Maintenance
+  extend ActiveSupport::Concern
+
+  MAINTENANCE_FILE = "#{Rails.root.join('tmp/maintenance/maintenance.txt')}"
+
+  included do
+    before_action :do_maintenance
+  end
+
+  def maintenance_mode?
+    File.exist?(MAINTENANCE_FILE)
+  end
+
+  def get_maintenance_period
+    maintenance_time = []
+    File.open(MAINTENANCE_FILE, 'r') do |file|
+      file.each_line do |line|
+        maintenance_time.push(line.split(' => '))
+      end
+    end
+
+    maintenance_time.to_h
+  end
+
+  def maintenance_period?
+    maintenance_time = get_maintenance_period
+    maintenance_time['start_at'].to_time <= DateTime.now && maintenance_time['end_at'].to_time > DateTime.now
+  end
+
+  def do_maintenance
+    if maintenance_mode? && maintenance_period?
+      maintenance_time = get_maintenance_period
+      render 'maintenance/normal',locals: { start_at: maintenance_time['start_at'], end_at: maintenance_time['end_at'] }
+    end
+  end
+end

--- a/training/app/controllers/concerns/maintenance.rb
+++ b/training/app/controllers/concerns/maintenance.rb
@@ -3,7 +3,7 @@
 module Maintenance
   extend ActiveSupport::Concern
 
-  MAINTENANCE_FILE = Rails.root.join('tmp', 'maintenance', 'timing.txt')
+  MAINTENANCE_FILE = Rails.root.join('tmp', 'maintenance', 'timing.yml')
 
   included do
     before_action :do_maintenance
@@ -13,26 +13,23 @@ module Maintenance
     File.exist?(MAINTENANCE_FILE)
   end
 
-  def get_maintenance_period
-    maintenance_time = []
-    File.open(MAINTENANCE_FILE, 'r') do |file|
-      file.each_line do |line|
-        maintenance_time.push(line.split(' => '))
-      end
-    end
+  def maintenance_time
+    return unless File.exist?(MAINTENANCE_FILE)
 
-    maintenance_time.to_h
+    data = File.open(MAINTENANCE_FILE, 'r') { |file| YAML.safe_load(file) }
+    data['start_at'] = data['start_at'].in_time_zone
+    data['end_at'] = data['end_at'].in_time_zone
+
+    data
   end
 
   def maintenance_period?
-    maintenance_time = get_maintenance_period
-    maintenance_time['start_at'].in_time_zone <= Time.zone.now && maintenance_time['end_at'].in_time_zone > Time.zone.now
+    period = maintenance_time
+    period['start_at'] <= Time.zone.now && period['end_at'] > Time.zone.now
   end
 
   def do_maintenance
-    return if maintenance_mode? && maintenance_period?
-
-    maintenance_time = get_maintenance_period
-    render 'maintenance/normal', locals: { start_at: maintenance_time['start_at'], end_at: maintenance_time['end_at'] }
+    period = maintenance_time
+    render 'maintenance/normal', locals: { start_at: period['start_at'], end_at: period['end_at'] } if maintenance_mode? && maintenance_period?
   end
 end

--- a/training/app/controllers/concerns/maintenance.rb
+++ b/training/app/controllers/concerns/maintenance.rb
@@ -30,6 +30,6 @@ module Maintenance
 
   def do_maintenance
     period = maintenance_time
-    render 'maintenance/normal', locals: { start_at: period['start_at'], end_at: period['end_at'] } if maintenance_mode? && maintenance_period?
+    render 'maintenance/normal', layout: false, locals: { start_at: period['start_at'], end_at: period['end_at'] } if maintenance_mode? && maintenance_period?
   end
 end

--- a/training/app/controllers/concerns/maintenance.rb
+++ b/training/app/controllers/concerns/maintenance.rb
@@ -1,7 +1,7 @@
 module Maintenance
   extend ActiveSupport::Concern
 
-  MAINTENANCE_FILE = "#{Rails.root.join('tmp/maintenance/maintenance.txt')}"
+  MAINTENANCE_FILE = "#{Rails.root.join('tmp/maintenance/timing.txt')}"
 
   included do
     before_action :do_maintenance

--- a/training/app/controllers/concerns/maintenance.rb
+++ b/training/app/controllers/concerns/maintenance.rb
@@ -9,10 +9,6 @@ module Maintenance
     before_action :do_maintenance
   end
 
-  def maintenance_mode?
-    File.exist?(MAINTENANCE_FILE)
-  end
-
   def maintenance_time
     return unless File.exist?(MAINTENANCE_FILE)
 
@@ -23,13 +19,15 @@ module Maintenance
     data
   end
 
-  def maintenance_period?
+  def maintenance_mode?
     period = maintenance_time
+    return false if period.blank?
     period['start_at'] <= Time.zone.now && period['end_at'] > Time.zone.now
   end
 
   def do_maintenance
+    return unless maintenance_mode?
     period = maintenance_time
-    render 'maintenance/normal', layout: false, locals: { start_at: period['start_at'], end_at: period['end_at'] } if maintenance_mode? && maintenance_period?
+    render 'maintenance/normal', layout: false, locals: { start_at: period['start_at'], end_at: period['end_at'] }
   end
 end

--- a/training/app/controllers/concerns/maintenance.rb
+++ b/training/app/controllers/concerns/maintenance.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Maintenance
   extend ActiveSupport::Concern
 
-  MAINTENANCE_FILE = "#{Rails.root.join('tmp/maintenance/timing.txt')}"
+  MAINTENANCE_FILE = Rails.root.join('tmp', 'maintenance', 'timing.txt')
 
   included do
     before_action :do_maintenance
@@ -24,13 +26,13 @@ module Maintenance
 
   def maintenance_period?
     maintenance_time = get_maintenance_period
-    maintenance_time['start_at'].to_time <= DateTime.now && maintenance_time['end_at'].to_time > DateTime.now
+    maintenance_time['start_at'].in_time_zone <= Time.zone.now && maintenance_time['end_at'].in_time_zone > Time.zone.now
   end
 
   def do_maintenance
-    if maintenance_mode? && maintenance_period?
-      maintenance_time = get_maintenance_period
-      render 'maintenance/normal',locals: { start_at: maintenance_time['start_at'], end_at: maintenance_time['end_at'] }
-    end
+    return if maintenance_mode? && maintenance_period?
+
+    maintenance_time = get_maintenance_period
+    render 'maintenance/normal', locals: { start_at: maintenance_time['start_at'], end_at: maintenance_time['end_at'] }
   end
 end

--- a/training/app/views/maintenance/normal.html.erb
+++ b/training/app/views/maintenance/normal.html.erb
@@ -1,3 +1,3 @@
 <h1><%= t '.title' %></h1>
 
-<p><%= t('.body', start_at: start_at, end_at: end_at) %></p>
+<p><%= t('.body', start_at: l(start_at, format: :long), end_at: l(end_at, format: :long)) %></p>

--- a/training/app/views/maintenance/normal.html.erb
+++ b/training/app/views/maintenance/normal.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<p><%= t('.body', start_at: start_at, end_at: end_at) %></p>

--- a/training/config/locales/views/maintenance/ja.yml
+++ b/training/config/locales/views/maintenance/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  maintenance:
+    normal:
+      title: メンテナンス
+      body: "%{start_at} 〜 %{end_at}までメンテナンスを行っております。"

--- a/training/config/locales/views/users/ja.yml
+++ b/training/config/locales/views/users/ja.yml
@@ -23,3 +23,4 @@ ja:
         update: ユーザが更新されました
         delete: ユーザが削除されました
         last_admin_user: 削除対象の管理ユーザが最後の1人なので削除できません
+        current_login_user: 現在ログインしているユーザは削除できません

--- a/training/lib/logger/task_logger.rb
+++ b/training/lib/logger/task_logger.rb
@@ -1,18 +1,22 @@
-class Logger::TaskLogger
-  attr_reader :logger
+# frozen_string_literal: true
 
-  delegate(
-    :debug,
-    :info,
-    :warn,
-    :error,
-    :fatal,
-    to: :logger,
-  )
+module Logger
+  class TaskLogger
+    attr_reader :logger
 
-  def initialize(log_name)
-    @logger =  ActiveSupport::Logger.new(Rails.root.join('log', "#{log_name}.log"))
-    @logger.formatter = ::Logger::Formatter.new
-    logger.datetime_format = '%Y-%m-%d %H:%M:%S'
+    delegate(
+      :debug,
+      :info,
+      :warn,
+      :error,
+      :fatal,
+      to: :logger,
+    )
+
+    def initialize(log_name)
+      @logger = ActiveSupport::Logger.new(Rails.root.join('log', "#{log_name}.log"))
+      @logger.formatter = ::Logger::Formatter.new
+      logger.datetime_format = '%Y-%m-%d %H:%M:%S'
+    end
   end
 end

--- a/training/lib/logger/task_logger.rb
+++ b/training/lib/logger/task_logger.rb
@@ -1,0 +1,18 @@
+class Logger::TaskLogger
+  attr_reader :logger
+
+  delegate(
+    :debug,
+    :info,
+    :warn,
+    :error,
+    :fatal,
+    to: :logger,
+  )
+
+  def initialize(log_name)
+    @logger =  ActiveSupport::Logger.new(Rails.root.join('log', "#{log_name}.log"))
+    @logger.formatter = ::Logger::Formatter.new
+    logger.datetime_format = '%Y-%m-%d %H:%M:%S'
+  end
+end

--- a/training/lib/logger/task_logger.rb
+++ b/training/lib/logger/task_logger.rb
@@ -1,22 +1,21 @@
 # frozen_string_literal: true
 
-module Logger
-  class TaskLogger
-    attr_reader :logger
+class TaskLogger
+  attr_reader :logger
 
-    delegate(
-      :debug,
-      :info,
-      :warn,
-      :error,
-      :fatal,
-      to: :logger,
-    )
+  delegate(
+    :debug,
+    :info,
+    :warn,
+    :error,
+    :fatal,
+    to: :logger,
+  )
 
-    def initialize(log_name)
-      @logger = ActiveSupport::Logger.new(Rails.root.join('log', "#{log_name}.log"))
-      @logger.formatter = ::Logger::Formatter.new
-      logger.datetime_format = '%Y-%m-%d %H:%M:%S'
-    end
+  def initialize(log_name)
+    @logger = ActiveSupport::Logger.new(Rails.root.join('log', "#{log_name}.log"))
+    @logger.formatter = ::Logger::Formatter.new
+    logger.datetime_format = '%Y-%m-%d %H:%M:%S'
   end
 end
+

--- a/training/lib/tasks/maintenance.rake
+++ b/training/lib/tasks/maintenance.rake
@@ -1,20 +1,22 @@
-require Rails.root.join('lib/logger/task_logger.rb')
+# frozen_string_literal: true
+
+require Rails.root.join('lib', 'logger', 'task_logger.rb')
 
 namespace :maintenance do
-  MAINTENANCE_DIR = "#{Rails.root.join('tmp/maintenance')}"
+  MAINTENANCE_DIR = Rails.root.join('tmp', 'maintenance')
   logger = Logger::TaskLogger.new('maintenance')
 
   desc 'set maintenance start time, end date and start maintenance'
   task :start, ['start_at', 'end_at'] do |_, args|
     if args.start_at.blank? || args.end_at.blank?
-      logger.info "メンテナンスの開始時間と終了時間を入力してください"
-      p "メンテナンスの開始時間と終了時間を入力してください"
+      logger.info 'メンテナンスの開始時間と終了時間を入力してください'
+      p 'メンテナンスの開始時間と終了時間を入力してください'
       exit
     end
 
     if Dir.exist?(MAINTENANCE_DIR)
-      logger.info "前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください"
-      p "前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください"
+      logger.info '前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください'
+      p '前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください'
       exit
     end
 
@@ -31,7 +33,7 @@ namespace :maintenance do
   desc 'end maintenance'
   task :end do
     FileUtils.rm_rf(MAINTENANCE_DIR)
-    logger.info "メンテナンスを終了しました"
-    p "メンテナンスを終了しました"
+    logger.info 'メンテナンスを終了しました'
+    p 'メンテナンスを終了しました'
   end
 end

--- a/training/lib/tasks/maintenance.rake
+++ b/training/lib/tasks/maintenance.rake
@@ -1,11 +1,11 @@
-Dir[Rails.root.join('lib/logger/*.rb')].each {|file| require file }
+require Rails.root.join('lib/logger/task_logger.rb')
 
 namespace :maintenance do
+  MAINTENANCE_DIR = "#{Rails.root.join('tmp/maintenance')}"
+  logger = Logger::TaskLogger.new('maintenance')
+
   desc 'set maintenance start time, end date and start maintenance'
   task :start, ['start_at', 'end_at'] do |_, args|
-    MAINTENANCE_DIR = "#{Rails.root.join('tmp/maintenance')}"
-    logger = Logger::TaskLogger.new('maintenance')
-
     if args.start_at.blank? || args.end_at.blank?
       logger.info "メンテナンスの開始時間と終了時間を入力してください"
       p "メンテナンスの開始時間と終了時間を入力してください"
@@ -19,7 +19,7 @@ namespace :maintenance do
     end
 
     Dir.mkdir(MAINTENANCE_DIR)
-    File.open("#{MAINTENANCE_DIR}/maintenance.txt", 'w') do |file|
+    File.open("#{MAINTENANCE_DIR}/timing.txt", 'w') do |file|
       file.write("start_at => #{args.start_at}\n")
       file.write("end_at => #{args.end_at}")
     end
@@ -28,9 +28,8 @@ namespace :maintenance do
     p "メンテナンス開始時間を#{args.start_at} ~ #{args.end_at}で設定しました"
   end
 
+  desc 'end maintenance'
   task :end do
-    MAINTENANCE_DIR = "#{Rails.root.join('tmp/maintenance')}"
-    logger = Logger::TaskLogger.new('maintenance')
     FileUtils.rm_rf(MAINTENANCE_DIR)
     logger.info "メンテナンスを終了しました"
     p "メンテナンスを終了しました"

--- a/training/lib/tasks/maintenance.rake
+++ b/training/lib/tasks/maintenance.rake
@@ -4,9 +4,10 @@ require Rails.root.join('lib', 'logger', 'task_logger.rb')
 
 namespace :maintenance do
   MAINTENANCE_DIR = Rails.root.join('tmp', 'maintenance')
-  logger = Logger::TaskLogger.new('maintenance')
+  MAINTENANCE_FILE = Rails.root.join('tmp', 'maintenance', 'timing.yml')
+  logger = TaskLogger.new('maintenance')
 
-  desc 'set maintenance start time, end date and start maintenance'
+  desc 'set maintenance start_time and end_time'
   task :start, ['start_at', 'end_at'] do |_, args|
     if args.start_at.blank? || args.end_at.blank?
       logger.info 'メンテナンスの開始時間と終了時間を入力してください'
@@ -14,17 +15,32 @@ namespace :maintenance do
       exit
     end
 
-    if Dir.exist?(MAINTENANCE_DIR)
-      logger.info '前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください'
-      p '前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください'
+    if args.start_at.in_time_zone >= args.end_at.in_time_zone
+      logger.info 'メンテナンスの終了時間は開始時間以降の時間を設定してください'
+      p 'メンテナンスの終了時間は開始時間以降の時間を設定してください'
       exit
     end
 
-    Dir.mkdir(MAINTENANCE_DIR)
-    File.open("#{MAINTENANCE_DIR}/timing.txt", 'w') do |file|
-      file.write("start_at => #{args.start_at}\n")
-      file.write("end_at => #{args.end_at}")
+    if args.start_at.in_time_zone < Time.current || args.end_at.in_time_zone <= Time.current
+      logger.info 'メンテナンス時間は現在時刻より未来を入力してください'
+      p 'メンテナンス時間は現在時刻より未来を入力してください'
+      exit
     end
+
+    if File.exist?(MAINTENANCE_FILE)
+      data = File.open(MAINTENANCE_FILE, 'r') { |file| YAML.safe_load(file) }
+      if data['end_at'].in_time_zone <= Time.current
+        FileUtils.rm(MAINTENANCE_FILE)
+      else
+        logger.info '前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください'
+        p '前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください'
+        exit
+      end
+    end
+
+    Dir.mkdir(MAINTENANCE_DIR) unless Dir.exist?(MAINTENANCE_DIR)
+    data = { 'start_at' => args.start_at, 'end_at' => args.end_at }
+    YAML.dump(data, File.open(MAINTENANCE_FILE, 'w'))
 
     logger.info "メンテナンス開始時間を#{args.start_at} ~ #{args.end_at}で設定しました"
     p "メンテナンス開始時間を#{args.start_at} ~ #{args.end_at}で設定しました"
@@ -32,7 +48,7 @@ namespace :maintenance do
 
   desc 'end maintenance'
   task :end do
-    FileUtils.rm_rf(MAINTENANCE_DIR)
+    FileUtils.rm(MAINTENANCE_FILE)
     logger.info 'メンテナンスを終了しました'
     p 'メンテナンスを終了しました'
   end

--- a/training/lib/tasks/maintenance.rake
+++ b/training/lib/tasks/maintenance.rake
@@ -22,8 +22,8 @@ namespace :maintenance do
     end
 
     if args.end_at.in_time_zone <= Time.current
-      logger.info 'メンテナンス終了は現在時刻より未来を入力してください'
-      p 'メンテナンス終了は現在時刻より未来を入力してください'
+      logger.info 'メンテナンス終了時間は現在時刻より未来を入力してください'
+      p 'メンテナンス終了時刻は現在時間より未来を入力してください'
       exit
     end
 

--- a/training/lib/tasks/maintenance.rake
+++ b/training/lib/tasks/maintenance.rake
@@ -21,7 +21,7 @@ namespace :maintenance do
       exit
     end
 
-    if args.start_at.in_time_zone < Time.current || args.end_at.in_time_zone <= Time.current
+    if args.end_at.in_time_zone <= Time.current
       logger.info 'メンテナンス時間は現在時刻より未来を入力してください'
       p 'メンテナンス時間は現在時刻より未来を入力してください'
       exit

--- a/training/lib/tasks/maintenance.rake
+++ b/training/lib/tasks/maintenance.rake
@@ -1,0 +1,38 @@
+Dir[Rails.root.join('lib/logger/*.rb')].each {|file| require file }
+
+namespace :maintenance do
+  desc 'set maintenance start time, end date and start maintenance'
+  task :start, ['start_at', 'end_at'] do |_, args|
+    MAINTENANCE_DIR = "#{Rails.root.join('tmp/maintenance')}"
+    logger = Logger::TaskLogger.new('maintenance')
+
+    if args.start_at.blank? || args.end_at.blank?
+      logger.info "メンテナンスの開始時間と終了時間を入力してください"
+      p "メンテナンスの開始時間と終了時間を入力してください"
+      exit
+    end
+
+    if Dir.exist?(MAINTENANCE_DIR)
+      logger.info "前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください"
+      p "前回のメンテナンスが終了しておりません。前回のメンテナンスを終了させる場合はrake maintetance:endを実行してください"
+      exit
+    end
+
+    Dir.mkdir(MAINTENANCE_DIR)
+    File.open("#{MAINTENANCE_DIR}/maintenance.txt", 'w') do |file|
+      file.write("start_at => #{args.start_at}\n")
+      file.write("end_at => #{args.end_at}")
+    end
+
+    logger.info "メンテナンス開始時間を#{args.start_at} ~ #{args.end_at}で設定しました"
+    p "メンテナンス開始時間を#{args.start_at} ~ #{args.end_at}で設定しました"
+  end
+
+  task :end do
+    MAINTENANCE_DIR = "#{Rails.root.join('tmp/maintenance')}"
+    logger = Logger::TaskLogger.new('maintenance')
+    FileUtils.rm_rf(MAINTENANCE_DIR)
+    logger.info "メンテナンスを終了しました"
+    p "メンテナンスを終了しました"
+  end
+end

--- a/training/lib/tasks/maintenance.rake
+++ b/training/lib/tasks/maintenance.rake
@@ -22,8 +22,8 @@ namespace :maintenance do
     end
 
     if args.end_at.in_time_zone <= Time.current
-      logger.info 'メンテナンス時間は現在時刻より未来を入力してください'
-      p 'メンテナンス時間は現在時刻より未来を入力してください'
+      logger.info 'メンテナンス終了は現在時刻より未来を入力してください'
+      p 'メンテナンス終了は現在時刻より未来を入力してください'
       exit
     end
 

--- a/training/spec/requests/admin/users_spec.rb
+++ b/training/spec/requests/admin/users_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe 'Admin::Users', type: :request do
             delete admin_user_path(other_admin_user)
           }.to change { User.count }.by(-1)
         end
+
+        context 'not delete current login admin' do
+          it 'not delete record' do
+            expect {
+              delete admin_user_path(user)
+            }.to change { User.count }.by(0)
+          end
+        end
       end
 
       context 'one admin remain' do


### PR DESCRIPTION
# 概要
[ステップ21](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)

# やったこと
- maintenanceタスクの作成
- メンテナンス画面の作成
- ログインユーザを削除できる不具合の対応

# 仕様

### メンテナンス開始コマンド
`rake maintenance:start\[2020-06-16\ 14:00,2020-06-16\ 15:00\]`

### メンテナンス終了コマンド
`rake maintenance:end`

### 処理順

メンテナンス開始コマンドを打つと、
tmp/maintenance/timing.ymlが作成されて、メンテの開始時間と終了時間が記載されている

```
start_at: 2020-06-16 14:00
end_at: 2020-06-16 15:00
```

ログ情報は以下ファイルに格納される
log/maintenance.log

# 画面イメージ
<img width="568" alt="Screen Shot 2020-06-16 at 15 59 34" src="https://user-images.githubusercontent.com/64940424/84741706-6b8f8f80-afea-11ea-953a-fc07a72ee641.png">

# 備考
メンテナンスの開始情報をDBに保存しようかとも考えましたが、
画面表示するたびにDBへ取得処理を走らせるとパフォーマンスが悪くなりそうなので、
テキストに保存する方法を採用しました。