### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/task_board/Gemfile
+++ b/task_board/Gemfile
@@ -38,6 +38,8 @@ gem 'rails-i18n'
 
 gem 'ransack'
 
+gem 'enum_help'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/task_board/Gemfile
+++ b/task_board/Gemfile
@@ -36,6 +36,8 @@ gem 'rubocop-rails', require: false
 
 gem 'rails-i18n'
 
+gem 'ransack'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/task_board/Gemfile.lock
+++ b/task_board/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (6.1.0)
@@ -275,6 +277,7 @@ DEPENDENCIES
   bootstrap (~> 4.1.1)
   byebug
   capybara (>= 2.15)
+  enum_help
   factory_bot_rails
   jbuilder (~> 2.7)
   jquery-rails

--- a/task_board/Gemfile.lock
+++ b/task_board/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
     parallel (1.19.2)
     parser (2.7.2.0)
       ast (~> 2.4.1)
+    polyamorous (2.3.2)
+      activerecord (>= 5.2.1)
     popper_js (1.16.0)
     public_suffix (4.0.6)
     puma (4.3.6)
@@ -163,6 +165,11 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    ransack (2.3.2)
+      activerecord (>= 5.2.1)
+      activesupport (>= 5.2.1)
+      i18n
+      polyamorous (= 2.3.2)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -276,6 +283,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
   rails-i18n
+  ransack
   rspec-rails
   rubocop
   rubocop-rails

--- a/task_board/app/controllers/tasks_controller.rb
+++ b/task_board/app/controllers/tasks_controller.rb
@@ -2,7 +2,8 @@ class TasksController < ApplicationController
   include TasksHelper
 
   def index
-    @tasks = Task.all.order("#{sort_column} #{sort_direction}")
+    @q = Task.ransack(params[:q])
+    @tasks = @q.result.order("#{sort_column} #{sort_direction}")
   end
 
   def new

--- a/task_board/app/controllers/tasks_controller.rb
+++ b/task_board/app/controllers/tasks_controller.rb
@@ -1,6 +1,4 @@
 class TasksController < ApplicationController
-  include TasksHelper
-
   def index
     @q = Task.ransack(params[:q])
     @q.sorts = 'created_at desc' if @q.sorts.empty?

--- a/task_board/app/controllers/tasks_controller.rb
+++ b/task_board/app/controllers/tasks_controller.rb
@@ -3,7 +3,8 @@ class TasksController < ApplicationController
 
   def index
     @q = Task.ransack(params[:q])
-    @tasks = @q.result.order("#{sort_column} #{sort_direction}")
+    @q.sorts = 'created_at desc' if @q.sorts.empty?
+    @tasks = @q.result
   end
 
   def new

--- a/task_board/app/helpers/tasks_helper.rb
+++ b/task_board/app/helpers/tasks_helper.rb
@@ -1,15 +1,2 @@
 module TasksHelper
-  def task_sort(column, title = nil)
-    title ||= column.titleize
-    direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
-    link_to title, { sort: column, direction: direction }
-  end
-
-  def sort_column
-    Task.column_names.include?(params[:sort]) ? params[:sort] : 'created_at'
-  end
-
-  def sort_direction
-    %w[asc desc].include?(params[:direction]) ? params[:direction] : 'desc'
-  end
 end

--- a/task_board/app/models/task.rb
+++ b/task_board/app/models/task.rb
@@ -3,4 +3,6 @@ class Task < ApplicationRecord
 
   enum priority: { low: 1, nomal: 2, high: 3 }
   enum status: { todo: 1, in_progress: 2, done: 3 }
+
+  ransacker :status, formatter: proc { |v| statuses[v] }
 end

--- a/task_board/app/views/tasks/index.html.erb
+++ b/task_board/app/views/tasks/index.html.erb
@@ -8,7 +8,7 @@
           <%= f.label :name %>
           <%= f.search_field :name_cont, class: 'form-control' %>
           <%= f.label :status %>
-          <%= f.select :status_eq, Task.statuses.keys, { include_blank: true }, class: 'form-control' %>
+          <%= f.select :status_eq, Task.statuses_i18n.invert, { include_blank: true }, class: 'form-control' %>
         </div>
         <%= link_to "Clear", request.path, class: "btn btn-default" %>
         <%= f.button '検索', class: 'btn btn-dark' %>
@@ -32,8 +32,8 @@
             <tr>
               <td><%= link_to task.name, task %></td>
               <td><%= task.end_date %></td>
