### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -56,11 +56,10 @@ class TasksController < ApplicationController
   private
 
   def set_task
-    @task = Task.find_by(id: params[:id])
-    if @task.present?
-      return @task
-    else
-      return redirect_to root_path, danger: '存在しないタスクです'
+    begin
+      @task = Task.find(params[:id])
+    rescue => e
+      redirect_to root_path, danger: '存在しないタスクです'
     end
   end
 

--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -4,7 +4,6 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @task = Task.new
     @tasks = Task.all.order(created_at: :desc)
   end
 

--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -50,7 +50,11 @@ class TasksController < ApplicationController
     @word_search = params[:keyword_text]
 
     # 終了期限のソート・ステータスorタスク名の検索
-    @tasks = Task.sort(params[:keyword]).where("title LIKE ? OR status LIKE ?", "%#{params[:keyword_text]}%", "%#{Task.replace_letters_with_numbers(params[:keyword_text])}%")
+    if Task.replace_letters_with_numbers(@word_search).present?
+      @tasks = Task.sort(@selection).where("status LIKE ?", "%#{Task.replace_letters_with_numbers(@word_search)}%")
+    else
+      @tasks = Task.sort(@selection).where("title LIKE ?", "%#{@word_search}%")
+    end
   end
 
   private

--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -50,7 +50,7 @@ class TasksController < ApplicationController
     @word_search = params[:keyword_text]
 
     # 終了期限のソート・ステータスorタスク名の検索
-    @tasks = Task.sort(@selection).where("status LIKE ?", "%#{Task.replace_letters_with_numbers(@word_search)}%").or(Task.sort(@selection).where("title LIKE ?", "%#{@word_search}%"))
+    @tasks = Task.sort(params[:keyword]).where("title LIKE ? OR status LIKE ?", "%#{params[:keyword_text]}%", "%#{Task.replace_letters_with_numbers(params[:keyword_text])}%")
   end
 
   private

--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -45,12 +45,8 @@ class TasksController < ApplicationController
   end
 
   def search
-    # 終了期限のソート・ステータスorタスク名の検索
-    if Task.replace_letters_with_numbers(params[:keyword_text]).present?
-      @tasks = Task.sort(params[:keyword]).where("status LIKE ?", "%#{Task.replace_letters_with_numbers(params[:keyword_text])}%")
-    else
-      @tasks = Task.sort(params[:keyword]).where("title LIKE ?", "%#{params[:keyword_text]}%")
-    end
+    # 終了期限のソートorステータスorタスク名の検索
+    @tasks = Task.deadline_sort(params[:deadline_keyword]).search_status(params[:status_keyword]).search_title(params[:title_keyword])
   end
 
   private

--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -46,14 +46,11 @@ class TasksController < ApplicationController
   end
 
   def search
-    @selection = params[:keyword]
-    @word_search = params[:keyword_text]
-
     # 終了期限のソート・ステータスorタスク名の検索
-    if Task.replace_letters_with_numbers(@word_search).present?
-      @tasks = Task.sort(@selection).where("status LIKE ?", "%#{Task.replace_letters_with_numbers(@word_search)}%")
+    if Task.replace_letters_with_numbers(params[:keyword_text]).present?
+      @tasks = Task.sort(params[:keyword]).where("status LIKE ?", "%#{Task.replace_letters_with_numbers(params[:keyword_text])}%")
     else
-      @tasks = Task.sort(@selection).where("title LIKE ?", "%#{@word_search}%")
+      @tasks = Task.sort(params[:keyword]).where("title LIKE ?", "%#{params[:keyword_text]}%")
     end
   end
 

--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -48,13 +48,9 @@ class TasksController < ApplicationController
   def search
     @selection = params[:keyword]
     @word_search = params[:keyword_text]
