### PR TITLE
step11：フォーム入力に対するバリデーション機能とそのテストケースを実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -22,10 +22,10 @@ class TasksController < ApplicationController
     titleParam =  params[:task][:title]
     detailParam =  params[:task][:detail]
 
-    insertTask = Task.new(status: statusParam, title: titleParam, detail: detailParam)
+    @task = Task.new(status: statusParam, title: titleParam, detail: detailParam)
 
     # 登録成功
-    if insertTask.save
+    if @task.save
       flash[:success] = "登録に成功しました！"
       redirect_to action: "index"
     # 失敗

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -26,11 +26,11 @@ class TasksController < ApplicationController
 
     # 登録成功
     if @task.save
-      flash[:success] = "登録に成功しました！"
+      flash[:success] = I18n.t("msg.success_registration")
       redirect_to action: "index"
     # 失敗
     else
-      flash.now[:warning] = "登録に失敗しました・・・"
+      flash.now[:warning] = I18n.t("msg.failed_registration")
       render "newtask"
     end
   end
@@ -53,7 +53,6 @@ class TasksController < ApplicationController
 
     # パラメータのIDを元にタスクテーブルを検索
     @task = Task.find(param_id)
-
   end
 
   # タスク更新処理
@@ -73,11 +72,11 @@ class TasksController < ApplicationController
     # 更新成功
     if updateTask.save
 
-      flash[:success] = "更新に成功しました！"
+      flash[:success] = I18n.t("msg.success_update")
       redirect_to action: "index"
     # 失敗
     else
-      flash.now[:warning] = "更新に失敗しました・・・"
+      flash.now[:warning] = I18n.t("msg.failed_update")
       render "taskupdate"
     end
   end
@@ -91,11 +90,11 @@ class TasksController < ApplicationController
 
     # 削除成功
     if delTask
-      flash[:success] = "削除に成功しました！"
+      flash[:success] = I18n.t("msg.success_delete")
       redirect_to action: "index"
     # 失敗
     else
-      flash.now[:warning] = "削除に失敗しました・・・"
+      flash.now[:warning] = I18n.t("msg.failed_delete")
       render "taskdetail"
     end
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,17 @@
 class Task < ApplicationRecord
+
   enum status: { 未着手: 10, 着手: 20, 完了: 30 }
+
+  #入力必須
+  validates :status, :title, :detail, presence: true
+
+  #3文字以上
+  validates :title, :detail, length: { minimum: 3 }
+
+  #20文字以内
+  validates :title, length: { maximum: 20 }
+
+  #200文字以内
+  validates :detail, length: { maximum: 200 }
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,17 +1,20 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Taskmanager</title>
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application' %>
-    <%= stylesheet_pack_tag 'application' %>
-  </head>
+<head>
+  <title>Taskmanager</title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
 
-  <body>
-    <%= yield %>
-  </body>
+  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_pack_tag 'application' %>
+  <%= stylesheet_pack_tag 'application' %>
+</head>
+
+<body>
+  <%= render 'layouts/flash' %>
+  <%= yield %>
+</body>
+
 </html>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,3 @@
-<%= render 'layouts/flash' %>
 <div class="container">
   <div class="mt-3">
     <h1 class="text-center"><%= I18n.t('tasks.index.page_title') %></h1>

--- a/app/views/tasks/newtask.html.erb
+++ b/app/views/tasks/newtask.html.erb
@@ -6,7 +6,7 @@
     <%# ここからエラーメッセージ %>
     <% if @task.errors.any? %>
     <div class="mt-5">
-      <h4>エラーが発生しました！</h4>
+      <h4><%= I18n.t('tasks.newtask.error_title') %></h4>
       <ul>
         <% @task.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/tasks/newtask.html.erb
+++ b/app/views/tasks/newtask.html.erb
@@ -2,6 +2,20 @@
   <div class="mt-3">
     <h1 class="text-center"><%= I18n.t('tasks.newtask.page_title') %></h1>
   </div>
+  <div class="col-sm-5 mx-auto">
+    <%# ここからエラーメッセージ %>
+    <% if @task.errors.any? %>
+    <div class="mt-5">
+      <h4>エラーが発生しました！</h4>
+      <ul>
+        <% @task.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+    <% end %>
+    <%# ここまでエラーメッセージ %>
+  </div>
   <div class="row mt-5">
     <div class="col-sm-8 mx-auto">
       <%= form_for(@task, url: {controller: 'tasks', action: 'createtask'}) do |f| %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,21 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        task:
