### PR TITLE
ステップ12: 終了期限を追加しよう

### DIFF
--- a/gotodo/app/controllers/tasks_controller.rb
+++ b/gotodo/app/controllers/tasks_controller.rb
@@ -55,6 +55,6 @@ class TasksController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def task_params
-    params.require(:task).permit(:title, :detail)
+    params.require(:task).permit(:title, :detail, :end_date)
   end
 end

--- a/gotodo/app/views/tasks/_form.html.erb
+++ b/gotodo/app/views/tasks/_form.html.erb
@@ -16,6 +16,11 @@
   <%= form.label :detail %>
   <br>
   <%= form.text_area :detail, size: "60x12" %>
+  <br>
+  <%= form.label :end_date %>
+  <br>
+  <%= form.date_field :end_date %>
+  <br>
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/gotodo/app/views/tasks/_task.html.erb
+++ b/gotodo/app/views/tasks/_task.html.erb
@@ -1,6 +1,7 @@
 <tr>
   <td><%= link_to task.title, task %></td>
   <td><%= task.detail %></td>
+  <td><%= task.end_date %></td>
   <td><%= task.created_at %></td>
   <td><%= task.updated_at %></td>
   <td>

--- a/gotodo/app/views/tasks/index.html.erb
+++ b/gotodo/app/views/tasks/index.html.erb
@@ -5,6 +5,7 @@
   <thead>
     <td><%= sortable :title %></td>
     <td><%= sortable :detail %></td>
+    <td><%= sortable :end_date %></td>
     <td><%= sortable :created_at %></td>
     <td><%= sortable :updated_at %></td>
   </thead>

--- a/gotodo/app/views/tasks/show.html.erb
+++ b/gotodo/app/views/tasks/show.html.erb
@@ -5,6 +5,7 @@
   <tbody>
     <tr>
       <td><%= @task.detail %></td>
+      <td><%= @task.end_date %></td>
       <td><%= @task.created_at %></td>
       <td><%= @task.updated_at %></td>
     </tr>

--- a/gotodo/config/locales/views/tasks/ja.yml
+++ b/gotodo/config/locales/views/tasks/ja.yml
@@ -6,12 +6,13 @@ ja:
       task:
         title: 'タスク名'
         detail: '詳細'
+        end_date: '終了期限'
     errors:
       models:
         task:
           attributes:
             title:
-              blank: 'が空になっています。'
+              blank: 'が空になっています'
   tasks:
     index:
       page_title: 'GoToDo一覧'

--- a/gotodo/db/migrate/20210106083959_change_column_to_tasks.rb
+++ b/gotodo/db/migrate/20210106083959_change_column_to_tasks.rb
@@ -2,10 +2,12 @@ class ChangeColumnToTasks < ActiveRecord::Migration[6.1]
   def up
     change_column :tasks, :title, :string, limit: 50
     change_column :tasks, :detail, :string, limit: 200
+    change_column :tasks, :end_date, :date
   end
 
   def down
     change_column :tasks, :title, :string
     change_column :tasks, :detail, :text
+    change_column :tasks, :end_date, :datetime
   end
 end

--- a/gotodo/db/schema.rb
+++ b/gotodo/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_083959) do
     t.decimal "lat", precision: 10
     t.decimal "lng", precision: 10
     t.integer "status", limit: 1
-    t.datetime "end_date"
+    t.date "end_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/gotodo/spec/factories/tasks.rb
+++ b/gotodo/spec/factories/tasks.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :task, class: Task do
     title { 'テスト' }
     detail { 'テスト' }
+    end_date { Time.zone.today }
   end
 
   # 今後使いたいためメモとしてコメントアウト

--- a/gotodo/spec/models/task_spec.rb
+++ b/gotodo/spec/models/task_spec.rb
@@ -3,59 +3,64 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  shared_examples 'バリデーションを通過すること' do
-    it { expect(task).to be_valid }
-  end
-  
-  shared_examples '期待したバリデーションエラーメッセージが表示されること' do
-    it do
-      task.valid?
-      expect(task.errors.full_messages).to match_array(message)
-    end
-  end
-
   describe 'title (NotNull, maximum:50)' do
-    let(:task) { FactoryBot.build(:task, title: title) }
+    let(:task) { FactoryBot.build_stubbed(:task, title: title) }
 
     context '0文字の場合' do
       let(:title) { 'a' * 0 }