-    
-    # 未着手、着手、完了のワードがあれば、ステータスで検索をかけるそれ以外はタスク名での検索
-    if Task.replace_letters_with_numbers(@word_search).present?
-      @tasks = Task.sort(@selection).where("status LIKE ?", "%#{Task.replace_letters_with_numbers(@word_search)}%")
-    else
-      @tasks = Task.sort(@selection).where("title LIKE ?", "%#{@word_search}%")
-    end
+
+    # 終了期限のソート・ステータスorタスク名の検索
+    @tasks = Task.sort(@selection).where("status LIKE ?", "%#{Task.replace_letters_with_numbers(@word_search)}%").or(Task.sort(@selection).where("title LIKE ?", "%#{@word_search}%"))
   end
 
   private

--- a/TaskManagementSystem/app/controllers/tasks_controller.rb
+++ b/TaskManagementSystem/app/controllers/tasks_controller.rb
@@ -47,7 +47,14 @@ class TasksController < ApplicationController
 
   def search
     @selection = params[:keyword]
-    @tasks = Task.sort(@selection)
+    @word_search = params[:keyword_text]
+    
+    # 未着手、着手、完了のワードがあれば、ステータスで検索をかけるそれ以外はタスク名での検索
+    if Task.replace_letters_with_numbers(@word_search).present?
+      @tasks = Task.sort(@selection).where("status LIKE ?", "%#{Task.replace_letters_with_numbers(@word_search)}%")
+    else
+      @tasks = Task.sort(@selection).where("title LIKE ?", "%#{@word_search}%")
+    end
   end
 
   private

--- a/TaskManagementSystem/app/models/task.rb
+++ b/TaskManagementSystem/app/models/task.rb
@@ -23,6 +23,21 @@ class Task < ApplicationRecord
       all.order(created_at: :desc)
     end
   end
+
+  # ステータスを文字から数字へ置き換える
+  def self.replace_letters_with_numbers(letter)
+    case letter
+    when '未着手' then
+      0
+    when '着手' then
+      1
+    when '完了' then
+      2
+    else
+      nil
+    end
+  end
+  
   # 終了期限のコールバック
   before_save :deadline_blank?
 

--- a/TaskManagementSystem/app/models/task.rb
+++ b/TaskManagementSystem/app/models/task.rb
@@ -25,22 +25,15 @@ class Task < ApplicationRecord
   end
 
   # ステータス検索
-  def self.search_status(letter)
-    case letter
-    when "1" then
-      where(status: 1)
-    when "2" then
-      where(status: 2)
-    when "3" then
-      where(status: 3)
-    else
-      order(created_at: :desc)
-    end
+  def self.search_status(status)
+    return where(status: status) if status.present?
+    order(created_at: :desc)
   end
 
   # タスク名検索
   def self.search_title(title)
-    where("title LIKE ?", "%#{title}%")
+    where("title LIKE ?", "%#{title}%") if title.present?
+    order(created_at: :desc)
   end  
   
   # 終了期限のコールバック

--- a/TaskManagementSystem/app/models/task.rb
+++ b/TaskManagementSystem/app/models/task.rb
@@ -5,7 +5,7 @@ class Task < ApplicationRecord
   validates :status, presence: true
   validate :deadline_not_before_today
 
-  enum status: { waiting: 0, working: 1, completed: 2}
+  enum status: { waiting: 1, working: 2, completed: 3}
 
   # バリデーション用のメソッドを定義
   def deadline_not_before_today
@@ -13,7 +13,7 @@ class Task < ApplicationRecord
   end
 
   # 終了期限新旧ソート機能
-  def self.sort(selection)
+  def self.deadline_sort(selection)
     case selection
     when 'new' then
       all.order(deadline: :desc)
@@ -24,19 +24,24 @@ class Task < ApplicationRecord
     end
   end
 
-  # ステータスを文字から数字へ置き換える
-  def self.replace_letters_with_numbers(letter)
+  # ステータス検索
+  def self.search_status(letter)
     case letter
-    when '未着手' then
-      0
-    when '着手' then
-      1
-    when '完了' then
-      2
+    when "1" then
+      where(status: 1)
+    when "2" then
+      where(status: 2)
+    when "3" then
+      where(status: 3)
     else
-      nil
+      order(created_at: :desc)
     end
   end
+
+  # タスク名検索
+  def self.search_title(title)
+    where("title LIKE ?", "%#{title}%")
+  end  
   
   # 終了期限のコールバック
   before_save :deadline_blank?

