### PR TITLE
step13:一覧画面でタイトルとステータスで検索ができる機能と、検索インデックスを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,5 @@ end
 gem 'rails-i18n'
 
 gem 'ransack'
+
+gem 'enum_help'

--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,5 @@ group :development do
 end
 
 gem 'rails-i18n'
+
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,10 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    ransack (2.4.0)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -256,6 +260,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
   rails-i18n
+  ransack
   rspec-rails
   sass-rails (>= 6)
   selenium-webdriver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     fablicop (1.0.6)
       rubocop (~> 0.53.0)
@@ -252,6 +254,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  enum_help
   fablicop
   factory_bot_rails
   jbuilder (~> 2.7)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,9 +19,6 @@ class TasksController < ApplicationController
       # 検索機能を利用した検索結果を取得
       @tasks = @search.result
     end
-
-    @sort_order_list = [{ name: I18n.t('tasks.index.sort_create_at'), sort: 'created_at ASC' },
-                        { name: I18n.t('tasks.index.sort_end_date'), sort: 'end_date DESC' }]
   end
 
   # タスク登録画面

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,25 +3,25 @@
 class TasksController < ApplicationController
   # タスク一覧画面
   def index
-    # デフォルトの並び順をセット
-    params[:q] = { sorts: 'id desc' }
+    if params[:q].nil?
+      # デフォルトの並び順をセット
+      params[:q] = { sorts: 'created_at desc' }
 
-    # デフォルトの検索
-    @search = Task.ransack()
+      # デフォルトの検索
+      @search = Task.ransack()
 
-    # 全件取得
-    @tasks = Task.all
-  end
+      # 全件取得
+      @tasks = Task.all
+    else
+      # 入力に応じて検索機能を設定
+      @search = Task.ransack(params.require(:q).permit(:sorts, :status_eq, :title_cont))
 
-  # タスク絞り込み後の一覧画面
-  def search
-    # 入力に応じて検索機能を設定
-    @search = Task.ransack(params.require(:q).permit(:sorts, :status_eq, :title_cont))
+      # 検索機能を利用した検索結果を取得
+      @tasks = @search.result
+    end
 
-    # 検索機能を利用した検索結果を取得
-    @tasks = @search.result
-
-    render "index"
+    @sort_order_list = [{ name: I18n.t('tasks.index.sort_create_at'), sort: 'created_at ASC' },
+                        { name: I18n.t('tasks.index.sort_end_date'), sort: 'end_date DESC' }]
   end
 
   # タスク登録画面
@@ -54,7 +54,7 @@ class TasksController < ApplicationController
     param_id = params[:id]
 
     # パラメータのIDを元にタスクテーブルを検索
-    @taskInfos = Task.find(param_id)
+    @task_infos = Task.find(param_id)
   end
 
   # タスク更新
@@ -62,7 +62,7 @@ class TasksController < ApplicationController
     # Getパラメータの取得
     param_id = params[:id]
 
-    @tasksList = Task.statuses
+    @tasks_list = Task.statuses
 
     # パラメータのIDを元にタスクテーブルを検索
     @task = Task.find(param_id)
@@ -75,17 +75,17 @@ class TasksController < ApplicationController
     param_status = params[:task][:status].to_i
     param_title = params[:task][:title]
     param_detail = params[:task][:detail]
-    param_endDate = params[:task][:end_date]
+    param_end_date = params[:task][:end_date]
 
     # タスクテーブルを検索
-    updateTask = Task.find(param_id)
-    updateTask.status = param_status
-    updateTask.title = param_title
-    updateTask.detail = param_detail
-    updateTask.end_date = param_endDate
+    update_task = Task.find(param_id)
+    update_task.status = param_status
+    update_task.title = param_title
+    update_task.detail = param_detail
+    update_task.end_date = param_end_date
 
     # 更新成功
-    if updateTask.save
+    if update_task.save
 
       flash[:success] = I18n.t('msg.success_update')
       redirect_to action: 'index'
@@ -101,10 +101,10 @@ class TasksController < ApplicationController
     param_id = params[:id]
 
     # 削除実行
