### PR TITLE
step12：タスク登録時に終了期限が設定できる機能、一覧画面でソートできる機能を実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,8 +3,18 @@
 class TasksController < ApplicationController
   # タスク一覧画面
   def index
+    # ソート順のパラメータを取得
+    @sortno = params['sortno']
+    # デフォルトのソート順は作成日順
+    sortOrder = "created_at DESC";
+
+    # 終了期限順だった場合
+    if @sortno == "2"
+      sortOrder = "end_date DESC";
+    end
+
     # タスクテーブルからデータを取り出す
-    @tasks = Task.all.order(created_at: :desc)
+    @tasks = Task.all.order(sortOrder)
   end
 
   # タスク登録画面
@@ -21,8 +31,9 @@ class TasksController < ApplicationController
     statusParam =  params[:task][:status].to_i
     titleParam =  params[:task][:title]
     detailParam =  params[:task][:detail]
+    endDateParam =  params[:task][:end_date]
 
-    @task = Task.new(status: statusParam, title: titleParam, detail: detailParam)
+    @task = Task.new(status: statusParam, title: titleParam, detail: detailParam, end_date: endDateParam)
 
     # 登録成功
     if @task.save
@@ -62,12 +73,14 @@ class TasksController < ApplicationController
     param_status = params[:task][:status].to_i
     param_title = params[:task][:title]
     param_detail = params[:task][:detail]
+    param_endDate = params[:task][:end_date]
 
     # タスクテーブルを検索
     updateTask = Task.find(param_id)
     updateTask.status = param_status
     updateTask.title = param_title
     updateTask.detail = param_detail
+    updateTask.end_date = param_endDate
 
     # 更新成功
     if updateTask.save

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,12 +5,13 @@ class TasksController < ApplicationController
   def index
     # ソート順のパラメータを取得
     @sortno = params['sortno']
-    # デフォルトのソート順は作成日順
-    sortOrder = "created_at DESC";
 
-    # 終了期限順だった場合
-    if @sortno == "2"
-      sortOrder = "end_date DESC";
+    # 終了期限順
+    if @sortno == '2'
+      sortOrder = 'end_date DESC'
+    # デフォルトのソート順は作成日順
+    else
+      sortOrder = 'created_at DESC'
     end
 
     # タスクテーブルからデータを取り出す
@@ -23,26 +24,21 @@ class TasksController < ApplicationController
     @task = Task.new
 
     # Viewの呼び出し
-    render "newtask"
+    render 'newtask'
   end
 
   # タスク登録処理
   def createtask
-    statusParam =  params[:task][:status].to_i
-    titleParam =  params[:task][:title]
-    detailParam =  params[:task][:detail]
-    endDateParam =  params[:task][:end_date]
-
-    @task = Task.new(status: statusParam, title: titleParam, detail: detailParam, end_date: endDateParam)
+    @task = Task.new(user_params)
 
     # 登録成功
     if @task.save
-      flash[:success] = I18n.t("msg.success_registration")
-      redirect_to action: "index"
+      flash[:success] = I18n.t('msg.success_registration')
+      redirect_to action: 'index'
     # 失敗
     else
-      flash.now[:warning] = I18n.t("msg.failed_registration")
-      render "newtask"
+      flash.now[:warning] = I18n.t('msg.failed_registration')
+      render 'newtask'
     end
   end
 
@@ -85,12 +81,12 @@ class TasksController < ApplicationController
     # 更新成功
     if updateTask.save
 
-      flash[:success] = I18n.t("msg.success_update")
-      redirect_to action: "index"
+      flash[:success] = I18n.t('msg.success_update')
+      redirect_to action: 'index'
     # 失敗
     else
-      flash.now[:warning] = I18n.t("msg.failed_update")
-      render "taskupdate"
+      flash.now[:warning] = I18n.t('msg.failed_update')
+      render 'taskupdate'
     end
   end
 
@@ -103,12 +99,12 @@ class TasksController < ApplicationController
 
     # 削除成功
     if delTask
-      flash[:success] = I18n.t("msg.success_delete")
-      redirect_to action: "index"
+      flash[:success] = I18n.t('msg.success_delete')
+      redirect_to action: 'index'
     # 失敗
     else
