### PR TITLE
ステップ13・14: ステータスを追加して、検索できるようにしよう／ページネーションを追加しよう

### DIFF
--- a/eumetopias_2/Gemfile
+++ b/eumetopias_2/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/eumetopias_2/Gemfile
+++ b/eumetopias_2/Gemfile
@@ -30,6 +30,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'dotenv-rails'
 gem 'rails-i18n'
+gem 'kaminari'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/eumetopias_2/Gemfile.lock
+++ b/eumetopias_2/Gemfile.lock
@@ -87,6 +87,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -228,6 +240,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   dotenv-rails
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   puma (~> 4.1)

--- a/eumetopias_2/Gemfile.lock
+++ b/eumetopias_2/Gemfile.lock
@@ -80,6 +80,11 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.9.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -239,6 +244,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   dotenv-rails
+  factory_bot_rails
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.2)

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -6,12 +6,10 @@ class TaskController < ApplicationController
     else
       @task = Task.search_by_status_id(task_status_id)
     end
-    @status_selection = task_status_list
   end
 
   def new
      @task = Task.new
-     @status_selection = task_status_list
   end
 
   def create
@@ -58,8 +56,4 @@ end
 private
   def task_params
     params.require(:task).permit(:title, :description, :task_status_id)
-  end
-
-  def task_status_list
-    TaskStatus.all.map{|status| [status.name, status.id]}.to_h
   end

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -21,6 +21,7 @@ class TaskController < ApplicationController
       flash[:notice] = t('dictionary.message.create.complete')
       redirect_to root_path
     else
+      @status_selection = task_status_list
       render 'new'
     end
   end

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -62,5 +62,8 @@ private
   end
 
   def task_status_list
-    TaskStatus.all.map{ |status| [status.name, status.id] }.to_h
+    TaskStatus.all.map{
+      |status| [status.name, status.id]
+    }.to_h
+
   end

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -1,6 +1,13 @@
 class TaskController < ApplicationController
   def index
-    @task = Task.all
+    task_status_id = params[:task_status_id]
+    if !task_status_id.blank?
+      @task = Task.where(task_status_id: task_status_id)
+    else
+      @task = Task.all
+    end
+    @status_selection = task_status_list
+    @status_selection.store('全て', '')
   end
 
   def new
@@ -54,5 +61,5 @@ private
   end
 
   def task_status_list
-    TaskStatus.all.map{ |status| [status.name, status.id] }
+    TaskStatus.all.map{ |status| [status.name, status.id] }.to_h
   end

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -1,10 +1,10 @@
 class TaskController < ApplicationController
   def index
     task_status_id = params[:task_status_id]
-    if !task_status_id.blank?
-      @task = Task.where(task_status_id: task_status_id)
-    else
+    if task_status_id.blank?
       @task = Task.all
+    else
+      @task = Task.search_by_status(task_status_id)
     end
     @status_selection = task_status_list
     @status_selection.store('全て', '')

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -4,7 +4,7 @@ class TaskController < ApplicationController
     if task_status_id.blank?
       @task = Task.all
     else
-      @task = Task.search_by_status(task_status_id)
+      @task = Task.search_by_status_id(task_status_id)
     end
     @status_selection = task_status_list
     @status_selection.store('全て', '')

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -5,6 +5,7 @@ class TaskController < ApplicationController
 
   def new
      @task = Task.new
+     @status_selection = task_status_list
   end
 
   def create
@@ -36,6 +37,7 @@ class TaskController < ApplicationController
 
   def edit
     @task = Task.find(params[:id])
+    @status_selection = task_status_list
   end
 
   def destroy
@@ -49,4 +51,8 @@ end
 private
   def task_params
     params.require(:task).permit(:title, :description, :task_status_id)
+  end
+
+  def task_status_list
+    TaskStatus.all.map{ |status| [status.name, status.id] }
   end

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -7,7 +7,6 @@ class TaskController < ApplicationController
       @task = Task.search_by_status_id(task_status_id)
     end
     @status_selection = task_status_list
-    @status_selection.store('全て', '')
   end
 
   def new
@@ -62,8 +61,5 @@ private
   end
 
   def task_status_list
-    TaskStatus.all.map{
-      |status| [status.name, status.id]
-    }.to_h
-
+    TaskStatus.all.map{|status| [status.name, status.id]}.to_h
   end

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -1,10 +1,12 @@
 class TaskController < ApplicationController
+  PER = 10
+
   def index
     task_status_id = params[:task_status_id]
     if task_status_id.blank?
-      @task = Task.all
+      @task = Task.page(params[:page]).per(PER)
     else
