### PR TITLE
【Rails研修 step19】 ユーザにロールを追加

### DIFF
--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -45,10 +45,11 @@ module Admin
 
     def destroy
       @admin_user = Admin::User.find(params[:id])
-      if @admin_user.destroy
+      valid_user_role
+      if @admin_user.present? && @admin_user.destroy
         flash[:success] = t '.flash.success', action: :削除
       else
-        flash.now[:danger] = t '.flash.danger', action: :削除
+        flash[:danger] = t '.flash.danger', action: :削除
       end
       redirect_to admin_users_path
     end
@@ -61,6 +62,10 @@ module Admin
 
     def set_admin_user_role
       @admin_user_roles = Admin::User.roles.map { |k, _| [Admin::User.human_attribute_enum_val(:role, k), k] }.to_h
+    end
+
+    def valid_user_role
+      @admin_user = nil if @admin_user.admin? && Admin::User.where(role: 1).size < 2
     end
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class UsersController < ApplicationController
     include SessionsHelper
+    before_action :check_admin_user
     before_action :set_admin_user_role, only: %i[new create edit update]
     before_action :require_login
     PAGE_PER = 5
@@ -66,6 +67,10 @@ module Admin
 
     def valid_user_role
       @admin_user = nil if @admin_user.admin? && Admin::User.where(role: 1).size < 2
+    end
+
+    def check_admin_user
+      redirect_to tasks_path unless current_user.admin?
     end
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -42,8 +42,7 @@ module Admin
     end
 
     def destroy
-      valid_user_role
-      if @admin_user.present? && @admin_user.destroy
+      if @admin_user.destroy
         flash[:success] = t '.flash.success', action: :削除
       else
         flash[:danger] = t '.flash.danger', action: :削除
@@ -63,10 +62,6 @@ module Admin
 
     def find_admin_user_role
       @admin_user_roles = User.roles.map { |k, _| [User.human_attribute_enum_val(:role, k), k] }.to_h
-    end
-
-    def valid_user_role
-      @admin_user = nil if @admin_user.admin? && User.where(role: 1).size < 2
     end
 
     def check_admin_user

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -48,10 +48,10 @@ class User < ApplicationRecord
   end
 
   def valid_admin_for_destroy
-    valid_admin if self.admin?
+    valid_admin if admin?
   end
 
   def valid_admin_for_update
-    valid_admin if self.general?
+    valid_admin if general?
   end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -11,8 +11,8 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :password, presence: true
   validates :role, presence: true
-  before_destroy :valid_admin_for_destroy
-  validate :valid_admin_for_update, on: :update
+  before_destroy :valid_admin, if: :admin?
+  validate :valid_admin, if: :general?, on: :update
 
   enum role: { general: 0, admin: 1 }
 
@@ -45,13 +45,5 @@ class User < ApplicationRecord
     return if 1 < User.where(role: 1).size
     errors.add(:role, I18n.t('admin.users.flash.admin_danger'))
     throw :abort
-  end
-
-  def valid_admin_for_destroy
-    valid_admin if admin?
-  end
-
-  def valid_admin_for_update
-    valid_admin if general?
   end
 end

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -35,5 +35,5 @@
 </table>
 <div>
   <div class="task-paginate"><%= paginate @tasks %></div>
-  <div class="admin-user"><%= link_to t('.admin_user'), admin_users_path, class: 'btn btn-primary' %></div>
+  <div class="admin-user"><%= link_to t('.admin_user'), admin_users_path, class: 'btn btn-primary' if @current_user.admin? %></div>
 </div>

--- a/myapp/config/locales/views/admin/users/ja.yml
+++ b/myapp/config/locales/views/admin/users/ja.yml
@@ -4,6 +4,7 @@ ja:
       flash:
         success: 'ユーザーの%{action}に成功しました'
         danger: 'ユーザーの%{action}に失敗しました'
+        admin_danger: 'は１人以上管理者がいる必要があります。'
       index:
         title: 'ユーザー一覧'
         task_size: 'タスク数'

--- a/myapp/spec/features/admin/users_feature_spec.rb
+++ b/myapp/spec/features/admin/users_feature_spec.rb
@@ -7,7 +7,7 @@ describe 'User', type: :feature do
     visit login_path
     fill_in 'email', with: user.email
     fill_in 'password', with: user.password
-    click_on I18n.t('sessions.new.login')
+    click_on 'ログイン'
   end
 
   describe '#index' do
@@ -69,7 +69,7 @@ describe 'User', type: :feature do
         visit edit_admin_user_path(user)
         fill_in 'ユーザー名', with: 'Ziro'
         fill_in 'メールアドレス', with: 'ziro@example.com'