-      flash.now[:warning] = I18n.t("msg.failed_delete")
-      render "taskdetail"
+      flash.now[:warning] = I18n.t('msg.failed_delete')
+      render 'taskdetail'
     end
   end
 
@@ -119,4 +115,12 @@ class TasksController < ApplicationController
       end
     end
   end
+
+  private
+    def user_params
+      data = params.require(:task).permit(:status, :title, :detail, :end_date)
+      # statusはenumのテキスト型なので、整数型に変換する
+      data[:status] = params[:task][:status].to_i
+      return data
+    end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require("jquery")
 
 import 'bootstrap'
 import '../src/application.scss'

--- a/app/javascript/packs/task/index.js
+++ b/app/javascript/packs/task/index.js
@@ -1,0 +1,11 @@
+$('#select-sort').on('change',function(e){
+  var selectedSortNo = $(this).val();
+  console.log(selectedSortNo);
+
+  if(selectedSortNo == 2){
+    location.href = '/2';
+  }
+  else{
+    location.href = '/';
+  }
+})

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,16 +2,23 @@ class Task < ApplicationRecord
 
   enum status: { 未着手: 10, 着手: 20, 完了: 30 }
 
-  #入力必須
+  # 入力必須
   validates :status, :title, :detail, presence: true
 
-  #3文字以上
+  # 3文字以上
   validates :title, :detail, length: { minimum: 3 }
 
-  #20文字以内
+  # 20文字以内
   validates :title, length: { maximum: 20 }
 
-  #200文字以内
+  # 200文字以内
   validates :detail, length: { maximum: 200 }
+
+  # 終了期限は今日以降の日のみ
+  validate :date_before_start
+
+  def date_before_start
+    errors.add(:end_date, I18n.t('msg.validate_end_date')) if !end_date.nil? && end_date < Date.today
+  end
 
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,10 +4,10 @@
   </div>
   <div class="mt-5">
     <div class="form-inline">
-      <label for="select-sort">並び順:</label>
+      <label for="select-sort"><%= I18n.t('tasks.index.sort_order') %></label>
       <select name="select-sort" id="select-sort" class="form-control">
-        <option value="1" <%= @sortno != "2" ? "selected" : "" %>>作成日</option>
-        <option value="2" <%= @sortno == "2" ? "selected" : "" %>>終了期限</option>
+        <option value="1" <%= @sortno != "2" ? "selected" : "" %>><%= I18n.t('tasks.index.sort_create_at') %></option>
+        <option value="2" <%= @sortno == "2" ? "selected" : "" %>><%= I18n.t('tasks.index.sort_end_date') %></option>
       </select>
     </div>
     <div class="mt-4">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,7 +3,14 @@
     <h1 class="text-center"><%= I18n.t('tasks.index.page_title') %></h1>
   </div>
   <div class="mt-5">
-    <div>
+    <div class="form-inline">
+      <label for="select-sort">並び順:</label>
+      <select name="select-sort" id="select-sort" class="form-control">
+        <option value="1" <%= @sortno != "2" ? "selected" : "" %>>作成日</option>
+        <option value="2" <%= @sortno == "2" ? "selected" : "" %>>終了期限</option>
+      </select>
+    </div>
+    <div class="mt-4">
       <table class="table table-bordered">
         <thead class="thead-light">
           <tr>
@@ -28,3 +35,4 @@
     </div>
   </div>
 </div>
+<%= javascript_pack_tag 'task/index' %>

--- a/app/views/tasks/newtask.html.erb
+++ b/app/views/tasks/newtask.html.erb
@@ -32,7 +32,7 @@
         <%= f.text_area :detail, rows: "10", class: "col-sm-7" %>
       </div>
       <div class="form-group">
-        <%= f.label :end_date,"終了期限", class: "col-sm-4" %>
+        <%= f.label :end_date, class: "col-sm-4" %>
         <%= f.date_field :end_date, class: "col-sm-7" %>
       </div>
       <div class="row mt-5">

--- a/app/views/tasks/newtask.html.erb
+++ b/app/views/tasks/newtask.html.erb
@@ -31,6 +31,10 @@
         <%= f.label :detail, class: "col-sm-4" %>
         <%= f.text_area :detail, rows: "10", class: "col-sm-7" %>
       </div>