-      @task = Task.search_by_status_id(task_status_id)
+      @task = Task.search_by_status_id(task_status_id).page(params[:page]).per(PER)
     end
   end
 

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -20,7 +20,6 @@ class TaskController < ApplicationController
       flash[:notice] = t('dictionary.message.create.complete')
       redirect_to root_path
     else
-      @status_selection = task_status_list
       render 'new'
     end
   end
@@ -44,7 +43,6 @@ class TaskController < ApplicationController
 
   def edit
     @task = Task.find(params[:id])
-    @status_selection = task_status_list
   end
 
   def destroy

--- a/eumetopias_2/app/controllers/task_controller.rb
+++ b/eumetopias_2/app/controllers/task_controller.rb
@@ -48,5 +48,5 @@ end
 
 private
   def task_params
-    params.require(:task).permit(:title, :description)
+    params.require(:task).permit(:title, :description, :task_status_id)
   end

--- a/eumetopias_2/app/controllers/task_status_controller.rb
+++ b/eumetopias_2/app/controllers/task_status_controller.rb
@@ -1,0 +1,2 @@
+class TaskStatusController < ApplicationController
+end

--- a/eumetopias_2/app/models/task.rb
+++ b/eumetopias_2/app/models/task.rb
@@ -3,5 +3,5 @@ class Task < ApplicationRecord
   validates :title, presence: true
   validates :description, presence: true
 
-  scope :search_by_status, -> (term){where(task_status_id: term)}
+  scope :search_by_status_id, -> (term){where(task_status_id: term)}
 end

--- a/eumetopias_2/app/models/task.rb
+++ b/eumetopias_2/app/models/task.rb
@@ -2,4 +2,6 @@ class Task < ApplicationRecord
   belongs_to :task_status
   validates :title, presence: true
   validates :description, presence: true
+
+  scope :search_by_status, -> (term){where(task_status_id: term)}
 end

--- a/eumetopias_2/app/models/task.rb
+++ b/eumetopias_2/app/models/task.rb
@@ -2,6 +2,7 @@ class Task < ApplicationRecord
   belongs_to :task_status
   validates :title, presence: true
   validates :description, presence: true
+  validates :task_status_id, presence: true
 
   scope :search_by_status_id, -> (term){where(task_status_id: term)}
 end

--- a/eumetopias_2/app/models/task.rb
+++ b/eumetopias_2/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ApplicationRecord
+  belongs_to :task_status
   validates :title, presence: true
   validates :description, presence: true
 end

--- a/eumetopias_2/app/models/task_status.rb
+++ b/eumetopias_2/app/models/task_status.rb
@@ -1,0 +1,3 @@
+class TaskStatus < ApplicationRecord
+  has_many :task
+end

--- a/eumetopias_2/app/views/task/edit.html.erb
+++ b/eumetopias_2/app/views/task/edit.html.erb
@@ -13,7 +13,7 @@
 
 <p>
   <%= form.label :task_status_id %>
-  <%= form.select :task_status_id, @status_selection %>
+  <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name %>
 </p>
 
 <p>

--- a/eumetopias_2/app/views/task/edit.html.erb
+++ b/eumetopias_2/app/views/task/edit.html.erb
@@ -13,7 +13,7 @@
 
 <p>
   <%= form.label :task_status_id %>
-  <%= form.select :task_status_id, [['未着手', 1], ['着手中', 2], ['完了', 3]] %>
+  <%= form.select :task_status_id, @status_selection %>
 </p>
 
 <p>

--- a/eumetopias_2/app/views/task/edit.html.erb
+++ b/eumetopias_2/app/views/task/edit.html.erb
@@ -2,15 +2,19 @@
 <%= render 'layouts/error_messages', model: @task %>
 <%= form_with(model: @task, local: true) do |form| %>
 <p>
-  <%= form.label :title %><br>
+  <%= form.label :title %>
   <%= form.text_field :title %>
 </p>
 
 <p>
-  <%= form.label :description %><br>
+  <%= form.label :description %>
   <%= form.text_field :description %>
 </p>
 
+<p>
+  <%= form.label :task_status_id %>
+  <%= form.select :task_status_id, [['未着手', 1], ['着手中', 2], ['完了', 3]] %>
+</p>
 
 <p>
   <%= form.submit %>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -7,7 +7,7 @@
 <%= form_with url: root_path, method: :get, local: true do |form| %>
   <%= form.label 'status' %>
   <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name, prompt: '全て' %>
-  <%= form.submit '検索' %>
+  <%= form.submit t('dictionary.button.search') %>
 <% end %>
 <table>
   <tr>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -6,7 +6,7 @@
 </p>
 <%= form_with url: root_path, method: :get, local: true do |form| %>
   <%= form.label 'status' %>
