### PR TITLE
ステップ18: ユーザの管理画面を実装しよう

### DIFF
--- a/task_management/app/controllers/admin/users_controller.rb
+++ b/task_management/app/controllers/admin/users_controller.rb
@@ -1,0 +1,49 @@
+class Admin::UsersController < ApplicationController
+  before_action :set_user, only: %i[show edit update destroy]
+
+  def index
+    @users = User.includes(:tasks).all.page(params[:page])
+  end
+
+  def show
+    @tasks = @user.tasks.order(created_at: :desc).page(params[:page])
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_users_path, notice: I18n.t('users.flash.create')
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_users_path, notice: I18n.t('users.flash.update')
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @user.destroy if redirect_to admin_users_path, notice: I18n.t('users.flash.destroy')
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :mail_address, :password, :password_confirmation)
+  end
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+end

--- a/task_management/app/models/user.rb
+++ b/task_management/app/models/user.rb
@@ -1,4 +1,15 @@
 class User < ApplicationRecord
+  before_save { self.mail_address = mail_address.downcase }
+
   has_secure_password
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
+
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_PASSWORD_REGEX =/\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[\d])\w{6,100}\z/
+
+  validates :name, presence: true
+  validates :mail_address, { presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } }
+  validates :password, presence: true,
+            format: { with: VALID_PASSWORD_REGEX,
+            message: I18n.t('errors.message.invalid_mail_address') }, allow_nil: true
 end

--- a/task_management/app/models/user.rb
+++ b/task_management/app/models/user.rb
@@ -4,12 +4,17 @@ class User < ApplicationRecord
   has_secure_password
   has_many :tasks, dependent: :destroy
 
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  VALID_PASSWORD_REGEX =/\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[\d])\w{6,100}\z/
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[\d])\w{6,100}\z/.freeze
 
   validates :name, presence: true
-  validates :mail_address, { presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } }
+  validates :mail_address, {
+    presence: true, format: { with: VALID_EMAIL_REGEX },
+    uniqueness: { case_sensitive: false },
+  }
   validates :password, presence: true,
-            format: { with: VALID_PASSWORD_REGEX,
-            message: I18n.t('errors.message.invalid_mail_address') }, allow_nil: true
+                       format: {
+                         with: VALID_PASSWORD_REGEX,
+                         message: I18n.t('errors.message.invalid_mail_address'),
+                       }, allow_nil: true
 end

--- a/task_management/app/views/admin/users/_input_form.html.erb
+++ b/task_management/app/views/admin/users/_input_form.html.erb
@@ -5,15 +5,15 @@
   </div>
   <div class="form-group">
     <%= f.label :mail_address %>
-    <%= f.text_field :mail_address, class: 'form-control' %>
+    <%= f.email_field :mail_address, class: 'form-control' %>
   </div>
   <div class="form-group">
     <%= f.label :password %>
-    <%= f.text_field :password, class: 'form-control' %>
+    <%= f.password_field :password, class: 'form-control' %>
   </div>
   <div class="form-group">
     <%= f.label :password_confirmation %>
-    <%= f.text_field :password_confirmation, class: 'form-control' %>
+    <%= f.password_field :password_confirmation, class: 'form-control' %>
   </div>
   <div>
     <%= link_to I18n.t('link.back'), admin_users_path, class: 'btn btn-dark' %>

