### PR TITLE
ステップ15: デザインを当てよう 

### DIFF
--- a/eumetopias_2/Gemfile
+++ b/eumetopias_2/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'dotenv-rails'
 gem 'rails-i18n'
 gem 'kaminari'
+gem 'kaminari-bootstrap'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/eumetopias_2/Gemfile.lock
+++ b/eumetopias_2/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
     kaminari-activerecord (1.2.1)
       activerecord
       kaminari-core (= 1.2.1)
+    kaminari-bootstrap (3.0.1)
+      kaminari (>= 0.13.0)
+      rails
     kaminari-core (1.2.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -247,6 +250,7 @@ DEPENDENCIES
   factory_bot_rails
   jbuilder (~> 2.7)
   kaminari
+  kaminari-bootstrap
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   puma (~> 4.1)

--- a/eumetopias_2/app/helpers/task_helper.rb
+++ b/eumetopias_2/app/helpers/task_helper.rb
@@ -1,2 +1,7 @@
 module TaskHelper
+  def status_select_options
+    options =  [['全て', '']]
+    TaskStatus.all.each {|status| options.push([status.name, status.id])}
+    return options
+  end
 end

--- a/eumetopias_2/app/javascript/packs/application.js
+++ b/eumetopias_2/app/javascript/packs/application.js
@@ -7,7 +7,7 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-
+require("jquery")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
@@ -15,3 +15,6 @@ require("channels")
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+
+import 'bootstrap'
+import '../src/application.scss'

--- a/eumetopias_2/app/javascript/src/application.scss
+++ b/eumetopias_2/app/javascript/src/application.scss
@@ -1,0 +1,1 @@
+@import '~bootstrap/scss/bootstrap';

--- a/eumetopias_2/app/views/kaminari/_first_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/eumetopias_2/app/views/kaminari/_first_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_first_page.html.erb
@@ -1,3 +1,7 @@
-<li class="page-item">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+<% if current_page.first? %>
+  <li class="page-item disabled">
+<%else%>
+  <li class="page-item">
+<%end%>
+  <%= link_to raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
 </li>

--- a/eumetopias_2/app/views/kaminari/_gap.html.erb
+++ b/eumetopias_2/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/eumetopias_2/app/views/kaminari/_last_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/eumetopias_2/app/views/kaminari/_last_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_last_page.html.erb
@@ -1,3 +1,7 @@
-<li class="page-item">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+<% if current_page.last? %>
+  <li class="page-item disabled">
+<% else %>
+  <li class="page-item">
+<% end %>
+  <%= link_to raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
 </li>

--- a/eumetopias_2/app/views/kaminari/_next_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/eumetopias_2/app/views/kaminari/_next_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,7 @@
-<li class="page-item">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+<% if current_page.last? %>
+  <li class="page-item disabled">
+<% else %>
+  <li class="page-item">
+<% end %>
+  <%= link_to raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
 </li>

--- a/eumetopias_2/app/views/kaminari/_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/eumetopias_2/app/views/kaminari/_paginator.html.erb
+++ b/eumetopias_2/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/eumetopias_2/app/views/kaminari/_paginator.html.erb
+++ b/eumetopias_2/app/views/kaminari/_paginator.html.erb
@@ -1,8 +1,8 @@
 <%= paginator.render do %>
   <nav>
     <ul class="pagination">
-      <%= first_page_tag unless current_page.first? %>
-      <%= prev_page_tag unless current_page.first? %>
+      <%= first_page_tag %>
+      <%= prev_page_tag %>
       <% each_page do |page| %>
         <% if page.left_outer? || page.right_outer? || page.inside_window? %>
           <%= page_tag page %>
@@ -10,8 +10,8 @@
           <%= gap_tag %>
         <% end %>
       <% end %>
-      <%= next_page_tag unless current_page.last? %>
-      <%= last_page_tag unless current_page.last? %>
+      <%= next_page_tag %>
+      <%= last_page_tag %>
     </ul>
   </nav>
 <% end %>

--- a/eumetopias_2/app/views/kaminari/_prev_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/eumetopias_2/app/views/kaminari/_prev_page.html.erb
+++ b/eumetopias_2/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,7 @@
-<li class="page-item">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+<% if current_page.first? %>
+  <li class="page-item disabled">
+<%else%>
+  <li class="page-item">
+<%end%>
+  <%= link_to raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
 </li>

--- a/eumetopias_2/app/views/task/edit.html.erb
+++ b/eumetopias_2/app/views/task/edit.html.erb
@@ -1,19 +1,19 @@
 <div class="container">
   <div class="jumbotron m-3">
-    <h2><%= t('dictionary.title.update') %></h2>
+    <h2><%= t('dictionary.title.task_edit') %></h2>
     <hr>
     <%= render 'layouts/error_messages', model: @task %>
     <%= form_with(model: @task, class: 'form-group', local: true) do |form| %>
       <p>
-        <%= form.label t('dictionary.table.title') %>
+        <%= form.label t('activerecord.attributes.task.title') %>
         <%= form.text_field :title, size:'40', class: 'form-control' %>
       </p>
       <p>
-        <%= form.label "ステータス" %>
+        <%= form.label t('activerecord.attributes.task_status.name') %>
         <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name,{}, {class: 'form-control'}  %>
       </p>
       <p>
-        <%= form.label t('dictionary.table.description') %>
+        <%= form.label t('activerecord.attributes.task.description') %>
         <%= form.text_area :description, size: '75x6', class: 'form-control' %>
       </p>
       <p class="row float-right">

--- a/eumetopias_2/app/views/task/edit.html.erb
+++ b/eumetopias_2/app/views/task/edit.html.erb
@@ -1,25 +1,25 @@
-<h1><%= t('dictionary.title.update') %></h1>
-<%= render 'layouts/error_messages', model: @task %>
-<%= form_with(model: @task, local: true) do |form| %>
-<p>
-  <%= form.label t('dictionary.table.title') %><br>
-  <%= form.text_field :title %>
-</p>
-
-<p>
-  <%= form.label t('dictionary.table.description') %><br>
-  <%= form.text_field :description %>
-</p>
-
-<p>
-  <%= form.label :task_status_id %>
-  <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name %>
-</p>
-
-<p>
-  <%= form.submit t('dictionary.button.update') %>
-</p>
-
-<% end %>
-
-<%= link_to t('dictionary.browse.back'), root_path  %>
+<div class="container">
+  <div class="jumbotron m-3">
+    <h2><%= t('dictionary.title.update') %></h2>
+    <hr>
+    <%= render 'layouts/error_messages', model: @task %>
+    <%= form_with(model: @task, class: 'form-group', local: true) do |form| %>
+      <p>
+        <%= form.label t('dictionary.table.title') %>
+        <%= form.text_field :title, size:'40', class: 'form-control' %>
+      </p>
+      <p>
+        <%= form.label "ステータス" %>
+        <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name,{}, {class: 'form-control'}  %>
+      </p>
+      <p>
+        <%= form.label t('dictionary.table.description') %>
+        <%= form.text_area :description, size: '75x6', class: 'form-control' %>
+      </p>
+      <p class="row float-right">
+        <%= link_to t('dictionary.browse.back'), root_path, class: 'btn btn-outline-primary' %>
+        <%= form.submit t('dictionary.button.update'), class: 'btn btn-primary' %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -11,7 +11,9 @@
     <%= link_to t('dictionary.button.create'), new_task_path, class: 'btn btn-primary float-left' %>
     <%= form_with url: root_path, method: :get, class: 'form-group form-inline float-right', local: true do |form| %>
       <%= form.label 'status検索' %>
-      <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name, {prompt: '全て'}, {class: 'form-control'} %>
+      <% select_options =  [['全て', '']] %>
+      <% TaskStatus.all.each {|status| select_options.push([status.name, status.id])} %>
+      <%= form.select :task_status_id, select_options, {selected: params[:task_status_id] || ''}, {class: 'form-control'} %>
       <%= form.submit '検索', class: 'btn btn-primary' %>
     <% end %>
 

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -1,33 +1,46 @@
-<h1>タスク一覧</h1>
-<p>
-<% flash.each do |name, msg| %>
-<%= content_tag :div, msg, class: name  %>
-<% end %>
-</p>
-<%= form_with url: root_path, method: :get, local: true do |form| %>
-  <%= form.label 'status' %>
-  <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name, prompt: '全て' %>
-  <%= form.submit t('dictionary.button.search') %>
-<% end %>
-<table>
-  <tr>
-    <th><%= t('dictionary.table.title') %></th>
-    <th><%= t('dictionary.table.description') %></th>
-    <th>Status</th>
-    <th></th>
-    <th></th>
-    <th></th>
-  </tr>
-  <% @task.each do |task| %>
-  <tr>
-    <th><%= task.title %></th>
-    <th><%=task.description %></th>
-    <th><%=task.task_status.name %></th>
-    <th><%= link_to t('dictionary.button.show'), task_path(task) %></th>
-    <th><%= link_to t('dictionary.button.edit'), edit_task_path(task) %></th>
-    <th><%= link_to t('dictionary.button.destroy'), task_path(task), method: :delete, data:{ confirm: t('dictionary.message.destroy.confirm')} %></th>
-  <tr>
-  <% end %>
-</table>
-<%= paginate @task %>
-<%= link_to t('dictionary.button.create'), new_task_path %>
+<div class="container">
+  <div class="jumbotron m-3">
+    <h3 class="display-4">タスク一覧</h2>
+    <hr class="my-4">
+    <p>
+      <% flash.each do |name, msg| %>
+      <%= content_tag :div, msg, class: name  %>
+      <% end %>
+    </p>
+
+    <%= link_to t('dictionary.button.create'), new_task_path, class: 'btn btn-primary float-left' %>
+    <%= form_with url: root_path, method: :get, class: 'form-group form-inline float-right', local: true do |form| %>
+      <%= form.label 'status検索' %>
+      <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name, {prompt: '全て'}, {class: 'form-control'} %>
+      <%= form.submit '検索', class: 'btn btn-primary' %>
+    <% end %>
+
+    <table class="table table-striped table-hover">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col"><%= t('dictionary.table.title') %></th>
+          <th scope="col"><%= t('dictionary.table.description') %></th>
+          <th scope="col">ステータス</th>
+          <th scope="col"></th>
+          <th scope="col"></th>
+          <th scope="col"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @task.each do |task| %>
+          <tr>
+            <th scope="row"><%= task.id %></th>
+            <td><%= task.title %></td>
+            <td><%= task.description %></td>
+            <td><%= task.task_status.name %></td>
+            <td><%= link_to t('dictionary.button.show'), task_path(task) %></td>
+            <td><%= link_to t('dictionary.button.edit'), edit_task_path(task) %></td>
+            <td><%= link_to t('dictionary.button.destroy'), task_path(task), {method: :delete, data:{ confirm: t('dictionary.message.destroy.confirm')}} %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= paginate @task %>
+  </div>
+</div>

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="jumbotron m-3">
-    <h3 class="display-4">タスク一覧</h2>
+    <h3 class="display-4"><%= t('dictionary.title.task_index') %></h2>
     <hr class="my-4">
     <p>
       <% flash.each do |name, msg| %>
@@ -10,9 +10,9 @@
 
     <%= link_to t('dictionary.button.create'), new_task_path, class: 'btn btn-primary float-left' %>
     <%= form_with url: root_path, method: :get, class: 'form-group form-inline float-right', local: true do |form| %>
-      <%= form.label 'status検索' %>
+      <%= form.label t('activerecord.attributes.task_status.name') %>
       <%= form.select :task_status_id, status_select_options, {selected: params[:task_status_id] || ''}, {class: 'form-control'} %>
-      <%= form.submit '検索', class: 'btn btn-primary' %>
+      <%= form.submit t('dictionary.button.search'), class: 'btn btn-primary' %>
     <% end %>
 
     <table class="table table-striped table-hover">

--- a/eumetopias_2/app/views/task/index.html.erb
+++ b/eumetopias_2/app/views/task/index.html.erb
@@ -11,9 +11,7 @@
     <%= link_to t('dictionary.button.create'), new_task_path, class: 'btn btn-primary float-left' %>
     <%= form_with url: root_path, method: :get, class: 'form-group form-inline float-right', local: true do |form| %>
       <%= form.label 'status検索' %>
-      <% select_options =  [['全て', '']] %>
-      <% TaskStatus.all.each {|status| select_options.push([status.name, status.id])} %>
-      <%= form.select :task_status_id, select_options, {selected: params[:task_status_id] || ''}, {class: 'form-control'} %>
+      <%= form.select :task_status_id, status_select_options, {selected: params[:task_status_id] || ''}, {class: 'form-control'} %>
       <%= form.submit '検索', class: 'btn btn-primary' %>
     <% end %>
 

--- a/eumetopias_2/app/views/task/new.html.erb
+++ b/eumetopias_2/app/views/task/new.html.erb
@@ -5,15 +5,15 @@
     <%= render 'layouts/error_messages', model: @task %>
     <%= form_with scope: :task,url: task_index_path, class: 'form-group', local: true do |form| %>
       <p>
-        <%= form.label t('dictionary.table.title') %>
+        <%= form.label t('activerecord.attributes.task.title') %>
         <%= form.text_field :title, size: '40', class: 'form-control' %>
       </p>
       <p>
-        <%= form.label "ステータス" %>
+        <%= form.label t('activerecord.attributes.task_status.name') %>
         <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name, {},  {class: 'form-control'}  %>
       </p>
       <p>
-        <%= form.label t('dictionary.table.description') %>
+        <%= form.label t('activerecord.attributes.task.description') %>
         <%= form.text_area :description, size: '75x6', class: 'form-control' %>
       </p>
       <p class="row float-right">

--- a/eumetopias_2/app/views/task/new.html.erb
+++ b/eumetopias_2/app/views/task/new.html.erb
@@ -1,26 +1,25 @@
-<h1><%= t('dictionary.title.create') %></h1>
-<%= render 'layouts/error_messages', model: @task %>
-<%= form_with scope: :task,url: task_index_path, local: true do |form| %>
-<p>
-  <%= form.label t('dictionary.table.title') %>
-  <%= form.text_field :title %>
-</p>
-
-<p>
-  <%= form.label t('dictionary.table.description') %>
-  <%= form.text_field :description %>
-</p>
-
-<p>
-  <%= form.label :task_status_id %>
-  <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name %>
-</p>
-
-<p>
-  <%= form.submit t('dictionary.button.create') %>
-  <%= %>
-  <%= %>
-</p>
-<% end %>
-
-<%= link_to t('dictionary.browse.back'), root_path  %>
+<div class="container">
+  <div class="jumbotron m-3">
+    <h2><%= t('dictionary.title.create') %></h2>
+    <hr>
+    <%= render 'layouts/error_messages', model: @task %>
+    <%= form_with scope: :task,url: task_index_path, class: 'form-group', local: true do |form| %>
+      <p>
+        <%= form.label t('dictionary.table.title') %>
+        <%= form.text_field :title, size: '40', class: 'form-control' %>
+      </p>
+      <p>
+        <%= form.label "ステータス" %>
+        <%= form.collection_select  :task_status_id, TaskStatus.all, :id, :name, {},  {class: 'form-control'}  %>
+      </p>
+      <p>
+        <%= form.label t('dictionary.table.description') %>
+        <%= form.text_area :description, size: '75x6', class: 'form-control' %>
+      </p>
+      <p class="row float-right">
+        <%= link_to t('dictionary.browse.back'), root_path, class: 'btn btn-outline-primary' %>
+        <%= form.submit t('dictionary.button.create'), class: 'btn btn-primary' %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/eumetopias_2/app/views/task/show.html.erb
+++ b/eumetopias_2/app/views/task/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="jumbotron m-3">
-    <h2>タスク詳細</h2>
+    <h2><%= t('dictionary.title.task_show') %></h2>
     <hr>
     <p>
       <% flash.each do |name, msg| %>
@@ -12,7 +12,7 @@
       <div class="row">
         <div class="col-sm-3">
           <p>
-            <%= t('dictionary.table.title') %>
+            <%= t('activerecord.attributes.task.title') %>
           </p>
         </div>
         <div class="col-sm-9 align-bottom">
@@ -23,7 +23,7 @@
       <div class="row">
         <div class="col-sm-3">
           <p>
-            ID
+          <%= t('activerecord.attributes.task.id') %>
           </p>
         </div>
         <div class="col-sm-9 align-bottom">
@@ -36,7 +36,7 @@
       <div class="row">
         <div class="col-sm-3">
           <p>
-            ステータス
+            <%= t('activerecord.attributes.task_status.name') %>
           </p>
         </div>
         <div class="col-sm-9">
@@ -53,7 +53,7 @@
       <div class="row">
         <div class="col-sm-3">
           <p>
-            <%= t('dictionary.table.description') %>
+            <%= t('activerecord.attributes.task.description') %>
           </p>
         </div>
         <div class="col-sm-9">

--- a/eumetopias_2/app/views/task/show.html.erb
+++ b/eumetopias_2/app/views/task/show.html.erb
@@ -1,23 +1,71 @@
-<h1>タスク詳細</h1>
-<p>
-<% flash.each do |name, msg| %>
-<%= content_tag :div, msg, class: name  %>
-<% end %>
-</p>
+<div class="container">
+  <div class="jumbotron m-3">
+    <h2>タスク詳細</h2>
+    <hr>
+    <p>
+      <% flash.each do |name, msg| %>
+      <%= content_tag :div, msg, class: name  %>
+      <% end %>
+    </p>
+    <div class="container-fluid">
 
-<p>
-  <strong><%= t('dictionary.table.title') %>:</strong>
-  <%= @task.title %>
-</p>
+      <div class="row">
+        <div class="col-sm-3">
+          <p>
+            <%= t('dictionary.table.title') %>
+          </p>
+        </div>
+        <div class="col-sm-9 align-bottom">
+          <p><%= @task.title %></p>
+        </div>
+      </div>
 
-<p>
-  <strong><%= t('dictionary.table.description') %>:</strong>
-  <%= @task.description %>
-</p>
+      <div class="row">
+        <div class="col-sm-3">
+          <p>
+            ID
+          </p>
+        </div>
+        <div class="col-sm-9 align-bottom">
+          <p>
+            <%= @task.id %>
+          </p>
+        </div>
+      </div>
 
-<p>
-  <strong>Status:</strong>
-  <%= @task.task_status.name %>
-</p>
+      <div class="row">
+        <div class="col-sm-3">
+          <p>
+            ステータス
+          </p>
+        </div>
+        <div class="col-sm-9">
+          <p>
+            <% if task_status = @task.task_status %>
+              <%= task_status.name %>
+            <% else %>
+              <%= '-' %>
+            <% end %>
+          </p>
+        </div>
+      </div>
 
-<%= link_to t('dictionary.browse.back'), root_path  %>
+      <div class="row">
+        <div class="col-sm-3">
+          <p>
+            <%= t('dictionary.table.description') %>
+          </p>
+        </div>
+        <div class="col-sm-9">
+          <%= @task.description %>
+        </div>
+      </div>
+    </div>
+
+    <hr>
+
+    <p class="pull-right">
+      <%= link_to t('dictionary.browse.back'), root_path, class: 'btn btn-outline-primary' %>
+    </p>
+  </div>
+</div>

--- a/eumetopias_2/app/views/task/show.html.erb
+++ b/eumetopias_2/app/views/task/show.html.erb
@@ -41,11 +41,7 @@
         </div>
         <div class="col-sm-9">
           <p>
-            <% if task_status = @task.task_status %>
-              <%= task_status.name %>
-            <% else %>
-              <%= '-' %>
-            <% end %>
+            <%= @task.task_status.name %>
           </p>
         </div>
       </div>

--- a/eumetopias_2/config/locales/ja.yml
+++ b/eumetopias_2/config/locales/ja.yml
@@ -31,6 +31,13 @@ ja:
       back: "戻る"
       next: "次へ"
       previous: "前へ"
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."
   time:
     formats:
       default: ! "%Y-%m-%d %H:%M:%S"

--- a/eumetopias_2/config/locales/ja.yml
+++ b/eumetopias_2/config/locales/ja.yml
@@ -33,10 +33,10 @@ ja:
       previous: "前へ"
   views:
     pagination:
-      first: "&laquo; 最初"
-      last: "最後 &raquo;"
-      previous: "&lsaquo; 前"
-      next: "次 &rsaquo;"
+      first: "&laquo;"
+      last: "&raquo;"
+      previous: "&lsaquo;"
+      next: "&rsaquo;"
       truncate: "..."
   time:
     formats:

--- a/eumetopias_2/config/locales/ja.yml
+++ b/eumetopias_2/config/locales/ja.yml
@@ -26,7 +26,7 @@ ja:
     table:
       title: "題名"
       name: "名前"
-      description: "内容"
+      description: "説明"
     browse:
       back: "戻る"
       next: "次へ"
@@ -41,3 +41,11 @@ ja:
   time:
     formats:
       default: ! "%Y-%m-%d %H:%M:%S"
+  activerecord:
+    models:
+      task: "タスク"
+      task_status: "ステータス"
+    attributes:
+      task:
+        title: "題名"
+        description: "説明"

--- a/eumetopias_2/config/locales/ja.yml
+++ b/eumetopias_2/config/locales/ja.yml
@@ -1,10 +1,10 @@
 ja:
   dictionary:
     title:
-      create: "新規作成"
-      update: "更新"
-      destroy:
-        confirm: "削除確認"
+      task_index: "タスク一覧"
+      task_edit: "タスク編集"
+      task_create: "新規タスク"
+      task_show: "タスク詳細"
     message:
       create:
         complete: "登録しました"
@@ -23,10 +23,6 @@ ja:
       cancel: "キャンセル"
       edit: "編集"
       show: "確認"
-    table:
-      title: "題名"
-      name: "名前"
-      description: "説明"
     browse:
       back: "戻る"
       next: "次へ"
@@ -44,8 +40,16 @@ ja:
   activerecord:
     models:
       task: "タスク"
-      task_status: "ステータス"
+      task_status: "タスクステータス"
+      user: "ユーザー"
     attributes:
       task:
+        id: "タスクID"
         title: "題名"
         description: "説明"
+      task_status:
+        name: "ステータス"
+      user:
+        name: "名前"
+        email: "メールアドレス"
+        password: "パスワード"

--- a/eumetopias_2/config/webpack/environment.js
+++ b/eumetopias_2/config/webpack/environment.js
@@ -1,3 +1,12 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+
+environment.plugins.prepend('Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery/src/jquery',
+    jQuery: 'jquery/src/jquery'
+  })
+)
+
 module.exports = environment

