### PR TITLE
ステータスを追加して、検索できるようにする

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -30,6 +30,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'bcrypt', '~> 3.1.7'
+gem 'ransack', '~> 2.3.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     parallel (1.20.0)
     parser (2.7.2.0)
       ast (~> 2.4.1)
+    polyamorous (2.3.2)
+      activerecord (>= 5.2.1)
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
@@ -152,6 +154,11 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    ransack (2.3.2)
+      activerecord (>= 5.2.1)
+      activesupport (>= 5.2.1)
+      i18n
+      polyamorous (= 2.3.2)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -259,6 +266,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
   rails-i18n (~> 6.0.0)
+  ransack (~> 2.3.1)
   rspec-rails
   rubocop
   rubocop-rails

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -7,11 +7,14 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::RoutingError, with: :render404
   rescue_from Exception, with: :render500
 
-  def render404
+  def render404(e)
+    logger.warn e
     render status: :not_found, template: 'errors/404', locals: { message: 'Page Not Found' }
   end
 
-  def render500
+  def render500(e)
+    logger.error e
+    logger.error e.backtrace.join('\n')
     render status: :internal_server_error, template: 'errors/500', locals: { message: 'Internal Server Error' }
   end
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -4,8 +4,9 @@ class TasksController < ApplicationController
   # GET /tasks
   # GET /tasks.json
   def index
+    @q = Task.ransack(params[:q])
     order = params[:order] || :desc
-    @tasks = Task.order({ created_at: order }).all
+    @tasks = @q.result.order({ created_at: order })
   end
 
   # GET /tasks/1

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,10 +2,30 @@
 
 <h1><%= t('.title') %></h1>
 
+<%= search_form_for @q do |f| %>
+  <%= f.label :title, t('title') %>
+  <%= f.search_field :title_cont %>
+
+  <br>
+
+  <%= f.label :status, t('status') %>
+  <%= f.radio_button :status_eq, '', {:checked => true} %><%= t('unspecified') %>
+  <% Task.statuses.each do |k, v| %>
+    <%= f.radio_button :status_eq, v %><%= t("models.tasks.status.#{k}") %>
+  <% end %>
+
+  <br>
+
+  <%= f.submit t('search') %>
+<% end %>
+
+<br>
+
 <table>
   <thead>
     <tr>
       <th><%= t('title') %></th>
+      <th><%= t('status') %>
       <th><%= t('created_at') %></th>
     </tr>
   </thead>
@@ -13,6 +33,7 @@
     <% @tasks.each do |task| %>
       <tr>
         <td><%= link_to task.title, task %></td>
+        <td><%= t("models.tasks.status.#{task.status}") %></td>
         <td><%= l task.created_at %></td>
       </tr>
     <% end %>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -8,3 +8,6 @@ ja:
   last_modified: '最終更新日時'
   delete: '削除'
   delete_confirm: '削除してよろしいでしょうか'
+  search: '検索'
+  status: 'ステータス'
+  unspecified: '指定なし'

--- a/myapp/config/locales/models/tasks/ja.yml
+++ b/myapp/config/locales/models/tasks/ja.yml
@@ -2,8 +2,8 @@ ja:
   models:
     tasks:
       status:
-        todo: '未対応'
-        doing: '対応中'
+        todo: '未着手'
+        doing: '着手中'
         done: '完了'
       priority:
         low: '低'

--- a/myapp/db/migrate/20201113055425_alter_task_add_status_index.rb
+++ b/myapp/db/migrate/20201113055425_alter_task_add_status_index.rb
@@ -1,0 +1,5 @@
+class AlterTaskAddStatusIndex < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_045627) do
+ActiveRecord::Schema.define(version: 2020_11_13_055425) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_045627) do
     t.integer "priority", limit: 1
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status"], name: "index_tasks_on_status"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe 'Task', js: true, type: :system do
       expect(page.text).to match(/#{task2.title}.*\n*.*#{task1.title}/)
     end
 
+    it 'search task' do
+      visit_with_basic_auth root_path
+      fill_in 'q_title_cont', with: task1.title
+      click_button I18n.t('search')
+      expect(page).to have_content task1.title
+      expect(page).not_to have_content task2.title
+
+      choose 'q_status_eq_2'
+      click_button I18n.t('search')
+      expect(page).not_to have_content task1.title
+      expect(page).not_to have_content task2.title
+    end
+
     it 'new task' do
       visit_with_basic_auth new_task_path
       click_button I18n.t('submit')


### PR DESCRIPTION
- ステータス（未着手・着手中・完了）は以前から追加しましたので、今回はスキップ
- 一覧画面でタイトルとステータスで検索ができるようにしました
  - ransack導入
- 検索フォーム追加
  画面イメージ:
<img width="467" alt="Screen Shot 2020-11-13 at 15 20 30" src="https://user-images.githubusercontent.com/17140497/99035824-ccd08480-25c3-11eb-9269-f4267a6a5370.png">

- 検索インデックスを貼りました
- 検索に対してsystem specを追加しました

ref:
https://github.com/Fablic/training/tree/use_docker#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86