--- a/TaskManagementSystem/app/views/layouts/_select_form.html.slim
+++ b/TaskManagementSystem/app/views/layouts/_select_form.html.slim
@@ -6,6 +6,6 @@ scss:
 
 = form_with url: search_path, method: :get, class:"form-inline", local: true do |f|
   = f.text_field :title_keyword, placeholder: "タスク名", value: params[:title_keyword]
-  = f.select :status_keyword, options_for_select([['ステータス', 0], ['未着手', 1], ['着手', 2], ['完了', 3]], params[:status_keyword])
+  = f.select :status_keyword, options_for_select([['ステータス', nil], ['未着手', 'waiting'], ['着手', 'working'], ['完了', 'completed']], params[:status_keyword])
   = f.select :deadline_keyword, options_for_select([['終了期限の表示順', 'unselected'],['新しい順', 'new'], ['古い順', 'old']], params[:deadline_keyword]), class: "ml-2"
   = f.submit '検索', class:'btn btn-secondary btn-sm align-self-end ml-1'

--- a/TaskManagementSystem/app/views/layouts/_select_form.html.slim
+++ b/TaskManagementSystem/app/views/layouts/_select_form.html.slim
@@ -1,9 +1,11 @@
 scss:
   select{
     height: 100%;
+    margin-left: 10px;
   }
 
 = form_with url: search_path, method: :get, class:"form-inline", local: true do |f|
-  = f.text_field :keyword_text, placeholder: "タスク名・ステータス", class: "mr-2"
-  = f.select :keyword, options_for_select([['終了期限が新しい順', 'new'], ['終了期限が古い順', 'old']], params[:keyword])
+  = f.text_field :title_keyword, placeholder: "タスク名", value: params[:title_keyword]
+  = f.select :status_keyword, options_for_select([['ステータス', 0], ['未着手', 1], ['着手', 2], ['完了', 3]], params[:status_keyword])
+  = f.select :deadline_keyword, options_for_select([['終了期限の表示順', 'unselected'],['新しい順', 'new'], ['古い順', 'old']], params[:deadline_keyword]), class: "ml-2"
   = f.submit '検索', class:'btn btn-secondary btn-sm align-self-end ml-1'

--- a/TaskManagementSystem/app/views/layouts/_select_form.html.slim
+++ b/TaskManagementSystem/app/views/layouts/_select_form.html.slim
@@ -1,6 +1,9 @@
 scss:
-  select{height: 100%;}
+  select{
+    height: 100%;
+  }
 
-= form_with url: search_path, method: :get, local: true do |f|
+= form_with url: search_path, method: :get, class:"form-inline", local: true do |f|
+  = f.text_field :keyword_text, placeholder: "タスク名・ステータス", class: "mr-2"
   = f.select :keyword, options_for_select([['終了期限が新しい順', 'new'], ['終了期限が古い順', 'old']], @selection)
-  = f.submit '検索', class:'btn btn-secondary btn-sm align-self-end'
+  = f.submit '検索', class:'btn btn-secondary btn-sm align-self-end ml-1'

--- a/TaskManagementSystem/app/views/layouts/_select_form.html.slim
+++ b/TaskManagementSystem/app/views/layouts/_select_form.html.slim
@@ -5,5 +5,5 @@ scss:
 
 = form_with url: search_path, method: :get, class:"form-inline", local: true do |f|
   = f.text_field :keyword_text, placeholder: "タスク名・ステータス", class: "mr-2"
-  = f.select :keyword, options_for_select([['終了期限が新しい順', 'new'], ['終了期限が古い順', 'old']], @selection)
+  = f.select :keyword, options_for_select([['終了期限が新しい順', 'new'], ['終了期限が古い順', 'old']], params[:keyword])
   = f.submit '検索', class:'btn btn-secondary btn-sm align-self-end ml-1'

--- a/TaskManagementSystem/app/views/tasks/index.html.slim
+++ b/TaskManagementSystem/app/views/tasks/index.html.slim
@@ -6,9 +6,9 @@
   .task-index-head.row.px-5
     .col-3
       = link_to 'タスク登録', new_task_path, class: "btn btn-primary btn-sm"
