### PR TITLE
ステップ19: ユーザにロールを追加しよう

### DIFF
--- a/job_san/app/controllers/admin/users_controller.rb
+++ b/job_san/app/controllers/admin/users_controller.rb
@@ -33,11 +33,11 @@ module Admin
       @user = User.find_by(id: params[:id])
       return redirect_to admin_users_path, notice: I18n.t('view.user.error.not_found') unless @user
 
-      @user = UserService.new(@user).update_user(user_params.except(:password, :password_confirmation))
+      @user = UserService.new(@user, @current_user).update_user(user_params.except(:password, :password_confirmation))
       @errors = @user.errors
       return redirect_to admin_users_path, notice: I18n.t('view.user.flash.updated') if @errors.blank?
 
-      render :edit, alert: I18n.t('view.user.flash.not_updated')
+      render 'admin/users/edit', id: @user.id, alert: I18n.t('view.user.flash.not_updated')
     end
 
     def user_tasks
@@ -49,16 +49,12 @@ module Admin
     end
 
     def destroy
-      user = User.find_by(id: params[:id])
-      return redirect_to admin_users_path, notice: I18n.t('view.user.error.not_found') unless user
+      @user = User.find_by(id: params[:id])
+      return redirect_to admin_users_path, notice: I18n.t('view.user.error.not_found') unless @user
+      return redirect_to admin_users_path, notice: I18n.t('view.user.flash.deleted') if @user.destroy
 
-      if user.destroy
-        redirect_to admin_users_path, notice: I18n.t('view.user.flash.deleted')
-      else
-        @errors = user.errors
-        flash.now[:alert] = I18n.t('view.user.flash.not_deleted')
-        render admin_users_path
-      end
+      @errors = @user.errors
+      render 'admin/users/edit', id: @user.id, alert: I18n.t('view.user.flash.not_deleted')
     end
 
     private

--- a/job_san/app/controllers/admin/users_controller.rb
+++ b/job_san/app/controllers/admin/users_controller.rb
@@ -64,7 +64,7 @@ module Admin
     end
 
     def authorized_user
-      redirect_to tasks_path unless @current_user&.admin?
+      redirect_to tasks_path unless @current_user&.role_type_admin?
     end
   end
 end

--- a/job_san/app/models/user.rb
+++ b/job_san/app/models/user.rb
@@ -49,7 +49,7 @@ class User < ApplicationRecord
     return unless User.admin.exists?
     return unless role_type_admin? && User.count < 2
 
-    errors.add(:base, '最後の管理者です')
+    errors.add(:base, I18n.t('user.error.last_admin'))
     throw :abort
   end
 end

--- a/job_san/app/services/user_service.rb
+++ b/job_san/app/services/user_service.rb
@@ -18,8 +18,8 @@ class UserService
   def updatable_role_type?(role_type)
     return true if role_type.blank?
 
-    @update_user.errors.add(:role_type, 'は不正な値です') unless %w[admin member].include?(role_type)
-    @update_user.errors.add(:base, '最後の管理者です') if last_admin? && update_own? && role_type == 'member'
+    @update_user.errors.add(:role_type, :invalid) unless %w[admin member].include?(role_type)
+    @update_user.errors.add(:base, I18n.t('user.error.last_admin')) if last_admin? && update_own? && role_type == User::MEMBER_ROLE
     @update_user.errors.blank?
   end
 

--- a/job_san/app/services/user_service.rb
+++ b/job_san/app/services/user_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class UserService
+  def initialize(user)
+    @update_user = user
+  end
+
+  def update_user(params)
+    return @update_user unless updatable_role_type?(params[:role_type])
+
+    @update_user.update(params.except(:id))
+    @update_user
+  end
+
+  private
+
+  def updatable_role_type?(role_type)
+    return true if role_type.blank?
+
+    @update_user.errors.add(:role_type, 'は不正な値です') unless %w[admin member].include?(role_type)
+    @update_user.errors.add(:base, '最後の管理者です') if User.admin.count < 2 && role_type == 'member'
+    @update_user.errors.blank?
+  end
+end

