### PR TITLE
ステップ19: ユーザにロールを追加しよう

### DIFF
--- a/task_management/app/controllers/admin/users_controller.rb
+++ b/task_management/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < ApplicationController
   before_action :set_user, only: %i[show edit update destroy]
+  before_action :require_admin
 
   def index
     @users = User.includes(:tasks).all.page(params[:page])
@@ -34,16 +35,29 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
-    @user.destroy if redirect_to admin_users_path, notice: I18n.t('users.flash.destroy')
+    if last_admin_user
+      redirect_to admin_users_path, notice: I18n.t('users.flash.last_admin_user')
+      return
+    end
+
+    redirect_to admin_users_path, notice: I18n.t('users.flash.destroy') if @user.destroy
   end
 
   private
 
   def user_params
-    params.require(:user).permit(:name, :mail_address, :password, :password_confirmation)
+    params.require(:user).permit(:name, :mail_address, :role, :password, :password_confirmation)
   end
 
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def require_admin
+    redirect_to root_path unless current_user.admin?
+  end
+
+  def last_admin_user
+    @user.admin? && User.where(role: :admin).size == 1
   end
 end

--- a/task_management/app/models/user.rb
+++ b/task_management/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   has_secure_password
   has_many :tasks, dependent: :destroy
 
+  enum role: { admin: 0, general: 1 }
+
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[\d])\w{6,100}\z/.freeze
 

--- a/task_management/app/views/admin/users/_input_form.html.erb
+++ b/task_management/app/views/admin/users/_input_form.html.erb
@@ -8,6 +8,10 @@
     <%= f.text_field :mail_address, class: 'form-control' %>
   </div>
   <div class="form-group">
+    <%= f.label :role%>
+    <%= f.select :role, User.roles_i18n.invert, {}, class: 'form-control' %>
+  </div>
+  <div class="form-group">
     <%= f.label :password %>
     <%= f.text_field :password, class: 'form-control' %>
   </div>

--- a/task_management/app/views/admin/users/_input_form.html.erb
+++ b/task_management/app/views/admin/users/_input_form.html.erb
@@ -8,7 +8,7 @@
     <%= f.email_field :mail_address, class: 'form-control' %>
   </div>
   <div class="form-group">
-    <%= f.label :role%>
+    <%= f.label :role %>
     <%= f.select :role, User.roles_i18n.invert, {}, class: 'form-control' %>
   </div>
   <div class="form-group">

--- a/task_management/app/views/admin/users/index.html.erb
+++ b/task_management/app/views/admin/users/index.html.erb
@@ -8,6 +8,7 @@
       <th><%= I18n.t('activerecord.attributes.user.name') %></th>
       <th><%= I18n.t('activerecord.attributes.user.mail_address') %></th>
       <th><%= I18n.t('activerecord.attributes.user.task_count') %></th>
+      <th><%= I18n.t('activerecord.attributes.user.role') %></th>
       <th><%= I18n.t('activerecord.attributes.common.created_at') %></th>
       <th><%= I18n.t('link.edit') %></th>
       <th><%= I18n.t('link.delete') %></th>
@@ -19,6 +20,7 @@
         <td><%= link_to u.name, admin_user_path(u.id) %></td>
         <td><%= u.mail_address %></td>
         <td><%= u.tasks.size %></td>
+        <td><%= u.role_i18n %></td>
         <td><%= l u.created_at %></td>
         <td><%= link_to I18n.t('link.edit'), edit_admin_user_path(u.id), class: 'btn btn-secondary btn-sm' %></td>
         <td><%= link_to I18n.t('link.delete'), admin_user_path(u.id), method: :delete, data: { confirm: I18n.t('confirm.delete') }, class: 'btn btn-danger btn-sm' %></td>

--- a/task_management/app/views/layouts/application.html.erb
+++ b/task_management/app/views/layouts/application.html.erb
@@ -11,14 +11,14 @@
   <body>
     <nav class="navbar navbar-expand navbar-dark bg-dark fixed-top">
       <span class="navbar-brand mb-0 h1"><%= I18n.t('navbar.title') %></span>
-      <% if current_user.admin? && request.path_info != admin_users_path %>
-        <ul class="navbar-nav">
-          <li class="nav-item">
-            <%= link_to I18n.t('link.user_list'), admin_users_path, class: 'nav-link' %>
-          </li>
-        </ul>
-      <% end %>
       <% if current_user %>