-    .col-5.ml-auto
-      .row
-        = link_to 'ラベル作成', '#', class: "btn btn-primary btn-sm mr-3"
+    .col-8.ml-auto
+      .row.pull-right
+        = link_to 'ラベル作成', '#', class: "btn btn-primary btn-sm mr-4"
         = render "layouts/select_form"
           
   = render "layouts/result", tasks: @tasks

--- a/TaskManagementSystem/app/views/tasks/index.html.slim
+++ b/TaskManagementSystem/app/views/tasks/index.html.slim
@@ -3,11 +3,11 @@
   = render  "layouts/flash"
   .row.index-title
     h2 タスク一覧
-  .task-index-head.row.px-5
-    .col-3
+  .task-index-head.row
+    .col-2
       = link_to 'タスク登録', new_task_path, class: "btn btn-primary btn-sm"
-    .col-8.ml-auto
-      .row.pull-right
+    .col-10
+      .row.float-right.mr-2
         = link_to 'ラベル作成', '#', class: "btn btn-primary btn-sm mr-4"
         = render "layouts/select_form"
           

--- a/TaskManagementSystem/app/views/tasks/search.html.slim
+++ b/TaskManagementSystem/app/views/tasks/search.html.slim
@@ -6,9 +6,9 @@
   .task-index-head.row.px-5
     .col-3
       = link_to 'タスク登録', new_task_path, class: "btn btn-primary btn-sm"
-    .col-5.ml-auto
-      .row
-        = link_to 'ラベル作成', '#', class: "btn btn-primary btn-sm mr-3"
+    .col-8.ml-auto
+      .row.pull-right
+        = link_to 'ラベル作成', '#', class: "btn btn-primary btn-sm mr-4"
         = render "layouts/select_form"
         
   = render "layouts/result", tasks: @tasks

--- a/TaskManagementSystem/app/views/tasks/search.html.slim
+++ b/TaskManagementSystem/app/views/tasks/search.html.slim
@@ -3,12 +3,12 @@
   = render  "layouts/flash"
   .row.index-title
     h2 タスク一覧
-  .task-index-head.row.px-5
-    .col-3
+  .task-index-head.row
+    .col-2
       = link_to 'タスク登録', new_task_path, class: "btn btn-primary btn-sm"
-    .col-8.ml-auto
-      .row.pull-right
+    .col-10
+      .row.float-right.mr-2
         = link_to 'ラベル作成', '#', class: "btn btn-primary btn-sm mr-4"
         = render "layouts/select_form"
-        
+          
   = render "layouts/result", tasks: @tasks

--- a/TaskManagementSystem/db/migrate/20200811023340_create_tasks.rb
+++ b/TaskManagementSystem/db/migrate/20200811023340_create_tasks.rb
@@ -4,11 +4,11 @@ class CreateTasks < ActiveRecord::Migration[6.0]
   def change
     create_table :tasks do |t|
       t.integer :user_id, null: false
-      t.string :title, null: false, limit: 50
+      t.string :title, null: false, limit: 50, index: true
       t.text :description, null: true, limit: 250
       t.integer :priority, default: 1
       t.datetime :deadline
-      t.integer :status, default: 0
+      t.integer :status, default: 0, index: true
 
       t.timestamps
     end

--- a/TaskManagementSystem/db/schema.rb
+++ b/TaskManagementSystem/db/schema.rb
@@ -44,6 +44,8 @@ ActiveRecord::Schema.define(version: 2020_08_11_023555) do
     t.integer "status", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status"], name: "index_tasks_on_status"
+    t.index ["title"], name: "index_tasks_on_title"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/TaskManagementSystem/db/seeds.rb
+++ b/TaskManagementSystem/db/seeds.rb
@@ -15,7 +15,7 @@
     description: "タスクの説明#{n}",
     priority: n,
     deadline: Time.strptime("2020年10月#{n + 1}日 12:13:23", '%Y年%m月%d日 %H:%M:%S'),
-    status: n
+    status: n + 1
   )
 end
 