+      <div class="form-group">
+        <%= f.label :end_date,"終了期限", class: "col-sm-4" %>
+        <%= f.date_field :end_date, class: "col-sm-7" %>
+      </div>
       <div class="row mt-5">
         <div class="col-sm-4 text-left">
           <%= link_to("#{I18n.t('tasks.newtask.back_button')}" , "/", class: "btn btn-secondary") %>

--- a/app/views/tasks/taskupdate.html.erb
+++ b/app/views/tasks/taskupdate.html.erb
@@ -33,7 +33,7 @@
           </tr>
           <tr>
             <th scope="col">
-              <%= f.label :end_date,"終了期限" %>
+              <%= f.label :end_date %>
             </th>
             <td>
               <%= f.date_field :end_date, class: "col-sm-12" %>

--- a/app/views/tasks/taskupdate.html.erb
+++ b/app/views/tasks/taskupdate.html.erb
@@ -31,6 +31,14 @@
               <%= f.text_area :detail,rows: "10", class: "col-sm-12" %>
             </td>
           </tr>
+          <tr>
+            <th scope="col">
+              <%= f.label :end_date,"終了期限" %>
+            </th>
+            <td>
+              <%= f.date_field :end_date, class: "col-sm-12" %>
+            </td>
+          </tr>
         </tbody>
       </table>
       <div class="row mt-5">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,3 +19,4 @@ ja:
     failed_update: "更新に失敗しました・・・"
     success_delete: "削除に成功しました！"
     failed_delete: "削除に失敗しました・・・"
+    validate_end_date: "は今日以降のものを選択してください"

--- a/config/locales/mode.ja.yml
+++ b/config/locales/mode.ja.yml
@@ -7,3 +7,4 @@ ja:
         status: "ステータス"
         title: "タイトル"
         detail: "内容"
+        end_date: "終了期限"

--- a/config/locales/views/tasks/index/ja.yml
+++ b/config/locales/views/tasks/index/ja.yml
@@ -6,3 +6,6 @@ ja:
       task: "タスク"
       end_date: "終了期限"
       submit_button: "タスク登録"
+      sort_order: "並び順"
+      sort_create_at: "作成日"
+      sort_end_date: "終了期限"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   # トップ
   root 'tasks#index'
 
+  get '/:sortno', :to => 'tasks#index'
+
   # タスク登録画面
   get 'tasks/newtask' => "tasks#newtask"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,8 @@
 Rails.application.routes.draw do
-
   # トップ
   root 'tasks#index'
 
-  get '/:sortno', :to => 'tasks#index'
+  get '/:sortno' => 'tasks#index'
 
   # タスク登録画面
   get 'tasks/newtask' => "tasks#newtask"
@@ -12,14 +11,13 @@ Rails.application.routes.draw do
   post 'tasks/createtask' => "tasks#createtask"
 
   # タスク詳細画面
-  get 'tasks/taskdetail/:id', :to => 'tasks#taskdetail',:as => :tasks_taskdetail
+  get 'tasks/taskdetail/:id' => 'tasks#taskdetail', :as => :tasks_taskdetail
 
   # タスク編集画面
-  get 'tasks/taskupdate/:id', :to => 'tasks#taskupdate',:as => :tasks_taskupdate
+  get 'tasks/taskupdate/:id' => 'tasks#taskupdate', :as => :tasks_taskupdate
 
   # タスク更新処理
   patch 'tasks/taskupdateprocess' => "tasks#taskupdateprocess"
 
-  delete 'tasks/taskdelete/:id', :to => "tasks#taskdelete",:as => :tasks_taskdelete
-
+  delete 'tasks/taskdelete/:id' => "tasks#taskdelete", :as => :tasks_taskdelete
 end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery/src/jquery',
+    jQuery: 'jquery/src/jquery'
+  })
+)
+
 module.exports = environment

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     status { 10 }
     sequence(:title) { |n| "TEST_TITLE#{n}" }
     sequence(:detail) { |n| "TEST_DETAIL#{n}" }
-    end_date { Date.new(2020, 12, 2) }
+    sequence(:end_date) { |n| Time.zone.now + 1000.days - n.days }
   end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Tasks", type: :system do
     end
 
     context 'フォームの入力値が正常' do