--- a/task_management/app/views/admin/users/_input_form.html.erb
+++ b/task_management/app/views/admin/users/_input_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with model: [:admin, @user], local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :mail_address %>
+    <%= f.text_field :mail_address, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :password %>
+    <%= f.text_field :password, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :password_confirmation %>
+    <%= f.text_field :password_confirmation, class: 'form-control' %>
+  </div>
+  <div>
+    <%= link_to I18n.t('link.back'), admin_users_path, class: 'btn btn-dark' %>
+    <% if request.path_info == new_admin_user_path %>
+      <%= f.submit I18n.t('button.register'), class: 'btn btn-primary' %>
+    <% else %>
+      <%= f.submit I18n.t('button.update'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+<% end %>

--- a/task_management/app/views/admin/users/edit.html.erb
+++ b/task_management/app/views/admin/users/edit.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/error_message', model: @user %>
+<div>
+  <h2><%= I18n.t('users.edit.title') %></h2>
+</div>
+<%= render 'input_form' %>

--- a/task_management/app/views/admin/users/index.html.erb
+++ b/task_management/app/views/admin/users/index.html.erb
@@ -1,0 +1,29 @@
+<div>
+  <h2><%= I18n.t('users.index.title') %></h2>
+</div>
+<%= link_to I18n.t('link.new'),  new_admin_user_path %>
+<table class="table table-striped">
+  <thead class="thead-dark">
+    <tr>
+      <th><%= I18n.t('activerecord.attributes.user.name') %></th>
+      <th><%= I18n.t('activerecord.attributes.user.mail_address') %></th>
+      <th><%= I18n.t('activerecord.attributes.user.task_count') %></th>
+      <th><%= I18n.t('activerecord.attributes.common.created_at') %></th>
+      <th><%= I18n.t('link.edit') %></th>
+      <th><%= I18n.t('link.delete') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |u| %>
+      <tr>
+        <td><%= link_to u.name, admin_user_path(u.id) %></td>
+        <td><%= u.mail_address %></td>
+        <td><%= u.tasks.size %></td>
+        <td><%= l u.created_at %></td>
+        <td><%= link_to I18n.t('link.edit'), edit_admin_user_path(u.id), class: 'btn btn-secondary btn-sm' %></td>
+        <td><%= link_to I18n.t('link.delete'), admin_user_path(u.id), method: :delete, data: { confirm: I18n.t('confirm.delete') }, class: 'btn btn-danger btn-sm' %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate @users %>

--- a/task_management/app/views/admin/users/new.html.erb
+++ b/task_management/app/views/admin/users/new.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/error_message', model: @user %>
+<div>
+  <h2><%= I18n.t('users.new.title') %></h2>
+</div>
+<%= render 'input_form' %>

--- a/task_management/app/views/admin/users/show.html.erb
+++ b/task_management/app/views/admin/users/show.html.erb
@@ -1,0 +1,74 @@
+<div>
+  <h2><%= I18n.t('users.show.title') %></h2>
+</div>
+<br/>
+<h4><%= I18n.t('users.show.user_info') %></h4>
+<table class="table">
+  <tbody>
+    <tr>
+      <th class="w-25">
+        <label><%= I18n.t('activerecord.attributes.user.id') %></label>
+      </th>
+      <td>
+        <%= @user.id%>
+      </td>
+    </tr>
+    <tr>
+      <th class="w-25">
+        <label><%= I18n.t('activerecord.attributes.user.name') %></label>
+      </th>
+      <td>
+        <%= @user.name%>
+      </td>
+    </tr>
+    <tr>
+      <th class="w-25">
+        <label><%= I18n.t('activerecord.attributes.user.mail_address') %></label>
+      </th>
+      <td>
+        <%= @user.mail_address%>
+      </td>
+    </tr>
+    <tr>
+      <th class="w-25">
+        <label><%= I18n.t('activerecord.attributes.common.created_at') %></label>
+      </th>
+      <td>
+        <%= l @user.created_at%>
+      </td>
+    </tr>
+    <tr class="w-25">
+      <th>
+        <label><%= I18n.t('activerecord.attributes.common.updated_at') %></label>
+      </th>
+      <td>
+        <%= l @user.updated_at%>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4><%= I18n.t('users.show.task_info') %></h4>
+<table class="table table-striped">
+  <thead class="thead-dark">
+    <tr>
+      <th class="w-25"><%= I18n.t('activerecord.attributes.task.title') %></th>
+      <th><%= I18n.t('activerecord.attributes.task.priority') %></th>
+      <th class="w-15"><%= I18n.t('activerecord.attributes.task.status') %></th>
+      <th class="w-15"><%= I18n.t('activerecord.attributes.task.due') %></th>
+      <th><%= I18n.t('activerecord.attributes.common.created_at') %></th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @tasks.each do |t| %>
+    <tr>
+      <td><%= t.title %></td>
+      <td><%= t.priority_i18n %></td>
+      <td><%= t.status_i18n %></td>
+      <td><%= t.due %></td>
+      <td><%= l t.created_at %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+<%= paginate @tasks %>
+<%= link_to I18n.t('link.back'), admin_users_path, class: 'btn btn-dark' %>

--- a/task_management/app/views/layouts/application.html.erb
+++ b/task_management/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
       <% if current_user %>
         <ul class="navbar-nav ml-auto">
           <li class="nav-item">
-            <%= link_to I18n.t('navbar.link.logout'), logout_path, method: :delete, class: 'nav-link' %>
+            <%= link_to I18n.t('link.logout'), logout_path, method: :delete, class: 'nav-link' %>
           </li>
         </ul>
       <% end %>

--- a/task_management/app/views/sessions/new.html.erb
+++ b/task_management/app/views/sessions/new.html.erb
@@ -8,5 +8,5 @@
     <%= f.label :password, I18n.t('activerecord.attributes.user.password') %>
     <%= f.password_field :password, class: 'form-control' %>
   </div>
-  <%= f.submit I18n.t('sessions.button.login'), class: 'btn btn-primary' %>
+  <%= f.submit I18n.t('button.login'), class: 'btn btn-primary' %>
 <% end %>

--- a/task_management/app/views/shared/_error_message.html.erb
+++ b/task_management/app/views/shared/_error_message.html.erb
@@ -1,7 +1,7 @@
-<% if @task.errors.any? %>
+<% if model.errors.any? %>
   <div class="alert alert-danger">
     <ul class="list-unstyled">
-      <% @task.errors.full_messages.each do |message| %>
+      <% model.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>

--- a/task_management/app/views/tasks/_input_form.html.erb
+++ b/task_management/app/views/tasks/_input_form.html.erb
@@ -22,11 +22,11 @@
     <%= f.text_area :description, class: 'form-control' %>
   </div>
   <div>
-    <%= link_to I18n.t('tasks.link.back'), tasks_path, class: 'btn btn-dark' %>
+    <%= link_to I18n.t('link.back'), tasks_path, class: 'btn btn-dark' %>
     <% if request.path_info == new_task_path %>
-      <%= f.submit I18n.t('tasks.button.register'), class: 'btn btn-primary' %>
+      <%= f.submit I18n.t('button.register'), class: 'btn btn-primary' %>
     <%else%>
-      <%= f.submit I18n.t('tasks.button.update'), class: 'btn btn-primary' %>
+      <%= f.submit I18n.t('button.update'), class: 'btn btn-primary' %>
     <% end%>
   <div>
 <% end %>

--- a/task_management/app/views/tasks/edit.html.erb
+++ b/task_management/app/views/tasks/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/error_message' %>
+<%= render 'shared/error_message', model: @task %>
 <div>
   <h2><%= I18n.t('tasks.edit.title') %></h2>
 <div>

--- a/task_management/app/views/tasks/index.html.erb
+++ b/task_management/app/views/tasks/index.html.erb
@@ -11,10 +11,10 @@
     <%= f.select :status, Task.statuses_i18n.invert, { include_blank: true, selected: @search_params[:status] }, class: 'form-control' %>
   </div>
   <div class="form-group mx-sm-3 mb-2">
-    <%= f.submit I18n.t('tasks.button.search'), class: 'btn btn-primary' %>
+    <%= f.submit I18n.t('button.search'), class: 'btn btn-primary' %>
   </div>
 <% end %>
-<%= link_to I18n.t('tasks.link.new'), new_task_path %>
+<%= link_to I18n.t('link.new'), new_task_path %>
 <table class="table table-striped">
   <thead class="thead-dark">
     <tr>
@@ -22,8 +22,8 @@
       <th><%= I18n.t('activerecord.attributes.task.priority') %></th>
       <th class="w-15"><%= I18n.t('activerecord.attributes.task.status') %></th>
       <th class="w-15"><%= sortable 'due', I18n.t('activerecord.attributes.task.due') %></th>
-      <th><%= I18n.t('tasks.link.edit') %></th>
-      <th><%= I18n.t('tasks.link.delete') %></th>
+      <th><%= I18n.t('link.edit') %></th>
+      <th><%= I18n.t('link.delete') %></th>
     </tr>
   </thead>
   <tbody>
@@ -33,8 +33,8 @@
         <td><%= t.priority_i18n %></td>
         <td><%= t.status_i18n %></td>
         <td><%= t.due %></td>
-        <td><%= link_to I18n.t('tasks.link.edit'), edit_task_path(t.id), class: 'btn btn-secondary btn-sm' %></td>
-        <td><%= link_to I18n.t('tasks.link.delete'), task_path(t.id), method: :delete, data: { confirm: I18n.t('tasks.confirm.delete') }, class: 'btn btn-danger btn-sm' %></td>
+        <td><%= link_to I18n.t('link.edit'), edit_task_path(t.id), class: 'btn btn-secondary btn-sm' %></td>
+        <td><%= link_to I18n.t('link.delete'), task_path(t.id), method: :delete, data: { confirm: I18n.t('confirm.delete') }, class: 'btn btn-danger btn-sm' %></td>
       </tr>
     <% end %>
   </tbody>

--- a/task_management/app/views/tasks/new.html.erb
+++ b/task_management/app/views/tasks/new.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/error_message' %>
+<%= render 'shared/error_message', model: @task %>
 <div>
   <h2><%= I18n.t('tasks.new.title') %></h2>
 <div>

--- a/task_management/app/views/tasks/show.html.erb
+++ b/task_management/app/views/tasks/show.html.erb
@@ -45,4 +45,4 @@
     </tr>
   </tbody>
 </table>
-<%= link_to I18n.t('tasks.link.back'), tasks_path, class: 'btn btn-dark' %>
+<%= link_to I18n.t('link.back'), tasks_path, class: 'btn btn-dark' %>

--- a/task_management/config/locales/model.ja.yml
+++ b/task_management/config/locales/model.ja.yml
@@ -8,8 +8,15 @@ ja:
         due: 期限
         description: 説明
       user:
+        id: ユーザID
+        name: ユーザ名
         mail_address: メールアドレス
         password: パスワード
+        password_confirmation: パスワード確認
+        task_count: タスク数
+      common:
+        created_at: 作成日時
+        updated_at: 更新日時
   enums:
     task:
       priority:
@@ -20,6 +27,7 @@ ja:
         waiting: 未着手
         working: 着手
         completed: 完了
-  erroes:
+  errors:
     message:
       invalid_date: 無効な日付です
+      invalid_mail_address: は半角6~100文字英大文字・小文字・数字それぞれ１文字以上含む必要があります

--- a/task_management/config/locales/view.ja.yml
+++ b/task_management/config/locales/view.ja.yml
@@ -8,18 +8,6 @@ ja:
       title: タスク登録
     edit:
       title: タスク編集
-    link:
-      show: 詳細
-      edit: 編集
-      new: 新規登録
-      delete: 削除
-      back: 戻る
-    button:
-      search: 検索
-      update: 更新
-      register: 登録
-    confirm:
-      delete: タスクを削除しますか？
     flash:
       create: タスクが登録されました
       update: タスクが編集されました
@@ -27,13 +15,39 @@ ja:
   sessions:
     new:
       title: ログイン
-    button:
-      login: ログイン
     flash:
       create: ログインに成功しました
       failed_create: ログインに失敗しました
       destroy: ログアウトしました
-
+  users:
+    index:
+      title:  ユーザ一覧
+    show:
+      title: ユーザ詳細
+      user_info: ユーザ情報
+      task_info: タスク情報
+    new:
+      title: ユーザ登録
+    edit:
+      title: ユーザ編集
+    flash:
+      create: ユーザが登録されました
+      update: ユーザが編集されました
+      destroy: ユーザを削除しました
+  button:
+    search: 検索
+    update: 更新
+    register: 登録
+    login: ログイン
+  link:
+    show: 詳細
+    edit: 編集
+    new: 新規登録
+    delete: 削除
+    back: 戻る
+    logout: ログアウト
+  confirm:
+    delete: 削除しますか？
   errors:
     message:
       404: お探しのページが見つかりません。
@@ -47,5 +61,6 @@ ja:
       truncate: "..."
   navbar:
     title: タスク管理
-    link:
-      logout: ログアウト
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"

--- a/task_management/config/routes.rb
+++ b/task_management/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
+  namespace :admin do
+    resources :users
+  end
   root 'tasks#index'
   resources :tasks
   get '*path', to: 'application#render404'

--- a/task_management/spec/factories/users.rb
+++ b/task_management/spec/factories/users.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :user do
     name { 'test_user' }
     sequence(:mail_address) { |n| "test#{n}@example.com" }
-    password { 'password' }
+    password { 'pAssw0rd' }
   end
 end

--- a/task_management/spec/models/user_spec.rb
+++ b/task_management/spec/models/user_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  describe 'バリデーション' do
+    describe 'ユーザ名' do
+      subject { user }
+
+      let!(:user) { build(:user, name: name) }
+
+      context '入力が正しい場合' do
+        let(:name) { 'test_user' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context '空欄の場合' do
+        let(:name) { '' }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+
+    describe 'メールアドレス' do
+      subject { user }
+
+      let!(:user) { build(:user, mail_address: mail_address) }
+
+      context '入力が正しい場合' do
+        let(:mail_address) { 'test1000000@example.com' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context '空欄の場合' do
+        let(:mail_address) { '' }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'メールアドレスに使用できない文字列の場合' do
+        let(:mail_address) { '<>!?@example.com' }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '文字列中に「@」がない場合' do
+        let(:mail_address) { 'testexample.com' }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '既に登録済みのメールアドレスの場合' do
+        let!(:userA) { create(:user) }
+
+        let(:mail_address) { userA.mail_address }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+
+    describe 'パスワード' do
+      subject { user }
+
+      let!(:user) { build(:user, password: password, password_confirmation: password_confirmation) }
+
+      context '入力が正しい場合(半角、及、数字・英小文字、英大文字それぞれ最低１文字以上' do
+        let(:password) { 'pAssw0rd' }
+        let(:password_confirmation) { 'pAssw0rd' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context '空欄の場合' do
+        let(:password) { '' }
+        let(:password_confirmation) { '' }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'パスワードとパスワード確認で内容が異なる場合' do
+        let(:password) { 'pAssw0rd' }
+        let(:password_confirmation) { 'Passw0rd' }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '全角英数字の場合' do
+        let(:password) { 'ｐＡｓｓｗ０ｒｄ' }
+        let(:password_confirmation) { 'ｐＡｓｓｗ０ｒｄ' }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '数字のみ場合' do
+        let(:password) { '12345' }
+        let(:password_confirmation) { '12345' }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '半角数字&英小文字の場合' do
+        let(:password) { 'passw0rd' }
+        let(:password_confirmation) { 'passw0rd' }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+  end
+end

--- a/task_management/spec/system/errors_spec.rb
+++ b/task_management/spec/system/errors_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'error handling', type: :system do
   before do
     visit login_path
     fill_in 'session_mail_address', with: user.mail_address
-    fill_in 'session_password', with: 'password'
+    fill_in 'session_password', with: 'pAssw0rd'
     click_button 'ログイン'
   end
 

--- a/task_management/spec/system/sessions_spec.rb
+++ b/task_management/spec/system/sessions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Sessions', type: :system do
       context '正しい認証情報を入力した場合' do
         it 'タスク一覧画面に遷移する' do
           fill_in 'session_mail_address', with: user.mail_address
-          fill_in 'session_password', with: 'password'
+          fill_in 'session_password', with: 'pAssw0rd'
           click_button 'ログイン'
           expect(page).to have_current_path '/'
           expect(page).to have_content 'ログインに成功しました'
@@ -21,7 +21,7 @@ RSpec.describe 'Sessions', type: :system do
         context '誤ったメールアドレスを入力した場合' do
           it 'ログインに失敗する' do
             fill_in 'session_mail_address', with: 'wrong_mail_address'
-            fill_in 'session_password', with: 'password'
+            fill_in 'session_password', with: 'pAssw0rd'
             click_button 'ログイン'
             expect(page).to have_current_path '/login'
             expect(page).to have_content 'ログインに失敗しました'
@@ -45,7 +45,7 @@ RSpec.describe 'Sessions', type: :system do
     context 'ログアウトした場合' do
       it 'ログイン画面に遷移する' do
         fill_in 'session_mail_address', with: user.mail_address
-        fill_in 'session_password', with: 'password'
+        fill_in 'session_password', with: 'pAssw0rd'
         click_button 'ログイン'
         click_link 'ログアウト'
         expect(page).to have_current_path '/login'

--- a/task_management/spec/system/tasks_spec.rb
+++ b/task_management/spec/system/tasks_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Tasks', type: :system do
   before do
     visit login_path
     fill_in 'session_mail_address', with: task.user.mail_address
-    fill_in 'session_password', with: 'password'
+    fill_in 'session_password', with: 'pAssw0rd'
     click_on 'ログイン'
   end
 
@@ -211,7 +211,7 @@ RSpec.describe 'Tasks', type: :system do
     it 'ダイアログが表示される' do
       page.dismiss_confirm do
         click_link '削除'
-        expect(page.driver.browser.switch_to.alert.text).to eq 'タスクを削除しますか？'
+        expect(page.driver.browser.switch_to.alert.text).to eq '削除しますか？'
       end
     end
 


### PR DESCRIPTION
### 概要
[ステップ18: ユーザの管理画面を実装しよう](https://github.com/Fablic/training/tree/satoshi-kwn#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

### 実施内容
・ユーザ一覧・詳細・作成・編集画面の実装
・userモデルのバリデーションテスト作成
（その他のテストはstep19にまとめて作成しました）

### その他
・デフォルト設定のままのrubocopを利用しています。
・下記のrubocopのエラーは対応していません。対応の必要があればご指摘ください。
　-自動生成されたコードに対するエラー
　-本ステップ以前のレビューアーの方から対応が不要であると指摘を受けたエラー
　　「Airbnb/OptArgParameters:〜」
　　「Style/PercentLiteralDelimiters:〜」
　　「RiskyActiverecordInvocation:〜」

### 動作確認
[こちらで確認ください](https://github.com/Fablic/training/pull/717)