+        <% if current_user.admin? && request.path_info != admin_users_path %>
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <%= link_to I18n.t('link.user_list'), admin_users_path, class: 'nav-link' %>
+            </li>
+          </ul>
+        <% end %>
         <ul class="navbar-nav ml-auto">
           <li class="nav-item">
             <%= link_to I18n.t('link.logout'), logout_path, method: :delete, class: 'nav-link' %>

--- a/task_management/app/views/layouts/application.html.erb
+++ b/task_management/app/views/layouts/application.html.erb
@@ -11,6 +11,13 @@
   <body>
     <nav class="navbar navbar-expand navbar-dark bg-dark fixed-top">
       <span class="navbar-brand mb-0 h1"><%= I18n.t('navbar.title') %></span>
+      <% if current_user.admin? && request.path_info != admin_users_path %>
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <%= link_to I18n.t('link.user_list'), admin_users_path, class: 'nav-link' %>
+          </li>
+        </ul>
+      <% end %>
       <% if current_user %>
         <ul class="navbar-nav ml-auto">
           <li class="nav-item">

--- a/task_management/config/locales/model.ja.yml
+++ b/task_management/config/locales/model.ja.yml
@@ -14,6 +14,7 @@ ja:
         password: パスワード
         password_confirmation: パスワード確認
         task_count: タスク数
+        role: ロール
       common:
         created_at: 作成日時
         updated_at: 更新日時
@@ -27,6 +28,10 @@ ja:
         waiting: 未着手
         working: 着手
         completed: 完了
+    user:
+      role:
+        admin: 管理者
+        general: 一般ユーザ
   errors:
     message:
       invalid_date: 無効な日付です

--- a/task_management/config/locales/view.ja.yml
+++ b/task_management/config/locales/view.ja.yml
@@ -34,6 +34,7 @@ ja:
       create: ユーザが登録されました
       update: ユーザが編集されました
       destroy: ユーザを削除しました
+      last_admin_user: 他に管理者ユーザが存在しないため削除できません
   button:
     search: 検索
     update: 更新
@@ -46,6 +47,7 @@ ja:
     delete: 削除
     back: 戻る
     logout: ログアウト
+    user_list: ユーザ一覧
   confirm:
     delete: 削除しますか？
   errors:

--- a/task_management/db/migrate/20200715075325_add_role_to_users.rb
+++ b/task_management/db/migrate/20200715075325_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer, limit: 1, null: false, after: :password_digest
+  end
+end

--- a/task_management/db/schema.rb
+++ b/task_management/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_13_022828) do
+ActiveRecord::Schema.define(version: 2020_07_15_075325) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_022828) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "role", limit: 1, null: false
     t.index ["mail_address"], name: "index_users_on_mail_address", unique: true
   end
 

--- a/task_management/db/seeds.rb
+++ b/task_management/db/seeds.rb
@@ -5,4 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-User.create(name: 'test_user', mail_address: 'test@example.com', password: 'password', password_confirmation: 'password' )
+User.create(name: 'test_admin_user', mail_address: 'test@example.com', password: 'pAssw0rd', password_confirmation: 'pAssw0rd', role: 0 )
+User.create(name: 'test_user', mail_address: 'test3@example.com', password: 'pAssw0rd', password_confirmation: 'pAssw0rd', role: 1 )

--- a/task_management/spec/factories/users.rb
+++ b/task_management/spec/factories/users.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { 'test_user' }
     sequence(:mail_address) { |n| "test#{n}@example.com" }
     password { 'pAssw0rd' }
+    role { 1 }
   end
 end

--- a/task_management/spec/models/user_spec.rb
+++ b/task_management/spec/models/user_spec.rb
@@ -106,4 +106,17 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe '削除機能' do
+    let!(:user) { create(:user) }
+    let!(:task) { create(:task, user_id: user.id) }
+
+    context 'ユーザを削除した場合' do
+      it 'ユーザに紐づくタスクが削除される' do
+        User.find_by(id: user.id).destroy
+        expect(Task.where(user_id: user.id).size).to eq 0
+      end
+    end
+
+  end
 end

--- a/task_management/spec/models/user_spec.rb
+++ b/task_management/spec/models/user_spec.rb
@@ -117,6 +117,5 @@ RSpec.describe Task, type: :model do
         expect(Task.where(user_id: user.id).size).to eq 0
       end
     end
-
   end
 end