-    delTask = Task.destroy(param_id)
+    del_task = Task.destroy(param_id)
 
     # 削除成功
-    if delTask
+    if del_task
       flash[:success] = I18n.t('msg.success_delete')
       redirect_to action: 'index'
     # 失敗

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,9 +14,17 @@ class TasksController < ApplicationController
       sortOrder = 'created_at DESC'
     end
 
-    # タスクテーブルからデータを取り出す
-    @tasks = Task.all.order(sortOrder)
+    @q = Task.ransack(params[:q])
+    @tasks = @q.result(distinct: true)
   end
+
+  def search
+    @q = Task.ransack(params[:q])
+    @tasks = @q.result(distinct: true)
+
+    render "index"
+  end
+
 
   # タスク登録画面
   def newtask

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,28 +3,26 @@
 class TasksController < ApplicationController
   # タスク一覧画面
   def index
-    # ソート順のパラメータを取得
-    @sortno = params['sortno']
+    # デフォルトの並び順をセット
+    params[:q] = { sorts: 'id desc' }
 
-    # 終了期限順
-    if @sortno == '2'
-      sortOrder = 'end_date DESC'
-    # デフォルトのソート順は作成日順
-    else
-      sortOrder = 'created_at DESC'
-    end
+    # デフォルトの検索
+    @search = Task.ransack()
 
-    @q = Task.ransack(params[:q])
-    @tasks = @q.result(distinct: true)
+    # 全件取得
+    @tasks = Task.all
   end
 
+  # タスク絞り込み後の一覧画面
   def search
-    @q = Task.ransack(params[:q])
-    @tasks = @q.result(distinct: true)
+    # 入力に応じて検索機能を設定
+    @search = Task.ransack(params.require(:q).permit(:sorts, :status_eq, :title_cont))
+
+    # 検索機能を利用した検索結果を取得
+    @tasks = @search.result
 
     render "index"
   end
-
 
   # タスク登録画面
   def newtask

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,10 @@
 class Task < ApplicationRecord
   enum status: { not_start: 10, start: 20, done: 30 }
 
+  SORT_ORDER_LIST = [{ name: I18n.t('tasks.index.sort_create_at'), sort: 'created_at ASC' },
+                     { name: I18n.t('tasks.index.sort_end_date'), sort: 'end_date DESC' }]
+  SORT_ORDER_LIST.freeze
+
   # 入力必須
   validates :status, :title, :detail, presence: true
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
-
   enum status: { 未着手: 10, 着手: 20, 完了: 30 }
+  enum sort_order: { 作成日: 'created_at ASC', 終了期限: 'end_date DESC' }
 
   # 入力必須
   validates :status, :title, :detail, presence: true
@@ -20,5 +20,4 @@ class Task < ApplicationRecord
   def date_before_start
     errors.add(:end_date, I18n.t('msg.validate_end_date')) if !end_date.nil? && end_date < Date.today
   end
-
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,5 @@
 class Task < ApplicationRecord
-  enum status: { 未着手: 10, 着手: 20, 完了: 30 }
-  enum sort_order: { 作成日: 'created_at ASC', 終了期限: 'end_date DESC' }
+  enum status: { not_start: 10, start: 20, done: 30 }
 
   # 入力必須
   validates :status, :title, :detail, presence: true

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -7,7 +7,7 @@
       <%= search_form_for(@search, url: root_path)  do |f| %>
       <div class="form-group">
         <%= f.label :sorts, I18n.t('tasks.index.sort_order') %>
-        <%= f.select :sorts, options_for_select(@sort_order_list.map{|c|[c[:name], c[:sort]]}, selected:params[:q][:sorts]), {}, {onchange: 'this.form.submit()'} %>
+        <%= f.select :sorts, options_for_select(Task::SORT_ORDER_LIST.map{|c|[c[:name], c[:sort]]}, selected:params[:q][:sorts]), {}, {onchange: 'this.form.submit()'} %>
       </div>
       <div class="row mt-5">
         <div class="form-group">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,20 +6,20 @@
     <div class="mt-3">
       <%= search_form_for(@search, url: search_path)  do |f| %>
       <div class="form-group">