--- a/job_san/app/services/user_service.rb
+++ b/job_san/app/services/user_service.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class UserService
-  def initialize(user)
+  def initialize(user, login_user)
     @update_user = user
+    @login_user = login_user
   end
 
   def update_user(params)
@@ -18,7 +19,15 @@ class UserService
     return true if role_type.blank?
 
     @update_user.errors.add(:role_type, 'は不正な値です') unless %w[admin member].include?(role_type)
-    @update_user.errors.add(:base, '最後の管理者です') if User.admin.count < 2 && role_type == 'member'
+    @update_user.errors.add(:base, '最後の管理者です') if last_admin? && update_own? && role_type == 'member'
     @update_user.errors.blank?
+  end
+
+  def update_own?
+    @login_user.id == @update_user.id
+  end
+
+  def last_admin?
+    User.admin.count < 2
   end
 end

--- a/job_san/app/views/admin/users/_form.html.erb
+++ b/job_san/app/views/admin/users/_form.html.erb
@@ -17,5 +17,9 @@
       <%= form.password_field :password_confirmation %>
     </div>
   <% end %>
+  <div>
+    <%= form.label(:role_type) %>
+    <%= form.select(:role_type, User.role_types_i18n.map{|k,v| [v,k]}) %>
+  </div>
   <%= form.submit "#{action_label}" %>
 <% end %>

--- a/job_san/config/database.yml
+++ b/job_san/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
-  collation: utf8mb4_general_ci
+  collation: utf8mb4_bin
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: 'password'

--- a/job_san/config/locales/models/ja.yml
+++ b/job_san/config/locales/models/ja.yml
@@ -16,3 +16,4 @@ ja:
         password: パスワード
         password_confirmation: パスワード確認
         name: 名前
+        role_type: ロール

--- a/job_san/config/locales/models/users/ja.yml
+++ b/job_san/config/locales/models/users/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  enums:
+    user:
+      role_type:
+        member: メンバー
+        admin: 管理者

--- a/job_san/config/locales/models/users/ja.yml
+++ b/job_san/config/locales/models/users/ja.yml
@@ -4,3 +4,6 @@ ja:
       role_type:
         member: メンバー
         admin: 管理者
+  user:
+    error:
+      last_admin: 最後の管理者です

--- a/job_san/db/migrate/20210106054519_create_users.rb
+++ b/job_san/db/migrate/20210106054519_create_users.rb
@@ -1,7 +1,5 @@
 class CreateUsers < ActiveRecord::Migration[6.1]
   def up
-    drop_table :users
-
     create_table :users, id: false do |t|
       t.string :id, limit: 36, null: false, primary_key: true, default: ->{"(uuid())"}
       t.string :name, null: false, limit: 100

--- a/job_san/db/migrate/20210108015157_add_column_role_type_to_users.rb
+++ b/job_san/db/migrate/20210108015157_add_column_role_type_to_users.rb
@@ -1,0 +1,14 @@
+class AddColumnRoleTypeToUsers < ActiveRecord::Migration[6.1]
+  def up
+    add_column :users, :role_type, :string, null: false, default: 'member', limit: 6
+    if User.exists?
+      User.update_all(role_type: 'member')
+    end
+    execute "ALTER TABLE `users` ADD CONSTRAINT `check_users_role_type` CHECK (`role_type` IN ('member', 'admin'))"
+  end
+
+  def down
+    execute 'ALTER TABLE `users` DROP CONSTRAINT `check_users_role_type`'
+    remove_column :users, :role_type, :string
+  end
+end

--- a/job_san/db/schema.rb
+++ b/job_san/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_06_054519) do
+ActiveRecord::Schema.define(version: 2021_01_08_015157) do
 
-  create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.timestamp "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_054519) do
     t.check_constraint "`status` in ('todo','doing','done')", name: "check_tasks_status"
   end
 
-  create_table "users", id: { type: :string, limit: 36, default: -> { "(uuid())" } }, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "users", id: { type: :string, limit: 36, default: -> { "(uuid())" } }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 100, null: false
     t.string "email", null: false
     t.string "password_digest", null: false