-      it '並び順を選択' do
+      example '並び順を選択' do
         # セレクトボックスを選択
         select '終了期限', from: 'select-sort'
 

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -60,15 +60,15 @@ RSpec.describe 'Tasks', type: :system do
 
       example '並び順を終了期限に変更することで、タスクの並び順が変わること' do
         # テーブル１行目
-        date1_bf = get_date_value(0).text(:visible)
+        date1_bf = all('tbody tr')[0].all('td')[2].text(:visible)
         # テーブル２行目
-        date2_bf = get_date_value(1).text(:visible)
+        date2_bf = all('tbody tr')[1].all('td')[2].text(:visible)
         # テーブル３行目
-        date3_bf = get_date_value(2).text(:visible)
+        date3_bf = all('tbody tr')[2].all('td')[2].text(:visible)
         # テーブル４行目
-        date4_bf = get_date_value(3).text(:visible)
+        date4_bf = all('tbody tr')[3].all('td')[2].text(:visible)
         # テーブル５行目
-        date5_bf = get_date_value(4).text(:visible)
+        date5_bf = all('tbody tr')[4].all('td')[2].text(:visible)
 
         # 終了期限が昇順で並んでいること
         expect(date5_bf).to be > date4_bf
@@ -83,15 +83,15 @@ RSpec.describe 'Tasks', type: :system do
         expect(current_path).to eq '/2'
 
         # テーブル１行目
-        date1_af = get_date_value(0).text(:visible)
+        date1_af = all('tbody tr')[0].all('td')[2].text(:visible)
         # テーブル２行目
-        date2_af = get_date_value(1).text(:visible)
+        date2_af = all('tbody tr')[1].all('td')[2].text(:visible)
         # テーブル３行目
-        date3_af = get_date_value(2).text(:visible)
+        date3_af = all('tbody tr')[2].all('td')[2].text(:visible)
         # テーブル４行目
-        date4_af = get_date_value(3).text(:visible)
+        date4_af = all('tbody tr')[3].all('td')[2].text(:visible)
         # テーブル５行目
-        date5_af = get_date_value(4).text(:visible)
+        date5_af = all('tbody tr')[4].all('td')[2].text(:visible)
 
         # 終了期限が降順で並んでいること
         expect(date1_af).to be > date2_af
@@ -312,9 +312,5 @@ RSpec.describe 'Tasks', type: :system do
         expect(page).to have_content I18n.t('msg.success_delete')
       end
     end
-  end
-
-  def get_date_value(tr_no)
-    all('tbody tr')[tr_no].all('td')[2]
   end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe "Tasks", type: :system do
         expect(page).to have_link 'タスク登録'
       end
 
+      example '並び順のセレクトボックスが表示されること' do
+        expect(page).to have_select('並び順:', selected: '作成日', options: ['作成日', '終了期限'])
+      end
+
       example '表示項目の確認 - 登録したステータスが表示されること' do
         td1 = all('tbody tr')[0].all('td')[0]
         expect(td1).to have_content "#{task.status}"
@@ -30,6 +34,28 @@ RSpec.describe "Tasks", type: :system do
       example '表示項目の確認 - 登録した終了期限が表示されること' do
         td3 = all('tbody tr')[0].all('td')[2]
         expect(td3).to have_content "#{task.end_date.strftime('%Y/%m/%d')}"
+      end
+    end
+
+    context 'フォームの入力値が正常' do
+      it '並び順を選択' do
+        # セレクトボックスを選択
+        select '終了期限', from: 'select-sort'
+
+        # セレクトボックスの変更をチェック
+        expect(page).to have_select('並び順:', selected: '終了期限')
+
+        # URLの遷移をチェック
+        expect(current_path).to eq '/2'
+
+        # セレクトボックスを選択
+        select '作成日', from: 'select-sort'
+
+        # セレクトボックスの変更をチェック
+        expect(page).to have_select('並び順:', selected: '作成日')
+
+        # URLの遷移をチェック
+        expect(current_path).to eq '/'
       end
     end
   end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Tasks", type: :system do
-  let!(:task) { create(:task) }
+RSpec.describe 'Tasks', type: :system do
+  let!(:task) { create_list(:task, 5) }
 
   describe 'タスク一覧画面' do
     before do
@@ -10,7 +10,7 @@ RSpec.describe "Tasks", type: :system do
 
     context '画面表示が正常' do
       example '表示されること' do