-        <%= f.label :sorts, "並び順" %>
-        <%= f.select :sorts, [['作成日','created_at ASC'], ['終了期限', 'end_date DESC']],{selected:params[:q][:sorts]}, { onchange: 'this.form.submit()'} %>
+        <%= f.label :sorts, I18n.t('tasks.index.sort_order') %>
+        <%= f.select :sorts, options_for_select(Task.sort_orders, selected:params[:q][:sorts]), {}, {onchange: 'this.form.submit()'} %>
       </div>
       <div class="row mt-5">
         <div class="form-group">
-          <%= f.label :status_eq, "ステータス" %>
-          <%= f.select :status_eq, options_for_select(Task.statuses,selected:params[:q][:status_eq]), include_blank: true %>
+          <%= f.label :status_eq, I18n.t('tasks.index.status') %>
+          <%= f.select :status_eq, options_for_select(Task.statuses, selected:params[:q][:status_eq]), include_blank: true %>
         </div>
         <div class="form-group">
-          <%= f.label :title_cont, "検索" %>
+          <%= f.label :title_cont, I18n.t('tasks.index.search_task_name') %>
           <%= f.search_field :title_cont, value: params[:q][:title_cont] %>
         </div>
         <div class="form-group">
-          <%= f.submit "検索" %>
+          <%= f.submit %>
         </div>
       </div>
       <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,15 +4,15 @@
   </div>
   <div class="mt-5">
     <div class="mt-3">
-      <%= search_form_for(@search, url: search_path)  do |f| %>
+      <%= search_form_for(@search, url: root_path)  do |f| %>
       <div class="form-group">
         <%= f.label :sorts, I18n.t('tasks.index.sort_order') %>
-        <%= f.select :sorts, options_for_select(Task.sort_orders, selected:params[:q][:sorts]), {}, {onchange: 'this.form.submit()'} %>
+        <%= f.select :sorts, options_for_select(@sort_order_list.map{|c|[c[:name], c[:sort]]}, selected:params[:q][:sorts]), {}, {onchange: 'this.form.submit()'} %>
       </div>
       <div class="row mt-5">
         <div class="form-group">
           <%= f.label :status_eq, I18n.t('tasks.index.status') %>
-          <%= f.select :status_eq, options_for_select(Task.statuses, selected:params[:q][:status_eq]), include_blank: true %>
+          <%= f.select :status_eq, Task.statuses.keys.map {|k| [I18n.t("enums.task.status.#{k}"), k]} , include_blank: true %>
         </div>
         <div class="form-group">
           <%= f.label :title_cont, I18n.t('tasks.index.search_task_name') %>
@@ -36,7 +36,7 @@
         <tbody>
           <% @tasks.each do |tasks| %>
           <tr>
-            <td><%= tasks.status %></td>
+            <td><%= I18n.t("enums.task.status.#{tasks.status}") %></td>
             <td><a href="tasks/taskdetail/<%= tasks.id %>"><%= tasks.title %></a></td>
             <td><%= tasks.end_date == nil ? "-" : tasks.end_date.strftime("%Y/%m/%d") %></td>
           </tr>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -10,6 +10,23 @@
         <option value="2" <%= @sortno == "2" ? "selected" : "" %>><%= I18n.t('tasks.index.sort_end_date') %></option>
       </select>
     </div>
+    <div class="mt-3">
+      <%= search_form_for(@q, url:search_path)  do |f| %>
+      <div class="row mt-5">
+        <div class="form-group">
+          <%= f.label :status_eq, "ステータス" %>
+          <%= f.select :status_eq, options_for_select(Task.statuses) %>
+        </div>
+        <div class="form-group">
+          <%= f.label :title_cont, "検索" %>
+          <%= f.search_field :title_cont %>
+        </div>
+        <div class="form-group">
+          <%= f.submit "検索" %>
+        </div>
+      </div>
+      <% end %>
+    </div>
     <div class="mt-4">
       <table class="table table-bordered">
         <thead class="thead-light">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,23 +3,20 @@
     <h1 class="text-center"><%= I18n.t('tasks.index.page_title') %></h1>
   </div>
   <div class="mt-5">