@@ -37,7 +37,9 @@ ActiveRecord::Schema.define(version: 2021_01_06_054519) do
     t.timestamp "deleted_at", comment: "for soft delete"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "role_type", limit: 6, default: "member", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.check_constraint "`role_type` in ('member','admin')", name: "check_users_role_type"
   end
 
   add_foreign_key "tasks", "users"

--- a/job_san/docker-compose.yml
+++ b/job_san/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       MYSQL_DATABASE: job_san_development
       MYSQL_ROOT_PASSWORD: "password"
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
   web:
     build: .
     volumes:

--- a/job_san/package.json
+++ b/job_san/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^3.11.1"
   }
 }

--- a/job_san/spec/factories/users.rb
+++ b/job_san/spec/factories/users.rb
@@ -7,5 +7,10 @@ FactoryBot.define do
     email { Faker::Internet.email }
     password { 'password' }
     password_confirmation { 'password' }
+    role_type { 'member' }
+
+    trait :with_admin do
+      role_type { 'admin' }
+    end
   end
 end

--- a/job_san/spec/services/user_service_spec.rb
+++ b/job_san/spec/services/user_service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserService, type: :model do
+  describe '#update_user' do
+    let!(:sample_user) { create(:user, name: name, role_type: role) }
+    let(:name) { 'ユーザ名' }
+    let(:role) { 'admin' }
+    let(:update_name) { '更新するユーザ名' }
+    let(:update_role) { 'member' }
+    let(:update_param) { { name: update_name, role_type: update_role } }
+
+    context 'when there are some admins' do
+      before { create_list(:user, 3, :with_admin) }
+      let!(:login_user) { create(:user, :with_admin) }
+
+      it 'should update the user' do
+        service = UserService.new(sample_user, login_user)
+        expect { service.update_user(update_param) }.to change {
+          sample_user.reload
+          sample_user.name
+        }.from(name).to(update_name)
+        .and change {
+          sample_user.role_type
+        }.from(role).to(update_role)
+      end
+    end
+
+    context 'when update to unexpected role_type' do
+      let(:update_role) { 'wrong_role' }
+      let!(:login_user) { create(:user, :with_admin) }
+
+      it 'should not be updated' do
+        service = UserService.new(sample_user, login_user)
+        expect(service.update_user(update_param).errors.full_messages).to eq(['ロールは不正な値です'])
+      end
+    end
+
+    context 'when last admin' do
+      context 'when update own role_type to member' do
+        it 'should not be updated' do
+          service = UserService.new(sample_user, sample_user)
+          expect(service.update_user(update_param).errors.full_messages).to eq(['最後の管理者です'])
+        end
+      end
+
+      context 'when update own name' do
+        let(:update_param) { { name: update_name } }
+
+        it 'should be updated' do
+          service = UserService.new(sample_user, sample_user)
+          expect { service.update_user(update_param) }.to change {
+            sample_user.reload
+            sample_user.name
+          }.from(name).to(update_name)
+        end
+      end
+    end
+  end
+end

--- a/job_san/spec/system/admin/users_spec.rb
+++ b/job_san/spec/system/admin/users_spec.rb
@@ -141,7 +141,6 @@ RSpec.describe User, js: true, type: :system do
       let(:update_user_name) { Faker::JapaneseMedia::OnePiece.character }
       let(:update_user_email) { Faker::Internet.email }
       let(:update_password) { 'これから更新するユーザのpassword' }
-      let(:updated_user) { User.find(sample_user.id) }
 
       subject { click_button '更新' }
 
@@ -153,8 +152,10 @@ RSpec.describe User, js: true, type: :system do
           fill_in 'Email', with: update_user_email
         end
 
-        it 'move to updated user page' do
+        it 'move to user list' do
           expect { subject }.to change {
+            # 更新処理が完了する前にテストコードが進んでしまうので、待機する。
+            sleep(0.3)
             current_path
           }.from(edit_admin_user_path(id: sample_user.id))
            .to(admin_users_path)
