### PR TITLE
ステップ14: ページネーションを追加しよう

### DIFF
--- a/task_board/Gemfile
+++ b/task_board/Gemfile
@@ -40,6 +40,8 @@ gem 'ransack'
 
 gem 'enum_help'
 
+gem 'kaminari'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/task_board/Gemfile.lock
+++ b/task_board/Gemfile.lock
@@ -102,6 +102,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -281,6 +293,7 @@ DEPENDENCIES
   factory_bot_rails
   jbuilder (~> 2.7)
   jquery-rails
+  kaminari
   listen (~> 3.2)
   mysql2
   puma (~> 4.1)

--- a/task_board/app/controllers/tasks_controller.rb
+++ b/task_board/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   def index
     @q = Task.ransack(params[:q])
     @q.sorts = 'created_at desc' if @q.sorts.empty?
-    @tasks = @q.result
+    @tasks = @q.result.page(params[:page])
   end
 
   def new

--- a/task_board/app/views/kaminari/_first_page.html.erb
+++ b/task_board/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/task_board/app/views/kaminari/_gap.html.erb
+++ b/task_board/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/task_board/app/views/kaminari/_last_page.html.erb
+++ b/task_board/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/task_board/app/views/kaminari/_next_page.html.erb
+++ b/task_board/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/task_board/app/views/kaminari/_page.html.erb
+++ b/task_board/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/task_board/app/views/kaminari/_paginator.html.erb
+++ b/task_board/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination justify-content-md-center">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/task_board/app/views/kaminari/_prev_page.html.erb
+++ b/task_board/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/task_board/app/views/tasks/index.html.erb
+++ b/task_board/app/views/tasks/index.html.erb
@@ -42,6 +42,7 @@
           <% end %>
         </tbody>
       </table>
+      <%= paginate @tasks %>
     </div>
   </div>
 </div>

--- a/task_board/config/initializers/kaminari_config.rb
+++ b/task_board/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 7
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/task_board/spec/system/tasks_spec.rb
+++ b/task_board/spec/system/tasks_spec.rb
@@ -82,6 +82,30 @@ RSpec.describe Task, type: :system do
         end
       end
     end
+
+    describe 'pagination' do
+      before do
+        10.times do |n|
+          create(:task, name: "task-#{n}", status: :todo)
+        end
+        visit root_path
+      end
+
+      context 'first page' do
+        it 'show Next link in pagination' do
+          expect(page).to have_link 'Next'
+          expect(page).to have_link 'Last'
+        end
+      end
+
+      context 'click Next page' do
+        it 'show Previous link in pagination' do
+          click_link 'Next'
+          expect(page).to have_link 'Previous'
+          expect(page).to have_link 'First'
+        end
+      end
+    end
   end
 
   describe '#new' do

--- a/task_board/spec/system/tasks_spec.rb
+++ b/task_board/spec/system/tasks_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Task, type: :system do
       end
       it 'fail to create task' do
         click_button '作成'
-        expect(page).to have_content "タスク名を入力してください"
+        expect(page).to have_content 'タスク名を入力してください'
       end
     end
   end


### PR DESCRIPTION
# 概要
[ステップ14: ページネーションを追加しよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9714-%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)

# 実施内容
一覧画面にページネーションを追加(kaminari 導入)

# 確認
<img width="1180" alt="Screen Shot 2020-11-11 at 18 19 59" src="https://user-images.githubusercontent.com/72183246/98792929-89063f80-244a-11eb-91be-9d91aa70f99c.png">