-    <div class="form-inline">
-      <label for="select-sort"><%= I18n.t('tasks.index.sort_order') %></label>
-      <select name="select-sort" id="select-sort" class="form-control">
-        <option value="1" <%= @sortno != "2" ? "selected" : "" %>><%= I18n.t('tasks.index.sort_create_at') %></option>
-        <option value="2" <%= @sortno == "2" ? "selected" : "" %>><%= I18n.t('tasks.index.sort_end_date') %></option>
-      </select>
-    </div>
     <div class="mt-3">
-      <%= search_form_for(@q, url:search_path)  do |f| %>
+      <%= search_form_for(@search, url: search_path)  do |f| %>
+      <div class="form-group">
+        <%= f.label :sorts, "並び順" %>
+        <%= f.select :sorts, [['作成日','created_at ASC'], ['終了期限', 'end_date DESC']],{selected:params[:q][:sorts]}, { onchange: 'this.form.submit()'} %>
+      </div>
       <div class="row mt-5">
         <div class="form-group">
           <%= f.label :status_eq, "ステータス" %>
-          <%= f.select :status_eq, options_for_select(Task.statuses) %>
+          <%= f.select :status_eq, options_for_select(Task.statuses,selected:params[:q][:status_eq]), include_blank: true %>
         </div>
         <div class="form-group">
           <%= f.label :title_cont, "検索" %>
-          <%= f.search_field :title_cont %>
+          <%= f.search_field :title_cont, value: params[:q][:title_cont] %>
         </div>
         <div class="form-group">
           <%= f.submit "検索" %>
@@ -52,4 +49,3 @@
     </div>
   </div>
 </div>
-<%= javascript_pack_tag 'task/index' %>

--- a/app/views/tasks/taskdetail.html.erb
+++ b/app/views/tasks/taskdetail.html.erb
@@ -8,19 +8,19 @@
         <tbody>
           <tr>
             <th scope="col"><%= I18n.t('tasks.taskdetail.status') %></th>
-            <td><%= @taskInfos.status %></td>
+            <td><%= @task_infos.status %></td>
           </tr>
           <tr>
             <th scope="col"><%= I18n.t('tasks.taskdetail.title') %></th>
-            <td><%= @taskInfos.title %></td>
+            <td><%= @task_infos.title %></td>
           </tr>
           <tr>
             <th scope="col"><%= I18n.t('tasks.taskdetail.detail') %></th>
-            <td><%= @taskInfos.detail %></td>
+            <td><%= @task_infos.detail %></td>
           </tr>
           <tr>
             <th scope="col"><%= I18n.t('tasks.taskdetail.end_date') %></th>
-            <td><%= @taskInfos.end_date == nil ? "-" : @taskInfos.end_date.strftime("%Y/%m/%d") %></td>
+            <td><%= @task_infos.end_date == nil ? "-" : @task_infos.end_date.strftime("%Y/%m/%d") %></td>
           </tr>
         </tbody>
       </table>
@@ -29,10 +29,10 @@
           <%= link_to("#{I18n.t('tasks.taskdetail.back_button')}" , "/", class: "btn btn-secondary") %>
         </div>
         <div class="col-sm-4 text-right">
-          <%= link_to("#{I18n.t('tasks.taskdetail.edit_button')}" , tasks_taskupdate_path(@taskInfos.id), class: "btn btn-secondary") %>
+          <%= link_to("#{I18n.t('tasks.taskdetail.edit_button')}" , tasks_taskupdate_path(@task_infos.id), class: "btn btn-secondary") %>
         </div>
         <div class="col-sm-4 text-right">