@@ -165,11 +166,11 @@ RSpec.describe User, js: true, type: :system do
           expect { subject }.to change {
             # 更新処理が完了する前にテストコードが進んでしまうので、待機する。
             sleep(0.3)
-            updated_user.reload
-            updated_user.name
+            sample_user.reload
+            sample_user.name
           }.from(sample_user_name).to(update_user_name)
            .and change {
-             updated_user.email
+             sample_user.email
            }.from(sample_user_email).to(update_user_email)
         end
       end

--- a/job_san/spec/system/admin/users_spec.rb
+++ b/job_san/spec/system/admin/users_spec.rb
@@ -2,7 +2,42 @@
 
 require 'rails_helper'
 
-RSpec.describe User, :require_login, js: true, type: :system do
+RSpec.describe User, js: true, type: :system do
+  let(:login_user_email) { Faker::Internet.email }
+  let(:login_user_password) { 'password' }
+
+  shared_context 'admin' do
+    let!(:login_user) { create(:user, :with_admin, email: login_user_email, password: login_user_password, password_confirmation: login_user_password) }
+    before do
+      visit login_path
+      fill_in 'session_email', with: login_user.email
+      fill_in 'session_password', with: login_user_password
+      click_button 'ログイン'
+    end
+  end
+
+  shared_examples 'when login as a member' do
+    let!(:login_user) { create(:user, email: login_user_email, password: login_user_password, password_confirmation: login_user_password) }
+    before do
+      visit login_path
+      fill_in 'session_email', with: login_user.email
+      fill_in 'session_password', with: login_user_password
+      click_button 'ログイン'
+    end
+
+    it 'redirect to task list page' do
+      visit admin_users_path
+      expect(current_path).to eq tasks_path
+    end
+  end
+
+  shared_examples 'when not logged in yet' do
+    it 'redirect to login' do
+      visit admin_users_path
+      expect(current_path).to eq login_path
+    end
+  end
+
   before do
     create_list(:task, 5, user: sample_user)
     build_list(:user, 5) { |user, i| create_list(:task, i, user: user) }
@@ -12,223 +47,250 @@ RSpec.describe User, :require_login, js: true, type: :system do
   let!(:sample_user) { create(:user, name: sample_user_name, email: sample_user_email) }
 
   describe '#index' do
-    before { visit admin_users_path }
+    context 'when login as an admin' do
+      include_context 'admin'
 
-    it 'show all users' do
-      user_ids = page.all('tbody td:first-child').map(&:text)
-      expect(user_ids).to match_array(User.all.pluck(:id).map(&:to_s))
-    end
+      before { visit admin_users_path }
 
-    context 'when users exist over 10' do
-      before do
-        create_list(:user, 10)
-        visit admin_users_path
-      end
-
-      it 'should show paginated users' do
+      it 'show all users' do
         user_ids = page.all('tbody td:first-child').map(&:text)
-        expect(user_ids.count).to eq(10)
-        click_on '次へ ›'
-        # ページネーション処理が完了する前にテストコードが進んでしまうので、待機する。
-        sleep(0.3)
-        expect(page.all('tbody td:first-child').map(&:text)).not_to match_array(user_ids)
+        expect(user_ids).to match_array(User.all.pluck(:id).map(&:to_s))
+      end
+
+      context 'when users exist over 10' do
+        before do
+          create_list(:user, 10)
+          visit admin_users_path
+        end
+
+        it 'should show paginated users' do
+          user_ids = page.all('tbody td:first-child').map(&:text)
+          expect(user_ids.count).to eq(10)
+          click_on '次へ ›'
+          # ページネーション処理が完了する前にテストコードが進んでしまうので、待機する。
+          sleep(0.3)
+          expect(page.all('tbody td:first-child').map(&:text)).not_to match_array(user_ids)
+        end
+      end
+
+      context 'when search users by a user_name' do
+        let(:search_user_name) { SecureRandom.uuid }
+        let!(:filtered_users) { create_list(:user, 3, name: search_user_name) }
+        before do
+          fill_in '名前 は以下を含む', with: search_user_name[2..7]
+          click_button '検索'
+          # 検索処理が完了する前にテストコードが進んでしまうので、待機する。
+          sleep(0.3)
+        end
+
+        it 'users are filtered by partial matched name' do
+          ids = page.all('tbody td:first-child').map(&:text)
+          expect(ids).to match_array(filtered_users.map { |t| t.id.to_s })
+        end
       end
     end
 