-        select '一般ユーザー', from: '役割'
+        select '管理ユーザー', from: '役割'
         fill_in 'パスワード', with: 'password2'
         fill_in 'パスワード（確認用）', with: 'password2'
 
@@ -77,7 +77,7 @@ describe 'User', type: :feature do
         expect(page).to have_content 'ユーザーの更新に成功しました'
         expect(page).to have_content 'Ziro'
         expect(page).to have_content 'ziro@example.com'
-        expect(page).to have_content '一般ユーザー'
+        expect(page).to have_content '管理ユーザー'
       end
     end
   end
@@ -97,8 +97,8 @@ describe 'User', type: :feature do
     context 'when admin user is alone (ex role.size < 2 )' do
       it 'return error message' do
         visit admin_user_path(user)
-        click_on I18n.t('admin.users.show.delete')
-        expect(page).to have_content I18n.t('admin.users.flash.danger', action: :削除)
+        click_on '削除'
+        expect(page).to have_content 'ユーザーの削除に失敗しました'
       end
     end
   end
@@ -110,16 +110,16 @@ describe 'User', type: :feature do
         visit login_path
         fill_in 'email', with: default_user.email
         fill_in 'password', with: default_user.password
-        click_on I18n.t('sessions.new.login')
-        expect(page).to have_no_content I18n.t('tasks.index.admin_user')
+        click_on 'ログイン'
+        expect(page).to have_no_content 'ユーザー管理画面'
       end
       it 'return tasks page' do
         visit login_path
         fill_in 'email', with: default_user.email
         fill_in 'password', with: default_user.password
-        click_on I18n.t('sessions.new.login')
+        click_on 'ログイン'
         visit admin_users_path
-        expect(page).to have_no_content I18n.t('admin.users.index.title')
+        expect(page).to have_no_content 'ユーザー一覧'
       end
     end
   end

--- a/myapp/spec/features/admin/users_feature_spec.rb
+++ b/myapp/spec/features/admin/users_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'capybara/rspec'
 
 describe 'User', type: :feature do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, role: 1) }
   before do
     visit login_path
     fill_in 'email', with: user.email
@@ -21,7 +21,7 @@ describe 'User', type: :feature do
         expect(page).to have_content I18n.t('admin.users.index.task_size')
       end
     end
-  end
+   end
 
   describe '#show' do
     let!(:task) { create(:task, user: user) }
@@ -30,7 +30,7 @@ describe 'User', type: :feature do
         visit admin_user_path(user)
         expect(page).to have_content user.name
         expect(page).to have_content user.email
-        expect(page).to have_content I18n.t('activerecord.attributes.user/role.default')
+        expect(page).to have_content I18n.t('activerecord.attributes.user/role.admin')
 
         expect(page).to have_content task.title
         expect(page).to have_content task.memo
@@ -83,9 +83,8 @@ describe 'User', type: :feature do
       end
     end
     context 'when admin user is alone (ex role.size < 2 )' do
-      let(:admin_user) { create(:user, role: 1) }
       it 'return error message' do
-        visit admin_user_path(admin_user)
+        visit admin_user_path(user)
         click_on I18n.t('admin.users.show.delete')
         expect(page).to have_content I18n.t('admin.users.flash.danger', action: :削除)
       end

--- a/myapp/spec/features/admin/users_feature_spec.rb
+++ b/myapp/spec/features/admin/users_feature_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'capybara/rspec'
 
 describe 'User', type: :feature do
-  let(:user) { create(:user, role: 1) }
+  let(:user) { create(:user) }
   before do
     visit login_path
     fill_in 'email', with: user.email
@@ -30,7 +30,7 @@ describe 'User', type: :feature do
         visit admin_user_path(user)
         expect(page).to have_content user.name
         expect(page).to have_content user.email
-        expect(page).to have_content I18n.t('activerecord.attributes.user/role.admin')
+        expect(page).to have_content I18n.t('activerecord.attributes.user/role.default')
 
         expect(page).to have_content task.title
         expect(page).to have_content task.memo
@@ -80,6 +80,14 @@ describe 'User', type: :feature do
         visit admin_user_path(default_user)
         click_on I18n.t('admin.users.show.delete')
         expect(page).to have_content I18n.t('admin.users.flash.success', action: :削除)
+      end
+    end
+    context 'when admin user is alone (ex role.size < 2 )' do
+      let(:admin_user) { create(:user, role: 1) }
+      it 'return error message' do
+        visit admin_user_path(admin_user)
+        click_on I18n.t('admin.users.show.delete')
+        expect(page).to have_content I18n.t('admin.users.flash.danger', action: :削除)
       end
     end
   end