-          <%= link_to("#{I18n.t('tasks.taskdetail.delete_button')}" , tasks_taskdelete_path(@taskInfos.id), class: "btn btn-secondary",method: :delete) %>
+          <%= link_to("#{I18n.t('tasks.taskdetail.delete_button')}" , tasks_taskdelete_path(@task_infos.id), class: "btn btn-secondary",method: :delete) %>
         </div>
       </div>
     </div>

--- a/app/views/tasks/taskupdate.html.erb
+++ b/app/views/tasks/taskupdate.html.erb
@@ -12,7 +12,7 @@
               <%= f.label :status %>
             </th>
             <td>
-              <%= f.select :status,@tasksList, :selected=>@task.status_before_type_cast , class: "" %>
+              <%= f.select :status,@tasks_list, :selected=>@task.status_before_type_cast , class: "" %>
             </td>
           </tr>
           <tr>

--- a/config/locales/views/tasks/index/ja.yml
+++ b/config/locales/views/tasks/index/ja.yml
@@ -12,3 +12,9 @@ ja:
       search_task_name: "タスク名検索"
       search: "検索"
       done: "完了"
+  enums:
+    task:
+      status:
+        not_start: '未着手'
+        start: '着手'
+        done: '完了'

--- a/config/locales/views/tasks/index/ja.yml
+++ b/config/locales/views/tasks/index/ja.yml
@@ -9,3 +9,6 @@ ja:
       sort_order: "並び順"
       sort_create_at: "作成日"
       sort_end_date: "終了期限"
+      search_task_name: "タスク名検索"
+      search: "検索"
+      done: "完了"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   get '/:sortno' => 'tasks#index'
 
+  get '/search', :to => 'tasks#index'
+
   # タスク登録画面
   get 'tasks/newtask' => "tasks#newtask"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,7 @@ Rails.application.routes.draw do
   # トップ
   root 'tasks#index'
 
-  get '/:sortno' => 'tasks#index'
-
-  get '/search', :to => 'tasks#index'
+  match '/search' => 'tasks#search', via: [:get, :post]
 
   # タスク登録画面
   get 'tasks/newtask' => "tasks#newtask"

--- a/db/migrate/20201202002924_add_index_tasks_title.rb
+++ b/db/migrate/20201202002924_add_index_tasks_title.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksTitle < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_014943) do
+ActiveRecord::Schema.define(version: 2020_12_02_002924) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "task_id"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_014943) do
     t.timestamp "end_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["title"], name: "index_tasks_on_title"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_002924) do
+ActiveRecord::Schema.define(version: 2020_12_14_033456) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "task_id"
@@ -19,23 +19,58 @@ ActiveRecord::Schema.define(version: 2020_12_02_002924) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "maintenances", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "status", limit: 1
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", collation: "utf8_bin"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id"
     t.string "title", limit: 100
     t.integer "status", limit: 2
     t.text "detail"
     t.timestamp "end_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
     t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "user_name", limit: 100
-    t.string "password", limit: 100
+    t.string "password_digest", limit: 100
     t.integer "roll", limit: 2
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "tasks", "users"
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :task do
-    status { 30 }
+    sequence(:status) {|n| 10*((n % 3)+1) }
     sequence(:title) { |n| "TEST_TITLE#{n}" }
     sequence(:detail) { |n| "TEST_DETAIL#{n}" }
     sequence(:end_date) { |n| Time.zone.now + 1000.days - n.days }

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :task do
-    status { 10 }
+    status { 30 }
     sequence(:title) { |n| "TEST_TITLE#{n}" }
     sequence(:detail) { |n| "TEST_DETAIL#{n}" }
     sequence(:end_date) { |n| Time.zone.now + 1000.days - n.days }

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Tasks', type: :system do
         expect(page).to have_select('並び順', selected: '作成日')
       end
 
-      example 'ステータスを「完了」で絞り込み表示' do
+      example 'ステータス「完了」を検索することで、完了のタスクが表示されること' do
         # セレクトボックスを選択
         select '完了', from: 'q[status_eq]'
 
@@ -63,15 +63,18 @@ RSpec.describe 'Tasks', type: :system do
         expect(td1).to have_content '完了'
       end
 