-    context 'when search users with a user_name' do
-      let(:search_user_name) { SecureRandom.uuid }
-      let!(:filtered_users) { create_list(:user, 3, name: search_user_name) }
-      before do
-        fill_in '名前 は以下を含む', with: search_user_name[2..7]
-        click_button '検索'
-        # 検索処理が完了する前にテストコードが進んでしまうので、待機する。
-        sleep(0.3)
-      end
-
-      it 'users are filtered by partial matched name' do
-        ids = page.all('tbody td:first-child').map(&:text)
-        expect(ids).to match_array(filtered_users.map { |t| t.id.to_s })
-      end
-    end
-
-    context 'when user does not login yet' do
-      before do
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(nil)
-        visit admin_users_path
-      end
-
-      it 'render login page' do
-        expect(current_path).to eq login_path
-      end
-    end
+    it_behaves_like 'when login as a member'
+    it_behaves_like 'when not logged in yet'
   end
 
   describe '#new' do
-    before { visit new_admin_user_path }
+    context 'when login as an admin' do
+      include_context 'admin'
 
-    context 'submit valid values' do
-      let(:create_user_name) { Faker::JapaneseMedia::OnePiece.character }
-      let(:create_user_email) { Faker::Internet.email }
-      let(:create_password) { 'これから作るユーザのpassword' }
+      before { visit new_admin_user_path }
 
-      before do
-        fill_in '名前', with: create_user_name
-        fill_in 'Email', with: create_user_email
-        fill_in 'パスワード', with: create_password
-        fill_in 'パスワード確認', with: create_password
-      end
+      context 'submit valid values' do
+        let(:create_user_name) { Faker::JapaneseMedia::OnePiece.character }
+        let(:create_user_email) { Faker::Internet.email }
+        let(:create_password) { 'これから作るユーザのpassword' }
 
-      subject { click_button '作成' }
+        before do
+          fill_in '名前', with: create_user_name
+          fill_in 'Email', with: create_user_email
+          fill_in 'パスワード', with: create_password
+          fill_in 'パスワード確認', with: create_password
+        end
 
-      it 'move to user list page' do
-        subject
-        expect(current_path).to eq admin_users_path
-        expect(page).to have_content 'ユーザを作成したよ'
-      end
+        subject { click_button '作成' }
 
-      it 'create new user' do
-        expect { subject }.to change(User.all, :count).by(1)
-        # 作成処理が完了する前にテストコードが進んでしまうので、待機する。
-        sleep(0.3)
-        created_user = User.find_by(email: create_user_email)
-        expect(created_user.name).to eq(create_user_name)
-      end
-    end
+        it 'move to user list page' do
+          subject
+          expect(current_path).to eq admin_users_path
+          expect(page).to have_content 'ユーザを作成したよ'
+        end
 
-    context 'when user does not login yet' do
-      before do
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(nil)
-        visit new_admin_user_path
-      end
-
-      it 'render login page' do
-        expect(current_path).to eq login_path
+        it 'create new user' do
+          expect {
+            subject
+            # 作成処理が完了する前に処理が進むのを防ぐ
+            sleep(0.3)
+          }.to change(User.all, :count).by(1)
+          created_user = User.find_by(email: create_user_email)
+          expect(created_user.name).to eq(create_user_name)
+        end
       end
     end
+
+    it_behaves_like 'when login as a member'
+    it_behaves_like 'when not logged in yet'
   end
 
   describe '#edit' do
