### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/task_management/app/controllers/tasks_controller.rb
+++ b/task_management/app/controllers/tasks_controller.rb
@@ -4,7 +4,11 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all.order("#{sort_column} #{sort_direction}")
+    @search_params = {
+      title: params[:title], status: params[:status],
+      sort_column: sort_column, sort_direction: sort_direction,
+    }
+    @tasks = Task.search(@search_params)
   end
 
   def show

--- a/task_management/app/models/task.rb
+++ b/task_management/app/models/task.rb
@@ -7,6 +7,15 @@ class Task < ApplicationRecord
   validates :priority, presence: true
   validate :due_valid?
 
+  def self.search(search_params)
+    title_like(search_params[:title]).
+      status_is(search_params[:status]).
+      order("#{search_params[:sort_column]} #{search_params[:sort_direction]}")
+  end
+
+  scope :title_like, -> (title) { where('title LIKE ?', "%#{title}%") if title.present? }
+  scope :status_is, -> (status) { where(status: status) if status.present? }
+
   private
 
   def due_valid?

--- a/task_management/app/models/task.rb
+++ b/task_management/app/models/task.rb
@@ -13,7 +13,7 @@ class Task < ApplicationRecord
       order("#{search_params[:sort_column]} #{search_params[:sort_direction]}")
   end
 
-  scope :title_like, -> (title) { where('title LIKE ?', "%#{title}%") if title.present? }
+  scope :title_like, -> (title) { where('title LIKE ?', "%#{sanitize_sql_like(title)}%") if title.present? }
   scope :status_is, -> (status) { where(status: status) if status.present? }
 
   private

--- a/task_management/app/views/tasks/index.html.erb
+++ b/task_management/app/views/tasks/index.html.erb
@@ -6,6 +6,17 @@
     <%= message %>
   <div>
 <% end %>
+<%= form_with url: tasks_path, method: :get, local: true do |f| %>
+  <div>
+    <%= f.label I18n.t('activerecord.attributes.task.title') %>
+    <%= f.text_field :title, value: @search_params[:title] %>
+  </div>
+  <div>
+    <%= f.label I18n.t('activerecord.attributes.task.status') %>
+    <%= f.select :status, Task.statuses_i18n.invert, { include_blank: true, selected: @search_params[:status] } %>
+  </div>
+  <%= f.submit I18n.t('tasks.button') %>
+<% end %>
 <%# 暫定対応：テーブルのレイアウトはCSSで整える予定だが、現時点ではCSSを使うステップにいない為、border="1"を使用 %>
 <table border="1">
   <tr>

--- a/task_management/db/migrate/20200706023821_add_index_to_tasks.rb
+++ b/task_management/db/migrate/20200706023821_add_index_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/task_management/db/schema.rb
+++ b/task_management/db/schema.rb
@@ -25,11 +25,4 @@ ActiveRecord::Schema.define(version: 2020_07_06_023821) do
     t.index ["status"], name: "index_tasks_on_status"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "mail_address", null: false
-    t.string "password_digest", null: false
-    t.integer "role", limit: 1, null: false
-  end
-
 end

--- a/task_management/db/schema.rb
+++ b/task_management/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_26_025302) do
+ActiveRecord::Schema.define(version: 2020_07_06_023821) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "user_id"
@@ -22,6 +22,14 @@ ActiveRecord::Schema.define(version: 2020_06_26_025302) do
     t.integer "label_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status"], name: "index_tasks_on_status"
+  end
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "mail_address", null: false
+    t.string "password_digest", null: false
+    t.integer "role", limit: 1, null: false
   end
 
 end