-      example 'タスク名を「TEST_TITLE」で絞り込み表示' do
+      example 'タスク名を検索することで、指定したタスク名のデータが取得できること' do
+        # １行目の登録データのタスクタイトルを取得
+        title_name = task[0].title
+
         # タスクタイトル名を入力
-        fill_in '検索', with: 'TEST_TITLE'
+        fill_in '検索', with: title_name
 
         click_button '検索'
 
         td1 = all('tbody tr')[0].all('td')[1]
 
-        expect(td1).to have_content 'TEST_TITLE'
+        expect(td1).to have_content title_name
       end
 
       example '並び順を終了期限に変更することで、タスクの並び順が変わること' do

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -40,22 +40,38 @@ RSpec.describe 'Tasks', type: :system do
     context 'フォームの入力値が正常' do
       example '並び順が切り替わること' do
         # セレクトボックスを選択
-        select '終了期限', from: 'select-sort'
+        select '終了期限', from: 'q[sorts]'
 
         # セレクトボックスの変更をチェック
         expect(page).to have_select('並び順', selected: '終了期限')
 
-        # URLの遷移をチェック
-        expect(current_path).to eq '/2'
-
         # セレクトボックスを選択
-        select '作成日', from: 'select-sort'
+        select '作成日', from: 'q[sorts]'
 
         # セレクトボックスの変更をチェック
         expect(page).to have_select('並び順', selected: '作成日')
+      end
 
-        # URLの遷移をチェック
-        expect(current_path).to eq '/'
+      example 'ステータスを「完了」で絞り込み表示' do
+        # セレクトボックスを選択
+        select '完了', from: 'q[status_eq]'
+
+        click_button '検索'
+
+        td1 = all('tbody tr')[0].all('td')[0]
+
+        expect(td1).to have_content '完了'
+      end
+
+      example 'タスク名を「TEST_TITLE」で絞り込み表示' do
+        # タスクタイトル名を入力
+        fill_in '検索', with: 'TEST_TITLE'
+
+        click_button '検索'
+
+        td1 = all('tbody tr')[0].all('td')[1]
+
+        expect(td1).to have_content 'TEST_TITLE'
       end
 
       example '並び順を終了期限に変更することで、タスクの並び順が変わること' do

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       example 'タスク登録ボタンが表示されること' do
-        expect(page).to have_link 'タスク登録'
+        expect(page).to have_link I18n.t('tasks.index.submit_button')
       end
 
       example '並び順のセレクトボックスが表示されること' do
-        expect(page).to have_select('並び順', selected: '作成日', options: ['作成日', '終了期限'])
+        expect(page).to have_select(I18n.t('tasks.index.sort_order'), selected: I18n.t('tasks.index.sort_create_at'), options: [I18n.t('tasks.index.sort_create_at'), I18n.t('tasks.index.sort_end_date')])
       end
 
       example '表示項目の確認 - 登録したステータスが表示されること' do
@@ -40,27 +40,27 @@ RSpec.describe 'Tasks', type: :system do
     context 'フォームの入力値が正常' do
       example '並び順が切り替わること' do
         # セレクトボックスを選択
-        select '終了期限', from: 'q[sorts]'
+        select I18n.t('tasks.index.sort_end_date'), from: 'q[sorts]'
 
         # セレクトボックスの変更をチェック
-        expect(page).to have_select('並び順', selected: '終了期限')
+        expect(page).to have_select(I18n.t('tasks.index.sort_order'), selected: I18n.t('tasks.index.sort_end_date'))
 
         # セレクトボックスを選択
-        select '作成日', from: 'q[sorts]'
+        select I18n.t('tasks.index.sort_create_at'), from: 'q[sorts]'
 
         # セレクトボックスの変更をチェック
-        expect(page).to have_select('並び順', selected: '作成日')
+        expect(page).to have_select(I18n.t('tasks.index.sort_order'), selected: I18n.t('tasks.index.sort_create_at'))
       end
 
       example 'ステータス「完了」を検索することで、完了のタスクが表示されること' do
         # セレクトボックスを選択