--- a/task_management/spec/system/user_spec.rb
+++ b/task_management/spec/system/user_spec.rb
@@ -1,0 +1,287 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :system do
+  let!(:general) { create(:user) }
+  let!(:admin) { create(:user, role: 0) }
+
+  before do
+    visit login_path
+    fill_in 'session_mail_address', with: admin.mail_address
+    fill_in 'session_password', with: admin.password
+    click_on 'ログイン'
+  end
+
+  describe '#index' do
+    context '管理者ユーザの場合' do
+      let!(:user1) { create(:user, name: 'user1', created_at: DateTime.now) }
+      let!(:task) { create(:task, user_id: user1.id) }
+      let!(:user2) { create(:user, name: 'user2', created_at: DateTime.now + 100) }
+      let!(:user3) { create(:user, name: 'user3', created_at: DateTime.now + 1000) }
+
+      it '登録済みユーザ一覧が作成日時の降順で表示される' do
+        visit admin_users_path
+        expect(page).to have_content user1.name
+        expect(page).to have_content user2.name
+        expect(page).to have_content user3.name
+        expect(page).to have_content user1.mail_address
+        expect(page).to have_content user2.mail_address
+        expect(page).to have_content user3.mail_address
+        expect(page).to have_content user1.tasks.size
+        expect(page).to have_content user2.tasks.size
+        expect(page).to have_content user3.tasks.size
+        expect(page.body.index(user1.name)).to be < page.body.index(user2.name)
+        expect(page.body.index(user2.name)).to be < page.body.index(user3.name)
+      end
+    end
+
+    context '一般ユーザの場合' do
+      it 'ユーザ一覧画面に遷移できない' do
+        click_on 'ログアウト'
+        fill_in 'session_mail_address', with: general.mail_address
+        fill_in 'session_password', with: general.password
+        click_on 'ログイン'
+        visit admin_users_path
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+
+  describe '#show' do
+    let!(:taskA) { create(:task, title: 'taskA', user_id: general.id) }
+
+    context '管理者ユーザの場合' do
+      it '登録済みユーザ情報の詳細情報が表示される' do
+        visit admin_user_path(general.id)
+        expect(page).to have_content general.id
+        expect(page).to have_content general.name
+        expect(page).to have_content general.mail_address
+        expect(page).to have_content taskA.title
+        expect(page).to have_content '中'
+        expect(page).to have_content '未着手'
+        expect(page).to have_content taskA.due
+      end
+    end
+
+    context '一般ユーザの場合' do
+      it 'ユーザ詳細画面に遷移できない' do
+        click_on 'ログアウト'
+        fill_in 'session_mail_address', with: general.mail_address
+        fill_in 'session_password', with: general.password
+        click_on 'ログイン'
+        visit admin_user_path(general.id)
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+
+  describe '#create' do
+    context '管理者ユーザの場合' do
+      before do
+        visit new_admin_user_path
+        fill_in 'user_name', with: 'user'
+        fill_in 'user_mail_address', with: 'test100@example.com'
+        select '一般ユーザ', from: 'user_role'
+        fill_in 'user_password', with: 'pAssw0rd'
+        fill_in 'user_password_confirmation', with: 'pAssw0rd'
+      end
+
+      context '正常な値が入力された場合' do
+        it 'ユーザ一覧画面に遷移し、新規ユーザが一覧に表示されている' do
+          click_on '登録'
+          expect(page).to have_content 'user'
+          expect(page).to have_content 'test100@example.com'
+          expect(page).to have_content '一般ユーザ'
+        end
+      end
+
+      context '異常な値が入力された場合' do
+        context 'ユーザ名が空欄の場合' do
+          it ' エラーメッセージが表示される' do
+            fill_in 'user_name', with: ''
+            click_on '登録'
+            expect(page).to have_content 'ユーザ名を入力してください'
+          end
+        end
+
+        context 'メールアドレスが空欄の場合' do
+          it ' エラーメッセージが表示される' do
+            fill_in 'user_mail_address', with: ''
+            click_on '登録'
+            expect(page).to have_content 'メールアドレスを入力してください'
+          end
+        end
+
+        context 'メールアドレスに使用できない文字列が含まれる場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_mail_address', with: '<>!?@example.com'
+            click_on '登録'
+            expect(page).to have_content 'メールアドレスは不正な値です'
+          end
+        end
+        context '既に登録済みのメールアドレスの場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_mail_address', with: general.mail_address
+            click_on '登録'
+            expect(page).to have_content 'メールアドレスはすでに存在します'
+          end
+        end
+
+        context 'パスワードが空欄の場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_password', with: ''
+            click_on '登録'
+            expect(page).to have_content 'パスワードを入力してください'
+          end
+        end
+
+        context 'パスワードとパスワード確認の内容が異なる場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_password_confirmation', with: ''
+            click_on '登録'
+            expect(page).to have_content 'パスワード確認とパスワードの入力が一致しません'
+          end
+        end
+
+        context 'パスワードポリシーに反する場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_password', with: 'passw0rd'
+            fill_in 'user_password_confirmation', with: 'passw0rd'
+            click_on '登録'
+            expect(page).to have_content 'パスワードは半角6~100文字英大文字・小文字・数字それぞれ１文字以上含む必要があります'
+          end
+        end
+      end
+    end
+
+    context '一般ユーザの場合' do
+      it 'ユーザ登録画面に遷移できない' do
+        click_on 'ログアウト'
+        fill_in 'session_mail_address', with: general.mail_address
+        fill_in 'session_password', with: general.password
+        click_on 'ログイン'
+        visit new_admin_user_path
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+
+  describe '#update' do
+    context '管理者ユーザの場合' do
+      before { visit edit_admin_user_path(general.id) }
+
+      context '正常な値が入力された場合' do
+        it 'ユーザ一覧画面に遷移し、新規ユーザが一覧に表示されている' do
+          fill_in 'user_name', with: 'updated_user'
+          click_on '更新'
+          expect(page).to have_content 'updated_user'
+        end
+      end
+
+      context '異常な値が入力された場合' do
+        context 'ユーザ名が空欄の場合' do
+          it ' エラーメッセージが表示される' do
+            fill_in 'user_name', with: ''
+            click_on '更新'
+            expect(page).to have_content 'ユーザ名を入力してください'
+          end
+        end
+
+        context 'メールアドレスが空欄の場合' do
+          it ' エラーメッセージが表示される' do
+            fill_in 'user_mail_address', with: ''
+            click_on '更新'
+            expect(page).to have_content 'メールアドレスを入力してください'
+          end
+        end
+
+        context 'メールアドレスに使用できない文字列が含まれる場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_mail_address', with: '<>!?@example.com'
+            click_on '更新'
+            expect(page).to have_content 'メールアドレスは不正な値です'
+          end
+        end
+        context '既に登録済みのメールアドレスの場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_mail_address', with: admin.mail_address
+            click_on '更新'
+            expect(page).to have_content 'メールアドレスはすでに存在します'
+          end
+        end
+
+        context 'パスワードとパスワード確認の内容が異なる場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_password', with: 'pAssw0rd'
+            fill_in 'user_password_confirmation', with: 'Passw0rd'
+            click_on '更新'
+            expect(page).to have_content 'パスワード確認とパスワードの入力が一致しません'
+          end
+        end
+
+        context 'パスワードポリシーに反する場合' do
+          it 'エラーメッセージが表示される' do
+            fill_in 'user_password', with: 'passw0rd'
+            fill_in 'user_password_confirmation', with: 'passw0rd'
+            click_on '更新'
+            expect(page).to have_content 'パスワードは半角6~100文字英大文字・小文字・数字それぞれ１文字以上含む必要があります'
+          end
+        end
+      end
+  end
+
+    context '一般ユーザの場合' do
+      it 'ユーザ登録画面に遷移できない' do
+        click_on 'ログアウト'
+        fill_in 'session_mail_address', with: general.mail_address
+        fill_in 'session_password', with: general.password
+        click_on 'ログイン'
+        visit edit_admin_user_path(general.id)
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+
+  describe '#destroy' do
+    before { visit admin_users_path }
+
+    it 'ダイアログが表示される' do
+      page.dismiss_confirm do
+        click_link '削除', match: :first
+        expect(page.driver.browser.switch_to.alert.text).to eq '削除しますか？'
+      end
+    end
+
+    context '一般ユーザを削除する場合' do
+      it '一覧画面にユーザ削除完了のメッセージが表示される' do
+        page.accept_confirm do
+          click_link '削除', match: :first
+        end
+        expect(page).to have_content 'ユーザを削除しました'
+        expect(User.general.size).to eq 0
+      end
+    end
+
+    context '管理者を削除する場合' do
+      context 'DBに登録されている管理者が複数件ある場合' do
+        let!(:admin) { create(:user, role: 0) }
+        it '一覧画面にユーザ削除完了のメッセージが表示される' do
+          page.accept_confirm do
+            click_link '削除', match: :first
+          end
+          expect(page).to have_content 'ユーザを削除しました'
+          expect(User.admin.size).to eq 1
+        end
+      end
+
+      context 'DBに登録されている管理者が1件の場合' do
+        it '一覧画面にユーザ削除失敗のメッセージが表示される' do
+          page.accept_confirm do
+            all(:link, '削除')[1].click
+          end
+          expect(page).to have_content '他に管理者ユーザが存在しないため削除できません'
+          expect(User.admin.size).to eq 1
+        end
+      end
+    end
+  end
+end