--- a/task_management/spec/models/task_spec.rb
+++ b/task_management/spec/models/task_spec.rb
@@ -122,4 +122,61 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe '検索機能' do
+    subject { Task.search(search_params) }
+
+    let!(:task1) { create(:task, title: 'task1', status: 0) }
+    let!(:task2) { create(:task, title: '2task2', status: 1) }
+    let!(:task3) { create(:task, title: '3task', status: 2) }
+    let!(:task4) { create(:task, title: 'English', status: 2) }
+
+    context 'タイトルで検索した場合' do
+      context 'タイトルを入力して検索した場合' do
+        let(:search_params) { { title: 'task' } }
+
+        it '部分一致したタスクが出力される' do
+          expect(subject.size).to eq 3
+          expect(subject[0]).to eq task1
+          expect(subject[1]).to eq task2
+          expect(subject[2]).to eq task3
+        end
+      end
+
+      context 'タイトルを入力せずに検索した場合' do
+        let(:search_params) { {} }
+
+        it '全てのタスクが出力される' do
+          expect(subject.size).to eq 4
+          expect(subject[0]).to eq task1
+          expect(subject[1]).to eq task2
+          expect(subject[2]).to eq task3
+          expect(subject[3]).to eq task4
+        end
+      end
+    end
+
+    context 'ステータスで検索した場合' do
+      context 'ステータスを指定した場合' do
+        let(:search_params) { { status: 1 } }
+
+        it '着手中のタスクが出力される' do
+          expect(subject.size).to eq 1
+          expect(subject[0]).to eq task2
+        end
+      end
+
+      context 'ステータスを指定しない場合' do
+        let(:search_params) { {} }
+
+        it '全てのタスクが出力される' do
+          expect(subject.size).to eq 4
+          expect(subject[0]).to eq task1
+          expect(subject[1]).to eq task2
+          expect(subject[2]).to eq task3
+          expect(subject[3]).to eq task4
+        end
+      end
+    end
+  end
 end

--- a/task_management/spec/system/tasks_spec.rb
+++ b/task_management/spec/system/tasks_spec.rb
@@ -56,6 +56,37 @@ RSpec.describe 'Tasks', type: :system do
         end
       end
     end
+
+    context '検索機能を使用した場合' do
+      subject { Task.search(search_params) }
+
+      let!(:task1) { create(:task, title: 'task1', status: 0) }
+      let!(:task2) { create(:task, title: '2task2', status: 1) }
+      let!(:task3) { create(:task, title: '3task', status: 2) }
+      let!(:task4) { create(:task, title: 'English', status: 2) }
+
+      context 'タイトルで検索した場合' do
+        it '入力された値と部分一致したタスクが表示される' do
+          fill_in 'title', with: 'task'
+          click_button '送信'
+          # table headerの行数を１引く
+          expect(page.find('table').all('tr').length - 1).to eq(3)
+          expect(page).to have_content 'task1'
+          expect(page).to have_content '2task2'
+          expect(page).to have_content '3task'
+        end
+      end
+
+      context 'ステータスで検索した場合' do
+        it '指定されたステータスに合致するタスクが表示される' do
+          select '着手', from: 'status'
+          click_button '送信'
+          # table headerの行数を１引く
+          expect(page.find('table').all('tr').length - 1).to eq(1)
+          expect(page).to have_content '2task2'
+        end
+      end
+    end
   end
 
   describe '#show' do


### PR DESCRIPTION
### 概要
[ステップ13: ステータスを追加して、検索できるようにしよう ](https://github.com/Fablic/training/tree/satoshi-kwn#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)

### 実施内容
・タスク一覧画面に検索機能を実装
・ステータスに検索インデックスを貼る
・上記機能のテスト作成

### その他
・デフォルト設定のままのrubocopを利用しています。
・下記のrubocopのエラーは対応していません。対応の必要があればご指摘ください。
　-自動生成されたコードに対するエラー
　-本ステップ以前のレビューアーの方から対応が不要であると指摘を受けたエラー
　　「Airbnb/OptArgParameters:〜」
　　「Style/PercentLiteralDelimiters:〜」
　-自身で対応不要と判断したもの
　　「RiskyActiverecordInvocation」
　　　パラメータチェックも行っており、指摘箇所でSQLインジェクションが発生するリスクはないと判断したため。

### 動作確認
![step13](https://user-images.githubusercontent.com/54238761/86561329-5aa7bd80-bf9b-11ea-9c46-3ae18a4b94d7.gif)