### PR TITLE
ステップ20.5 テストの修正

### DIFF
--- a/neko/app/controllers/application_controller.rb
+++ b/neko/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
-  helper_method :logged_in?, :current_user, :owner?
+  include SessionHundle
+
   unless Rails.env.development?
     rescue_from StandardError, with: :render500
     rescue_from ActionController::RoutingError, with: :render404
@@ -14,44 +15,5 @@ class ApplicationController < ActionController::Base
   def render500(exception = nil)
     logger.error "Rendering 500 with exception: #{exception.message}" if exception
     render 'errors/500', status: :internal_server_error
-  end
-
-  private
-
-  def log_in(user)
-    session[:user_id] = user.id
-  end
-
-  def logged_in?
-    current_user
-  end
-
-  def current_user
-    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
-  end
-
-  def current_user?(user)
-    user == current_user
-  end
-
-  def log_out
-    session.delete(:user_id)
-    @current_user = nil
-  end
-
-  def logged_in_user
-    redirect_to login_url unless logged_in?
-  end
-
-  def not_permit(msg)
-    redirect_to root_url, flash: { danger: I18n.t(msg) }
-  end
-
-  def only_admin
-    not_permit('flash.admin.permit') unless current_user.administrator?
-  end
-
-  def owner?(model)
-    model.user == current_user
   end
 end

--- a/neko/app/controllers/concerns/session_hundle.rb
+++ b/neko/app/controllers/concerns/session_hundle.rb
@@ -1,0 +1,44 @@
+module SessionHundle
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :logged_in?, :current_user, :owner?
+
+    def log_in(user)
+      session[:user_id] = user.id
+    end
+
+    def current_user?(user)
+      user == current_user
+    end
+
+    def log_out
+      session.delete(:user_id)
+      @current_user = nil
+    end
+
+    def logged_in_user
+      redirect_to login_url unless logged_in?
+    end
+
+    def not_permit(msg)
+      redirect_to root_url, flash: { danger: I18n.t(msg) }
+    end
+
+    def only_admin
+      not_permit('flash.admin.permit') unless current_user.administrator?
+    end
+  end
+
+  def logged_in?
+    current_user
+  end
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def owner?(model)
+    model.user == current_user
+  end
+end

--- a/neko/app/controllers/concerns/session_hundle.rb
+++ b/neko/app/controllers/concerns/session_hundle.rb
@@ -3,31 +3,31 @@ module SessionHundle
 
   included do
     helper_method :logged_in?, :current_user, :owner?
+  end
 
-    def log_in(user)
-      session[:user_id] = user.id
-    end
+  def log_in(user)
+    session[:user_id] = user.id
+  end
 
-    def current_user?(user)
-      user == current_user
-    end
+  def current_user?(user)
+    user == current_user
+  end
 
-    def log_out
-      session.delete(:user_id)
-      @current_user = nil
-    end
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
 
-    def logged_in_user
-      redirect_to login_url unless logged_in?
-    end
+  def logged_in_user
+    redirect_to login_url unless logged_in?
+  end
 
-    def not_permit(msg)
-      redirect_to root_url, flash: { danger: I18n.t(msg) }
-    end
+  def not_permit(msg)
+    redirect_to root_url, flash: { danger: I18n.t(msg) }
+  end
 
-    def only_admin
-      not_permit('flash.admin.permit') unless current_user.administrator?
-    end
+  def only_admin
+    not_permit('flash.admin.permit') unless current_user.administrator?
   end
 
   def logged_in?

--- a/neko/spec/factories/task.rb
+++ b/neko/spec/factories/task.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :task, class: Task do
-    sequence(:name) { Faker::Name.name }
-    sequence(:description) { Faker::Lorem.sentence }
+    sequence(:name, 'task_1')
+    sequence(:description, 'this is task_1')
     sequence(:due_at) { Faker::Time.forward(days: 300) }
     sequence(:have_a_due) { Faker::Boolean.boolean }
     sequence(:status) { Task.statuses.values.sample }

--- a/neko/spec/models/auth_info_spec.rb
+++ b/neko/spec/models/auth_info_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AuthInfo, type: :model do
   end
 
   context 'email address entered is a duplicate' do
-    let(:auth) { create(:auth) }
+    let!(:auth) { create(:auth) }
     context '& case is same' do
       let(:duplicate_auth) { build(:auth, email: auth.email) }
       it 'raise a error' do

--- a/neko/spec/models/auth_info_spec.rb
+++ b/neko/spec/models/auth_info_spec.rb
@@ -2,44 +2,44 @@ require 'rails_helper'
 
 RSpec.describe AuthInfo, type: :model do
   context 'all informations are correct' do
-    let(:auth) { build(:auth, email: 'asbc@example.com', password: 'password', password_confirmation: 'password') }
-    it 'should be OK' do
-      expect(auth).to be_valid
-    end
+    subject { build(:auth, email: 'asbc@example.com', password: 'password', password_confirmation: 'password') }
+    it { is_expected.to be_valid }
   end
 
   context 'email formatting is not correct' do
-    let(:auth) { build(:auth, email: 'abcdefg12345') }
+    subject { build(:auth, email: 'abcdefg12345') }
     it 'raise a error' do
-      expect(auth.valid?).to eq false
-      expect(auth.errors.full_messages).to eq ['メールアドレスは不正な値です']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['メールアドレスは不正な値です']
     end
   end
 
   context 'email address entered is a duplicate' do
-    let!(:auth) { create(:auth) }
+    subject { build(:auth, email: auth_email) }
+    let!(:auth_existed) { create(:auth) }
+
     context '& case is same' do
-      let(:duplicate_auth) { build(:auth, email: auth.email) }
+      let(:auth_email){ auth_existed.email }
       it 'raise a error' do