-  <%= form.select :task_status_id, @status_selection.store('全て', ''), selected: params[:task_status_id] || '' %>
+  <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name, prompt: '全て' %>
   <%= form.submit '検索' %>
 <% end %>
 <table>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -8,6 +8,7 @@
   <tr>
     <th>Title</th>
     <th>Description</th>
+    <th>Status</th>
     <th></th>
     <th></th>
     <th></th>
@@ -15,7 +16,14 @@
   <% @task.each do |task| %>
   <tr>
     <th><%= task.title %></th>
-    <th><%=task.description %></th>
+    <th><%= task.description %></th>
+    <th>
+      <% if task_status = task.task_status %>
+        <%= task_status.name %>
+      <% else %>
+        <%= '-' %>
+      <% end %>
+    </th>
     <th><%= link_to 'show', task_path(task) %></th>
     <th><%= link_to 'edit', edit_task_path(task) %></th>
     <th><%= link_to 'destroy', task_path(task), method: :delete, data:{ confirm: 'Are you sure?'} %></th>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -4,6 +4,11 @@
 <%= content_tag :div, msg, class: name  %>
 <% end %>
 </p>
+<%= form_with url: root_path, method: :get, local: true do |form| %>
+  <%= form.label 'status' %>
+  <%= form.select :task_status_id, @status_selection, selected: params[:task_status_id] || '' %>
+  <%= form.submit '検索' %>
+<% end %>
 <table>
   <tr>
     <th>Title</th>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -29,4 +29,5 @@
   <tr>
   <% end %>
 </table>
+<%= paginate @task %>
 <%= link_to t('dictionary.button.create'), new_task_path %>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -6,7 +6,7 @@
 </p>
 <%= form_with url: root_path, method: :get, local: true do |form| %>
   <%= form.label 'status' %>
-  <%= form.select :task_status_id, @status_selection, selected: params[:task_status_id] || '' %>
+  <%= form.select :task_status_id, @status_selection.store('全て', ''), selected: params[:task_status_id] || '' %>
   <%= form.submit '検索' %>
 <% end %>
 <table>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -22,13 +22,7 @@
   <tr>
     <th><%= task.title %></th>
     <th><%=task.description %></th>
-    <th>
-      <% if task_status = task.task_status %>
-        <%= task_status.name %>
-      <% else %>
-        <%= '-' %>
-      <% end %>
-    </th>
+    <th><%=task.task_status.name %></th>
     <th><%= link_to t('dictionary.button.show'), task_path(task) %></th>
     <th><%= link_to t('dictionary.button.edit'), edit_task_path(task) %></th>
     <th><%= link_to t('dictionary.button.destroy'), task_path(task), method: :delete, data:{ confirm: t('dictionary.message.destroy.confirm')} %></th>

--- a/eumetopias_2/app/views/task/new.html.erb
+++ b/eumetopias_2/app/views/task/new.html.erb
@@ -13,7 +13,7 @@
 
 <p>
   <%= form.label :task_status_id %>
-  <%= form.select :task_status_id, @status_selection %>
+  <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name %>
 </p>
 
 <p>

--- a/eumetopias_2/app/views/task/new.html.erb
+++ b/eumetopias_2/app/views/task/new.html.erb
@@ -5,10 +5,17 @@
   <%= form.label :title %>
   <%= form.text_field :title %>
 </p>
+
 <p>
   <%= form.label :description %>
   <%= form.text_field :description %>
 </p>
+
+<p>
+  <%= form.label :task_status_id %>
+  <%= form.select :task_status_id, [['未着手', 1], ['着手中', 2], ['完了', 3]] %>
+</p>
+
 <p>
   <%= form.submit %>
   <%= %>

--- a/eumetopias_2/app/views/task/new.html.erb
+++ b/eumetopias_2/app/views/task/new.html.erb
@@ -13,7 +13,7 @@
 
 <p>
   <%= form.label :task_status_id %>
-  <%= form.select :task_status_id, [['未着手', 1], ['着手中', 2], ['完了', 3]] %>
+  <%= form.select :task_status_id, @status_selection %>
 </p>
 
 <p>

--- a/eumetopias_2/app/views/task/show.html.erb
+++ b/eumetopias_2/app/views/task/show.html.erb
@@ -17,7 +17,7 @@
 
 <p>
   <strong>Status:</strong>
-    <%= @task.task_status.name %>
+  <%= @task.task_status.name %>
 </p>
 
 <%= link_to t('dictionary.browse.back'), root_path  %>

--- a/eumetopias_2/app/views/task/show.html.erb
+++ b/eumetopias_2/app/views/task/show.html.erb
@@ -17,11 +17,7 @@
 
 <p>
   <strong>Status:</strong>
-  <% if task_status = @task.task_status %>
-    <%= task_status.name %>
-  <% else %>
-    <%= '-' %>
-  <% end %>
+    <%= @task.task_status.name %>
 </p>
 
 <%= link_to t('dictionary.browse.back'), root_path  %>

