### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/todo/app/controllers/tasks_controller.rb
+++ b/todo/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
 
   def index
     @project = Project.find(params[:project_id])
-    @tasks = @project.tasks
+    @tasks = @project.tasks.order(created_at: :desc)
   end
 
   def show

--- a/todo/spec/factories/projects.rb
+++ b/todo/spec/factories/projects.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :project do
-    sequence(:project_name) {'PJ_Factory'}
-    sequence(:status) {:in_progress}
-    sequence(:description) {'factory_test'}
-    sequence(:started_at) {Time.zone.today}
-    sequence(:finished_at) {Time.zone.today}
+    sequence(:project_name) { 'PJ_Factory' }
+    sequence(:status) { :in_progress }
+    sequence(:description) { 'factory_test' }
+    sequence(:started_at) { Time.zone.today }
+    sequence(:finished_at) { Time.zone.today }
   end
 end

--- a/todo/spec/factories/tasks.rb
+++ b/todo/spec/factories/tasks.rb
@@ -10,5 +10,10 @@ FactoryBot.define do
     sequence(:description) {'test_discription'}
     sequence(:started_at) {Time.zone.today}
     sequence(:finished_at) {Time.zone.today}
+
+    trait :order_by_created_at do
+      sequence(:task_name) { |task| task += 1}
+      sequence(:created_at) { |task| Time.zone.now - task.days }
+    end
   end
 end

--- a/todo/spec/factories/tasks.rb
+++ b/todo/spec/factories/tasks.rb
@@ -4,15 +4,15 @@ project = FactoryBot.create(:project)
 
 FactoryBot.define do
   factory :task do
-    sequence(:task_name) {'test_task'}
-    sequence(:project_id) {project.id}
-    sequence(:priority) {:high}
-    sequence(:description) {'test_discription'}
-    sequence(:started_at) {Time.zone.today}
-    sequence(:finished_at) {Time.zone.today}
+    sequence(:task_name) { 'test_task' }
+    sequence(:project_id) { project.id }
+    sequence(:priority) { :high }
+    sequence(:description) { 'test_discription' }
+    sequence(:started_at) { Time.zone.today }
+    sequence(:finished_at) { Time.zone.today }
 
     trait :order_by_created_at do
-      sequence(:task_name) { |task| task += 1}
+      sequence(:task_name) { |task| task + 1 }
       sequence(:created_at) { |task| Time.zone.now - task.days }
     end
   end

--- a/todo/spec/factories/users.rb
+++ b/todo/spec/factories/users.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     sequence :account_name do |n|
       "user_#{n}"
     end
-    sequence(:password) {'test'}
+    sequence(:password) { 'test' }
   end
 end

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :system do
-  let(:user) { FactoryBot.create(:user) }
-  let(:task) { FactoryBot.create(:task, assignee_id: user.id, reporter_id: user.id) }
+  let(:user) { create(:user) }
+  let(:task) { create(:task, assignee_id: user.id, reporter_id: user.id) }
 
   describe '#index' do
     it 'visit task index page' do
@@ -18,7 +18,7 @@ RSpec.describe Task, type: :system do
     end
 
     it 'task sorder by created_at' do
-      tasks = FactoryBot.create_list(:task, 2, :order_by_created_at, assignee_id: user.id, reporter_id: user.id)
+      tasks = create_list(:task, 2, :order_by_created_at, assignee_id: user.id, reporter_id: user.id)
 
       visit tasks_path(project_id: task.project.id)
 

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Task, type: :system do
     end
 
     it 'task sorder by created_at' do
-      tasks = FactoryBot.create_list(:task, 2, :order_by_created_at)
+      tasks = FactoryBot.create_list(:task, 2, :order_by_created_at, assignee_id: user.id, reporter_id: user.id)
 
-      visit tasks_path(project_id: pj.id)
+      visit tasks_path(project_id: task.project.id)
   
       #tasks[1]はtasks[0]より1日前の日付
       expect(tasks[1].created_at < tasks[0].created_at).to be true

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Task, type: :system do
       expect(page).to have_content '修正'
       expect(page).to have_content '削除'
     end
+
+    it 'task sorder by created_at' do
+      tasks = FactoryBot.create_list(:task, 2, :order_by_created_at)
+
+      visit tasks_path(project_id: pj.id)
+  
+      #tasks[1]はtasks[0]より1日前の日付
+      expect(tasks[1].created_at < tasks[0].created_at).to be true
+      expect(page.body.index(tasks[1].task_name)).to be < page.body.index(tasks[0].task_name)
+    end
   end
 
   describe '#new' do

--- a/todo/spec/system/tasks_spec.rb
+++ b/todo/spec/system/tasks_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :system do
   let(:user) { FactoryBot.create(:user) }
-  let(:task) { FactoryBot.create(:task, assignee_id: user.id, reporter_id: user.id ) }
+  let(:task) { FactoryBot.create(:task, assignee_id: user.id, reporter_id: user.id) }
 
   describe '#index' do
     it 'visit task index page' do
@@ -21,8 +21,8 @@ RSpec.describe Task, type: :system do
       tasks = FactoryBot.create_list(:task, 2, :order_by_created_at, assignee_id: user.id, reporter_id: user.id)
 
       visit tasks_path(project_id: task.project.id)
-  
-      #tasks[1]はtasks[0]より1日前の日付
+
+      # tasks[1]はtasks[0]より1日前の日付
       expect(tasks[1].created_at < tasks[0].created_at).to be true
       expect(page.body.index(tasks[1].task_name)).to be < page.body.index(tasks[0].task_name)
     end


### PR DESCRIPTION
### 概要

タスク一覧の並び順をidから作成日時に変更する。

### 実行内容

- [x] タスクコントローラー修正

- [x] タスクsystem spec修正

- [x] rsepcテスト

- [x] 動作確認