--- a/eumetopias_2/package.json
+++ b/eumetopias_2/package.json
@@ -6,6 +6,9 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
+    "bootstrap": "^4.5.2",
+    "jquery": "^3.5.1",
+    "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/eumetopias_2/yarn.lock
+++ b/eumetopias_2/yarn.lock
@@ -1498,6 +1498,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.2.tgz#a85c4eda59155f0d71186b6e6ad9b875813779ab"
+  integrity sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3956,6 +3961,11 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.8:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
@@ -5109,6 +5119,11 @@ pnp-webpack-plugin@^1.5.0:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portfinder@^1.0.26:
   version "1.0.28"


### PR DESCRIPTION
## 課題
- [ステップ15: デザインを当てよう ](https://github.com/Fablic/training/tree/m-nakamura#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

## 変更内容
- bootstrap, jqueryをインストール、設定を追加
- kaminariへbootstrapを反映
- 既存View（task/index, new, show, edit）へbootstrapスタイルを当て込み

## コメント
- オプション要件の自作CSSはスキップ
- レビュー用にベースブランチを `m-nakamura_13_add_status_and_search` に設定しています  
　（Merge時は `m-nakamura` に戻して実行予定）

### 動作確認時の要設定事項
- DB設定について
  - `dotenv-rails`でDBの設定情報を隠蔽しているため、`$ mv .env.template .env`して、[ユーザー名]、[パスワード] をご自身の環境のものに書き換えてください。

# 実行結果コード／SS
### スタイル反映後の各ページSS
<img width="615" alt="スクリーンショット 2020-09-01 17 27 28" src="https://user-images.githubusercontent.com/69135260/91827104-60f3a680-ec79-11ea-878b-9073f82e4cd0.png">
<img width="616" alt="スクリーンショット 2020-09-01 17 28 13" src="https://user-images.githubusercontent.com/69135260/91827126-68b34b00-ec79-11ea-9507-b61aa25c8e50.png">
<img width="616" alt="スクリーンショット 2020-09-01 17 28 25" src="https://user-images.githubusercontent.com/69135260/91827139-6d77ff00-ec79-11ea-933e-c2a783c7818a.png">
<img width="618" alt="スクリーンショット 2020-09-01 17 28 42" src="https://user-images.githubusercontent.com/69135260/91827144-6f41c280-ec79-11ea-876f-7b3d97d6b4d5.png">