-    before { visit edit_admin_user_path id: sample_user.id }
-    let(:update_user_name) { Faker::JapaneseMedia::OnePiece.character }
-    let(:update_user_email) { Faker::Internet.email }
-    let(:update_password) { 'これから更新するユーザのpassword' }
-    let(:updated_user) { User.find(sample_user.id) }
-
-    context 'submit valid values' do
-      before do
-        fill_in '名前', with: update_user_name
-        fill_in 'Email', with: update_user_email
-      end
+    context 'when login as an admin' do
+      let(:update_user_name) { Faker::JapaneseMedia::OnePiece.character }
+      let(:update_user_email) { Faker::Internet.email }
+      let(:update_password) { 'これから更新するユーザのpassword' }
+      let(:updated_user) { User.find(sample_user.id) }
 
       subject { click_button '更新' }
 
-      it 'move to updated user page' do
-        expect { subject }.to change {
-          current_path
-        }.from(edit_admin_user_path(id: sample_user.id))
-         .to(admin_users_path)
-        expect(page).to have_content 'ユーザを更新したよ'
+      context 'submit valid values' do
+        include_context 'admin'
+        before do
+          visit edit_admin_user_path id: sample_user.id
+          fill_in '名前', with: update_user_name
+          fill_in 'Email', with: update_user_email
+        end
+
+        it 'move to updated user page' do
+          expect { subject }.to change {
+            current_path
+          }.from(edit_admin_user_path(id: sample_user.id))
+           .to(admin_users_path)
+          expect(page).to have_content 'ユーザを更新したよ'
+        end
+
+        it 'update selected user' do
+          expect { subject }.to change {
+            # 更新処理が完了する前にテストコードが進んでしまうので、待機する。
+            sleep(0.3)
+            updated_user.reload
+            updated_user.name
+          }.from(sample_user_name).to(update_user_name)
+           .and change {
+             updated_user.email
+           }.from(sample_user_email).to(update_user_email)
+        end
       end
 
