### PR TITLE
ステップ19: ユーザにロールを追加する

### DIFF
--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -32,8 +32,12 @@ class Admin::UsersController < AdminController
   end
 
   def destroy
-    @user.destroy
-    redirect_to admin_users_url, notice: I18n.t('notice_deleted')
+    if User.where(role: :admin).count <= 1
+      render :show, notice: I18n.t('admin.users.notice_cannot_delete_the_last_admin')
+    else
+      @user.destroy
+      redirect_to admin_users_url, notice: I18n.t('notice_deleted')
+    end
   end
 
   private

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -45,7 +45,7 @@ class Admin::UsersController < ApplicationController
   end
 
   def user_params
-    params.fetch(:user, {}).permit(:name, :email, :password, :password_confirmation)
+    params.fetch(:user, {}).permit(:name, :email, :role, :password, :password_confirmation)
   end
 
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -33,7 +33,7 @@ class Admin::UsersController < AdminController
 
   def destroy
     if User.where(role: :admin).count <= 1
-      render :show, notice: I18n.t('admin.users.notice_cannot_delete_the_last_admin')
+      render :show, locals: { notice: I18n.t('admin.users.notice_cannot_delete_the_last_admin') }
     else
       @user.destroy
       redirect_to admin_users_url, notice: I18n.t('notice_deleted')

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,4 +1,4 @@
-class Admin::UsersController < ApplicationController
+class Admin::UsersController < AdminController
   before_action :set_user, only: [:show, :update, :destroy]
 
   def index

--- a/myapp/app/controllers/admin_controller.rb
+++ b/myapp/app/controllers/admin_controller.rb
@@ -1,4 +1,5 @@
 class AdminController < ApplicationController
+  before_action :require_admin_privilege
 
   def index; end
 

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include SessionsHelper
+  include ApplicationHelper, SessionsHelper
 
   before_action :should_log_in
 
@@ -24,4 +24,11 @@ class ApplicationController < ActionController::Base
   def should_log_in
     redirect_to login_path unless logged_in?
   end
+
+  def require_admin_privilege
+    unless admin?
+      render404 "unauthorized access: #{request.path} #{logged_in? ? current_user.id : '-'}"
+    end
+  end
+
 end

--- a/myapp/app/helpers/application_helper.rb
+++ b/myapp/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+
+  def admin?
+    current_user&.admin?
+  end
+
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -6,5 +6,11 @@ class User < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { minimum: 3, maximum: 30 }
   validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :password, presence: true, confirmation: true, on: :create
+  validates :role, presence: true
+
+  enum role: {
+    admin: 1,
+    member: 2,
+  }
 
 end

--- a/myapp/app/views/admin/users/new.html.erb
+++ b/myapp/app/views/admin/users/new.html.erb
@@ -10,6 +10,9 @@
   <%= f.label :name, t('username') %>
   <%= f.text_field :name %>
   <br>
+  <%= f.label :role, t('activerecord.attributes.user.role') %>
+  <%= f.select :role, User.roles.keys.map {|k| [t("activerecord.attributes.user.roles.#{k}"), k] } %>
+  <br>
   <%= f.label :password, t('password') %>
   <%= f.password_field :password %>
   <br>

--- a/myapp/app/views/admin/users/show.html.erb
+++ b/myapp/app/views/admin/users/show.html.erb
@@ -10,6 +10,9 @@
   <%= f.label :name, t('username') %>
   <%= f.text_field :name %>
   <br>
+  <%= f.label :role, t('activerecord.attributes.user.role') %>
+  <%= f.select :role, User.roles.keys.map {|k| [t("activerecord.attributes.user.roles.#{k}"), k] } %>
+  <br>
   <p><%= t('created_at') %>: <%= l @user.created_at %></p>
   <p><%= t('last_modified') %>: <%= l @user.updated_at %></p>
   <%= f.submit t('submit') %>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -13,7 +13,9 @@
     <% if logged_in? %>
       <div style='text-align: right'>
         <%= current_user.name %>
-        <%= link_to t('admin_page'), admin_path %>
+        <% if admin? %>
+          <%= link_to t('admin_page'), admin_path %>
+        <% end %>
         <%= link_to t('logout'), logout_path, method: :delete %>
       </div>
     <% end %>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -39,3 +39,7 @@ ja:
           other: "<strong>1-%{count}</strong>/%{count}件中"
       more_pages:
         display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"
+
+  time:
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒"

--- a/myapp/config/locales/models/users/ja.yml
+++ b/myapp/config/locales/models/users/ja.yml
@@ -6,5 +6,9 @@ ja:
       user:
         name: ユーザー名
         email: Eメール
+        role: ロール
         password: パスワード
         password_confirmation: パスワード確認
+        roles:
+          admin: 管理者
+          member: メンバー

--- a/myapp/config/locales/views/admin/users/ja.yml
+++ b/myapp/config/locales/views/admin/users/ja.yml
@@ -3,6 +3,7 @@ ja:
     users:
       not_found: 'ユーザーが見つかりませんでした'
       notice_user_created: ユーザーを作成しました