@@ -26,6 +26,6 @@ end
     description: "タスクの説明#{3 + n}",
     priority: n + 3,
     deadline: Time.strptime("2020年10月#{n + 4}日 12:13:23", '%Y年%m月%d日 %H:%M:%S'),
-    status: n
+    status: n + 1
   )
 end

--- a/TaskManagementSystem/spec/factories/tasks.rb
+++ b/TaskManagementSystem/spec/factories/tasks.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :valid_sample_task, class: Task do
     sequence(:user_id){|i| i}
-    title {'タスク名の編集テスト'}
-    description {'タスク説明の編集テスト'}
+    sequence(:title){|i| "タスク名のテスト#{i}"}
+    description {'タスク説明のテスト'}
     priority {1}
     sequence(:deadline){ |i| Time.strptime("2020年10月#{i}日 12:13:23", '%Y年%m月%d日 %H:%M:%S') }
     status {1}

--- a/TaskManagementSystem/spec/factories/tasks.rb
+++ b/TaskManagementSystem/spec/factories/tasks.rb
@@ -1,25 +1,11 @@
 FactoryBot.define do
-  # 異なる作成日を生成
-  sequence :sample_user_id do |i|
-    i
-  end
-
-  sequence :sample_created do |i|
-    Time.strptime("2020年9月#{i}日 12:13:23", '%Y年%m月%d日 %H:%M:%S')
-  end
-
-  sequence :sample_deadline do |i|
-    Time.strptime("2020年10月#{i}日 12:13:23", '%Y年%m月%d日 %H:%M:%S')
-  end
-
-
   factory :valid_sample_task, class: Task do
-    user_id {generate :sample_user_id}
+    sequence(:user_id){|i| i}
     title {'タスク名の編集テスト'}
     description {'タスク説明の編集テスト'}
     priority {1}
-    deadline {generate :sample_deadline}
+    sequence(:deadline){ |i| Time.strptime("2020年10月#{i}日 12:13:23", '%Y年%m月%d日 %H:%M:%S') }
     status {1}
-    created_at {generate :sample_created}
+    sequence(:created_at){ |i| Time.strptime("2020年9月#{i}日 12:13:23", '%Y年%m月%d日 %H:%M:%S') }
   end
 end

--- a/TaskManagementSystem/spec/features/tasks_spec.rb
+++ b/TaskManagementSystem/spec/features/tasks_spec.rb
@@ -23,16 +23,16 @@ RSpec.feature "Task", type: :feature do
       visit root_path
 
       # 終了期限が新しい順になっている
-      select('終了期限が新しい順', from: 'keyword')
-      expect(page).to have_select('keyword', selected: '終了期限が新しい順')
+      select('新しい順', from: 'deadline_keyword')
+      expect(page).to have_select('deadline_keyword', selected: '新しい順')
       click_on('検索')
       4.times do |n|
         expect(page.body.index(tasks[n].deadline.strftime('%Y/%m/%d'))).to be > page.body.index(tasks[n+1].deadline.strftime('%Y/%m/%d'))
       end
 
       # 終了期限が古い順になっている
-      select('終了期限が古い順', from: 'keyword')
-      expect(page).to have_select('keyword', selected: '終了期限が古い順')
+      select('古い順', from: 'deadline_keyword')
+      expect(page).to have_select('deadline_keyword', selected: '古い順')
       click_on('検索')
       4.times do |n|
         expect(page.body.index(tasks[n].deadline.strftime('%Y/%m/%d'))).to be < page.body.index(tasks[n+1].deadline.strftime('%Y/%m/%d'))
@@ -51,7 +51,7 @@ RSpec.feature "Task", type: :feature do
       visit root_path
 
       # 検索フォームへ入力
-      fill_in 'keyword_text', with: 'タスク名のテスト1'
+      fill_in 'title_keyword', with: 'タスク名のテスト1'
       click_button '検索'
 
       # 検索結果が表示されている
@@ -64,7 +64,7 @@ RSpec.feature "Task", type: :feature do
       visit root_path
 
       # 検索フォームへ入力