--- a/eumetopias_2/app/views/task/show.html.erb
+++ b/eumetopias_2/app/views/task/show.html.erb
@@ -4,14 +4,24 @@
 <%= content_tag :div, msg, class: name  %>
 <% end %>
 </p>
+
 <p>
   <strong>Title:</strong>
   <%= @task.title %>
 </p>
+
 <p>
   <strong>Description:</strong>
   <%= @task.description %>
+</p>
 
+<p>
+  <strong>Status:</strong>
+  <% if task_status = @task.task_status %>
+    <%= task_status.name %>
+  <% else %>
+    <%= '-' %>
+  <% end %>
 </p>
 
 <%= link_to 'Back', root_path  %>

--- a/eumetopias_2/db/migrate/20200821061915_create_task_status.rb
+++ b/eumetopias_2/db/migrate/20200821061915_create_task_status.rb
@@ -1,0 +1,10 @@
+class CreateTaskStatus < ActiveRecord::Migration[6.0]
+  def change
+    create_table :task_statuses do |t|
+      t.string :name
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/eumetopias_2/db/migrate/20200821064931_add_task_status_ref_to_task.rb
+++ b/eumetopias_2/db/migrate/20200821064931_add_task_status_ref_to_task.rb
@@ -1,0 +1,5 @@
+class AddTaskStatusRefToTask < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :tasks, :task_status, foreigh_key: true
+  end
+end

--- a/eumetopias_2/db/migrate/20200826044923_insert_initial_task_status.rb
+++ b/eumetopias_2/db/migrate/20200826044923_insert_initial_task_status.rb
@@ -1,0 +1,8 @@
+class InsertInitialTaskStatus < ActiveRecord::Migration[6.0]
+  def change
+    statuses = {"未着手"=>"誰も手を付けていない", "着手中"=>"対応中", "完了"=>"対応完了"}
+    statuses.each do |key, value|
+      TaskStatus.create(name: key, description: value)
+    end
+  end
+end

--- a/eumetopias_2/db/migrate/20200827062551_change_column_on_task.rb
+++ b/eumetopias_2/db/migrate/20200827062551_change_column_on_task.rb
@@ -1,0 +1,5 @@
+class ChangeColumnOnTask < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :tasks, :task_status_id, false
+  end
+end

--- a/eumetopias_2/db/schema.rb
+++ b/eumetopias_2/db/schema.rb
@@ -10,13 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_20_082625) do
+ActiveRecord::Schema.define(version: 2020_08_21_064931) do
+
+  create_table "task_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
     t.string "description", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "task_status_id"
+    t.index ["task_status_id"], name: "index_tasks_on_task_status_id"
   end
 
 end

--- a/eumetopias_2/db/schema.rb
+++ b/eumetopias_2/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_26_044923) do
+ActiveRecord::Schema.define(version: 2020_08_27_062551) do
 
   create_table "task_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 2020_08_26_044923) do
     t.string "description", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "task_status_id"
+    t.bigint "task_status_id", null: false
     t.index ["task_status_id"], name: "index_tasks_on_task_status_id"
   end
 

--- a/eumetopias_2/db/schema.rb
+++ b/eumetopias_2/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_21_064931) do
+ActiveRecord::Schema.define(version: 2020_08_26_044923) do
 
   create_table "task_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"

--- a/eumetopias_2/spec/factories/task_statuses.rb
+++ b/eumetopias_2/spec/factories/task_statuses.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+    factory :untouch, class: TaskStatus do
+        name { "未着手" }
+        description { "誰も手を付けていない" }
+    end
+
+    factory :in_progress, class: TaskStatus do
+        name { "着手中" }
+        description { "対応中" }
+    end
+
+    factory :finished, class: TaskStatus do
+        name { "完了" }
+        description { "対応完了" }
+    end
+end

--- a/eumetopias_2/spec/factories/task_statuses.rb
+++ b/eumetopias_2/spec/factories/task_statuses.rb
@@ -13,4 +13,10 @@ FactoryBot.define do
         name { "完了" }
         description { "対応完了" }
     end
+
+    factory :task, class: Task do
+        sequence(:title) {|n| "task_#{n}" }
+        description { "sample description" }
+        task_status_id { 1 }
+    end
 end

--- a/eumetopias_2/spec/models/task_spec.rb
+++ b/eumetopias_2/spec/models/task_spec.rb
@@ -6,15 +6,6 @@ RSpec.describe Task, type: :model do
   let!(:task_status_finished) { create(:finished) }
 
   before do