+      notice_cannot_delete_the_last_admin: 最後の管理者は削除できません
       index:
         users: ユーザー一覧
         new_user: ユーザー追加

--- a/myapp/db/migrate/20201119072527_add_role_to_user.rb
+++ b/myapp/db/migrate/20201119072527_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer, limit: 1, null: false
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_073813) do
+ActiveRecord::Schema.define(version: 2020_11_19_072527) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_073813) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "email", null: false
+    t.integer "role", limit: 1, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
   end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -10,6 +10,7 @@ user = User.create!(
   name: 'admin',
   email: 'admin@example.com',
   password: 'admin',
+  role: User.roles.admin,
 )
 
 if Rails.env.development?

--- a/myapp/spec/factories/user.rb
+++ b/myapp/spec/factories/user.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:name) { |n| "user#{n}" }
     sequence(:email) { |n| "user#{n}@example.com" }
     password { 'password' }
+    role { User.roles[:admin] }
   end
 end

--- a/myapp/spec/requests/admin/user_spec.rb
+++ b/myapp/spec/requests/admin/user_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "Admin Users", type: :request do
+
+  describe "DELETE /admin/users/:id" do
+    let(:user) { create(:user) }
+    let(:member) { create(:user, role: User.roles[:member]) }
+
+    it 'cannot delete the last admin user' do
+      params = { session: { username: user.email, password: user.password } }
+      post login_path, params: params
+      delete admin_user_path(user)
+
+      expect(response.body).to include I18n.t('admin.users.notice_cannot_delete_the_last_admin')
+    end
+
+  end
+
+end

--- a/myapp/spec/system/admin/user_spec.rb
+++ b/myapp/spec/system/admin/user_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe 'Visit admin user page', js: true, type: :system do
     context 'delete user' do
       let!(:user_to_delete) { create(:user) }
 
+      it 'cannot delete self' do
+        visit_with_login admin_user_path(admin), username: admin.name
+        expect(page).to have_no_selector(:link_or_button, I18n.t('delete'))
+      end
+
       it 'successfully' do
         visit_with_login admin_user_path(user_to_delete), username: admin.name
         page.accept_confirm I18n.t('delete_confirm') do

--- a/myapp/spec/system/admin/user_spec.rb
+++ b/myapp/spec/system/admin/user_spec.rb
@@ -2,83 +2,105 @@ require 'rails_helper'
 
 RSpec.describe 'Visit admin user page', js: true, type: :system do
 
-  context 'on index' do
-    let!(:users) { create_list(:user, 2) }
+  context 'with admin user' do
+    let!(:admin) { create(:user) }
 
-    it 'has two users' do
-      visit_with_login admin_users_path, username: users[0].name
-      expect(page).to have_content users[0].email
-      expect(page).to have_content users[1].email
-    end
+    context 'on index' do
+      let!(:member) { create(:user, role: User.roles[:member]) }
 
-  end
-
-  context 'create user' do
-    let!(:user) { create(:user) }
-
-    it 'with wrong password confirmation' do
-      visit_with_login new_admin_user_path
-      fill_in I18n.t('username'), with: 'uuuuser'
-      fill_in I18n.t('email'), with: 'uuuuser@myapp.com'
-      fill_in I18n.t('password'), with: 'p@sSw0rD'
-      fill_in I18n.t('password_confirmation'), with: 'password'
-      click_button I18n.t('submit')
-
-      expect(page).to have_content sprintf(I18n.t(
-        'errors.format',
-        attribute: I18n.t('activerecord.attributes.user.password_confirmation'),
-        message: sprintf(I18n.t(
-          'errors.messages.confirmation'),
-          attribute: I18n.t('activerecord.attributes.user.password'),
-        ),
-      ))
-    end
-
-    it 'successfully' do
-      visit_with_login new_admin_user_path
-      fill_in I18n.t('username'), with: 'uuuuser'
-      fill_in I18n.t('email'), with: 'uuuuser@myapp.com'
-      fill_in I18n.t('password'), with: 'p@sSw0rD'
-      fill_in I18n.t('password_confirmation'), with: 'p@sSw0rD'
-      click_button I18n.t('submit')
-
-      expect(current_path).to match "#{admin_users_path}/#{User.find_by(name: 'uuuuser').id}"
-      expect(page).to have_content I18n.t('admin.users.notice_user_created')
-      expect(page).to have_field I18n.t('username'), with: 'uuuuser'
-      expect(page).to have_field I18n.t('email'), with: 'uuuuser@myapp.com'
-    end
-
-  end
-
-  context 'edit user' do
-    let!(:user) { create(:user) }
-    let!(:user_to_edit) { create(:user) }
-
-    it 'successfully' do
-      visit_with_login admin_user_path(user_to_edit)
-      expect(page).to have_field I18n.t('username'), with: user_to_edit.name
-      expect(page).to have_field I18n.t('email'), with: user_to_edit.email
-
-      fill_in I18n.t('email'), with: 'user@example.com'
-      click_button I18n.t('submit')
-
-      expect(page).to have_content I18n.t('notice_updated')
-      expect(page).to have_field I18n.t('email'), with: 'user@example.com'
-    end
-  end
-
-  context 'delete user' do
-    let!(:user) { create(:user) }
-    let!(:user_to_delete) { create(:user) }
-
-    it 'successfully' do
-      visit_with_login admin_user_path(user_to_delete)
-      page.accept_confirm I18n.t('delete_confirm') do
-        click_button(I18n.t('delete'))
+      it 'has two users' do
+        visit_with_login admin_users_path, username: admin.name
+        expect(page).to have_content admin.email
+        expect(page).to have_content member.email
       end