-        expect(duplicate_auth.valid?).to eq false
-        expect(duplicate_auth.errors.full_messages).to eq ['メールアドレスはすでに存在します']
+        is_expected.not_to be_valid
+        expect(subject.errors.full_messages).to eq ['メールアドレスはすでに存在します']
       end
     end
 
     context '& case is different' do
-      let(:duplicate_auth) { build(:auth, email: auth.email.upcase) }
+      let(:auth_email){ auth_existed.email.upcase }
       it 'raise a error' do
-        expect(duplicate_auth.valid?).to eq false
-        expect(duplicate_auth.errors.full_messages).to eq ['メールアドレスはすでに存在します']
+        is_expected.not_to be_valid
+        expect(subject.errors.full_messages).to eq ['メールアドレスはすでに存在します']
       end
     end
   end
 
   context 'password-confirm is not correct' do
-    let(:auth) { build(:auth, password_confirmation: 'wrongpassword') }
+    subject { build(:auth, password_confirmation: 'wrongpassword') }
     it 'raise a error' do
-      expect(auth.valid?).to eq false
-      expect(auth.errors.full_messages).to eq ['パスワード（確認用）とパスワードの入力が一致しません']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['パスワード（確認用）とパスワードの入力が一致しません']
     end
   end
 end

--- a/neko/spec/models/auth_info_spec.rb
+++ b/neko/spec/models/auth_info_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe AuthInfo, type: :model do
   context 'all informations are correct' do
-    let!(:auth) { build(:auth, email: 'asbc@example.com', password: 'password', password_confirmation: 'password') }
+    let(:auth) { build(:auth, email: 'asbc@example.com', password: 'password', password_confirmation: 'password') }
     it 'should be OK' do
       expect(auth).to be_valid
     end
   end
 
   context 'email formatting is not correct' do
-    let!(:auth) { build(:auth, email: 'abcdefg12345') }
+    let(:auth) { build(:auth, email: 'abcdefg12345') }
     it 'raise a error' do
       expect(auth.valid?).to eq false
       expect(auth.errors.full_messages).to eq ['メールアドレスは不正な値です']
@@ -17,9 +17,9 @@ RSpec.describe AuthInfo, type: :model do
   end
 
   context 'email address entered is a duplicate' do
-    let!(:auth) { create(:auth) }
+    let(:auth) { create(:auth) }
     context '& case is same' do
-      let!(:duplicate_auth) { build(:auth) }
+      let(:duplicate_auth) { build(:auth, email: auth.email) }
       it 'raise a error' do
         expect(duplicate_auth.valid?).to eq false
         expect(duplicate_auth.errors.full_messages).to eq ['メールアドレスはすでに存在します']
@@ -27,7 +27,7 @@ RSpec.describe AuthInfo, type: :model do
     end
 
     context '& case is different' do
-      let!(:duplicate_auth) { build(:auth, email: auth.email.upcase) }
+      let(:duplicate_auth) { build(:auth, email: auth.email.upcase) }
       it 'raise a error' do
         expect(duplicate_auth.valid?).to eq false
         expect(duplicate_auth.errors.full_messages).to eq ['メールアドレスはすでに存在します']
@@ -36,7 +36,7 @@ RSpec.describe AuthInfo, type: :model do
   end
 
   context 'password-confirm is not correct' do
-    let!(:auth) { build(:auth, password_confirmation: 'wrongpassword') }
+    let(:auth) { build(:auth, password_confirmation: 'wrongpassword') }
     it 'raise a error' do
       expect(auth.valid?).to eq false
       expect(auth.errors.full_messages).to eq ['パスワード（確認用）とパスワードの入力が一致しません']

--- a/neko/spec/models/label_spec.rb
+++ b/neko/spec/models/label_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Label, type: :model do
+  let(:label) { build(:label, name: label_name) }
+
   context 'name is between 2 and 24 characters' do
-    let(:label) { build(:label, name: 'hoge') }
+    let(:label_name) { 'hoge' }
     it 'should be OK' do
       expect(label).to be_valid
     end
   end
 
   context 'name is less than 2 letters' do
-    let(:label) { build(:label, name: '1') }
+    let(:label_name) { '1' }
     it 'raise a error' do
       expect(label.valid?).to eq false
       expect(label.errors.full_messages).to eq ['名前は2文字以上で入力してください']
@@ -17,7 +19,7 @@ RSpec.describe Label, type: :model do
   end
 
   context 'name is more than 24 letters' do
-    let(:label) { build(:label, name: 'abcdefghijklmnopqrstuvwxy') }
+    let(:label_name) { 'abcdefghijklmnopqrstuvwxy' }
     it 'raise a error' do
       expect(label.valid?).to eq false
       expect(label.errors.full_messages).to eq ['名前は24文字以内で入力してください']
@@ -25,7 +27,7 @@ RSpec.describe Label, type: :model do
   end
 
   context 'name is duplicate' do
-    let(:label) { create(:label, name: 'label') }
+    let!(:label) { create(:label) }
     context ' & case is same' do
       let(:duplicate_label) { build(:label, name: label.name) }
       it 'raise a error' do

--- a/neko/spec/models/label_spec.rb
+++ b/neko/spec/models/label_spec.rb
@@ -2,45 +2,44 @@ require 'rails_helper'
 
 RSpec.describe Label, type: :model do
   let(:label) { build(:label, name: label_name) }
+  subject { label } 
 
   context 'name is between 2 and 24 characters' do
     let(:label_name) { 'hoge' }
-    it 'should be OK' do
-      expect(label).to be_valid
-    end
+    it { is_expected.to be_valid }
   end
 
   context 'name is less than 2 letters' do
     let(:label_name) { '1' }
     it 'raise a error' do
