### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替えましょう 

### DIFF
--- a/task_management/app/controllers/tasks_controller.rb
+++ b/task_management/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def show

--- a/task_management/spec/rails_helper.rb
+++ b/task_management/spec/rails_helper.rb
@@ -31,6 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/task_management/spec/system/tasks_spec.rb
+++ b/task_management/spec/system/tasks_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_content '未着手'
       expect(page).to have_content task.due
     end
+
+    context '複数のタスクが表示されている場合' do
+      let!(:old_task) { FactoryBot.create(:task, title: 'Old Task ', created_at: Time.now) }
+      let!(:new_task) { FactoryBot.create(:task, title: 'New Task', created_at: Time.now + 1.second) }
+
+      it 'タスクが作成日の降順で表示されている' do
+        visit current_path
+        expect(new_task.created_at.time > old_task.created_at.time).to be true
+        expect(page.body.index(new_task.title)).to be < page.body.index(old_task.title)
+      end
+    end
   end
 
   describe '#show' do

--- a/task_management/spec/system/tasks_spec.rb
+++ b/task_management/spec/system/tasks_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     context '複数のタスクが表示されている場合' do
-      let!(:old_task) { FactoryBot.create(:task, title: 'Old Task ', created_at: Time.now) }
-      let!(:new_task) { FactoryBot.create(:task, title: 'New Task', created_at: Time.now + 1.second) }
+      let!(:old_task) { FactoryBot.create(:task, title: 'OLD', created_at: Time.now) }
+      let!(:new_task) { FactoryBot.create(:task, title: 'NEW', created_at: Time.now + 1.second) }
 
       it 'タスクが作成日の降順で表示されている' do
         visit current_path

--- a/task_management/spec/system/tasks_spec.rb
+++ b/task_management/spec/system/tasks_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
-  let!(:task) { FactoryBot.create(:task) }
+  let!(:task) { create(:task) }
 
   describe '#index' do
     before do
@@ -16,8 +16,8 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     context '複数のタスクが表示されている場合' do
-      let!(:old_task) { FactoryBot.create(:task, title: 'OLD', created_at: Time.now) }
-      let!(:new_task) { FactoryBot.create(:task, title: 'NEW', created_at: Time.now + 1.second) }
+      let!(:old_task) { create(:task, title: 'OLD', created_at: Time.now) }
+      let!(:new_task) { create(:task, title: 'NEW', created_at: Time.now + 1.second) }
 
       it 'タスクが作成日の降順で表示されている' do
         visit current_path


### PR DESCRIPTION
### 概要
[ステップ10: タスク一覧を作成日時の順番で並び替えましょう ](https://github.com/Fablic/training/tree/satoshi-kwn#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

### 実施内容
・タスク一覧画面に作成日の降順でタスク情報が表示されるよう実装
・上記機能のテスト作成

### その他
・デフォルト設定のままのrubocopを利用しています。
・下記のrubocopのエラーは対応していません。対応の必要があればご指摘ください。
　-自動生成されたコードに対するエラー
　-本ステップ以前のレビューアーの方から対応が不要であると指摘を受けたエラー
　　「Airbnb/OptArgParameters:〜」
　　「Style/PercentLiteralDelimiters:〜」