-    @untouch_id = task_status_untouch.id
-    @in_progress_id = task_status_in_progress.id
-    @finished_id = task_status_finished.id
-    sample_status_ids = [@untouch_id]
-    2.times {sample_status_ids.push(@in_progress_id)}
-    3.times {sample_status_ids.push(@finished_id)}
-    sample_status_ids.each do |status_id|
-      Task.create(title: "test title", description: "test description", task_status_id: status_id)
-    end
   end
 
   it 'is invalid without title and description' do
@@ -24,9 +15,22 @@ RSpec.describe Task, type: :model do
     expect(new_task.errors.messages[:description]).to include('を入力してください')
   end
 
-  it 'search_by_status_id shoud match correct records count' do
-    expect(Task.search_by_status_id(@untouch_id).count).to eq 1
-    expect(Task.search_by_status_id(@in_progress_id).count).to eq 2
-    expect(Task.search_by_status_id(@finished_id).count).to eq 3
+  describe 'search_by_status_id ' do
+    before do
+      @untouch_id = task_status_untouch.id
+      @in_progress_id = task_status_in_progress.id
+      @finished_id = task_status_finished.id
+      sample_status_ids = [@untouch_id]
+      2.times {sample_status_ids.push(@in_progress_id)}
+      3.times {sample_status_ids.push(@finished_id)}
+      sample_status_ids.each do |status_id|
+        Task.create(title: "test title", description: "test description", task_status_id: status_id)
+      end
+    end
+    it 'shoud match correct records count' do
+      expect(Task.search_by_status_id(@untouch_id).count).to eq 1
+      expect(Task.search_by_status_id(@in_progress_id).count).to eq 2
+      expect(Task.search_by_status_id(@finished_id).count).to eq 3
+    end
   end
 end

--- a/eumetopias_2/spec/models/task_spec.rb
+++ b/eumetopias_2/spec/models/task_spec.rb
@@ -1,10 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  before do 
-    statuses = {"未着手"=>"誰も手を付けていない", "着手中"=>"対応中", "完了"=>"対応完了"}
-    statuses.each do |key, value| 
-      TaskStatus.create(name: key, description: value)
+  let!(:task_status_untouch) { create(:untouch) }
+  let!(:task_status_in_progress) { create(:in_progress) }
+  let!(:task_status_finished) { create(:finished) }
+
+  before do
+    @untouch_id = task_status_untouch.id
+    @in_progress_id = task_status_in_progress.id
+    @finished_id = task_status_finished.id
+    sample_status_ids = [@untouch_id]
+    2.times {sample_status_ids.push(@in_progress_id)}
+    3.times {sample_status_ids.push(@finished_id)}
+    sample_status_ids.each do |status_id|
+      Task.create(title: "test title", description: "test description", task_status_id: status_id)
     end
   end
 
@@ -16,17 +25,8 @@ RSpec.describe Task, type: :model do
   end
 
   it 'search_by_status_id shoud match correct records count' do
-    untouch_id = TaskStatus.find_by(name: '未着手').id
-    in_progress_id = TaskStatus.find_by(name: '着手中').id
-    finished_id = TaskStatus.find_by(name: '完了').id
-    sample_ids = [untouch_id]
-    2.times {sample_ids.push(in_progress_id)}
-    3.times {sample_ids.push(finished_id)}
-    sample_ids.each do |status_id|
-      Task.create(title: "test title", description: "test description", task_status_id: status_id)
-    end
-    expect(Task.search_by_status_id(untouch_id).count).to eq 1
-    expect(Task.search_by_status_id(in_progress_id).count).to eq 2
-    expect(Task.search_by_status_id(finished_id).count).to eq 3
+    expect(Task.search_by_status_id(@untouch_id).count).to eq 1
+    expect(Task.search_by_status_id(@in_progress_id).count).to eq 2
+    expect(Task.search_by_status_id(@finished_id).count).to eq 3
   end
 end

--- a/eumetopias_2/spec/models/task_spec.rb
+++ b/eumetopias_2/spec/models/task_spec.rb
@@ -1,10 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
+  before do 
+    statuses = {"未着手"=>"誰も手を付けていない", "着手中"=>"対応中", "完了"=>"対応完了"}
+    statuses.each do |key, value| 
+      TaskStatus.create(name: key, description: value)
+    end
+  end
+
   it 'is invalid without title and description' do
     new_task = Task.new()
     new_task.valid?
     expect(new_task.errors.messages[:title]).to include('を入力してください')
     expect(new_task.errors.messages[:description]).to include('を入力してください')