+          attributes:
+            title:
+              blank: "入力してください"
+              too_short: "3文字以上で入力してください"
+              too_long: "20文字以内で入力してください"
+            detail:
+              blank: "入力してください"
+              too_short: "3文字以上で入力してください"
+              too_long: "200文字以内で入力してください"
+  msg:
+    success_registration: "登録に成功しました！"
+    failed_registration: "登録に失敗しました・・・"
+    success_update: "更新に成功しました！"
+    failed_update: "更新に失敗しました・・・"
+    success_delete: "削除に成功しました！"
+    failed_delete: "削除に失敗しました・・・"

--- a/config/locales/views/tasks/newtask/ja.yml
+++ b/config/locales/views/tasks/newtask/ja.yml
@@ -3,6 +3,7 @@ ja:
     newtask:
       page_title: "タスク登録画面"
       back_button: "戻る"
+      error_title: "エラーが発生しました！"
   helpers: # ここから下を追加する
     submit:
       create: "登録"

--- a/db/migrate/20201116004626_create_tasks.rb
+++ b/db/migrate/20201116004626_create_tasks.rb
@@ -2,9 +2,9 @@ class CreateTasks < ActiveRecord::Migration[6.0]
   def change
     create_table :tasks do |t|
       t.integer :user_id
-      t.string :title, limit: 100
-      t.integer :status, limit: 2
-      t.text :detail
+      t.string :title, limit: 100, null: false
+      t.integer :status, limit: 2, null: false
+      t.text :detail, null: false
       t.timestamp :end_date
 
       t.timestamps

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -107,4 +107,47 @@ RSpec.describe "Tasks", type: :system do
       expect(page).to have_content '削除に成功しました！'
     end
   end
+
+  context 'フォームの入力値が異常' do
+    context 'タスク登録処理' do
+      before do
+        visit 'tasks/newtask'
+      end
+
+      it 'タイトル・内容が未入力' do
+        # 送信ボタンをクリック
+        click_button '送信'
+
+        expect(page).to have_content 'エラーが発生しました！'
+        expect(page).to have_content 'Title can\'t be blank'
+        expect(page).to have_content 'Title is too short (minimum is 3 characters)'
+        expect(page).to have_content 'Detail can\'t be blank'
+        expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
+      end
+
+      it 'タイトルが未入力' do
+        # 内容に「テスト詳細更新 from rspec」と入力
+        fill_in '内容', with: 'テスト内容 from rspec'
+
+        # 送信ボタンをクリック
+        click_button '送信'
+
+        expect(page).to have_content 'エラーが発生しました！'
+        expect(page).to have_content 'Title can\'t be blank'
+        expect(page).to have_content 'Title is too short (minimum is 3 characters)'
+      end
+
+      it '内容が未入力' do
+        # タイトルに「テストタイトル from rspec」と入力
+        fill_in 'タイトル', with: 'テストタイトル from rspec'
+
+        # 送信ボタンをクリック
+        click_button '送信'
+
+        expect(page).to have_content 'エラーが発生しました！'
+        expect(page).to have_content 'Detail can\'t be blank'
+        expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
+      end
+    end
+  end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "Tasks", type: :system do
       end
 
       it 'タイトルが未入力' do
-        # 内容に「テスト詳細更新 from rspec」と入力
+        # 内容に入力
         fill_in '内容', with: 'テスト内容 from rspec'
 
         # 送信ボタンをクリック
@@ -138,7 +138,7 @@ RSpec.describe "Tasks", type: :system do
       end
 
       it '内容が未入力' do
-        # タイトルに「テストタイトル from rspec」と入力
+        # タイトルにと入力
         fill_in 'タイトル', with: 'テストタイトル from rspec'
 
         # 送信ボタンをクリック
@@ -148,6 +148,53 @@ RSpec.describe "Tasks", type: :system do
         expect(page).to have_content 'Detail can\'t be blank'
         expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
       end