-      let(:message) { 'タスク名が空になっています' }
-      it_behaves_like '期待したバリデーションエラーメッセージが表示されること'
+      it 'バリデーションを通過しないこと' do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array('タスク名が空になっています')
+      end
     end
     context '10文字の場合' do
       let(:title) { 'a' * 10 }
-      it_behaves_like 'バリデーションを通過すること'
+      it 'バリデーションを通過すること' do
+        expect(task).to be_valid
+      end
     end
     context '50文字の場合' do
       let(:title) { 'a' * 50 }
-      it_behaves_like 'バリデーションを通過すること'
+      it 'バリデーションを通過すること' do
+        expect(task).to be_valid
+      end
     end
     context '51文字の場合' do
       let(:title) { 'a' * 51 }
-      let(:message) { 'タスク名は50文字以内で入力してください' }
-      it_behaves_like '期待したバリデーションエラーメッセージが表示されること'
+      it 'バリデーションを通過しないこと' do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array('タスク名は50文字以内で入力してください')
+      end
     end
   end
 
   describe 'detail (maximum:200)' do
-    let(:task) { FactoryBot.build(:task, detail: detail) }
+    let(:task) { FactoryBot.build_stubbed(:task, detail: detail) }
 
     context '0文字の場合' do
       let(:detail) { 'a' * 0 }
-      it_behaves_like 'バリデーションを通過すること'
+      it 'バリデーションを通過すること' do
+        expect(task).to be_valid
+      end
     end
     context '10文字の場合' do
       let(:detail) { 'a' * 10 }
-      it_behaves_like 'バリデーションを通過すること'
+      it 'バリデーションを通過すること' do
+        expect(task).to be_valid
+      end
     end
     context '200文字の場合' do
       let(:detail) { 'a' * 200 }
-      it_behaves_like 'バリデーションを通過すること'
+      it 'バリデーションを通過すること' do
+        expect(task).to be_valid
+      end
     end
     context '201文字の場合' do
       let(:detail) { 'a' * 201 }
-      let(:message) { '詳細は200文字以内で入力してください' }
-      it_behaves_like '期待したバリデーションエラーメッセージが表示されること'
+      it 'バリデーションを通過しないこと' do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array('詳細は200文字以内で入力してください')
+      end
     end
   end
 end

--- a/gotodo/spec/models/task_spec.rb
+++ b/gotodo/spec/models/task_spec.rb
@@ -4,18 +4,23 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   shared_examples 'バリデーションを通過すること' do
-    it { is_expected.to be_valid }
+    it { expect(task).to be_valid }
   end
-  shared_examples 'バリデーションを通過しないこと' do
-    it { is_expected.to be_invalid }
+  
+  shared_examples '期待したバリデーションエラーメッセージが表示されること' do
+    it do
+      task.valid?
+      expect(task.errors.full_messages).to match_array(message)
+    end
   end
 
   describe 'title (NotNull, maximum:50)' do
-    subject(:task) { FactoryBot.build(:task, title: title) }
+    let(:task) { FactoryBot.build(:task, title: title) }
 
     context '0文字の場合' do
       let(:title) { 'a' * 0 }
-      it_behaves_like 'バリデーションを通過しないこと'
+      let(:message) { 'タスク名が空になっています' }
+      it_behaves_like '期待したバリデーションエラーメッセージが表示されること'
     end
     context '10文字の場合' do
       let(:title) { 'a' * 10 }
@@ -27,12 +32,13 @@ RSpec.describe Task, type: :model do
     end
     context '51文字の場合' do
       let(:title) { 'a' * 51 }
-      it_behaves_like 'バリデーションを通過しないこと'
+      let(:message) { 'タスク名は50文字以内で入力してください' }
+      it_behaves_like '期待したバリデーションエラーメッセージが表示されること'
     end
   end
 
   describe 'detail (maximum:200)' do
-    subject(:task) { FactoryBot.build(:task, detail: detail) }
+    let(:task) { FactoryBot.build(:task, detail: detail) }
 
     context '0文字の場合' do
       let(:detail) { 'a' * 0 }
@@ -48,7 +54,8 @@ RSpec.describe Task, type: :model do
     end
     context '201文字の場合' do
       let(:detail) { 'a' * 201 }
-      it_behaves_like 'バリデーションを通過しないこと'
+      let(:message) { '詳細は200文字以内で入力してください' }
+      it_behaves_like '期待したバリデーションエラーメッセージが表示されること'
     end
   end
 end