+  end
+
+  it 'search_by_status_id shoud match correct records count' do
+    untouch_id = TaskStatus.find_by(name: '未着手').id
+    in_progress_id = TaskStatus.find_by(name: '着手中').id
+    finished_id = TaskStatus.find_by(name: '完了').id
+    sample_ids = [untouch_id]
+    2.times {sample_ids.push(in_progress_id)}
+    3.times {sample_ids.push(finished_id)}
+    sample_ids.each do |status_id|
+      Task.create(title: "test title", description: "test description", task_status_id: status_id)
+    end
+    expect(Task.search_by_status_id(untouch_id).count).to eq 1
+    expect(Task.search_by_status_id(in_progress_id).count).to eq 2
+    expect(Task.search_by_status_id(finished_id).count).to eq 3
   end
 end

--- a/eumetopias_2/spec/rails_helper.rb
+++ b/eumetopias_2/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -61,4 +61,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  RSpec.configure do |config|
+    config.include FactoryBot::Syntax::Methods
+  end
 end

--- a/eumetopias_2/spec/system/tasks_spec.rb
+++ b/eumetopias_2/spec/system/tasks_spec.rb
@@ -103,20 +103,50 @@ RSpec.describe "Task", type: :system do
       expect(page).to have_content 'finished title'
     end
 
-    describe "pagination should match 10 tasks with correct title" do
+    describe "pagination with 20 tasks" do
       before do
         create_list(:task, 20, task_status_id: @untouch_id)
         visit root_path
       end
-      it 'in first page' do
+      it 'should match correct titles in 1st page' do
         Task.page(1).per(10).each do |task|
           expect(page).to have_content task.title
         end
       end
-      it 'in second page' do
+      it 'should match correct titles in 2nd page' do
         visit root_path(page: "2")
         Task.page(2).per(10).each do |task|
           expect(page).to have_content task.title
+        end
+      end
+      it 'should not contain any task titles in 3rd page' do
+        visit root_path(page: "3")
+        Task.all.each do |task|
+          expect(response).not_to have_content task.title
+        end
+      end
+    end
+
+    describe "pagination with 21 tasks" do
+      before do
+        create_list(:task, 21, task_status_id: @untouch_id)
+        visit root_path(page: "2")
+      end
+      it 'should match correct titles in 2nd page' do
+        Task.page(2).per(10).each do |task|
+          expect(page).to have_content task.title
+        end
+      end
+      it 'should match correct title in 3rd page' do
+        visit root_path(page: "3")
+        Task.page(3).per(10).each do |task|
+          expect(page).to have_content task.title
+        end
+      end
+      it 'should not contain any task titles in 4th page' do
+        visit root_path(page: "4")
+        Task.all.each do |task|
+          expect(response).not_to have_content task.title
         end
       end
     end

--- a/eumetopias_2/spec/system/tasks_spec.rb
+++ b/eumetopias_2/spec/system/tasks_spec.rb
@@ -1,12 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe "Task", type: :system do
-  before do 
-    statuses = {"未着手"=>"誰も手を付けていない", "着手中"=>"対応中", "完了"=>"対応完了"}
-    statuses.each do |key, value| 
-      TaskStatus.create(name: key, description: value)
+  let!(:task_status_untouch) { create(:untouch) }
+  let!(:task_status_in_progress) { create(:in_progress) }
+  let!(:task_status_finished) { create(:finished) }
+
+  before do
+    @untouch_id = task_status_untouch.id
+    @in_progress_id = task_status_in_progress.id
+    @finished_id = task_status_finished.id
+    search_sample_data = {"untouch title"=>@untouch_id, "in progress title"=>@in_progress_id, "finished title"=>@finished_id}
+    search_sample_data.each do |title, status_id|
+      Task.create(title: title, description: "dummy description", task_status_id: status_id)
     end
   end
+
   describe "Create new task" do
     let(:submit) { "新規作成" }
     before { visit new_task_path }
@@ -22,7 +30,7 @@ RSpec.describe "Task", type: :system do
         expect(page).to have_content error_message2
       end
     end
-    
+
     describe "with valid information" do
       before do
         fill_in "task_title", with: "example title"
@@ -50,7 +58,7 @@ RSpec.describe "Task", type: :system do
       click_button submit
       expect(Task.find_by(id: @task.id).title).to eq revised_title
       expect(Task.find_by(id: @task.id).description).to eq revised_description
-    end 
+    end
   end
 
   describe "Delete task" do
@@ -77,16 +85,8 @@ RSpec.describe "Task", type: :system do
 
   describe "Task list page search" do
     let(:submit) { "検索" }
-    before do 
-      untouch_id = TaskStatus.find_by(name: '未着手').id
-      in_progress_id = TaskStatus.find_by(name: '着手中').id
-      finished_id = TaskStatus.find_by(name: '完了').id
-      sample_data = {"untouch title"=>untouch_id, "in progress title"=>in_progress_id, "finished title"=>finished_id}
-      sample_data.each do |title, status_id|
-        Task.create(title: title, description: "dummy description", task_status_id: status_id)
-      end
+    before do
       visit root_path