+
+      it '入力文字数が３文字未満' do
+        # タイトルにと入力
+        fill_in 'タイトル', with: 'ab'
+
+        # 内容に入力
+        fill_in '内容', with: 'ab'
+
+        # 送信ボタンをクリック
+        click_button '送信'
+
+        expect(page).to have_content 'エラーが発生しました！'
+        expect(page).to have_content 'Title is too short (minimum is 3 characters)'
+        expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
+      end
+
+      it 'タイトルの入力文字数が２０文字以上' do
+        # タイトルに「ab」と入力
+        fill_in 'タイトル', with: '123456789012345678901'
+
+        # 内容にと入力
+        fill_in '内容', with: 'test'
+
+        # 送信ボタンをクリック
+        click_button '送信'
+
+        expect(page).to have_content 'エラーが発生しました！'
+        expect(page).to have_content 'Title is too long (maximum is 20 characters)'
+      end
+
+      it '内容の入力文字数が２００文字以上' do
+        # タイトルに入力
+        fill_in 'タイトル', with: 'test'
+
+        # 内容に入力
+        fill_in '内容', with: 'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnop
+                              qrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012345
+                              6789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklm
+                              nopqrstuvwxyz0123456789abcdefghijklmnopqrstu'
+
+        # 送信ボタンをクリック
+        click_button '送信'
+
+        expect(page).to have_content 'エラーが発生しました！'
+        expect(page).to have_content 'Detail is too long (maximum is 200 characters)'
+      end
+
     end
   end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -149,9 +149,24 @@ RSpec.describe "Tasks", type: :system do
         expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
       end
 
-      it '入力文字数が３文字未満' do
+      it '入力文字数が３文字未満（タイトル）' do
         # タイトルにと入力
         fill_in 'タイトル', with: 'ab'
+
+        # 内容に入力
+        fill_in '内容', with: 'abc'
+
+        # 送信ボタンをクリック
+        click_button '送信'
+
+        expect(page).to have_content 'エラーが発生しました！'
+        expect(page).to have_content 'Title is too short (minimum is 3 characters)'
+        expect(page).to have_no_content 'Title can\'t be blank'
+      end
+
+      it '入力文字数が３文字未満（内容）' do
+        # タイトルにと入力
+        fill_in 'タイトル', with: 'abc'
 
         # 内容に入力
         fill_in '内容', with: 'ab'
@@ -160,8 +175,8 @@ RSpec.describe "Tasks", type: :system do
         click_button '送信'
 
         expect(page).to have_content 'エラーが発生しました！'
-        expect(page).to have_content 'Title is too short (minimum is 3 characters)'
         expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
+        expect(page).to have_no_content 'Detail can\'t be blank'
       end
 
       it 'タイトルの入力文字数が２０文字以上' do

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -3,153 +3,160 @@ require 'rails_helper'
 RSpec.describe "Tasks", type: :system do
   let!(:task) { create(:task) }
 
-  context '画面表示が正常' do
+  describe '画面表示が正常' do
     context 'タスク一覧画面' do
       before do
         visit root_path
       end
 
-      it '表示されること' do
-        expect(page).to have_content 'タスク一覧画面'
+      example '表示されること' do
+        expect(page).to have_content I18n.t("tasks.index.page_title")
       end
 
-      it 'タスク登録ボタンが表示されること' do
+      example 'タスク登録ボタンが表示されること' do
         expect(page).to have_link 'タスク登録'
       end
 
-      it '表示項目の確認 - 登録したステータスが表示されること' do
+      example '表示項目の確認 - 登録したステータスが表示されること' do
         td1 = all('tbody tr')[0].all('td')[0]
         expect(td1).to have_content "#{task.status}"
       end
 
-      it '表示項目の確認 - 登録したタスクが表示されること' do
+      example '表示項目の確認 - 登録したタスクが表示されること' do
         td2 = all('tbody tr')[0].all('td')[1]
         expect(td2).to have_content "#{task.title}"
       end
 
-      it '表示項目の確認 - 登録した終了期限が表示されること' do
+      example '表示項目の確認 - 登録した終了期限が表示されること' do
         td3 = all('tbody tr')[0].all('td')[2]
         expect(td3).to have_content "#{task.end_date.strftime('%Y/%m/%d')}"
       end
     end
 
-    it 'タスク登録画面が表示されること' do
+    example 'タスク登録画面が表示されること' do
       visit 'tasks/newtask'
-      expect(page).to have_content 'タスク登録画面'
+      expect(page).to have_content I18n.t("tasks.newtask.page_title")
     end
 