-      fill_in 'keyword_text', with: '完了'
+      select('未着手', from: 'status_keyword')
       click_button '検索'
 
       # 検索結果が表示されている

--- a/TaskManagementSystem/spec/features/tasks_spec.rb
+++ b/TaskManagementSystem/spec/features/tasks_spec.rb
@@ -3,25 +3,21 @@ require 'rails_helper'
 RSpec.feature "Task", type: :feature do
   # タスク降順テスト
   feature 'TaskListDecendingOrder' do
-    before do
-      @tasks = create_list(:valid_sample_task, 5)
-    end
+    let!(:tasks){create_list(:valid_sample_task, 5)}
     scenario "is descending orders in task index screen" do
       # タスク一覧画面へ移動
       visit root_path
 
       # タスクが作成日時の降順になっていることを確認
       4.times do |n|
-        expect(page.body.index(@tasks[n].created_at.strftime('%Y/%m/%d'))).to be > page.body.index(@tasks[n+1].created_at.strftime('%Y/%m/%d'))
+        expect(page.body.index(tasks[n].created_at.strftime('%Y/%m/%d'))).to be > page.body.index(tasks[n+1].created_at.strftime('%Y/%m/%d'))
       end
     end  
   end
 
   # 終了期限ソート機能テスト
   feature 'SortTaskListByDeadline' do
-    before do
-      @tasks = create_list(:valid_sample_task, 5)
-    end
+    let!(:tasks){create_list(:valid_sample_task, 5)}
     scenario "can sort task's list by deadline" do
       # タスク一覧画面へ移動
       visit root_path
@@ -31,7 +27,7 @@ RSpec.feature "Task", type: :feature do
       expect(page).to have_select('keyword', selected: '終了期限が新しい順')
       click_on('検索')
       4.times do |n|
-        expect(page.body.index(@tasks[n].deadline.strftime('%Y/%m/%d'))).to be > page.body.index(@tasks[n+1].deadline.strftime('%Y/%m/%d'))
+        expect(page.body.index(tasks[n].deadline.strftime('%Y/%m/%d'))).to be > page.body.index(tasks[n+1].deadline.strftime('%Y/%m/%d'))
       end
 
       # 終了期限が古い順になっている
@@ -39,7 +35,7 @@ RSpec.feature "Task", type: :feature do
       expect(page).to have_select('keyword', selected: '終了期限が古い順')
       click_on('検索')
       4.times do |n|
-        expect(page.body.index(@tasks[n].deadline.strftime('%Y/%m/%d'))).to be < page.body.index(@tasks[n+1].deadline.strftime('%Y/%m/%d'))
+        expect(page.body.index(tasks[n].deadline.strftime('%Y/%m/%d'))).to be < page.body.index(tasks[n+1].deadline.strftime('%Y/%m/%d'))
       end
     end
   end

--- a/TaskManagementSystem/spec/features/tasks_spec.rb
+++ b/TaskManagementSystem/spec/features/tasks_spec.rb
@@ -39,4 +39,36 @@ RSpec.feature "Task", type: :feature do
       end
     end
   end
+
+  # タスク名とステータスで検索ができる
+  feature 'SearchTaskListByTitleAndStatus' do
+    3.times do |n|
+      let!(:valid_task) {create(:valid_sample_task, status: n)}
+    end
+    # タスク名での検索ができる
+    scenario 'can search tasks by title' do
+      # タスク一覧画面へ移動
+      visit root_path
+
+      # 検索フォームへ入力
+      fill_in 'keyword_text', with: 'タスク名のテスト1'
+      click_button '検索'
+
+      # 検索結果が表示されている
+      expect(page).to have_content 'タスク名のテスト1'
+    end
+
+    # ステータスでの検索ができる
+    scenario 'can search tasks by status' do
+      # タスク一覧画面へ移動
+      visit root_path
+
+      # 検索フォームへ入力
+      fill_in 'keyword_text', with: '完了'
+      click_button '検索'
+
+      # 検索結果が表示されている
+      expect(page).to have_content '完了'
+    end
+  end
 end