-
     end
     it 'should show search result with correct task title' do
       select "未着手", from: "task_status_id"
@@ -100,6 +100,6 @@ RSpec.describe "Task", type: :system do
       select "完了", from: "task_status_id"
       click_button submit
       expect(page).to have_content 'finished title'
-    end 
+    end
   end
 end

--- a/eumetopias_2/spec/system/tasks_spec.rb
+++ b/eumetopias_2/spec/system/tasks_spec.rb
@@ -10,11 +10,19 @@ RSpec.describe "Task", type: :system do
   describe "Create new task" do
     let(:submit) { "新規作成" }
     before { visit new_task_path }
-    # TODO:
-    # 不正な値が入力されたケースはバリデーション設定後に実装する。
-    # describe "with invalid information" do
-    # end
-
+    describe "with invalid information" do
+      let(:error_message1) {"Titleを入力してください"}
+      let(:error_message2) {"Descriptionを入力してください"}
+      before do
+        select "着手中", from: "task_task_status_id"
+      end
+      it "shoud respond with error and not create a task" do
+        expect { click_button submit }.to change(Task, :count).by(0)
+        expect(page).to have_content error_message1
+        expect(page).to have_content error_message2
+      end
+    end
+    
     describe "with valid information" do
       before do
         fill_in "task_title", with: "example title"

--- a/eumetopias_2/spec/system/tasks_spec.rb
+++ b/eumetopias_2/spec/system/tasks_spec.rb
@@ -79,34 +79,42 @@ RSpec.describe "Task", type: :system do
       @untouch_id = task_status_untouch.id
       @in_progress_id = task_status_in_progress.id
       @finished_id = task_status_finished.id
-      search_sample_data = [
-        {title: "untouch title", status_id: @untouch_id},
-        {title: "in progress title", status_id: @in_progress_id},
-        {title: "finished title", status_id: @finished_id}
-      ]
-      search_sample_data.each do |sample|
-        Task.create(title: sample[:title], description: "dummy description", task_status_id: sample[:status_id])
-      end
-      visit root_path
     end
-    it 'search should show search result with correct task title' do
-      select "未着手", from: "task_status_id"
-      click_button submit
-      expect(page).to have_content 'untouch title'
 
-      select "着手中", from: "task_status_id"
-      click_button submit
-      expect(page).to have_content 'in progress title'
+    describe "search" do
+      before do
+        search_sample_data = [
+          {title: "untouch title", status_id: @untouch_id},
+          {title: "in progress title", status_id: @in_progress_id},
+          {title: "finished title", status_id: @finished_id}
+        ]
+        search_sample_data.each do |sample|
+          Task.create(title: sample[:title], description: "dummy description", task_status_id: sample[:status_id])
+        end
+        visit root_path
+      end
+      it 'should show search result with correct task title' do
+        select "未着手", from: "task_status_id"
+        click_button submit
+        expect(page).to have_content 'untouch title'
 
-      select "完了", from: "task_status_id"
-      click_button submit
-      expect(page).to have_content 'finished title'
+        select "着手中", from: "task_status_id"
+        click_button submit
+        expect(page).to have_content 'in progress title'
+
+        select "完了", from: "task_status_id"
+        click_button submit
+        expect(page).to have_content 'finished title'
+      end
     end
 
     describe "pagination with 20 tasks" do
       before do
         create_list(:task, 20, task_status_id: @untouch_id)
         visit root_path
+      end
+      it 'should not have link to 3rd page' do
+        expect(page).not_to have_link '3'
       end
       it 'should match correct titles in 1st page' do
         Task.page(1).per(10).each do |task|
@@ -131,6 +139,9 @@ RSpec.describe "Task", type: :system do
       before do
         create_list(:task, 21, task_status_id: @untouch_id)
         visit root_path(page: "2")
+      end
+      it 'should not have link to 4th page' do
+        expect(page).not_to have_link '4'
       end
       it 'should match correct titles in 2nd page' do
         Task.page(2).per(10).each do |task|

--- a/eumetopias_2/spec/system/tasks_spec.rb
+++ b/eumetopias_2/spec/system/tasks_spec.rb
@@ -69,9 +69,37 @@ RSpec.describe "Task", type: :system do
       test_status = TaskStatus.find_by(name: "未着手").id
       Task.create(title: test_title, description: 'dummy', task_status_id: test_status)
     end
-    it "should have task title" do
+    it "should have added task title" do
       visit root_path
       expect(page).to have_content test_title
     end