-    it 'タスク詳細画面が表示されること' do
+    example 'タスク詳細画面が表示されること' do
       visit "tasks/taskdetail/#{task.id}"
-      expect(page).to have_content 'タスク詳細画面'
+      expect(page).to have_content I18n.t("tasks.taskdetail.page_title")
     end
 
-    it 'タスク更新画面が表示されること' do
+    example 'タスク更新画面が表示されること' do
       visit "tasks/taskupdate/#{task.id}"
-      expect(page).to have_content 'タスク更新画面'
+      expect(page).to have_content I18n.t("tasks.taskupdate.page_title")
     end
   end
 
-  context 'フォームの入力値が正常' do
-    it 'タスク登録処理' do
-      # 登録画面へ遷移
-      visit tasks_newtask_path
+  describe 'フォームの入力値が正常' do
+    context 'タスク登録処理' do
+      example 'タスク登録に成功すること' do
+        # 登録画面へ遷移
+        visit tasks_newtask_path
 
-      # ステータスで着手を選択
-      select '着手', from: 'task[status]'
+        # ステータスで着手を選択
+        select '着手', from: 'task[status]'
 
-      # タイトルに「テストタイトル登録 from rspec」と入力
-      fill_in 'タイトル', with: 'テストタイトル登録 from rspec'
+        # タイトルに「テストタイトル登録 from rspec」と入力
+        fill_in 'タイトル', with: 'テストタイトル登録 from rspec'
 
-      # 内容に「テスト内容登録 from rspec」と入力
-      fill_in '内容', with: 'テスト内容登録 from rspec'
+        # 内容に「テスト内容登録 from rspec」と入力
+        fill_in '内容', with: 'テスト内容登録 from rspec'
 
-      # 送信ボタンをクリック
-      click_button '送信'
+        # 送信ボタンをクリック
+        click_button I18n.t("helpers.submit.create")
 
-      # タスク一覧画面へ遷移することを期待する
-      expect(current_path).to eq root_path
+        # タスク一覧画面へ遷移することを期待する
+        expect(current_path).to eq root_path
 
-      # タスク一覧画面で登録成功のFlashメッセージが表示されることを確認する
-      expect(page).to have_content '登録に成功しました！'
+        # タスク一覧画面で登録成功のFlashメッセージが表示されることを確認する
+        expect(page).to have_content I18n.t("msg.success_registration")
+      end
+
     end
 
-    it 'タスク更新処理' do
-      # 更新画面へ遷移
-      visit "tasks/taskupdate/#{task.id}"
+    context 'タスク更新処理' do
+      example 'タスク更新に成功すること' do
+        # 更新画面へ遷移
+        visit "tasks/taskupdate/#{task.id}"
 
-      # タイトルに「テストタイトル更新 from rspec」と入力
-      fill_in 'タイトル', with: 'テストタイトル更新 from rspec'
+        # タイトルに「テストタイトル更新 from rspec」と入力
+        fill_in 'タイトル', with: 'テストタイトル更新 from rspec'
 
-      # 内容に「テスト詳細更新 from rspec」と入力
-      fill_in '詳細', with: 'テスト詳細更新 from rspec'
+        # 内容に「テスト詳細更新 from rspec」と入力
+        fill_in '内容', with: 'テスト詳細更新 from rspec'
 
-      # 更新ボタンをクリック
-      click_button '更新'
+        # 更新ボタンをクリック
+        click_button I18n.t("helpers.submit.update")
 
-      # タスク一覧画面へ遷移することを期待する
-      expect(current_path).to eq root_path
+        # タスク一覧画面へ遷移することを期待する
+        expect(current_path).to eq root_path
 
-      # タスク一覧画面で更新成功のFlashメッセージが表示されることを確認する
-      expect(page).to have_content '更新に成功しました！'
+        # タスク一覧画面で更新成功のFlashメッセージが表示されることを確認する
+        expect(page).to have_content I18n.t("msg.success_update")
+      end
     end
 
-    it 'タスク削除処理' do
-      # 詳細画面へ遷移
-      visit "tasks/taskdetail/#{task.id}"
+    context 'タスク削除処理' do
+      example 'タスク削除に成功すること' do
+        # 詳細画面へ遷移
+        visit "tasks/taskdetail/#{task.id}"
 