--- a/task_management/spec/system/user_spec.rb
+++ b/task_management/spec/system/user_spec.rb
@@ -113,11 +113,12 @@ RSpec.describe 'Users', type: :system do
 
         context 'メールアドレスに使用できない文字列が含まれる場合' do
           it 'エラーメッセージが表示される' do
-            fill_in 'user_mail_address', with: '<>!?@example.com'
+            fill_in 'user_mail_address', with: '!?@example.com'
             click_on '登録'
             expect(page).to have_content 'メールアドレスは不正な値です'
           end
         end
+
         context '既に登録済みのメールアドレスの場合' do
           it 'エラーメッセージが表示される' do
             fill_in 'user_mail_address', with: general.mail_address
@@ -196,11 +197,12 @@ RSpec.describe 'Users', type: :system do
 
         context 'メールアドレスに使用できない文字列が含まれる場合' do
           it 'エラーメッセージが表示される' do
-            fill_in 'user_mail_address', with: '<>!?@example.com'
+            fill_in 'user_mail_address', with: '!?@example.com'
             click_on '更新'
             expect(page).to have_content 'メールアドレスは不正な値です'
           end
         end
+
         context '既に登録済みのメールアドレスの場合' do
           it 'エラーメッセージが表示される' do
             fill_in 'user_mail_address', with: admin.mail_address