-              <td><%= task.status %></td>
-              <td><%= task.priority %></td>
+              <td><%= task.status_i18n %></td>
+              <td><%= task.priority_i18n %></td>
               <td style='display: flex'>
                 <%= link_to I18n.t('tasks.link.edit'), edit_task_path(task), class: 'btn btn-primary' %>
                 <%= button_to I18n.t('tasks.link.delete'), task_path(task), method: :delete, data: { confirm: I18n.t('tasks.delete_confirm', name: task.name) }, class: 'btn btn-danger' %>

--- a/task_board/app/views/tasks/index.html.erb
+++ b/task_board/app/views/tasks/index.html.erb
@@ -21,7 +21,7 @@
         <thead>
           <tr>
             <th scope='col'><%= @tasks.human_attribute_name(:name) %></th>
-            <th scope='col'><%= task_sort 'end_date', @tasks.human_attribute_name(:end_date) %></th>
+            <th scope='col'><%= sort_link(@q, :end_date, @tasks.human_attribute_name(:end_date)) %></th>
             <th scope='col'><%= @tasks.human_attribute_name(:status) %></th>
             <th scope='col'><%= @tasks.human_attribute_name(:priority) %></th>
             <th scope='col'> </th>

--- a/task_board/app/views/tasks/index.html.erb
+++ b/task_board/app/views/tasks/index.html.erb
@@ -1,30 +1,47 @@
 <div class='container'>
   <h1><%= I18n.t('tasks.title.index') %></h1>
-  <%= link_to I18n.t('tasks.link.new'), new_task_path, class: 'btn btn-info' %>
-
-  <table class='table'>
-    <thead>
-      <tr>
-        <th scope='col'><%= @tasks.human_attribute_name(:name) %></th>
-        <th scope='col'><%= task_sort 'end_date', @tasks.human_attribute_name(:end_date) %></th>
-        <th scope='col'><%= @tasks.human_attribute_name(:status) %></th>
-        <th scope='col'><%= @tasks.human_attribute_name(:priority) %></th>
-        <th scope='col'> </th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @tasks.each do |task| %>
-        <tr>
-          <td><%= link_to task.name, task %></td>
-          <td><%= task.end_date %></td>
-          <td><%= task.status %></td>
-          <td><%= task.priority %></td>
-          <td style='display: flex'>
-            <%= link_to I18n.t('tasks.link.edit'), edit_task_path(task), class: 'btn btn-primary' %>
-            <%= button_to I18n.t('tasks.link.delete'), task_path(task), method: :delete, data: { confirm: I18n.t('tasks.delete_confirm', name: task.name) }, class: 'btn btn-danger' %>
-          </td>
-        </tr>
+  <div class='row'>
+    <div class='col-2'>
+      <span class='badge badge-dark'>Search</span>
+      <%= search_form_for(@q, url: tasks_path, local: true) do |f| %>
+        <div class='form-group'>
+          <%= f.label :name %>
+          <%= f.search_field :name_cont, class: 'form-control' %>
+          <%= f.label :status %>
+          <%= f.select :status_eq, Task.statuses.keys, { include_blank: true }, class: 'form-control' %>
+        </div>
+        <%= link_to "Clear", request.path, class: "btn btn-default" %>
+        <%= f.button '検索', class: 'btn btn-dark' %>
       <% end %>
-    </tbody>
-  </table>
+    </div>
+
+    <div class='col-10'>
+      <%= link_to I18n.t('tasks.link.new'), new_task_path, class: 'btn btn-info' %>
+      <table class='table'>
+        <thead>
+          <tr>
+            <th scope='col'><%= @tasks.human_attribute_name(:name) %></th>
+            <th scope='col'><%= task_sort 'end_date', @tasks.human_attribute_name(:end_date) %></th>
+            <th scope='col'><%= @tasks.human_attribute_name(:status) %></th>
+            <th scope='col'><%= @tasks.human_attribute_name(:priority) %></th>
+            <th scope='col'> </th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @tasks.each do |task| %>
+            <tr>
+              <td><%= link_to task.name, task %></td>
+              <td><%= task.end_date %></td>
+              <td><%= task.status %></td>
+              <td><%= task.priority %></td>
+              <td style='display: flex'>
+                <%= link_to I18n.t('tasks.link.edit'), edit_task_path(task), class: 'btn btn-primary' %>
+                <%= button_to I18n.t('tasks.link.delete'), task_path(task), method: :delete, data: { confirm: I18n.t('tasks.delete_confirm', name: task.name) }, class: 'btn btn-danger' %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>