-        expect(page).to have_content I18n.t("tasks.index.page_title")
+        expect(page).to have_content I18n.t('tasks.index.page_title')
       end
 
       example 'タスク登録ボタンが表示されること' do
@@ -18,32 +18,32 @@ RSpec.describe "Tasks", type: :system do
       end
 
       example '並び順のセレクトボックスが表示されること' do
-        expect(page).to have_select('並び順:', selected: '作成日', options: ['作成日', '終了期限'])
+        expect(page).to have_select('並び順', selected: '作成日', options: ['作成日', '終了期限'])
       end
 
       example '表示項目の確認 - 登録したステータスが表示されること' do
         td1 = all('tbody tr')[0].all('td')[0]
-        expect(td1).to have_content "#{task.status}"
+        expect(td1).to have_content task[4].status.to_s
       end
 
       example '表示項目の確認 - 登録したタスクが表示されること' do
         td2 = all('tbody tr')[0].all('td')[1]
-        expect(td2).to have_content "#{task.title}"
+        expect(td2).to have_content task[4].title.to_s
       end
 
       example '表示項目の確認 - 登録した終了期限が表示されること' do
         td3 = all('tbody tr')[0].all('td')[2]
-        expect(td3).to have_content "#{task.end_date.strftime('%Y/%m/%d')}"
+        expect(td3).to have_content task[4].end_date.strftime('%Y/%m/%d').to_s
       end
     end
 
     context 'フォームの入力値が正常' do
-      example '並び順を選択' do
+      example '並び順が切り替わること' do
         # セレクトボックスを選択
         select '終了期限', from: 'select-sort'
 
         # セレクトボックスの変更をチェック
-        expect(page).to have_select('並び順:', selected: '終了期限')
+        expect(page).to have_select('並び順', selected: '終了期限')
 
         # URLの遷移をチェック
         expect(current_path).to eq '/2'
@@ -52,10 +52,52 @@ RSpec.describe "Tasks", type: :system do
         select '作成日', from: 'select-sort'
 
         # セレクトボックスの変更をチェック
-        expect(page).to have_select('並び順:', selected: '作成日')
+        expect(page).to have_select('並び順', selected: '作成日')
 
         # URLの遷移をチェック
         expect(current_path).to eq '/'
+      end
+
+      example '並び順を終了期限に変更することで、タスクの並び順が変わること' do
+        # テーブル１行目
+        date1_bf = get_date_value(0).text(:visible)
+        # テーブル２行目
+        date2_bf = get_date_value(1).text(:visible)
+        # テーブル３行目
+        date3_bf = get_date_value(2).text(:visible)
+        # テーブル４行目
+        date4_bf = get_date_value(3).text(:visible)
+        # テーブル５行目
+        date5_bf = get_date_value(4).text(:visible)
+
+        # 終了期限が昇順で並んでいること
+        expect(date5_bf).to be > date4_bf
+        expect(date4_bf).to be > date3_bf
+        expect(date3_bf).to be > date2_bf
+        expect(date2_bf).to be > date1_bf
+
+        # セレクトボックスを選択
+        select '終了期限', from: 'select-sort'
+
+        # URLの遷移をチェック
+        expect(current_path).to eq '/2'
+
+        # テーブル１行目
+        date1_af = get_date_value(0).text(:visible)
+        # テーブル２行目
+        date2_af = get_date_value(1).text(:visible)
+        # テーブル３行目
+        date3_af = get_date_value(2).text(:visible)
+        # テーブル４行目
+        date4_af = get_date_value(3).text(:visible)
+        # テーブル５行目
+        date5_af = get_date_value(4).text(:visible)
+
+        # 終了期限が降順で並んでいること
+        expect(date1_af).to be > date2_af
+        expect(date2_af).to be > date3_af
+        expect(date3_af).to be > date4_af
+        expect(date4_af).to be > date5_af
       end
     end
   end
@@ -68,13 +110,12 @@ RSpec.describe "Tasks", type: :system do
 
     context '画面表示が正常' do
       example 'タスク登録画面が表示されること' do
-        expect(page).to have_content I18n.t("tasks.newtask.page_title")
+        expect(page).to have_content I18n.t('tasks.newtask.page_title')
       end
     end
 
     context 'フォームの入力値が正常' do
       example 'タスク登録に成功すること' do