@@ -227,7 +229,7 @@ RSpec.describe 'Users', type: :system do
           end
         end
       end
-  end
+    end
 
     context '一般ユーザの場合' do
       it 'ユーザ登録画面に遷移できない' do
@@ -264,6 +266,7 @@ RSpec.describe 'Users', type: :system do
     context '管理者を削除する場合' do
       context 'DBに登録されている管理者が複数件ある場合' do
         let!(:admin) { create(:user, role: 0) }
+
         it '一覧画面にユーザ削除完了のメッセージが表示される' do
           page.accept_confirm do
             click_link '削除', match: :first

--- a/task_management/spec/system/user_spec.rb
+++ b/task_management/spec/system/user_spec.rb
@@ -265,11 +265,13 @@ RSpec.describe 'Users', type: :system do
 
     context '管理者を削除する場合' do
       context 'DBに登録されている管理者が複数件ある場合' do
-        let!(:admin) { create(:user, role: 0) }
+        let!(:adminA) { create(:user, role: 0) }
 
         it '一覧画面にユーザ削除完了のメッセージが表示される' do
+          visit current_path
+          expect(User.admin.size).to eq 2
           page.accept_confirm do
-            click_link '削除', match: :first
+            all(:link, '削除')[2].click
           end
           expect(page).to have_content 'ユーザを削除しました'
           expect(User.admin.size).to eq 1


### PR DESCRIPTION
### 概要
[ステップ19: ユーザにロールを追加しよう](https://github.com/Fablic/training/tree/satoshi-kwn#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

### 実施内容
・userモデルにカラム(role)を追加
・カラムを追加したため、view・controller・modelを修正
・認可機能の実装
・system&moldelテスト作成

### その他
・デフォルト設定のままのrubocopを利用しています。
・下記のrubocopのエラーは対応していません。対応の必要があればご指摘ください。
　-自動生成されたコードに対するエラー
　-本ステップ以前のレビューアーの方から対応が不要であると指摘を受けたエラー
　　「Airbnb/OptArgParameters:〜」
　　「Style/PercentLiteralDelimiters:〜」
　　「RiskyActiverecordInvocation:〜」

### 動作確認
![step19](https://user-images.githubusercontent.com/54238761/88012274-6fb44d00-cb54-11ea-93c2-c89ff66b9d4f.gif)