-      expect(label.valid?).to eq false
-      expect(label.errors.full_messages).to eq ['名前は2文字以上で入力してください']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['名前は2文字以上で入力してください']
     end
   end
 
   context 'name is more than 24 letters' do
     let(:label_name) { 'abcdefghijklmnopqrstuvwxy' }
     it 'raise a error' do
-      expect(label.valid?).to eq false
-      expect(label.errors.full_messages).to eq ['名前は24文字以内で入力してください']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['名前は24文字以内で入力してください']
     end
   end
 
   context 'name is duplicate' do
-    let!(:label) { create(:label) }
+    let!(:label_existed) { create(:label) }
     context ' & case is same' do
-      let(:duplicate_label) { build(:label, name: label.name) }
+      let(:label_name) { label_existed.name }
       it 'raise a error' do
-        expect(duplicate_label.valid?).to eq false
-        expect(duplicate_label.errors.full_messages).to eq ['名前はすでに存在します']
+        is_expected.not_to be_valid
+        expect(subject.errors.full_messages).to eq ['名前はすでに存在します']
       end
     end
 
     context '& case is different' do
-      let(:duplicate_label) { build(:label, name: label.name.upcase) }
+      let(:label_name) { label_existed.name.upcase }
       it 'raise a error' do
-        expect(duplicate_label.valid?).to eq false
-        expect(duplicate_label.errors.full_messages).to eq ['名前はすでに存在します']
+        is_expected.not_to be_valid
+        expect(subject.errors.full_messages).to eq ['名前はすでに存在します']
       end
     end
   end

--- a/neko/spec/models/label_spec.rb
+++ b/neko/spec/models/label_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Label, type: :model do
   context 'name is between 2 and 24 characters' do
-    let!(:label) { build(:label, name: 'hoge') }
+    let(:label) { build(:label, name: 'hoge') }
     it 'should be OK' do
       expect(label).to be_valid
     end
   end
 
   context 'name is less than 2 letters' do
-    let!(:label) { build(:label, name: '1') }
+    let(:label) { build(:label, name: '1') }
     it 'raise a error' do
       expect(label.valid?).to eq false
       expect(label.errors.full_messages).to eq ['名前は2文字以上で入力してください']
@@ -17,7 +17,7 @@ RSpec.describe Label, type: :model do
   end
 
   context 'name is more than 24 letters' do
-    let!(:label) { build(:label, name: 'abcdefghijklmnopqrstuvwxy') }
+    let(:label) { build(:label, name: 'abcdefghijklmnopqrstuvwxy') }
     it 'raise a error' do
       expect(label.valid?).to eq false
       expect(label.errors.full_messages).to eq ['名前は24文字以内で入力してください']
@@ -25,9 +25,9 @@ RSpec.describe Label, type: :model do
   end
 
   context 'name is duplicate' do
-    let!(:label) { create(:label, name: 'label') }
+    let(:label) { create(:label, name: 'label') }
     context ' & case is same' do
-      let!(:duplicate_label) { build(:label, name: label.name) }
+      let(:duplicate_label) { build(:label, name: label.name) }
       it 'raise a error' do
         expect(duplicate_label.valid?).to eq false
         expect(duplicate_label.errors.full_messages).to eq ['名前はすでに存在します']
@@ -35,7 +35,7 @@ RSpec.describe Label, type: :model do
     end
 
     context '& case is different' do
-      let!(:duplicate_label) { build(:label, name: label.name.upcase) }
+      let(:duplicate_label) { build(:label, name: label.name.upcase) }
       it 'raise a error' do
         expect(duplicate_label.valid?).to eq false
         expect(duplicate_label.errors.full_messages).to eq ['名前はすでに存在します']

--- a/neko/spec/models/task_spec.rb
+++ b/neko/spec/models/task_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   context 'name is between 2 and 24 characters' do
-    let!(:task) { build(:task, name: 'hoge') }
+    let(:task) { build(:task, name: 'hoge') }
     it 'should be OK' do
       expect(task).to be_valid
     end
   end
 
   context 'name is less than 2 characters' do
-    let!(:task) { build(:task, name: '1') }
+    let(:task) { build(:task, name: '1') }
     it 'raise a error' do
       expect(task.valid?).to eq false
       expect(task.errors.full_messages).to eq ['名前は2文字以上で入力してください']
@@ -17,7 +17,7 @@ RSpec.describe Task, type: :model do
   end
 
   context 'name is more than 24 characters' do
-    let!(:task) { build(:task, name: 'abcdefghijklmnopqrstuvwxy') }
+    let(:task) { build(:task, name: 'abcdefghijklmnopqrstuvwxy') }
     it 'raise a error' do
       expect(task.valid?).to eq false
       expect(task.errors.full_messages).to eq ['名前は24文字以内で入力してください']
@@ -25,7 +25,7 @@ RSpec.describe Task, type: :model do
   end
 
   context 'user_id is null' do
-    let!(:task) { build(:task, name: 'task', user: nil) }
+    let(:task) { build(:task, name: 'task', user: nil) }
     it 'raise a error' do
       expect(task.valid?).to eq false
       expect(task.errors.full_messages).to eq ['作成者を入力してください']
@@ -39,7 +39,7 @@ RSpec.describe Task, type: :model do
     let!(:task4) { create(:task, name: 'task4', status: 1) }
     let!(:taskA) { create(:task, name: 'タスクA', status: 0) }
     let!(:taskB) { create(:task, name: 'タスクB', status: 2) }