-      expect(current_path).to eq admin_users_path
-      expect(page).to have_content I18n.t('notice_deleted')
-      expect(page).to have_no_content user_to_delete.email
+
+    end
+
+    context 'create user' do
+
+      it 'with wrong password confirmation' do
+        visit_with_login new_admin_user_path, username: admin.name
+        fill_in I18n.t('username'), with: 'uuuuser'
+        fill_in I18n.t('email'), with: 'uuuuser@myapp.com'
+        fill_in I18n.t('password'), with: 'p@sSw0rD'
+        fill_in I18n.t('password_confirmation'), with: 'password'
+        click_button I18n.t('submit')
+
+        expect(page).to have_content sprintf(I18n.t(
+          'errors.format',
+          attribute: I18n.t('activerecord.attributes.user.password_confirmation'),
+          message: sprintf(I18n.t(
+            'errors.messages.confirmation'),
+            attribute: I18n.t('activerecord.attributes.user.password'),
+          ),
+        ))
+      end
+
+      it 'successfully' do
+        visit_with_login new_admin_user_path, username: admin.name
+        fill_in I18n.t('username'), with: 'uuuuser'
+        fill_in I18n.t('email'), with: 'uuuuser@myapp.com'
+        fill_in I18n.t('password'), with: 'p@sSw0rD'
+        fill_in I18n.t('password_confirmation'), with: 'p@sSw0rD'
+        click_button I18n.t('submit')
+
+        expect(current_path).to match "#{admin_users_path}/#{User.find_by(name: 'uuuuser').id}"
+        expect(page).to have_content I18n.t('admin.users.notice_user_created')
+        expect(page).to have_field I18n.t('username'), with: 'uuuuser'
+        expect(page).to have_field I18n.t('email'), with: 'uuuuser@myapp.com'
+      end
+
+    end # context 'create user'
+
+    context 'edit user' do
+      let!(:user_to_edit) { create(:user) }
+
+      it 'successfully' do
+        visit_with_login admin_user_path(user_to_edit), username: admin.name
+        expect(page).to have_field I18n.t('username'), with: user_to_edit.name
+        expect(page).to have_field I18n.t('email'), with: user_to_edit.email
+
+        fill_in I18n.t('email'), with: 'user@example.com'
+        click_button I18n.t('submit')
+
+        expect(page).to have_content I18n.t('notice_updated')
+        expect(page).to have_field I18n.t('email'), with: 'user@example.com'
+      end
+    end
+
+    context 'delete user' do
+      let!(:user_to_delete) { create(:user) }
+
+      it 'successfully' do
+        visit_with_login admin_user_path(user_to_delete), username: admin.name
+        page.accept_confirm I18n.t('delete_confirm') do
+          click_button(I18n.t('delete'))
+        end
+        expect(current_path).to eq admin_users_path
+        expect(page).to have_content I18n.t('notice_deleted')
+        expect(page).to have_no_content user_to_delete.email
+      end
+
+    end
+
+  end # context 'with admin user'
+
+  context 'with member user' do
+    let(:user) { create(:user, role: User.roles[:member]) }
+
+    it 'on index' do
+      visit_with_login admin_users_path
+      expect(page).to have_content 'Page Not Found'
+    end
+
+    it 'create user' do
+      visit_with_login new_admin_user_path
+      expect(page).to have_content 'Page Not Found'
+    end
+
+    it 'show user' do
+      visit_with_login admin_user_path(user)
+      expect(page).to have_content 'Page Not Found'
     end
 
   end


### PR DESCRIPTION
- [x] ユーザに管理ユーザと一般ユーザを区別するようにしました
- [x] 管理ユーザだけがユーザ管理画面にアクセスできるようにしました
- [x] ユーザ管理画面でロールを選択できるようにしました
<img width="419" alt="Screen Shot 2020-11-19 at 18 11 44" src="https://user-images.githubusercontent.com/17140497/99645548-b5e1d480-2a92-11eb-8888-0f050bb0f511.png">

- [x] 管理ユーザが1人もいなくならないように削除の制御をしました
  - [x] 前のステップで[自分を削除できない](https://github.com/Fablic/training/blob/e852c56b02c75a9408d6ae0ac4ca95d82facac6b/myapp/app/views/admin/users/show.html.erb#L18-L22)という仕様を勝手に実装してしまっているので、実質上はすでに今回の仕様に満たしていますが、controller層でのロジックも追加しました



REF: [ステップ19: ユーザにロールを追加しよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)