--- a/gotodo/spec/system/tasks_spec.rb
+++ b/gotodo/spec/system/tasks_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Tasks', type: :system do
   let!(:task1) { FactoryBot.create(:task, title: 'う　買い物に行く', detail: '卵、牛乳', end_date: Time.zone.today + 2.weeks) }
   let!(:task2) { FactoryBot.create(:task, title: 'あ　料理をする', end_date: Time.zone.today + 1.week, created_at: Time.current + 2.days) }
   let!(:task3) { FactoryBot.create(:task, title: 'い　食べる', end_date: Time.zone.today + 3.weeks, created_at: Time.current + 3.days) }
-  let(:task) { task1 }
   subject { page }
 
   shared_examples '期待したページに遷移すること' do
@@ -24,6 +23,7 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '#index' do
+    let(:task) { task1 }
     before do
       visit root_path
     end

--- a/gotodo/spec/system/tasks_spec.rb
+++ b/gotodo/spec/system/tasks_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   shared_examples '期待したタスクが表示されること' do
-    it { is_expected.to have_content task.title }
-    it { is_expected.to have_content task.detail }
+    it { is_expected.to have_content target_task.title }
+    it { is_expected.to have_content target_task.detail }
   end
 
   shared_examples '期待したFlashメッセージが表示されること' do
@@ -23,7 +23,7 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '#index' do
-    let(:task) { task1 }
+    let(:target_task) { task1 }
     before do
       visit root_path
     end
@@ -81,7 +81,7 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '#show(task_id)' do
-    let(:task) { task1 }
+    let(:target_task) { task1 }
     before do
       visit task_path task1.id
     end
@@ -90,13 +90,13 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '#edit(task_id)' do
-    let(:task) { FactoryBot.build(:task, title: '買い物に行く', detail: '卵、牛乳、人参') }
+    let(:target_task) { FactoryBot.build(:task, title: '買い物に行く', detail: '卵、牛乳、人参') }
     let(:target_path) { task_path task1.id }
     let(:message) { 'タスクが更新されました！' }
     before do
       visit edit_task_path task1.id
-      fill_in 'タスク名', with: task.title
-      fill_in '詳細', with: task.detail
+      fill_in 'タスク名', with: target_task.title
+      fill_in '詳細', with: target_task.detail
       click_button '更新する'
     end
 
@@ -106,13 +106,13 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '#new' do
-    let(:task) { FactoryBot.build(:task, title: '美容院に行く', detail: 'ヘアサロン・ラクマ') }
+    let(:target_task) { FactoryBot.build(:task, title: '美容院に行く', detail: 'ヘアサロン・ラクマ') }
     let(:target_path) { task_path Task.last.id }
     let(:message) { '新しいタスクが登録されました！' }
     before do
       visit new_task_path
-      fill_in 'タスク名', with: task.title
-      fill_in '詳細', with: task.detail
+      fill_in 'タスク名', with: target_task.title
+      fill_in '詳細', with: target_task.detail
       click_button '登録する'
     end
 

--- a/gotodo/spec/system/tasks_spec.rb
+++ b/gotodo/spec/system/tasks_spec.rb
@@ -9,116 +9,107 @@ RSpec.describe 'Tasks', type: :system do
   let!(:task3) { FactoryBot.create(:task, title: 'い　食べる', end_date: Time.zone.today + 3.weeks, created_at: Time.current + 3.days) }
   subject { page }
 
-  shared_examples '期待したページに遷移すること' do
-    it { is_expected.to have_current_path target_path }
-  end
-
-  shared_examples '期待したタスクが表示されること' do
-    it { is_expected.to have_content target_task.title }
-    it { is_expected.to have_content target_task.detail }
-  end
-
-  shared_examples '期待したFlashメッセージが表示されること' do
-    it { is_expected.to have_selector('#notice', text: message) }
-  end
-
   describe '#index' do
-    let(:target_task) { task1 }
     before do
       visit root_path
     end
 
-    it_behaves_like '期待したタスクが表示されること'
+    it '期待したタスクが表示されること' do
+      is_expected.to have_content task1.title
+      is_expected.to have_content task1.detail
+    end
 
     describe 'ソート機能' do
+      before do
+        hash = { 'asc' => '▲', 'desc' => '▼' }
+        click_link hash[sort_cond['direction']], href: tasks_path(sort: sort_cond['sort'], direction: sort_cond['direction'])
+      end
+
       shared_examples '期待した順番で表示されること' do
         it do