-    it 'search tasks by name & status' do
+    it 'could search tasks by name & status' do
       test_cases = [
         { name: 'task', status: 1 },
         { name: 'タスク', status: nil },

--- a/neko/spec/models/task_spec.rb
+++ b/neko/spec/models/task_spec.rb
@@ -2,35 +2,34 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   let(:task) { build(:task, name: task_name) }
+  subject { task }
 
   context 'name is between 2 and 24 characters' do
-    let(:task_name) { 'hoge' }
-    it 'should be OK' do
-      expect(task).to be_valid
-    end
+    let(:task_name) { 'hoge '}
+    it { is_expected.to be_valid }
   end
 
   context 'name is less than 2 characters' do
     let(:task_name) { '1' }
     it 'raise a error' do
-      expect(task.valid?).to eq false
-      expect(task.errors.full_messages).to eq ['名前は2文字以上で入力してください']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['名前は2文字以上で入力してください']
     end
   end
 
   context 'name is more than 24 characters' do
     let(:task_name) { 'abcdefghijklmnopqrstuvwxy' }
     it 'raise a error' do
-      expect(task.valid?).to eq false
-      expect(task.errors.full_messages).to eq ['名前は24文字以内で入力してください']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['名前は24文字以内で入力してください']
     end
   end
 
   context 'user_id is null' do
-    let(:task) { build(:task, name: 'task', user: nil) }
+    subject { build(:task, name: 'task', user: nil) }
     it 'raise a error' do
-      expect(task.valid?).to eq false
-      expect(task.errors.full_messages).to eq ['作成者を入力してください']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['作成者を入力してください']
     end
   end
 
@@ -41,6 +40,7 @@ RSpec.describe Task, type: :model do
     let!(:task4) { create(:task, name: 'task4', status: 1) }
     let!(:taskA) { create(:task, name: 'タスクA', status: 0) }
     let!(:taskB) { create(:task, name: 'タスクB', status: 2) }
+  
     it 'could search tasks by name & status' do
       test_cases = [
         { name: 'task', status: 1 },

--- a/neko/spec/models/task_spec.rb
+++ b/neko/spec/models/task_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
+  let(:task) { build(:task, name: task_name) }
+
   context 'name is between 2 and 24 characters' do
-    let(:task) { build(:task, name: 'hoge') }
+    let(:task_name) { 'hoge' }
     it 'should be OK' do
       expect(task).to be_valid
     end
   end
 
   context 'name is less than 2 characters' do
-    let(:task) { build(:task, name: '1') }
+    let(:task_name) { '1' }
     it 'raise a error' do
       expect(task.valid?).to eq false
       expect(task.errors.full_messages).to eq ['名前は2文字以上で入力してください']
@@ -17,7 +19,7 @@ RSpec.describe Task, type: :model do
   end
 
   context 'name is more than 24 characters' do
-    let(:task) { build(:task, name: 'abcdefghijklmnopqrstuvwxy') }
+    let(:task_name) { 'abcdefghijklmnopqrstuvwxy' }
     it 'raise a error' do
       expect(task.valid?).to eq false
       expect(task.errors.full_messages).to eq ['名前は24文字以内で入力してください']

--- a/neko/spec/models/user_spec.rb
+++ b/neko/spec/models/user_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   context 'name is between 4 and 15 characters' do
-    let!(:user) { build(:user, name: 'user') }
+    let(:user) { build(:user, name: 'user') }
     it 'should be OK' do
       expect(user).to be_valid
     end
   end
 
   context 'name is less than 4 letters' do
-    let!(:user) { build(:user, name: 'abc') }
+    let(:user) { build(:user, name: 'abc') }
     it 'raise a error' do
       expect(user.valid?).to eq false
       expect(user.errors.full_messages).to eq ['名前は4文字以上で入力してください']
@@ -17,7 +17,7 @@ RSpec.describe User, type: :model do
   end
 
   context 'name is less than 15 letters' do
-    let!(:user) { build(:user, name: '0123456789abcdef') }
+    let(:user) { build(:user, name: '0123456789abcdef') }
     it 'raise a error' do
       expect(user.valid?).to eq false
       expect(user.errors.full_messages).to eq ['名前は15文字以内で入力してください']
@@ -25,9 +25,9 @@ RSpec.describe User, type: :model do
   end
 
   context 'name is duplicate' do
-    let!(:user) { create(:user, name: 'user') }
+    let(:user) { create(:user, name: 'user') }
     context '& case is same' do
-      let!(:duplicate_user) { build(:user, name: user.name) }
+      let(:duplicate_user) { build(:user, name: user.name) }
       it 'raise a error' do
         expect(duplicate_user.valid?).to eq false
         expect(duplicate_user.errors.full_messages).to eq ['名前はすでに存在します']
@@ -35,7 +35,7 @@ RSpec.describe User, type: :model do
     end
 
     context '& case is different' do
-      let!(:duplicate_user) { build(:user, name: user.name.upcase) }
+      let(:duplicate_user) { build(:user, name: user.name.upcase) }
       it 'raise a error' do
         expect(duplicate_user.valid?).to eq false
         expect(duplicate_user.errors.full_messages).to eq ['名前はすでに存在します']

--- a/neko/spec/models/user_spec.rb
+++ b/neko/spec/models/user_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  let(:user) { build(:user, name: user_name) }
+
   context 'name is between 4 and 15 characters' do
-    let(:user) { build(:user, name: 'user') }
+    let(:user_name) { 'user' }
     it 'should be OK' do
       expect(user).to be_valid
     end
   end
 
   context 'name is less than 4 letters' do
-    let(:user) { build(:user, name: 'abc') }
+    let(:user_name) { 'abc' }
     it 'raise a error' do
       expect(user.valid?).to eq false
       expect(user.errors.full_messages).to eq ['名前は4文字以上で入力してください']
@@ -17,7 +19,7 @@ RSpec.describe User, type: :model do
   end
 
   context 'name is less than 15 letters' do
-    let(:user) { build(:user, name: '0123456789abcdef') }
+    let(:user_name) { '0123456789abcdef' }
     it 'raise a error' do
       expect(user.valid?).to eq false
       expect(user.errors.full_messages).to eq ['名前は15文字以内で入力してください']
@@ -25,7 +27,7 @@ RSpec.describe User, type: :model do
   end
 
   context 'name is duplicate' do
-    let(:user) { create(:user, name: 'user') }
+    let!(:user) { create(:user) }
     context '& case is same' do
       let(:duplicate_user) { build(:user, name: user.name) }
       it 'raise a error' do

--- a/neko/spec/models/user_spec.rb
+++ b/neko/spec/models/user_spec.rb
@@ -2,45 +2,44 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   let(:user) { build(:user, name: user_name) }
+  subject { user } 
 
   context 'name is between 4 and 15 characters' do
     let(:user_name) { 'user' }
-    it 'should be OK' do
-      expect(user).to be_valid
-    end
+    it { is_expected.to be_valid }
   end
 
   context 'name is less than 4 letters' do
     let(:user_name) { 'abc' }
     it 'raise a error' do
-      expect(user.valid?).to eq false
-      expect(user.errors.full_messages).to eq ['名前は4文字以上で入力してください']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['名前は4文字以上で入力してください']
     end
   end
 
   context 'name is less than 15 letters' do
     let(:user_name) { '0123456789abcdef' }
     it 'raise a error' do
-      expect(user.valid?).to eq false
-      expect(user.errors.full_messages).to eq ['名前は15文字以内で入力してください']
+      is_expected.not_to be_valid
+      expect(subject.errors.full_messages).to eq ['名前は15文字以内で入力してください']
     end
   end
 
   context 'name is duplicate' do
-    let!(:user) { create(:user) }
+    let!(:user_existed) { create(:user) }
     context '& case is same' do
-      let(:duplicate_user) { build(:user, name: user.name) }
+      let(:user_name) { user_existed.name }
       it 'raise a error' do
-        expect(duplicate_user.valid?).to eq false
-        expect(duplicate_user.errors.full_messages).to eq ['名前はすでに存在します']
+        is_expected.not_to be_valid
+        expect(subject.errors.full_messages).to eq ['名前はすでに存在します']
       end
     end
 
     context '& case is different' do
-      let(:duplicate_user) { build(:user, name: user.name.upcase) }
+      let(:user_name) { user_existed.name.upcase }
       it 'raise a error' do
-        expect(duplicate_user.valid?).to eq false
-        expect(duplicate_user.errors.full_messages).to eq ['名前はすでに存在します']
+        is_expected.not_to be_valid
+        expect(subject.errors.full_messages).to eq ['名前はすでに存在します']
       end
     end
   end

--- a/neko/spec/rails_helper.rb
+++ b/neko/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/neko/spec/rails_helper.rb
+++ b/neko/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/neko/spec/support/selectors.rb
+++ b/neko/spec/support/selectors.rb
@@ -1,0 +1,5 @@
+module Selectors
+  Capybara.add_selector(:linkhref) do
+    xpath {|href| ".//a[@href='#{href}']"}
+  end
+end

--- a/neko/spec/support/selectors.rb
+++ b/neko/spec/support/selectors.rb
@@ -1,5 +1,5 @@
 module Selectors
   Capybara.add_selector(:linkhref) do
-    xpath {|href| ".//a[@href='#{href}']"}
+    xpath { |href| ".//a[@href='#{href}']" }
   end
 end

--- a/neko/spec/support/selectors.rb
+++ b/neko/spec/support/selectors.rb
@@ -1,5 +1,0 @@
-module Selectors
-  Capybara.add_selector(:linkhref) do
-    xpath {|href| ".//a[@href='#{href}']"}
-  end
-end

--- a/neko/spec/system/label_spec.rb
+++ b/neko/spec/system/label_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe 'label', type: :system do
       it 'able to cancel' do
         expect {
           page.dismiss_confirm 'ラベルを削除しますか？' do
-            page.all('.label-delete > a')[1].click
+            find(:linkhref, "/labels/#{label2.id}").click
           end
           expect(page).to have_current_path labels_path
         }.to change(Label, :count).by(0)
@@ -149,7 +149,7 @@ RSpec.describe 'label', type: :system do
       it 'should be success to delete' do
         expect {
           page.accept_confirm 'ラベルを削除しますか？' do
-            page.all('.label-delete a')[1].click
+            find(:linkhref, "/labels/#{label2.id}").click
           end
           expect(page).to have_current_path labels_path
         }.to change(Label, :count).by(-1)

--- a/neko/spec/system/label_spec.rb
+++ b/neko/spec/system/label_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'label', type: :system do
   let(:admin) { create(:user, name: 'admin') }
   let(:owner) { create(:user, name: 'owner', role: :general_user) }
-  let!(:label1) { create(:label, name: 'label1', user: admin) }
+  let(:label1) { create(:label, name: 'label1', user: admin) }
   let!(:label2) { create(:label, name: 'label2', user: owner) }
 
   shared_context 'login as an administrator' do

--- a/neko/spec/system/label_spec.rb
+++ b/neko/spec/system/label_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'label', type: :system do
   let(:admin) { create(:user, name: 'admin') }
   let(:owner) { create(:user, name: 'owner', role: :general_user) }
-  let(:label1) { create(:label, name: 'label1', user: admin) }
+  let!(:label1) { create(:label, name: 'label1', user: admin) }
   let!(:label2) { create(:label, name: 'label2', user: owner) }
 
   shared_context 'login as an administrator' do

--- a/neko/spec/system/label_spec.rb
+++ b/neko/spec/system/label_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'label', type: :system do
   let(:admin) { create(:user, name: 'admin') }
   let(:owner) { create(:user, name: 'owner', role: :general_user) }
-  let!(:label1) { create(:label, name: 'label1', user: admin) }
+  let(:label1) { create(:label, name: 'label1', user: admin) }
   let!(:label2) { create(:label, name: 'label2', user: owner) }
 
   shared_context 'login as an administrator' do
@@ -140,7 +140,7 @@ RSpec.describe 'label', type: :system do
       it 'able to cancel' do
         expect {
           page.dismiss_confirm 'ラベルを削除しますか？' do
-            page.all('.label-delete > a')[1].click
+            find(:linkhref, "/labels/#{label2.id}").click
           end
           expect(page).to have_current_path labels_path
         }.to change(Label, :count).by(0)
@@ -149,7 +149,7 @@ RSpec.describe 'label', type: :system do
       it 'should be success to delete' do
         expect {
           page.accept_confirm 'ラベルを削除しますか？' do
-            page.all('.label-delete a')[1].click
+            find(:linkhref, "/labels/#{label2.id}").click
           end
           expect(page).to have_current_path labels_path
         }.to change(Label, :count).by(-1)

--- a/neko/spec/system/label_spec.rb
+++ b/neko/spec/system/label_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'label', type: :system do
-  let!(:admin) { create(:user, name: 'admin') }
-  let!(:owner) { create(:user, name: 'owner', role: :general_user) }
+  let(:admin) { create(:user, name: 'admin') }
+  let(:owner) { create(:user, name: 'owner', role: :general_user) }
   let!(:label1) { create(:label, name: 'label1', user: admin) }
   let!(:label2) { create(:label, name: 'label2', user: owner) }
 
@@ -140,7 +140,7 @@ RSpec.describe 'label', type: :system do
       it 'able to cancel' do
         expect {
           page.dismiss_confirm 'ラベルを削除しますか？' do
-            page.all('.label-delete a')[1].click
+            page.all('.label-delete > a')[1].click
           end
           expect(page).to have_current_path labels_path
         }.to change(Label, :count).by(0)

--- a/neko/spec/system/label_spec.rb
+++ b/neko/spec/system/label_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe 'label', type: :system do
       it 'able to cancel' do
         expect {
           page.dismiss_confirm 'ラベルを削除しますか？' do
-            find(:linkhref, "/labels/#{label2.id}").click
+            page.all('.label-delete > a')[1].click
           end
           expect(page).to have_current_path labels_path
         }.to change(Label, :count).by(0)
@@ -149,7 +149,7 @@ RSpec.describe 'label', type: :system do
       it 'should be success to delete' do
         expect {
           page.accept_confirm 'ラベルを削除しますか？' do
-            find(:linkhref, "/labels/#{label2.id}").click
+            page.all('.label-delete a')[1].click
           end
           expect(page).to have_current_path labels_path
         }.to change(Label, :count).by(-1)

--- a/neko/spec/system/task_spec.rb
+++ b/neko/spec/system/task_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'task', type: :system do
-  let!(:admin) { create(:user, name: 'admin') }
-  let!(:owner) { create(:user, name: 'owner', role: :general_user) }
+  let(:admin) { create(:user, name: 'admin') }
+  let(:owner) { create(:user, name: 'owner', role: :general_user) }
 
   let!(:task1) do
     create(:task, name: 'task1', description: 'a', status: 1,
@@ -42,7 +42,7 @@ RSpec.describe 'task', type: :system do
   end
 
   shared_context 'login as a general user' do
-    let!(:general) { create(:user, name: 'general', role: :general_user) }
+    let(:general) { create(:user, name: 'general', role: :general_user) }
     let!(:auth3) { create(:auth, user: general, email: 'abcde@example.com', password: 'password') }
     before do
       visit '/login'

--- a/neko/spec/system/task_spec.rb
+++ b/neko/spec/system/task_spec.rb
@@ -4,7 +4,19 @@ RSpec.describe 'task', type: :system do
   let(:admin) { create(:user, name: 'admin') }
   let(:owner) { create(:user, name: 'owner', role: :general_user) }
 
-  let(:task) do
+  let!(:task1) do
+    create(:task, name: 'task1', description: 'a', status: 1,
+                  have_a_due: true, due_at: Time.zone.local(2020, 9, 30, 17, 30), user: admin)
+  end
+  let!(:task2) do
+    create(:task, name: 'task2', description: 'c', status: 2,
+                  have_a_due: false, due_at: Time.zone.local(2020, 7, 10, 10, 15), user: admin)
+  end
+  let!(:task3) do
+    create(:task, name: 'task3', description: 'b', status: 0,
+                  have_a_due: true, due_at: Time.zone.local(2020, 8, 15, 16, 59), user: admin)
+  end
+  let!(:task4) do
     create(:task, name: 'task4', description: 'e', status: 0,
                   have_a_due: true, due_at: Time.zone.local(2020, 10, 15, 11, 59), user: owner)
   end
@@ -41,23 +53,6 @@ RSpec.describe 'task', type: :system do
   end
 
   describe '#index' do
-    let!(:task1) do
-      create(:task, name: 'task1', description: 'a', status: 1,
-                    have_a_due: true, due_at: Time.zone.local(2020, 9, 30, 17, 30), user: admin)
-    end
-    let!(:task2) do
-      create(:task, name: 'task2', description: 'c', status: 2,
-                    have_a_due: false, due_at: Time.zone.local(2020, 7, 10, 10, 15), user: admin)
-    end
-    let!(:task3) do
-      create(:task, name: 'task3', description: 'b', status: 0,
-                    have_a_due: true, due_at: Time.zone.local(2020, 8, 15, 16, 59), user: admin)
-    end
-    let!(:task4) do
-      create(:task, name: 'task4', description: 'e', status: 0,
-                    have_a_due: true, due_at: Time.zone.local(2020, 10, 15, 11, 59), user: owner)
-    end
-
     include_context 'login as an administrator'
     before { visit tasks_path }
     context 'accress root' do
@@ -149,9 +144,9 @@ RSpec.describe 'task', type: :system do
     context 'access edit_task_path as administrator' do
       include_context 'login as an administrator'
       it 'could not access' do
-        visit task_path(task.id)
+        visit task_path(task4.id)
 
-        expect(page).to have_current_path task_path(task.id)
+        expect(page).to have_current_path task_path(task4.id)
         expect(page).to have_content 'task4'
         expect(page).to have_content 'e'
         expect(page).to have_content '未着手'
@@ -163,16 +158,16 @@ RSpec.describe 'task', type: :system do
     context 'access edit_task_path as owner' do
       include_context 'login as owner'
       it 'could not access' do
-        visit task_path(task.id)
+        visit task_path(task4.id)
 
-        expect(page).to have_current_path task_path(task.id)
+        expect(page).to have_current_path task_path(task4.id)
       end
     end
 
     context 'access edit_task_path as general user' do
       include_context 'login as a general user'
       it 'could not access' do
-        visit task_path(task.id)
+        visit task_path(task4.id)
 
         expect(page).to have_current_path root_path
         expect(page).to have_content '管理者かもしくは作成者でなればアクセスできません'
@@ -182,14 +177,14 @@ RSpec.describe 'task', type: :system do
 
   describe '#edit (GET /tasks/:id/edit)' do
     include_context 'login as an administrator'
-    before { visit edit_task_path(task.id) }
+    before { visit edit_task_path(task1.id) }
     context 'name is more than 2 letters' do
       it 'should be success to update' do
         fill_in '名前', with: 'hogehoge'
         fill_in '説明', with: 'fugaguga'
 
         click_on '更新する'
-        expect(page).to have_current_path task_path(task.id)
+        expect(page).to have_current_path task_path(task1.id)
         expect(page).to have_content 'タスクを更新しました'
       end
     end
@@ -200,7 +195,7 @@ RSpec.describe 'task', type: :system do
         fill_in '説明', with: 'piyopiyo'
 
         click_on '更新する'
-        expect(page).to have_current_path task_path(task.id)
+        expect(page).to have_current_path task_path(task1.id)
         expect(page).to have_content 'タスクの更新に失敗しました'
         expect(page).to have_content '名前は2文字以上で入力してください'
       end
@@ -211,16 +206,16 @@ RSpec.describe 'task', type: :system do
     context 'access edit_task_path as general user' do
       include_context 'login as an administrator'
       it 'could not access' do
-        visit edit_task_path(task.id)
+        visit edit_task_path(task4.id)
 
-        expect(page).to have_current_path edit_task_path(task.id)
+        expect(page).to have_current_path edit_task_path(task4.id)
       end
     end
 
     context 'access edit_task_path as general user' do
       include_context 'login as a general user'
       it 'could not access' do
-        visit edit_task_path(task.id)
+        visit edit_task_path(task4.id)
 
         expect(page).to have_current_path root_path
         expect(page).to have_content '管理者かもしくは作成者でなればアクセスできません'
@@ -230,22 +225,22 @@ RSpec.describe 'task', type: :system do
     context 'access edit_task_path as owner' do
       include_context 'login as owner'
       it 'could not access' do
-        visit edit_task_path(task.id)
+        visit edit_task_path(task4.id)
 
-        expect(page).to have_current_path edit_task_path(task.id)
+        expect(page).to have_current_path edit_task_path(task4.id)
       end
     end
   end
 
   describe '#delete (DELETE /tasks/:id)', js: true do
-    include_context 'login as owner'
-    before { visit task_path(task.id) }
-    context 'delete a label' do
+    include_context 'login as an administrator'
+    before { visit task_path(task1.id) }
+    context 'delete a general label' do
       it 'able to cancel' do
         expect {
           click_on '削除'
           expect(page.dismiss_confirm).to eq 'タスクを削除しますか？'
-          expect(page).to have_current_path task_path(task.id)
+          expect(page).to have_current_path task_path(task1.id)
         }.to change(Task, :count).by(0)
       end
 

--- a/neko/spec/system/task_spec.rb
+++ b/neko/spec/system/task_spec.rb
@@ -4,19 +4,7 @@ RSpec.describe 'task', type: :system do
   let(:admin) { create(:user, name: 'admin') }
   let(:owner) { create(:user, name: 'owner', role: :general_user) }
 
-  let!(:task1) do
-    create(:task, name: 'task1', description: 'a', status: 1,
-                  have_a_due: true, due_at: Time.zone.local(2020, 9, 30, 17, 30), user: admin)
-  end
-  let!(:task2) do
-    create(:task, name: 'task2', description: 'c', status: 2,
-                  have_a_due: false, due_at: Time.zone.local(2020, 7, 10, 10, 15), user: admin)
-  end
-  let!(:task3) do
-    create(:task, name: 'task3', description: 'b', status: 0,
-                  have_a_due: true, due_at: Time.zone.local(2020, 8, 15, 16, 59), user: admin)
-  end
-  let!(:task4) do
+  let(:task) do
     create(:task, name: 'task4', description: 'e', status: 0,
                   have_a_due: true, due_at: Time.zone.local(2020, 10, 15, 11, 59), user: owner)
   end
@@ -53,6 +41,23 @@ RSpec.describe 'task', type: :system do
   end
 
   describe '#index' do
+    let!(:task1) do
+      create(:task, name: 'task1', description: 'a', status: 1,
+                    have_a_due: true, due_at: Time.zone.local(2020, 9, 30, 17, 30), user: admin)
+    end
+    let!(:task2) do
+      create(:task, name: 'task2', description: 'c', status: 2,
+                    have_a_due: false, due_at: Time.zone.local(2020, 7, 10, 10, 15), user: admin)
+    end
+    let!(:task3) do
+      create(:task, name: 'task3', description: 'b', status: 0,
+                    have_a_due: true, due_at: Time.zone.local(2020, 8, 15, 16, 59), user: admin)
+    end
+    let!(:task4) do
+      create(:task, name: 'task4', description: 'e', status: 0,
+                    have_a_due: true, due_at: Time.zone.local(2020, 10, 15, 11, 59), user: owner)
+    end
+
     include_context 'login as an administrator'
     before { visit tasks_path }
     context 'accress root' do
@@ -144,9 +149,9 @@ RSpec.describe 'task', type: :system do
     context 'access edit_task_path as administrator' do
       include_context 'login as an administrator'
       it 'could not access' do
-        visit task_path(task4.id)
+        visit task_path(task.id)
 
-        expect(page).to have_current_path task_path(task4.id)
+        expect(page).to have_current_path task_path(task.id)
         expect(page).to have_content 'task4'
         expect(page).to have_content 'e'
         expect(page).to have_content '未着手'
@@ -158,16 +163,16 @@ RSpec.describe 'task', type: :system do
     context 'access edit_task_path as owner' do
       include_context 'login as owner'
       it 'could not access' do
-        visit task_path(task4.id)
+        visit task_path(task.id)
 
-        expect(page).to have_current_path task_path(task4.id)
+        expect(page).to have_current_path task_path(task.id)
       end
     end
 
     context 'access edit_task_path as general user' do
       include_context 'login as a general user'
       it 'could not access' do
-        visit task_path(task4.id)
+        visit task_path(task.id)
 
         expect(page).to have_current_path root_path
         expect(page).to have_content '管理者かもしくは作成者でなればアクセスできません'
@@ -177,14 +182,14 @@ RSpec.describe 'task', type: :system do
 
   describe '#edit (GET /tasks/:id/edit)' do
     include_context 'login as an administrator'
-    before { visit edit_task_path(task1.id) }
+    before { visit edit_task_path(task.id) }
     context 'name is more than 2 letters' do
       it 'should be success to update' do
         fill_in '名前', with: 'hogehoge'
         fill_in '説明', with: 'fugaguga'
 
         click_on '更新する'
-        expect(page).to have_current_path task_path(task1.id)
+        expect(page).to have_current_path task_path(task.id)
         expect(page).to have_content 'タスクを更新しました'
       end
     end
@@ -195,7 +200,7 @@ RSpec.describe 'task', type: :system do
         fill_in '説明', with: 'piyopiyo'
 
         click_on '更新する'
-        expect(page).to have_current_path task_path(task1.id)
+        expect(page).to have_current_path task_path(task.id)
         expect(page).to have_content 'タスクの更新に失敗しました'
         expect(page).to have_content '名前は2文字以上で入力してください'
       end
@@ -206,16 +211,16 @@ RSpec.describe 'task', type: :system do
     context 'access edit_task_path as general user' do
       include_context 'login as an administrator'
       it 'could not access' do
-        visit edit_task_path(task4.id)
+        visit edit_task_path(task.id)
 
-        expect(page).to have_current_path edit_task_path(task4.id)
+        expect(page).to have_current_path edit_task_path(task.id)
       end
     end
 
     context 'access edit_task_path as general user' do
       include_context 'login as a general user'
       it 'could not access' do
-        visit edit_task_path(task4.id)
+        visit edit_task_path(task.id)
 
         expect(page).to have_current_path root_path
         expect(page).to have_content '管理者かもしくは作成者でなればアクセスできません'
@@ -225,22 +230,22 @@ RSpec.describe 'task', type: :system do
     context 'access edit_task_path as owner' do
       include_context 'login as owner'
       it 'could not access' do
-        visit edit_task_path(task4.id)
+        visit edit_task_path(task.id)
 
-        expect(page).to have_current_path edit_task_path(task4.id)
+        expect(page).to have_current_path edit_task_path(task.id)
       end
     end
   end
 
   describe '#delete (DELETE /tasks/:id)', js: true do
-    include_context 'login as an administrator'
-    before { visit task_path(task1.id) }
-    context 'delete a general label' do
+    include_context 'login as owner'
+    before { visit task_path(task.id) }
+    context 'delete a label' do
       it 'able to cancel' do
         expect {
           click_on '削除'
           expect(page.dismiss_confirm).to eq 'タスクを削除しますか？'
-          expect(page).to have_current_path task_path(task1.id)
+          expect(page).to have_current_path task_path(task.id)
         }.to change(Task, :count).by(0)
       end
 


### PR DESCRIPTION
## 概要
- 主に前ステップでZackyさんからアドバイスを頂いた内容を修正しています。
内容: https://github.com/Fablic/training/pull/676#issuecomment-646534325

## やったこと
- [x] 遅延評価で動かせる箇所の`let!`を`let`に修正
（遅延評価でも動くがテストの趣旨とずれるものに関してはそのままに）

- [x] テストのパフォーマンスが上がるようリファクタリング
- [x] `application_controller.rb`の中身が増えてきたため、セッション関連の処理を<br>`/concern/session_hundle.rb`に切り分け
- [x] モデルスペックのテストデータの記述を変更

## 備考
`spec/models/user_spec.rb` と `spec/models/label_spec.rb`の削除に関するテストにおいて、<br>capybaraでの削除リンクの指定をとりあえずで書いたもののしっくり来ておらず、、他に何か可読性が良い書き方をご存知でしたら教えていただけると幸いです:bow: