### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: "DESC")
   end
 
   def new

--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all.order(created_at: "DESC")
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def new

--- a/TaskManagementSystem/app/views/tasks/index.html.slim
+++ b/TaskManagementSystem/app/views/tasks/index.html.slim
@@ -12,22 +12,28 @@
   table.table.mt-3
     thead.thead-light
       tr
-        th.col-xs-1 優先度
+        th.col-xs-2.text-center 優先度
         th.col-xs-3 タスク名
-        th.col-xs-3 ラベル
-        th.col-xs-1 終了期限
-        th.col-xs-1 ステータス
-        th.col-xs-1 詳細
-        th.col-xs-1 編集
-        th.col-xs-1 削除
+        th.col-xs-1 
+          .row 終了期限/
+          .row 作成日
+        th.col-xs-3
+          .row ステータス/
+          .row ラベル
+        th.col-xs-1.text-center 詳細
+        th.col-xs-1.text-center 編集
+        th.col-xs-1.text-center 削除
       - @tasks.each do |task|
         tbody
           tr
-            td.col-xs-1.text-center = task.priority
+            td.col-xs-2.text-center = task.priority
             td.col-xs-3 = task.title
-            td.col-xs-3 ラベル
-            td.col-xs-1 = task.deadline.strftime('%Y/%m/%d')
-            td.col-xs-1 = task.status_i18n
-            td.col-xs-1 = link_to  '詳細', task_path(task), class:"btn btn-info btn-sm", style: "width:45px"
-            td.col-xs-1 = link_to  '編集', edit_task_path(task), class:"btn btn-warning btn-sm", style: "width:45px"
-            td.col-xs-1 = link_to  '削除', task_path(task), method: :delete, class:"btn btn-danger btn-sm", style: "width:45px"
+            td.col-xs-1 
+              .row = task.deadline.strftime('%Y/%m/%d')
+              .row = task.created_at.strftime('%Y/%m/%d')
+            td.col-xs-3
+              .row = task.status_i18n
+              .row.text-center ラベル
+            td.col-xs-1.text-center = link_to  '詳細', task_path(task), class:"btn btn-info btn-sm", style: "width:45px"
+            td.col-xs-1.text-center = link_to  '編集', edit_task_path(task), class:"btn btn-warning btn-sm", style: "width:45px"
+            td.col-xs-1.text-center = link_to  '削除', task_path(task), method: :delete, class:"btn btn-danger btn-sm", style: "width:45px"

--- a/TaskManagementSystem/spec/factories/tasks.rb
+++ b/TaskManagementSystem/spec/factories/tasks.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
+  # 異なる作成日を生成
+  sequence :sample_created do |i|
+    Time.strptime("2020年9月#{i}日 12:13:23", '%Y年%m月%d日 %H:%M:%S')
+  end
+
   factory :sample_task, class: Task do
     user_id {1}
     title {'タスク名の編集テスト'}
@@ -6,5 +11,6 @@ FactoryBot.define do
     priority {1}
     deadline {Time.strptime("2020年10月2日 12:13:23", '%Y年%m月%d日 %H:%M:%S')}
     status {1}
+    created_at {generate :sample_created}
   end
 end

--- a/TaskManagementSystem/spec/features/tasks_spec.rb
+++ b/TaskManagementSystem/spec/features/tasks_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.feature "Task", type: :feature do
+  # タスク降順テスト
+  describe 'TaskListDecendingOrder' do
+    before do
+      @tasks = create_list(:sample_task, 5)
+    end
+    it "is descending orders in task index screen" do
+      # タスクが作成日時の降順になっていることを確認
+      expect(Task.all.order(created_at: "DESC").map(&:created_at)).to eq @tasks.map(&:created_at).reverse!
+    end  
+  end
+end

--- a/TaskManagementSystem/spec/features/tasks_spec.rb
+++ b/TaskManagementSystem/spec/features/tasks_spec.rb
@@ -7,8 +7,13 @@ RSpec.feature "Task", type: :feature do
       @tasks = create_list(:sample_task, 5)
     end
     it "is descending orders in task index screen" do
+      # タスク一覧画面へ移動
+      visit root_path
+
       # タスクが作成日時の降順になっていることを確認
-      expect(Task.all.order(created_at: "DESC").map(&:created_at)).to eq @tasks.map(&:created_at).reverse!
+      4.times do |n|
+        expect(page.body.index(@tasks[n].created_at.strftime('%Y/%m/%d'))).to be > page.body.index(@tasks[n+1].created_at.strftime('%Y/%m/%d'))
+      end
     end  
   end
 end

--- a/TaskManagementSystem/spec/system/tasks_spec.rb
+++ b/TaskManagementSystem/spec/system/tasks_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_content('ステータス')
       expect(page).to have_content('詳細')
       expect(page).to have_content('編集')
-      expect(page).to have_content('削除')      
+      expect(page).to have_content('削除')
       
       # テーブルにタスクが出力されている
       expect(page).to have_content(@task.priority)


### PR DESCRIPTION
## 課題
[ステップ10: タスク一覧を作成日時の順番で並び替えましょう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

## 実施内容
 - 作成日時の降順で並び替え
 - 並び替えがうまく行っていることをfeature specで書く