-        select '完了', from: 'q[status_eq]'
+        select I18n.t('tasks.index.done'), from: 'q[status_eq]'
 
-        click_button '検索'
+        click_button I18n.t('tasks.index.search')
 
         td1 = all('tbody tr')[0].all('td')[0]
 
-        expect(td1).to have_content '完了'
+        expect(td1).to have_content I18n.t('tasks.index.done')
       end
 
       example 'タスク名を検索することで、指定したタスク名のデータが取得できること' do
@@ -68,9 +68,9 @@ RSpec.describe 'Tasks', type: :system do
         title_name = task[0].title
 
         # タスクタイトル名を入力
-        fill_in '検索', with: title_name
+        fill_in I18n.t('tasks.index.search_task_name'), with: title_name
 
-        click_button '検索'
+        click_button I18n.t('tasks.index.search')
 
         td1 = all('tbody tr')[0].all('td')[1]
 
@@ -96,7 +96,7 @@ RSpec.describe 'Tasks', type: :system do
         expect(date2_bf).to be > date1_bf
 
         # セレクトボックスを選択
-        select '終了期限', from: 'select-sort'
+        select I18n.t('tasks.index.sort_end_date'), from: 'select-sort'
 
         # URLの遷移をチェック
         expect(current_path).to eq '/2'
@@ -139,23 +139,23 @@ RSpec.describe 'Tasks', type: :system do
         select '着手', from: 'task[status]'
 
         # タイトルに「テストタイトル登録 from rspec」と入力
-        fill_in 'タイトル', with: 'テストタイトル登録 from rspec'
+        fill_in I18n.t('activerecord.attributes.task.title'), with: 'テストタイトル登録 from rspec'
 
         # 内容に「テスト内容登録 from rspec」と入力
-        fill_in '内容', with: 'テスト内容登録 from rspec'
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: 'テスト内容登録 from rspec'
 
         # 終了期限を入力
         tommorow = Time.now + 1.day
         fill_in 'task[end_date]', with: tommorow.strftime('00%Y-%m-%d')
 
         # 送信ボタンをクリック
-        click_button I18n.t("helpers.submit.create")
+        click_button I18n.t('helpers.submit.create')
 
         # タスク一覧画面へ遷移することを期待する
         expect(current_path).to eq root_path
 
         # タスク一覧画面で登録成功のFlashメッセージが表示されることを確認する
-        expect(page).to have_content I18n.t("msg.success_registration")
+        expect(page).to have_content I18n.t('msg.success_registration')
       end
     end
 
@@ -173,7 +173,7 @@ RSpec.describe 'Tasks', type: :system do
 
       example 'タイトルが未入力の時、エラーが表示されること' do
         # 内容に入力
-        fill_in '内容', with: 'テスト内容 from rspec'
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: 'テスト内容 from rspec'
 
         # 送信ボタンをクリック
         click_button I18n.t('helpers.submit.create')
@@ -185,7 +185,7 @@ RSpec.describe 'Tasks', type: :system do
 
       example '内容が未入力の時、エラーが表示されること' do
         # タイトルにと入力
-        fill_in 'タイトル', with: 'テストタイトル from rspec'
+        fill_in I18n.t('activerecord.attributes.task.title'), with: 'テストタイトル from rspec'
 
         # 送信ボタンをクリック
         click_button I18n.t('helpers.submit.create')
@@ -197,10 +197,10 @@ RSpec.describe 'Tasks', type: :system do
 
       example '入力文字数が３文字未満（タイトル）の時、エラーが表示されること' do
         # タイトルにと入力
-        fill_in 'タイトル', with: 'ab'
+        fill_in I18n.t('activerecord.attributes.task.title'), with: 'ab'
 
         # 内容に入力
-        fill_in '内容', with: 'abc'
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: 'abc'
 
         # 送信ボタンをクリック
         click_button I18n.t('helpers.submit.create')
@@ -212,10 +212,10 @@ RSpec.describe 'Tasks', type: :system do
 
       example '入力文字数が３文字未満（内容）の時、エラーが表示されること' do
         # タイトルにと入力