-      # 削除ボタンをクリック
-      click_link '削除'
+        # 削除ボタンをクリック
+        click_link I18n.t("tasks.taskdetail.delete_button")
 
-      # タスク一覧画面へ遷移することを期待する
-      expect(current_path).to eq root_path
+        # タスク一覧画面へ遷移することを期待する
+        expect(current_path).to eq root_path
 
-      # タスク一覧画面で削除成功のFlashメッセージが表示されることを確認する
-      expect(page).to have_content '削除に成功しました！'
+        # タスク一覧画面で削除成功のFlashメッセージが表示されることを確認する
+        expect(page).to have_content I18n.t("msg.success_delete")
+      end
     end
   end
 
-  context 'フォームの入力値が異常' do
+  describe 'フォームの入力値が異常' do
     context 'タスク登録処理' do
       before do
         visit 'tasks/newtask'
       end
 
-      it 'タイトル・内容が未入力' do
+      example 'タイトル・内容が未入力の時、エラーが表示されること' do
         # 送信ボタンをクリック
-        click_button '送信'
+        click_button I18n.t("helpers.submit.create")
 
-        expect(page).to have_content 'エラーが発生しました！'
-        expect(page).to have_content 'Title can\'t be blank'
-        expect(page).to have_content 'Title is too short (minimum is 3 characters)'
-        expect(page).to have_content 'Detail can\'t be blank'
-        expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
+        expect(page).to have_content I18n.t('tasks.newtask.error_title')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.blank')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.too_short')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.blank')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.too_short')
       end
 
-      it 'タイトルが未入力' do
+      example 'タイトルが未入力の時、エラーが表示されること' do
         # 内容に入力
         fill_in '内容', with: 'テスト内容 from rspec'
 
         # 送信ボタンをクリック
-        click_button '送信'
+        click_button I18n.t("helpers.submit.create")
 
-        expect(page).to have_content 'エラーが発生しました！'
-        expect(page).to have_content 'Title can\'t be blank'
-        expect(page).to have_content 'Title is too short (minimum is 3 characters)'
+        expect(page).to have_content I18n.t('tasks.newtask.error_title')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.blank')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.too_short')
       end
 
-      it '内容が未入力' do
+      example '内容が未入力の時、エラーが表示されること' do
         # タイトルにと入力
         fill_in 'タイトル', with: 'テストタイトル from rspec'
 
         # 送信ボタンをクリック
-        click_button '送信'
+        click_button I18n.t("helpers.submit.create")
 
-        expect(page).to have_content 'エラーが発生しました！'
-        expect(page).to have_content 'Detail can\'t be blank'
-        expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
+        expect(page).to have_content I18n.t('tasks.newtask.error_title')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.blank')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.too_short')
       end
 
-      it '入力文字数が３文字未満（タイトル）' do
+      example '入力文字数が３文字未満（タイトル）の時、エラーが表示されること' do
         # タイトルにと入力
         fill_in 'タイトル', with: 'ab'
 
@@ -157,14 +164,14 @@ RSpec.describe "Tasks", type: :system do
         fill_in '内容', with: 'abc'
 
         # 送信ボタンをクリック
-        click_button '送信'
+        click_button I18n.t("helpers.submit.create")
 
-        expect(page).to have_content 'エラーが発生しました！'
-        expect(page).to have_content 'Title is too short (minimum is 3 characters)'
-        expect(page).to have_no_content 'Title can\'t be blank'
+        expect(page).to have_content I18n.t('tasks.newtask.error_title')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.blank')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.too_short')
       end
 
-      it '入力文字数が３文字未満（内容）' do
+      example '入力文字数が３文字未満（内容）の時、エラーが表示されること' do
         # タイトルにと入力
         fill_in 'タイトル', with: 'abc'
 
@@ -172,44 +179,40 @@ RSpec.describe "Tasks", type: :system do
         fill_in '内容', with: 'ab'
 
         # 送信ボタンをクリック
-        click_button '送信'
+        click_button I18n.t("helpers.submit.create")
 
-        expect(page).to have_content 'エラーが発生しました！'
-        expect(page).to have_content 'Detail is too short (minimum is 3 characters)'
-        expect(page).to have_no_content 'Detail can\'t be blank'
+        expect(page).to have_content I18n.t('tasks.newtask.error_title')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.blank')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.too_short')
       end
 