-          hash = { 'asc' => '▲', 'desc' => '▼' }
-          click_link hash[direction], href: tasks_path(sort: sort, direction: direction)
           task_list = all('tbody tr')
           task_list.each_with_index do |task, i|
             expect(task).to have_content expected_list[i].title
           end
         end
       end
+
       context 'タスク名昇順' do
         let(:expected_list) { [task2, task3, task1] }
-        let(:sort) { 'title' }
-        let(:direction) { 'asc' }
+        let(:sort_cond) { { 'sort' => 'title', 'direction' => 'asc' } }
         it_behaves_like '期待した順番で表示されること'
       end
       context 'タスク名降順' do
         let(:expected_list) { [task1, task3, task2] }
-        let(:sort) { 'title' }
-        let(:direction) { 'desc' }
+        let(:sort_cond) { { 'sort' => 'title', 'direction' => 'desc' } }
         it_behaves_like '期待した順番で表示されること'
       end
       context '作成日時昇順' do
         let(:expected_list) { [task1, task2, task3] }
-        let(:sort) { 'created_at' }
-        let(:direction) { 'asc' }
+        let(:sort_cond) { { 'sort' => 'created_at', 'direction' => 'asc' } }
         it_behaves_like '期待した順番で表示されること'
       end
       context '作成日時降順' do
         let(:expected_list) { [task3, task2, task1] }
-        let(:sort) { 'created_at' }
-        let(:direction) { 'desc' }
+        let(:sort_cond) { { 'sort' => 'created_at', 'direction' => 'desc' } }
         it_behaves_like '期待した順番で表示されること'
       end
       context '終了期限昇順' do
         let(:expected_list) { [task2, task1, task3] }
-        let(:sort) { 'end_date' }
-        let(:direction) { 'asc' }
+        let(:sort_cond) { { 'sort' => 'end_date', 'direction' => 'asc' } }
         it_behaves_like '期待した順番で表示されること'
       end
       context '終了期限降順' do
         let(:expected_list) { [task3, task1, task2] }
-        let(:sort) { 'end_date' }
-        let(:direction) { 'desc' }
+        let(:sort_cond) { { 'sort' => 'end_date', 'direction' => 'desc' } }
         it_behaves_like '期待した順番で表示されること'
       end
     end
   end
 
   describe '#show(task_id)' do
-    let(:target_task) { task1 }
     before do
       visit task_path task1.id
     end
 
-    it_behaves_like '期待したタスクが表示されること'
+    it '期待したタスクが表示されること' do
+      is_expected.to have_content task1.title
+      is_expected.to have_content task1.detail
+    end
   end
 
   describe '#edit(task_id)' do
-    let(:target_task) { FactoryBot.build(:task, title: '買い物に行く', detail: '卵、牛乳、人参') }
-    let(:target_path) { task_path task1.id }
-    let(:message) { 'タスクが更新されました！' }
+    let(:edited_task) { { 'title' => '買い物に行く', 'detail' => '卵、牛乳、人参' } }
     before do
       visit edit_task_path task1.id
-      fill_in 'タスク名', with: target_task.title
-      fill_in '詳細', with: target_task.detail
+      fill_in 'タスク名', with: edited_task['title']
+      fill_in '詳細', with: edited_task['detail']
       click_button '更新する'
     end
 
-    it_behaves_like '期待したページに遷移すること'
-    it_behaves_like '期待したタスクが表示されること'
-    it_behaves_like '期待したFlashメッセージが表示されること'
+    it '期待したタスクが表示されること' do
+      is_expected.to have_current_path task_path task1.id
+      is_expected.to have_content edited_task['title']
+      is_expected.to have_content edited_task['detail']
+      is_expected.to have_selector('#notice', text: 'タスクが更新されました！')
+    end
   end
 
   describe '#new' do
-    let(:target_task) { FactoryBot.build(:task, title: '美容院に行く', detail: 'ヘアサロン・ラクマ') }
-    let(:target_path) { task_path Task.last.id }
-    let(:message) { '新しいタスクが登録されました！' }
+    let(:new_task) { { 'title' => '美容院に行く', 'detail' => 'ヘアサロン・ラクマ' } }
     before do
       visit new_task_path