+  end
+
+  describe "Task list page search" do
+    let(:submit) { "検索" }
+    before do 
+      untouch_id = TaskStatus.find_by(name: '未着手').id
+      in_progress_id = TaskStatus.find_by(name: '着手中').id
+      finished_id = TaskStatus.find_by(name: '完了').id
+      sample_data = {"untouch title"=>untouch_id, "in progress title"=>in_progress_id, "finished title"=>finished_id}
+      sample_data.each do |title, status_id|
+        Task.create(title: title, description: "dummy description", task_status_id: status_id)
+      end
+      visit root_path
+
+    end
+    it 'should show search result with correct task title' do
+      select "未着手", from: "task_status_id"
+      click_button submit
+      expect(page).to have_content 'untouch title'
+
+      select "着手中", from: "task_status_id"
+      click_button submit
+      expect(page).to have_content 'in progress title'
+
+      select "完了", from: "task_status_id"
+      click_button submit
+      expect(page).to have_content 'finished title'
+    end 
   end
 end


### PR DESCRIPTION
## 課題
- [ステップ13: ステータスを追加して、検索できるようにしよう](https://github.com/Fablic/training/tree/m-nakamura/eumetopias_2/docs#ステップ13-ステータスを追加して検索できるようにしよう)
- [ステップ14: ページネーションを追加しよう](https://github.com/Fablic/training/tree/m-nakamura_14_add_pagination)

## 変更内容
- ステップ１１のFYIコメントの対応
  - https://github.com/Fablic/training/pull/749#discussion_r476207051
- ステータス管理用にTaskStatusモデルを追加
  - task_statusesテーブルへの初期値投入migrationを作成
- 一覧画面にステータス検索機能を追加
- テスト追加
  - Taskの model spec
  - 検索機能の system spec
  - バリデーション（不正値入力）のsystem spec
- 一覧ページにページネーションを追加

## コメント
- 【オプション要件】のGemを利用せずステータス・検索を実装した。
- ページネーション追加時の差分コミット
  - https://github.com/Fablic/training/pull/760/commits/c06d2975d83d408a2ab15e5bf4d4e1bf600eff4b
## ※レビューアー要設定事項
- DB設定について
  - `dotenv-rails`でDBの設定情報を隠蔽しているため、`$ mv .env.template .env`して、[ユーザー名]、[パスワード] をご自身の環境のものに書き換えてください。


# 実行結果コード／SS
### ステップ13 絞り込んだ際のSQLログの比較
#### それぞれの最終行のSQL文の変化を確認。
- 検索なしのログ

```
Started GET "/" for 10.0.2.2 at 2020-08-24 08:13:51 +0000
Cannot render console from 10.0.2.2! Allowed networks: 127.0.0.0/127.255.255.255, ::1
Processing by TaskController#index as HTML
  TaskStatus Load (0.4ms)  SELECT `task_statuses`.* FROM `task_statuses`
  ↳ app/controllers/task_controller.rb:64:in `map'
  Rendering task/index.html.erb within layouts/application
  Task Load (0.2ms)  SELECT `tasks`.* FROM `tasks`  # 全てのタスクを抽出
　　・
```

- ステータス：未着手（TaskStatusId：1）で絞り込んだ時のログ

```
Started GET "/?task_status_id=1&commit=%E6%A4%9C%E7%B4%A2" for 10.0.2.2 at 2020-08-24 08:14:03 +0000
Cannot render console from 10.0.2.2! Allowed networks: 127.0.0.0/127.255.255.255, ::1
Processing by TaskController#index as HTML
  Parameters: {"task_status_id"=>"1", "commit"=>"検索"}
  TaskStatus Load (0.3ms)  SELECT `task_statuses`.* FROM `task_statuses`
  ↳ app/controllers/task_controller.rb:64:in `map'
  Rendering task/index.html.erb within layouts/application
  Task Load (0.2ms)  SELECT `tasks`.* FROM `tasks` WHERE `tasks`.`task_status_id` = 1  # task_status_id:1 のタスクを抽出
　　・
```

---


### テスト実行結果
```bash
$ bundle exec rspec spec/system/tasks_spec.rb 
......

Finished in 0.50024 seconds (files took 0.78523 seconds to load)
6 examples, 0 failures
```

```bash
$ bundle exec rspec spec/models/task_spec.rb 
..

Finished in 0.14408 seconds (files took 0.7566 seconds to load)
2 examples, 0 failures
```

---

### 検索機能SS
- プルダウンはデフォルトで `全て`
<img width="496" alt="スクリーンショット 2020-08-27 10 30 20" src="https://user-images.githubusercontent.com/69135260/91373117-7ff4d180-e850-11ea-9cc7-fbd1c77392d4.png">

---

### ページネーション追加後
<img width="350" alt="スクリーンショット 2020-08-28 13 32 36" src="https://user-images.githubusercontent.com/69135260/91521622-097cd000-e933-11ea-9110-d4e3752a35b9.png">