-      it 'タイトルの入力文字数が２０文字以上' do
+      example 'タイトルの入力文字数が２０文字以上の時、エラーが表示されること' do
         # タイトルに「ab」と入力
-        fill_in 'タイトル', with: '123456789012345678901'
+        fill_in 'タイトル', with: 'a' * 21
 
         # 内容にと入力
         fill_in '内容', with: 'test'
 
         # 送信ボタンをクリック
-        click_button '送信'
+        click_button I18n.t("helpers.submit.create")
 
-        expect(page).to have_content 'エラーが発生しました！'
-        expect(page).to have_content 'Title is too long (maximum is 20 characters)'
+        expect(page).to have_content I18n.t('tasks.newtask.error_title')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.too_long')
       end
 
-      it '内容の入力文字数が２００文字以上' do
+      example '内容の入力文字数が２００文字以上の時、エラーが表示されること' do
         # タイトルに入力
         fill_in 'タイトル', with: 'test'
 
         # 内容に入力
-        fill_in '内容', with: 'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnop
-                              qrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012345
-                              6789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklm
-                              nopqrstuvwxyz0123456789abcdefghijklmnopqrstu'
+        fill_in '内容', with: 'a' * 201
 
         # 送信ボタンをクリック
-        click_button '送信'
+        click_button I18n.t("helpers.submit.create")
 
-        expect(page).to have_content 'エラーが発生しました！'
-        expect(page).to have_content 'Detail is too long (maximum is 200 characters)'
+        expect(page).to have_content I18n.t('tasks.newtask.error_title')
+        expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.too_long')
       end
-
     end
   end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe "Tasks", type: :system do
   let!(:task) { create(:task) }
 
-  describe '画面表示が正常' do
-    context 'タスク一覧画面' do
-      before do
-        visit root_path
-      end
+  describe 'タスク一覧画面' do
+    before do
+      visit root_path
+    end
 
+    context '画面表示が正常' do
       example '表示されること' do
         expect(page).to have_content I18n.t("tasks.index.page_title")
       end
@@ -32,28 +32,22 @@ RSpec.describe "Tasks", type: :system do
         expect(td3).to have_content "#{task.end_date.strftime('%Y/%m/%d')}"
       end
     end
-
-    example 'タスク登録画面が表示されること' do
-      visit 'tasks/newtask'
-      expect(page).to have_content I18n.t("tasks.newtask.page_title")
-    end
-
-    example 'タスク詳細画面が表示されること' do
-      visit "tasks/taskdetail/#{task.id}"
-      expect(page).to have_content I18n.t("tasks.taskdetail.page_title")
-    end
-
-    example 'タスク更新画面が表示されること' do
-      visit "tasks/taskupdate/#{task.id}"
-      expect(page).to have_content I18n.t("tasks.taskupdate.page_title")
-    end
   end
 
-  describe 'フォームの入力値が正常' do
-    context 'タスク登録処理' do
+  describe 'タスク登録画面' do
+    before do
+      # 登録画面へ遷移
+      visit tasks_newtask_path
+    end
+
+    context '画面表示が正常' do
+      example 'タスク登録画面が表示されること' do
+        expect(page).to have_content I18n.t("tasks.newtask.page_title")
+      end
+    end
+
+    context 'フォームの入力値が正常' do
       example 'タスク登録に成功すること' do
-        # 登録画面へ遷移
-        visit tasks_newtask_path
 
         # ステータスで着手を選択
         select '着手', from: 'task[status]'
@@ -73,54 +67,9 @@ RSpec.describe "Tasks", type: :system do
         # タスク一覧画面で登録成功のFlashメッセージが表示されることを確認する
         expect(page).to have_content I18n.t("msg.success_registration")
       end
-
     end
 