-      it 'update selected user' do
-        expect { subject }.to change {
-          # 更新処理が完了する前にテストコードが進んでしまうので、待機する。
-          sleep(0.3)
-          updated_user.reload
-          updated_user.name
-        }.from(sample_user_name).to(update_user_name)
-          .and change {
-            updated_user.email
-          }.from(sample_user_email).to(update_user_email)
-      end
-    end
-
-    context 'when user does not login yet' do
-      before do
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(nil)
-        fill_in '名前', with: update_user_name
-        fill_in 'Email', with: update_user_email
-      end
-
-      it 'render login page' do
-        visit edit_admin_user_path id: sample_user.id
-        expect(current_path).to eq login_path
-      end
-
-      it 'should not update selected user' do
-        expect {
-          subject
-          updated_user.reload
-        }.not_to change {
-          [updated_user.name,
-           updated_user.email]
+      context 'when last admin' do
+        let(:login_user_name) { Faker::JapaneseMedia::OnePiece.character }
+        let!(:login_user) {
+          create(:user,
+                 :with_admin,
+                 name: login_user_name,
+                 email: login_user_email,
+                 password: login_user_password,
+                 password_confirmation: login_user_password)
         }
+        before do
+          visit login_path
+          fill_in 'session_email', with: login_user.email
+          fill_in 'session_password', with: login_user_password
+          click_button 'ログイン'
+        end
+
+        # context 'when update own role_type to member' do
+        #   it 'should not be updated' do
+        #
+        #   end
+        # end
+
+        context 'when update own name' do
+          before do
+            visit edit_admin_user_path id: login_user.id
+            fill_in '名前', with: update_user_name
+            fill_in 'Email', with: update_user_email
+          end
+
+          it 'update selected user' do
+            expect { subject }.to change {
+              # 更新処理が完了する前にテストコードが進んでしまうので、待機する。
+              sleep(0.3)
+              login_user.reload
+              login_user.name
+            }.from(login_user_name).to(update_user_name)
+             .and change {
+               login_user.email
+             }.from(login_user_email).to(update_user_email)
+          end
+        end
       end
     end
+
+    it_behaves_like 'when login as a member'
+    it_behaves_like 'when not logged in yet'
   end
 
   describe '#destroy' do
-    before { visit edit_admin_user_path(id: sample_user.id) }
-
-    subject do
-      page.accept_confirm do
-        click_on '削除'
-      end
-      # 削除処理が完了する前にテストコードが進んでしまうので、待機する。
-      sleep 0.3
-    end
-
-    it 'move to user list page' do
-      expect { subject }.to change { current_path }.from(edit_admin_user_path(id: sample_user.id)).to(admin_users_path)
-      expect(page).to have_content 'ユーザを削除したよ'
-    end
-
-    it 'delete selected user' do
-      expect { subject }.to change {
-        User.count
-      }.by(-1).and change {
-        Task.count
-      }.by(-sample_user.tasks.count)
-    end
-
-    context 'when user does not login yet' do
-      before { allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(nil) }
-
-      it 'render login page' do
-        visit edit_admin_user_path(id: sample_user.id)
-        expect(current_path).to eq login_path
+    context 'when login as an admin' do
+      subject do
+        page.accept_confirm do
+          click_on '削除'
+        end
+        # 削除処理が完了する前にテストコードが進んでしまうので、待機する。
+        sleep 0.3
       end
 
-      it 'should not delete selected user' do
-        expect { subject }.to change {
-          User.count
-        }.by(0).and change {
-          Task.count
-        }.by(0).and change {
-          current_path
-        }.from(edit_admin_user_path(id: sample_user.id)).to(login_path)
+      context 'when there are some admins' do
+        include_context 'admin'
+
+        before do
+          create_list(:user, 3, :with_admin)
+          visit edit_admin_user_path(id: sample_user.id)
+        end
+
+        it 'move to user list page' do
+          expect { subject }.to change { current_path }.from(edit_admin_user_path(id: sample_user.id)).to(admin_users_path)
+          expect(page).to have_content 'ユーザを削除したよ'
+        end
+
+        it 'delete selected user' do
+          expect { subject }.to change {
+            User.count
+          }.by(-1).and change {
+            Task.count
+          }.by(-sample_user.tasks.count)
+        end
       end
     end
+
+    context 'when last admin' do
+      let!(:login_user) { create(:user, :with_admin, email: login_user_email, password: login_user_password, password_confirmation: login_user_password) }
+      before do
+        visit login_path
+        fill_in 'session_email', with: login_user.email
+        fill_in 'session_password', with: login_user_password
+        click_button 'ログイン'
+        visit edit_admin_user_path id: login_user.id
+      end
+
+      it 'should not delete' do
+        expect { subject }.to change { User.count }.by(0)
+      end
+    end
+
+    it_behaves_like 'when login as a member'
+    it_behaves_like 'when not logged in yet'
   end
 
   describe 'user_tasks' do
-    before do
-      create_list(:task, 3, user: sample_user)
-      visit tasks_admin_user_path(id: sample_user.id)
-    end
+    context 'when login as an admin' do
+      include_context 'admin'
 
-    it 'show only tasks of the selected user' do
-      task_ids = sample_user.tasks.pluck(:id).map(&:to_s)
-      expect(page.all('tbody td:first-child').map(&:text)).to match_array(task_ids)
-    end
-
-    context 'when user does not login yet' do
-      before { allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(nil) }
-
-      it 'render login page' do
+      before do
+        create_list(:task, 3, user: sample_user)
         visit tasks_admin_user_path(id: sample_user.id)
-        expect(current_path).to eq login_path
+      end
+
+      it 'show only tasks of the selected user' do
+        task_ids = sample_user.tasks.pluck(:id).map(&:to_s)
+        expect(page.all('tbody td:first-child').map(&:text)).to match_array(task_ids)
       end
     end
+
+    it_behaves_like 'when login as a member'
+    it_behaves_like 'when not logged in yet'
   end
 end

--- a/job_san/yarn.lock
+++ b/job_san/yarn.lock
@@ -2387,7 +2387,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.1, debug@^3.2.5:
+debug@^3.1.1, debug@^3.2.6:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -2916,14 +2916,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-faye-websocket@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
-  integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
-  dependencies:
-    websocket-driver ">=0.5.1"
-
-faye-websocket@~0.11.1:
+faye-websocket@^0.11.3:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
   integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
@@ -4056,7 +4049,7 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json3@^3.3.2:
+json3@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
@@ -6369,7 +6362,7 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@^1.10.7:
+selfsigned@^1.10.8:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
   integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
@@ -6551,26 +6544,26 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sockjs-client@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.4.0.tgz#c9f2568e19c8fd8173b4997ea3420e0bb306c7d5"
-  integrity sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==
+sockjs-client@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.5.0.tgz#2f8ff5d4b659e0d092f7aba0b7c386bd2aa20add"
+  integrity sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==
   dependencies:
-    debug "^3.2.5"
+    debug "^3.2.6"
     eventsource "^1.0.7"
-    faye-websocket "~0.11.1"
-    inherits "^2.0.3"
-    json3 "^3.3.2"
-    url-parse "^1.4.3"
+    faye-websocket "^0.11.3"
+    inherits "^2.0.4"
+    json3 "^3.3.3"
+    url-parse "^1.4.7"
 
-sockjs@0.3.20:
-  version "0.3.20"
-  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.20.tgz#b26a283ec562ef8b2687b44033a4eeceac75d855"
-  integrity sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==
+sockjs@^0.3.21:
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.21.tgz#b34ffb98e796930b60a0cfa11904d6a339a7d417"
+  integrity sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==
   dependencies:
-    faye-websocket "^0.10.0"
+    faye-websocket "^0.11.3"
     uuid "^3.4.0"
-    websocket-driver "0.6.5"
+    websocket-driver "^0.7.4"
 
 sort-keys@^1.0.0:
   version "1.1.2"
@@ -7248,7 +7241,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-parse@^1.4.3:
+url-parse@^1.4.3, url-parse@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
   integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
@@ -7411,10 +7404,10 @@ webpack-dev-middleware@^3.7.2:
     range-parser "^1.2.1"
     webpack-log "^2.0.0"
 
-webpack-dev-server@^3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz#8f154a3bce1bcfd1cc618ef4e703278855e7ff8c"
-  integrity sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==
+webpack-dev-server@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz#c74028bf5ba8885aaf230e48a20e8936ab8511f0"
+  integrity sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==
   dependencies:
     ansi-html "0.0.7"
     bonjour "^3.5.0"
@@ -7436,11 +7429,11 @@ webpack-dev-server@^3.11.0:
     p-retry "^3.0.1"
     portfinder "^1.0.26"
     schema-utils "^1.0.0"
-    selfsigned "^1.10.7"
+    selfsigned "^1.10.8"
     semver "^6.3.0"
     serve-index "^1.9.1"
-    sockjs "0.3.20"
-    sockjs-client "1.4.0"
+    sockjs "^0.3.21"
+    sockjs-client "^1.5.0"
     spdy "^4.0.2"
     strip-ansi "^3.0.1"
     supports-color "^6.1.0"
@@ -7495,14 +7488,7 @@ webpack@^4.44.1:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-websocket-driver@0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.6.5.tgz#5cb2556ceb85f4373c6d8238aa691c8454e13a36"
-  integrity sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=
-  dependencies:
-    websocket-extensions ">=0.1.1"
-
-websocket-driver@>=0.5.1:
+websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
   integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==


### PR DESCRIPTION
# やること
- ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
- 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
- ユーザ管理画面でロールを選択できるようにしましょう
- 管理ユーザが1人もいなくならないように削除の制御をしましょう

# やったこと
- [x] 一般ユーザと管理ユーザの権限column追加
- [x] ユーザ権限ごとのアクセス制限追加
- [x] ユーザ作成・更新時に権限選択機能追加
- [x] 最後の管理ユーザがいなくならないように制御

# スクリーンショット
## 作成画面
![Screen Shot 2021-01-12 at 11 43 27](https://user-images.githubusercontent.com/75293120/104262696-71d7e280-54cb-11eb-9737-6a358e81686f.png)

## 更新画面
![Screen Shot 2021-01-12 at 11 43 17](https://user-images.githubusercontent.com/75293120/104262691-700e1f00-54cb-11eb-96eb-9a49c4abb4c1.png)