-
         # ステータスで着手を選択
         select '着手', from: 'task[status]'
 
@@ -83,6 +124,10 @@ RSpec.describe "Tasks", type: :system do
 
         # 内容に「テスト内容登録 from rspec」と入力
         fill_in '内容', with: 'テスト内容登録 from rspec'
+
+        # 終了期限を入力
+        tommorow = Time.now + 1.day
+        fill_in 'task[end_date]', with: tommorow.strftime('00%Y-%m-%d')
 
         # 送信ボタンをクリック
         click_button I18n.t("helpers.submit.create")
@@ -98,7 +143,7 @@ RSpec.describe "Tasks", type: :system do
     context 'フォームの入力値が異常' do
       example 'タイトル・内容が未入力の時、エラーが表示されること' do
         # 送信ボタンをクリック
-        click_button I18n.t("helpers.submit.create")
+        click_button I18n.t('helpers.submit.create')
 
         expect(page).to have_content I18n.t('tasks.newtask.error_title')
         expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.blank')
@@ -112,7 +157,7 @@ RSpec.describe "Tasks", type: :system do
         fill_in '内容', with: 'テスト内容 from rspec'
 
         # 送信ボタンをクリック
-        click_button I18n.t("helpers.submit.create")
+        click_button I18n.t('helpers.submit.create')
 
         expect(page).to have_content I18n.t('tasks.newtask.error_title')
         expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.blank')
@@ -124,7 +169,7 @@ RSpec.describe "Tasks", type: :system do
         fill_in 'タイトル', with: 'テストタイトル from rspec'
 
         # 送信ボタンをクリック
-        click_button I18n.t("helpers.submit.create")
+        click_button I18n.t('helpers.submit.create')
 
         expect(page).to have_content I18n.t('tasks.newtask.error_title')
         expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.blank')
@@ -139,7 +184,7 @@ RSpec.describe "Tasks", type: :system do
         fill_in '内容', with: 'abc'
 
         # 送信ボタンをクリック
-        click_button I18n.t("helpers.submit.create")
+        click_button I18n.t('helpers.submit.create')
 
         expect(page).to have_content I18n.t('tasks.newtask.error_title')
         expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.blank')
@@ -154,7 +199,7 @@ RSpec.describe "Tasks", type: :system do
         fill_in '内容', with: 'ab'
 
         # 送信ボタンをクリック
-        click_button I18n.t("helpers.submit.create")
+        click_button I18n.t('helpers.submit.create')
 
         expect(page).to have_content I18n.t('tasks.newtask.error_title')
         expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.blank')
@@ -169,7 +214,7 @@ RSpec.describe "Tasks", type: :system do
         fill_in '内容', with: 'test'
 
         # 送信ボタンをクリック
-        click_button I18n.t("helpers.submit.create")
+        click_button I18n.t('helpers.submit.create')
 
         expect(page).to have_content I18n.t('tasks.newtask.error_title')
         expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.title.too_long')
@@ -183,10 +228,29 @@ RSpec.describe "Tasks", type: :system do
         fill_in '内容', with: 'a' * 201
 
         # 送信ボタンをクリック
-        click_button I18n.t("helpers.submit.create")
+        click_button I18n.t('helpers.submit.create')
 
         expect(page).to have_content I18n.t('tasks.newtask.error_title')
         expect(page).to have_content I18n.t('activerecord.errors.models.task.attributes.detail.too_long')
+      end
+
+      example '終了期限が過去の日付だった場合、エラーが表示されること' do
+
+        # タイトルに「テストタイトル登録 from rspec」と入力
+        fill_in 'タイトル', with: 'テストタイトル登録 from rspec'
+
+        # 内容に「テスト内容登録 from rspec」と入力
+        fill_in '内容', with: 'テスト内容登録 from rspec'
+
+        # 過去の終了期限を入力
+        yesterday = Time.now - 1.day
+        fill_in 'task[end_date]', with: yesterday.strftime('00%Y-%m-%d')
+
+        # 送信ボタンをクリック
+        click_button I18n.t('helpers.submit.create')
+
+        expect(page).to have_content I18n.t('tasks.newtask.error_title')
+        expect(page).to have_content (I18n.t('activerecord.attributes.task.end_date') + I18n.t('msg.validate_end_date'))
       end
     end
   end