--- a/myapp/spec/features/admin/users_feature_spec.rb
+++ b/myapp/spec/features/admin/users_feature_spec.rb
@@ -7,7 +7,7 @@ describe 'User', type: :feature do
     visit login_path
     fill_in 'email', with: user.email
     fill_in 'password', with: user.password
-    click_on 'ログイン'
+    click_on I18n.t('sessions.new.login')
   end
 
   describe '#index' do
@@ -21,7 +21,7 @@ describe 'User', type: :feature do
         expect(page).to have_content I18n.t('admin.users.index.task_size')
       end
     end
-   end
+  end
 
   describe '#show' do
     let!(:task) { create(:task, user: user) }
@@ -87,6 +87,27 @@ describe 'User', type: :feature do
         visit admin_user_path(user)
         click_on I18n.t('admin.users.show.delete')
         expect(page).to have_content I18n.t('admin.users.flash.danger', action: :削除)
+      end
+    end
+  end
+
+  describe 'check admin user when showing admin user page', :skip_before do
+    context 'when user is default' do
+      let(:default_user) { create(:user) }
+      it 'dont show admin user button' do
+        visit login_path
+        fill_in 'email', with: default_user.email
+        fill_in 'password', with: default_user.password
+        click_on I18n.t('sessions.new.login')
+        expect(page).to have_no_content I18n.t('tasks.index.admin_user')
+      end
+      it 'return tasks page' do
+        visit login_path
+        fill_in 'email', with: default_user.email
+        fill_in 'password', with: default_user.password
+        click_on I18n.t('sessions.new.login')
+        visit admin_users_path
+        expect(page).to have_no_content I18n.t('admin.users.index.title')
       end
     end
   end

--- a/myapp/spec/features/admin/users_feature_spec.rb
+++ b/myapp/spec/features/admin/users_feature_spec.rb
@@ -114,19 +114,19 @@ describe 'User', type: :feature do
   end
 
   describe 'check admin user when showing admin user page', :skip_before do
-    context 'when user is default' do
-      let(:default_user) { create(:user) }
+    context 'when user is general' do
+      let(:general_user) { create(:user) }
       it 'dont show admin user button' do
         visit login_path
-        fill_in 'email', with: default_user.email
-        fill_in 'password', with: default_user.password
+        fill_in 'email', with: general_user.email
+        fill_in 'password', with: general_user.password
         click_on 'ログイン'
         expect(page).to have_no_content 'ユーザー管理画面'
       end
       it 'return tasks page' do
         visit login_path
-        fill_in 'email', with: default_user.email
-        fill_in 'password', with: default_user.password
+        fill_in 'email', with: general_user.email
+        fill_in 'password', with: general_user.password
         click_on 'ログイン'
         visit admin_users_path
         expect(page).to have_no_content 'ユーザー一覧'

--- a/myapp/spec/features/admin/users_feature_spec.rb
+++ b/myapp/spec/features/admin/users_feature_spec.rb
@@ -80,6 +80,14 @@ describe 'User', type: :feature do
         expect(page).to have_content '管理ユーザー'
       end
     end
+    context 'when admin is none' do
+      it 'raise error message' do
+        visit edit_admin_user_path(user)
+        select '一般ユーザー', from: '役割'
+        click_button '更新する'
+        expect(page).to have_content '役割は１人以上管理者がいる必要があります。'
+      end
+    end
   end
 
   describe '#destroy' do
@@ -99,6 +107,8 @@ describe 'User', type: :feature do
         visit admin_user_path(user)
         click_on '削除'
         expect(page).to have_content 'ユーザーの削除に失敗しました'
+        expect(page).to have_content '管理ユーザー'
+        expect(User.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
## 課題
[ステップ19: ユーザにロールを追加しよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

[Rails研修レビュー持ち回り](https://fablic.qiita.com/shared/items/027af4532a046b94ca7e#rails%E7%A0%94%E4%BF%AE%E3%83%AC%E3%83%93%E3%83%A5%E3%83%BC%E6%8C%81%E3%81%A1%E5%9B%9E%E3%82%8A)
## やったこと
・管理ユーザだけがユーザ管理画面にアクセスできるように実装
・管理ユーザが1人もいなくならないように削除の制御

管理ユーザー時のtask画面
![Screen Shot 2020-06-16 at 14 37 09](https://user-images.githubusercontent.com/62979220/84735601-dfc43600-afde-11ea-8533-c20f55ff3b73.png)

一般ユーザーのtask画面
![Screen Shot 2020-06-16 at 14 38 04](https://user-images.githubusercontent.com/62979220/84735655-01bdb880-afdf-11ea-9480-b2e68e27c05a.png)

## 共有事項