-        fill_in 'タイトル', with: 'abc'
+        fill_in I18n.t('activerecord.attributes.task.title'), with: 'abc'
 
         # 内容に入力
-        fill_in '内容', with: 'ab'
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: 'ab'
 
         # 送信ボタンをクリック
         click_button I18n.t('helpers.submit.create')
@@ -227,10 +227,10 @@ RSpec.describe 'Tasks', type: :system do
 
       example 'タイトルの入力文字数が２０文字以上の時、エラーが表示されること' do
         # タイトルに「ab」と入力
-        fill_in 'タイトル', with: 'a' * 21
+        fill_in I18n.t('activerecord.attributes.task.title'), with: 'a' * 21
 
         # 内容にと入力
-        fill_in '内容', with: 'test'
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: 'test'
 
         # 送信ボタンをクリック
         click_button I18n.t('helpers.submit.create')
@@ -241,10 +241,10 @@ RSpec.describe 'Tasks', type: :system do
 
       example '内容の入力文字数が２００文字以上の時、エラーが表示されること' do
         # タイトルに入力
-        fill_in 'タイトル', with: 'test'
+        fill_in I18n.t('activerecord.attributes.task.title'), with: 'test'
 
         # 内容に入力
-        fill_in '内容', with: 'a' * 201
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: 'a' * 201
 
         # 送信ボタンをクリック
         click_button I18n.t('helpers.submit.create')
@@ -256,10 +256,10 @@ RSpec.describe 'Tasks', type: :system do
       example '終了期限が過去の日付だった場合、エラーが表示されること' do
 
         # タイトルに「テストタイトル登録 from rspec」と入力
-        fill_in 'タイトル', with: 'テストタイトル登録 from rspec'
+        fill_in I18n.t('activerecord.attributes.task.title'), with: 'テストタイトル登録 from rspec'
 
         # 内容に「テスト内容登録 from rspec」と入力
-        fill_in '内容', with: 'テスト内容登録 from rspec'
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: 'テスト内容登録 from rspec'
 
         # 過去の終了期限を入力
         yesterday = Time.now - 1.day
@@ -298,10 +298,10 @@ RSpec.describe 'Tasks', type: :system do
     context 'フォームの入力値が正常' do
       example 'タスク更新に成功すること' do
         # タイトルに「テストタイトル更新 from rspec」と入力
-        fill_in 'タイトル', with: 'テストタイトル更新 from rspec'
+        fill_in I18n.t('activerecord.attributes.task.title'), with: 'テストタイトル更新 from rspec'
 
         # 内容に「テスト詳細更新 from rspec」と入力
-        fill_in '内容', with: 'テスト詳細更新 from rspec'
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: 'テスト詳細更新 from rspec'
 
         # 更新ボタンをクリック
         click_button I18n.t('helpers.submit.update')


### PR DESCRIPTION
![スクリーンショット 2020-12-11 15 52 25](https://user-images.githubusercontent.com/73919178/101872611-e7008100-3bc8-11eb-85fc-e00132bfe406.png)

### 概要
Rails研修「ステップ13: ステータスを追加して、検索できるようにしよう」

### 変更内容
**【一覧画面でタイトルとステータスで検索ができるようにしよう】**
→ (ルーティング) config/routes.rb
→ (コントローラ) app/controllers/tasks_controller.rb
→ (タスク一覧画面のビュー) app/views/tasks/index.html.erb

**【検索インデックスを貼りましょう】**
→ (スキーマ) db/schema.rb
→ (マイグレーション) db/migrate/20201202002924_add_index_tasks_title.rb

**【検索に対してmodel specを追加してみよう】**
→ (Rspec) spec/system/task_spec.rb

**【追加したGEM】**
→ ransack

**【その他の変更点】**
→ I18nの漏れを修正
→ 「並び順」の並び替え方法をransackに統合

### 期待される結果
・タスク一覧画面でステータスもしくはタスク名で検索ができること
・検索インデックスが貼られていること