@@ -194,8 +258,8 @@ RSpec.describe "Tasks", type: :system do
   describe 'タスク詳細画面' do
     context '画面表示が正常' do
       example 'タスク詳細画面が表示されること' do
-        visit "tasks/taskdetail/#{task.id}"
-        expect(page).to have_content I18n.t("tasks.taskdetail.page_title")
+        visit "tasks/taskdetail/#{task[0].id}"
+        expect(page).to have_content I18n.t('tasks.taskdetail.page_title')
       end
     end
   end
@@ -203,12 +267,12 @@ RSpec.describe "Tasks", type: :system do
   describe 'タスク更新画面' do
     before do
       # 更新画面へ遷移
-      visit "tasks/taskupdate/#{task.id}"
+      visit "tasks/taskupdate/#{task[0].id}"
     end
 
     context '画面表示が正常' do
       example 'タスク更新画面が表示されること' do
-        expect(page).to have_content I18n.t("tasks.taskupdate.page_title")
+        expect(page).to have_content I18n.t('tasks.taskupdate.page_title')
       end
     end
 
@@ -221,13 +285,13 @@ RSpec.describe "Tasks", type: :system do
         fill_in '内容', with: 'テスト詳細更新 from rspec'
 
         # 更新ボタンをクリック
-        click_button I18n.t("helpers.submit.update")
+        click_button I18n.t('helpers.submit.update')
 
         # タスク一覧画面へ遷移することを期待する
         expect(current_path).to eq root_path
 
         # タスク一覧画面で更新成功のFlashメッセージが表示されることを確認する
-        expect(page).to have_content I18n.t("msg.success_update")
+        expect(page).to have_content I18n.t('msg.success_update')
       end
     end
   end
@@ -236,17 +300,21 @@ RSpec.describe "Tasks", type: :system do
     context 'フォームの入力値が正常' do
       example 'タスク削除に成功すること' do
         # 詳細画面へ遷移
-        visit "tasks/taskdetail/#{task.id}"
+        visit "tasks/taskdetail/#{task[0].id}"
 
         # 削除ボタンをクリック
-        click_link I18n.t("tasks.taskdetail.delete_button")
+        click_link I18n.t('tasks.taskdetail.delete_button')
 
         # タスク一覧画面へ遷移することを期待する
         expect(current_path).to eq root_path
 
         # タスク一覧画面で削除成功のFlashメッセージが表示されることを確認する
-        expect(page).to have_content I18n.t("msg.success_delete")
+        expect(page).to have_content I18n.t('msg.success_delete')
       end
     end
+  end
+
+  def get_date_value(tr_no)
+    all('tbody tr')[tr_no].all('td')[2]
   end
 end


### PR DESCRIPTION
![スクリーンショット 2020-12-09 10 47 03](https://user-images.githubusercontent.com/73919178/101563041-e79fe880-3a0b-11eb-9710-5740859a0836.png)

![スクリーンショット 2020-12-09 10 48 34](https://user-images.githubusercontent.com/73919178/101563214-3057a180-3a0c-11eb-9851-d5eddc06a21f.png)


### 概要
Rails研修「ステップ12: 終了期限を追加しよう ★ スキップ可能」

### 変更内容
**【タスクに対して、終了期限を登録できるようにしてみましょう】**
→ (タスク登録画面View) app/views/tasks/newtask.html.erb
→ (タスク更新画面View) app/views/tasks/taskupdate.html.erb
→ (Controller) app/controllers/tasks_controller.rb

**【一覧画面で、終了期限でソートできるようにしましょう】**
→ (Route) config/routes.rb
→ (View) app/views/tasks/index.html.erb
→ (Controller) app/controllers/tasks_controller.rb
→ (Js) app/javascript/packs/task/index.js

**【specを拡充しましょう】**
→ spec/system/task_spec.rb

**【追加したプラグインや変更した設定ファイル】**
→ (JS) app/javascript/packs/application.js
→ (Config) config/webpack/environment.js

### 期待される結果
・タスクに対して、終了期限を登録できること
・一覧画面で、終了期限でソートできること
・Rspecによるテストが通ること