-    context 'タスク更新処理' do
-      example 'タスク更新に成功すること' do
-        # 更新画面へ遷移
-        visit "tasks/taskupdate/#{task.id}"
-
-        # タイトルに「テストタイトル更新 from rspec」と入力
-        fill_in 'タイトル', with: 'テストタイトル更新 from rspec'
-
-        # 内容に「テスト詳細更新 from rspec」と入力
-        fill_in '内容', with: 'テスト詳細更新 from rspec'
-
-        # 更新ボタンをクリック
-        click_button I18n.t("helpers.submit.update")
-
-        # タスク一覧画面へ遷移することを期待する
-        expect(current_path).to eq root_path
-
-        # タスク一覧画面で更新成功のFlashメッセージが表示されることを確認する
-        expect(page).to have_content I18n.t("msg.success_update")
-      end
-    end
-
-    context 'タスク削除処理' do
-      example 'タスク削除に成功すること' do
-        # 詳細画面へ遷移
-        visit "tasks/taskdetail/#{task.id}"
-
-        # 削除ボタンをクリック
-        click_link I18n.t("tasks.taskdetail.delete_button")
-
-        # タスク一覧画面へ遷移することを期待する
-        expect(current_path).to eq root_path
-
-        # タスク一覧画面で削除成功のFlashメッセージが表示されることを確認する
-        expect(page).to have_content I18n.t("msg.success_delete")
-      end
-    end
-  end
-
-  describe 'フォームの入力値が異常' do
-    context 'タスク登録処理' do
-      before do
-        visit 'tasks/newtask'
-      end
-
+    context 'フォームの入力値が異常' do
       example 'タイトル・内容が未入力の時、エラーが表示されること' do
         # 送信ボタンをクリック
         click_button I18n.t("helpers.submit.create")
@@ -212,6 +161,65 @@ RSpec.describe "Tasks", type: :system do
 
         expect(page).to have_content I18n.t('tasks.newtask.error_title')
         expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.too_long')
+      end
+    end
+  end
+
+  describe 'タスク詳細画面' do
+    context '画面表示が正常' do
+      example 'タスク詳細画面が表示されること' do
+        visit "tasks/taskdetail/#{task.id}"
+        expect(page).to have_content I18n.t("tasks.taskdetail.page_title")
+      end
+    end
+  end
+
+  describe 'タスク更新画面' do
+    before do
+      # 更新画面へ遷移
+      visit "tasks/taskupdate/#{task.id}"
+    end
+
+    context '画面表示が正常' do
+      example 'タスク更新画面が表示されること' do
+        expect(page).to have_content I18n.t("tasks.taskupdate.page_title")
+      end
+    end
+
+    context 'フォームの入力値が正常' do
+      example 'タスク更新に成功すること' do
+        # タイトルに「テストタイトル更新 from rspec」と入力
+        fill_in 'タイトル', with: 'テストタイトル更新 from rspec'
+
+        # 内容に「テスト詳細更新 from rspec」と入力
+        fill_in '内容', with: 'テスト詳細更新 from rspec'
+
+        # 更新ボタンをクリック
+        click_button I18n.t("helpers.submit.update")
+
+        # タスク一覧画面へ遷移することを期待する
+        expect(current_path).to eq root_path
+
+        # タスク一覧画面で更新成功のFlashメッセージが表示されることを確認する
+        expect(page).to have_content I18n.t("msg.success_update")
+      end
+    end
+  end
+
+  describe 'タスク削除画面' do
+    context 'フォームの入力値が正常' do
+      example 'タスク削除に成功すること' do
+        # 詳細画面へ遷移
+        visit "tasks/taskdetail/#{task.id}"
+
+        # 削除ボタンをクリック
+        click_link I18n.t("tasks.taskdetail.delete_button")
+
+        # タスク一覧画面へ遷移することを期待する
+        expect(current_path).to eq root_path
+
+        # タスク一覧画面で削除成功のFlashメッセージが表示されることを確認する
+        expect(page).to have_content I18n.t("msg.success_delete")
       end
     end
   end


### PR DESCRIPTION
### 概要
Rails研修「ステップ11: バリデーションを設定してみよう」

### 変更内容
【バリデーションを設定しましょう】
→ app/models/task.rb
→ db/migrate/20201116004626_create_tasks.rb

【画面にバリデーションエラーのメッセージを表示するようにしましょう】
→ app/controllers/tasks_controller.rb
→ app/views/tasks/newtask.html.erb

【バリデーションに対してモデルのテストを書いてみましょう】
→ spec/system/task_spec.rb

### 今回の研修ステップには関係のない変更ファイル
→ app/views/layouts/application.html.erb
→ app/views/tasks/index.html.erb


### 期待される結果
・不正な入力に対してバリデーションが有効に動作し、エラーメッセージが表示されること
・追加した不正入力用のテストが正常に動作すること