--- a/TaskManagementSystem/spec/models/task_spec.rb
+++ b/TaskManagementSystem/spec/models/task_spec.rb
@@ -20,14 +20,12 @@ RSpec.describe Task, type: :model do
     end
     # ステータスの検索ができる
     it 'can search task by status' do 
-      @tasks = Task.sort('old').where("status LIKE ?", "%1%")
-      @tasks.each do |task|
-        expect(task.status).to eq 1
-      end
+      @tasks = Task.where(status: 2)
+      @tasks.all? {|task| expect(task.status).to eq 'working'}
     end
     # タスク名の検索ができる
     it 'can search task by title' do 
-      @tasks = Task.sort('old').where("title LIKE ?", "%タスクの名前1%")
+      @tasks = Task.where("title LIKE ?", "%タスクの名前1%")
       @tasks.each do |task|
         expect(task.title).to eq "タスクの名前1"
       end

--- a/TaskManagementSystem/spec/models/task_spec.rb
+++ b/TaskManagementSystem/spec/models/task_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe Task, type: :model do
     # タスク名の検索ができる
     it 'can search task by title' do 
       @tasks = Task.where("title LIKE ?", "%タスクの名前1%")
-      @tasks.each do |task|
-        expect(task.title).to eq "タスクの名前1"
-      end
+      @tasks.all? {|task| expect(task.title).to eq 'タスクの名前1'}
     end
   end
 end

--- a/TaskManagementSystem/spec/models/task_spec.rb
+++ b/TaskManagementSystem/spec/models/task_spec.rb
@@ -13,4 +13,24 @@ RSpec.describe Task, type: :model do
       expect(invalid_task).not_to be_valid
     end
   end
+
+  describe 'SarchingTask' do
+    3.times do |n|
+      let!(:valid_task) {create(:valid_sample_task, status: n, title: "タスクの名前#{n}")}
+    end
+    # ステータスの検索ができる
+    it 'can search task by status' do 
+      @tasks = Task.sort('old').where("status LIKE ?", "%1%")
+      @tasks.each do |task|
+        expect(task.status).to eq 1
+      end
+    end
+    # タスク名の検索ができる
+    it 'can search task by title' do 
+      @tasks = Task.sort('old').where("title LIKE ?", "%タスクの名前1%")
+      @tasks.each do |task|
+        expect(task.title).to eq "タスクの名前1"
+      end
+    end
+  end
 end

--- a/TaskManagementSystem/spec/models/task_spec.rb
+++ b/TaskManagementSystem/spec/models/task_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Task, type: :model do
     end
     # ステータスの検索ができる
     it 'can search task by status' do 
-      @tasks = Task.where(status: 2)
+      @tasks = Task.where(status: "working")
       @tasks.all? {|task| expect(task.status).to eq 'working'}
     end
     # タスク名の検索ができる

--- a/TaskManagementSystem/spec/models/task_spec.rb
+++ b/TaskManagementSystem/spec/models/task_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Task, type: :model do
 
   describe 'SarchingTask' do
     3.times do |n|
-      let!(:valid_task) {create(:valid_sample_task, status: n, title: "タスクの名前#{n}")}
+      let!(:valid_task) {create(:valid_sample_task, status: n)}
     end
     # ステータスの検索ができる
     it 'can search task by status' do 


### PR DESCRIPTION
## 課題
[ステップ13: ステータスを追加して、検索できるようにしよう
](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)

## 実施内容
- [x] ステップ13: ステータスを追加して、検索できるようにする
   - [x] ステータス（未着手・着手中・完了）を追加
   - [x] 一覧画面でタイトルとステータスで検索ができるようにする
   - [x] 絞り込んだ際、ログを見て発行されるSQLの変化を確認
   - [x] 検索インデックスを貼る
   - [x] 検索に対してmodel specを追加（feature specの拡充もやる） 

### SQLの変化確認
タスク名（カラム：title）で検索をかけた場合。
- 変化前：`SELECT `tasks`.* FROM `tasks` ORDER BY `tasks`.`created_at` DESC`
- 変化後：`SELECT `tasks`.* FROM `tasks` WHERE (title LIKE '%タスクの名前5%') ORDER BY `tasks`.`deadline` DESC`