-      fill_in 'タスク名', with: target_task.title
-      fill_in '詳細', with: target_task.detail
+      fill_in 'タスク名', with: new_task['title']
+      fill_in '詳細', with: new_task['detail']
       click_button '登録する'
     end
 
-    it_behaves_like '期待したページに遷移すること'
-    it_behaves_like '期待したタスクが表示されること'
-    it_behaves_like '期待したFlashメッセージが表示されること'
+    it '期待したタスクが表示されること' do
+      is_expected.to have_current_path task_path Task.last.id
+      is_expected.to have_content new_task['title']
+      is_expected.to have_content new_task['detail']
+      is_expected.to have_selector('#notice', text: '新しいタスクが登録されました！')
+    end
   end
 
   describe '#destroy(task_id)' do
@@ -126,14 +117,12 @@ RSpec.describe 'Tasks', type: :system do
       visit root_path
       click_link nil, href: task_path(task1), class: 'delete-link'
     end
-    let(:message) { 'タスクが削除されました！' }
 
     it '削除した登録済みタスクが表示されないこと' do
       is_expected.to have_current_path root_path
       is_expected.to have_no_content task1.title
       is_expected.to have_no_content task1.detail
+      is_expected.to have_selector('#notice', text: 'タスクが削除されました！')
     end
-
-    it_behaves_like '期待したFlashメッセージが表示されること'
   end
 end


### PR DESCRIPTION
## 課題
- タスクに対して、終了期限を登録できるようにしてみましょう
- 一覧画面で、終了期限でソートできるようにしましょう
- specを拡充しましょう
- PRしてレビューをしてもらったら、リリースしてみましょう


## 環境構築必要手順
gotodo_web_1コンテナが立ち上がっている状態で
```console
x@x:~/Dev/training/gotodo$ docker exec -it gotodo_web_1 bundle exec rails db:migrate:redo
```


## 実施事項
* 終了期限の追加
  * DB変更
    * gotodo/db/migrate/20210106083959_change_column_to_tasks.rb
  * Controller/View修正
    * gotodo/app/controllers/tasks_controller.rb
    * gotodo/app/views/tasks/_form.html.erb
    * gotodo/app/views/tasks/_task.html.erb
    * gotodo/app/views/tasks/index.html.erb
    * gotodo/app/views/tasks/show.html.erb
    * gotodo/config/locales/views/tasks/ja.yml
  * テスト作成
    * gotodo/spec/factories/tasks.rb
    * gotodo/spec/system/tasks_spec.rb

* modelテストの改善
  * バリデーションエラ〜メッセージのテストを追加


## 確認事項

* systemテスト
```console
root@e9adc17a635f:/myapp# rspec spec/system/tasks_spec.rb 

Tasks
  #index
    期待したタスクが表示されること
    ソート機能
      タスク名昇順
        behaves like 期待した順番で表示されること
          is expected to have text "う　買い物に行く"
      タスク名降順
        behaves like 期待した順番で表示されること
          is expected to have text "あ　料理をする"
      作成日時昇順
        behaves like 期待した順番で表示されること
          is expected to have text "い　食べる"
      作成日時降順
        behaves like 期待した順番で表示されること
          is expected to have text "う　買い物に行く"
      終了期限昇順
        behaves like 期待した順番で表示されること
          is expected to have text "い　食べる"
      終了期限降順
        behaves like 期待した順番で表示されること
          is expected to have text "あ　料理をする"
  #show(task_id)
    期待したタスクが表示されること
  #edit(task_id)
    期待したタスクが表示されること
  #new
    期待したタスクが表示されること
  #destroy(task_id)
    削除した登録済みタスクが表示されないこと

Finished in 3.49 seconds (files took 4.37 seconds to load)
11 examples, 0 failures
```

* modelテスト
```console
root@e9adc17a635f:/myapp# rspec spec/models/task_spec.rb 

Task
  title (NotNull, maximum:50)
    0文字の場合
      バリデーションを通過しないこと
    10文字の場合
      バリデーションを通過すること
    50文字の場合
      バリデーションを通過すること
    51文字の場合
      バリデーションを通過しないこと
  detail (maximum:200)
    0文字の場合
      バリデーションを通過すること
    10文字の場合
      バリデーションを通過すること
    200文字の場合
      バリデーションを通過すること
    201文字の場合
      バリデーションを通過しないこと

Finished in 0.46363 seconds (files took 6.59 seconds to load)
8 examples, 0 failures
```

