### PR TITLE
ステップ11: バリデーションを設定してみよう

### DIFF
--- a/task_board/db/migrate/20201022060106_change_column_to_task.rb
+++ b/task_board/db/migrate/20201022060106_change_column_to_task.rb
@@ -1,0 +1,5 @@
+class ChangeColumnToTask < ActiveRecord::Migration[6.0]
+  def change
+    change_column :tasks, :name, :string, null: false, limit: 50
+  end
+end

--- a/task_board/db/migrate/20201022060106_change_column_to_task.rb
+++ b/task_board/db/migrate/20201022060106_change_column_to_task.rb
@@ -1,5 +1,9 @@
 class ChangeColumnToTask < ActiveRecord::Migration[6.0]
-  def change
+  def up
     change_column :tasks, :name, :string, null: false, limit: 50
+  end
+
+  def down
+    change_column :tasks, :name, :string, null: false
   end
 end

--- a/task_board/db/schema.rb
+++ b/task_board/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_11_135708) do
+ActiveRecord::Schema.define(version: 2020_10_22_060106) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2020_10_11_135708) do
   end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "name", limit: 50, null: false
     t.text "description"
     t.date "end_date"
     t.integer "priority", limit: 1

--- a/task_board/spec/models/task_spec.rb
+++ b/task_board/spec/models/task_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  let(:valid_task) { build(:task) }
+  it 'is valid with valid attributes' do
+    expect(valid_task).to be_valid
+  end
+
+  context 'invalid cases' do
+    let(:invalid_task_no_title) { build(:task, name: nil) }
+    let(:invaild_task_long_title) { build(:task, name: 'a' * 51) }
+    it 'is not valid without a title' do
+      expect(invalid_task_no_title).to_not be_valid
+    end
+
+    it 'is not valid with title over 50 length' do
+      expect(invaild_task_long_title).to_not be_valid
+    end
+  end
+end

--- a/task_board/spec/models/task_spec.rb
+++ b/task_board/spec/models/task_spec.rb
@@ -1,20 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  let(:valid_task) { build(:task) }
-  it 'is valid with valid attributes' do
-    expect(valid_task).to be_valid
-  end
+  describe 'validation' do
+    describe 'name' do
+      subject { build(:task, name: name) }
 
-  context 'invalid cases' do
-    let(:invalid_task_no_title) { build(:task, name: nil) }
-    let(:invaild_task_long_title) { build(:task, name: 'a' * 51) }
-    it 'is not valid without a title' do
-      expect(invalid_task_no_title).to_not be_valid
-    end
+      context 'valid' do
+        let(:name) { 'text' }
+        it { is_expected.to be_valid }
+      end
 
-    it 'is not valid with title over 50 length' do
-      expect(invaild_task_long_title).to_not be_valid
+      context 'empty' do
+        let(:name) { nil }
+        it { is_expected.to_not be_valid }
+      end
+
+      context 'length is greater than 50' do
+        let(:name) { 'a' * 51 }
+        it { is_expected.to_not be_valid }
+      end
     end
   end
 end


### PR DESCRIPTION
# 概要
ステップ11: バリデーションを設定してみよう
# 変更内容
- バリデーションを設定
`Tasks`の`name`にlimit:50制限を追加
画面にバリデーションエラーのメッセージはすでに実装済み
- バリデーションに対してモデルのテストを書く
# 確認
- バリデーションエラーメッセージ確認
タイトル無し
<img width="619" alt="Screen Shot 2020-10-22 at 16 23 24" src="https://user-images.githubusercontent.com/72183246/96838671-1de8cf00-1483-11eb-9d02-aac80d4aed77.png">
タイトルの長さが50を超える場合
<img width="727" alt="Screen Shot 2020-10-22 at 16 24 04" src="https://user-images.githubusercontent.com/72183246/96838729-30630880-1483-11eb-9235-572197ff3c22.png">

- rspec
```
bundle exec rspec spec/models/task_spec.rb
```

# 備考
rubocopでの以下のエラーは対応してないですが、、もし対応する必要がありましたら教えてください。
```
Metrics/BlockLength: Block has too many lines.
missing top-level class documentation comment
Missing frozen string literal comment. 
```