--- a/task_board/config/locales/model.ja.yml
+++ b/task_board/config/locales/model.ja.yml
@@ -7,3 +7,13 @@ ja:
         end_date: '最終期限'
         priority: '優先順位'
         status: 'ステータス'
+  enums:
+    task:
+      priority:
+        low: 低
+        nomal: 中
+        high: 高
+      status:
+        todo: 未着手
+        in_progress: 進行中
+        done: 完了

--- a/task_board/db/migrate/20201030074205_add_index_to_tasks.rb
+++ b/task_board/db/migrate/20201030074205_add_index_to_tasks.rb
@@ -1,0 +1,9 @@
+class AddIndexToTasks < ActiveRecord::Migration[6.0]
+  def up
+    add_index :tasks, :status
+  end
+
+  def down
+    remove_index :tasks, :status
+  end
+end

--- a/task_board/db/schema.rb
+++ b/task_board/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_22_060106) do
+ActiveRecord::Schema.define(version: 2020_10_30_074205) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2020_10_22_060106) do
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status"], name: "index_tasks_on_status"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 

--- a/task_board/spec/system/tasks_spec.rb
+++ b/task_board/spec/system/tasks_spec.rb
@@ -39,6 +39,49 @@ RSpec.describe Task, type: :system do
         end
       end
     end
+
+    describe 'search' do
+      let!(:taskA) { create(:task, name: 'Task_apple', status: :todo) }
+      let!(:taskB) { create(:task, name: 'Task_banana', status: :in_progress) }
+      let!(:taskC) { create(:task, name: 'Task_lemon', status: :done) }
+
+      before do
+        visit root_path
+      end
+
+      context 'search by name' do
+        before { fill_in 'q_name_cont', with: 'apple' }
+        it 'display taskA' do
+          click_button '検索'
+          expect(page.all('table tbody tr').count).to eq 1
+          expect(page).to have_content taskA.name
+          expect(page).to_not have_content taskB.name
+        end
+      end
+
+      context 'search by status' do
+        before { select :done, from: 'q_status_eq' }
+        it 'display taskC' do
+          click_button '検索'
+          expect(page.all('table tbody tr').count).to eq 1
+          expect(page).to have_content taskC.name
+          expect(page).to_not have_content taskA.name
+        end
+      end
+
+      context 'search by name and status' do
+        before do
+          fill_in 'q_name_cont', with: 'Task'
+          select :in_progress, from: 'q_status_eq'
+        end
+        it 'display taskB' do
+          click_button '検索'
+          expect(page.all('table tbody tr').count).to eq 1
+          expect(page).to have_content taskB.name
+          expect(page).to_not have_content taskC.name
+        end
+      end
+    end
   end
 
   describe '#new' do

--- a/task_board/spec/system/tasks_spec.rb
+++ b/task_board/spec/system/tasks_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Task, type: :system do
       end
 
       context 'search by status' do
-        before { select :done, from: 'q_status_eq' }
+        before { select '完了', from: 'q_status_eq' }
         it 'display taskC' do
           click_button '検索'
           expect(page.all('table tbody tr').count).to eq 1
@@ -72,7 +72,7 @@ RSpec.describe Task, type: :system do
       context 'search by name and status' do
         before do
           fill_in 'q_name_cont', with: 'Task'
-          select :in_progress, from: 'q_status_eq'
+          select '進行中', from: 'q_status_eq'
         end
         it 'display taskB' do
           click_button '検索'


### PR DESCRIPTION
# 概要
[ステップ13: ステータスを追加して、検索できるようにしよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)

# 実施内容
- タスク一覧画面に検索機能を実装（ransack導入）
  - ステータスとタスク名で検索
  - ステップ12で実装したソートもransackを使うように変更
- ステータスに検索インデックスを貼る
- テスト作成

# 確認
- タスク名で検索
<img width="1016" alt="Screen Shot 2020-11-02 at 9 53 13" src="https://user-images.githubusercontent.com/72183246/97820397-54c7ac00-1cf1-11eb-8933-173345548afc.png">
- ステータスで検索
<img width="1083" alt="Screen Shot 2020-11-02 at 9 53 32" src="https://user-images.githubusercontent.com/72183246/97820406-5abd8d00-1cf1-11eb-8555-ab7e0af41ae4.png">
