### PR TITLE
ステップ18: ユーザの管理画面を実装しよう [Phase1/2]

### DIFF
--- a/gotodo/app/controllers/admin/users_controller.rb
+++ b/gotodo/app/controllers/admin/users_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Admin::UsersController < ApplicationController
+  before_action :set_user, only: %i[show destroy]
+  before_action :login_check
+
+  def index
+    user_sort_params
+    @users = User.users_with_tasks_count
+                 .sorted(sort: params[:sort], direction: params[:direction])
+                 .page(params[:page])
+                 .per(10)
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  def edit
+  end
+
+  def create
+  end
+
+  def update
+  end
+
+  def destroy
+    @user.destroy
+    redirect_to root_url, success: I18n.t('flash.destroy_success', model: I18n.t('activerecord.models.user'))
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_sort_params
+    params.permit(:sort, :direction)
+  end
+end

--- a/gotodo/app/controllers/admin/users_controller.rb
+++ b/gotodo/app/controllers/admin/users_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Admin::UsersController < ApplicationController
-  before_action :set_user, only: %i[show destroy]
   before_action :login_check
 
   def index
@@ -12,32 +11,7 @@ class Admin::UsersController < ApplicationController
                  .per(10)
   end
 
-  def show
-  end
-
-  def new
-  end
-
-  def edit
-  end
-
-  def create
-  end
-
-  def update
-  end
-
-  def destroy
-    @user.destroy
-    redirect_to root_url, success: I18n.t('flash.destroy_success', model: I18n.t('activerecord.models.user'))
-  end
-
   private
-
-  # Use callbacks to share common setup or constraints between actions.
-  def set_user
-    @user = User.find(params[:id])
-  end
 
   def user_sort_params
     params.permit(:sort, :direction)

--- a/gotodo/app/controllers/users_controller.rb
+++ b/gotodo/app/controllers/users_controller.rb
@@ -40,7 +40,7 @@ class UsersController < ApplicationController
 
   def destroy
     @user.destroy
-    redirect_to root_url, success: I18n.t('flash.destroy_success', model: I18n.t('activerecord.models.user'))
+    redirect_to admin_users_path, success: I18n.t('flash.destroy_success', model: I18n.t('activerecord.models.user'))
   end
 
   private

--- a/gotodo/app/controllers/users_controller.rb
+++ b/gotodo/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[show edit update destroy]
+  before_action :set_user, only: %i[edit update destroy]
   before_action :login_check, except: %i[new create]
 
   def index
@@ -9,6 +9,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @user = User.find(@current_user.id)
   end
 
   def new
@@ -31,7 +32,7 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to @user, success: I18n.t('flash.update_success', model: I18n.t('activerecord.models.user'))
+      redirect_to profile_path, success: I18n.t('flash.update_success', model: I18n.t('activerecord.models.user'))
     else
       flash.now[:danger] = I18n.t('flash.update_error', model: I18n.t('activerecord.models.user'))
       render :edit

--- a/gotodo/app/helpers/admin/users_helper.rb
+++ b/gotodo/app/helpers/admin/users_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Admin::UsersHelper
+  def sortable(column)
+    column = column.to_s
+    asc = link_to '▲', { sort: column, direction: 'asc' }, { id: "#{column}_asc" }
+    desc = link_to '▼', { sort: column, direction: 'desc' }, { id: "#{column}_desc" }
+
+    sortable = [User.human_attribute_name(column) + '　']
+    if params[:sort] == column
+      sortable.concat(params[:direction] == 'asc' ? [desc] : [asc])
+    else
+      sortable.concat([asc, desc])
+    end
+    safe_join(sortable)
+  end
+end

--- a/gotodo/app/models/task.rb
+++ b/gotodo/app/models/task.rb
@@ -16,9 +16,9 @@ class Task < ApplicationRecord
   scope :title_like, -> (title) { where('title LIKE ?', "%#{title}%") if title.present? }
   scope :status_is, -> (status) { where(status: status) if status.present? }
   scope :sorted, (lambda do |sort, direction|
-    sort_list = ['title', 'detail', 'end_date', 'status', 'created_at', 'edited_at']
+    sort_list = %w[title detail end_date status created_at edited_at]
     sort = sort_list.include?(sort) ? sort : nil
-    direction_list = ['asc', 'desc']
+    direction_list = %w[asc desc]
     direction = direction_list.include?(direction) ? direction : nil
     sort.present? && direction.present? ? order("#{sort} #{direction}, id desc") : order('id desc')
   end)

--- a/gotodo/app/models/user.rb
+++ b/gotodo/app/models/user.rb
@@ -1,10 +1,30 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_secure_password
+
   has_many :tasks, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 10 }
   validates :email, presence: true, length: { maximum: 30 }, uniqueness: true, email: true
 
-  has_secure_password
+  scope :users_with_tasks_count, (lambda do
+    left_outer_joins(:tasks)
+      .select(Arel.sql('users.*, COUNT(tasks.id) AS count_all'))
+      .group('users.id')
+  end)
+
+  scope :sorted, (lambda do |params|
+    sort_hash = {
+      'name' => 'users.name',
+      'email' => 'users.email',
+      'tasks_count' => 'count_all',
+      'created_at' => 'users.created_at',
+      'updated_at' => 'users.updated_at',
+    }
+    sort = sort_hash[params[:sort]]
+    direction_list = %w[asc desc]
+    direction = direction_list.include?(params[:direction]) ? params[:direction] : nil
+    sort.present? && direction.present? ? order("#{sort} #{direction}, users.id desc") : order('users.id desc')
+  end)
 end

--- a/gotodo/app/views/admin/users/_user.html.erb
+++ b/gotodo/app/views/admin/users/_user.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td><%= user.name %></td>
+  <td><%= user.email %></td>
+  <td><%= user.count_all %></td>
+  <td><%= I18n.l(user.created_at) %></td>
+  <td><%= I18n.l(user.updated_at) %></td>
+  <td><%= link_to(icon('fas', 'trash-alt'), user, { method: :delete, data: { confirm: I18n.t('confirms.delete') }, class: 'delete-link' }) %></td>
+</tr>

--- a/gotodo/app/views/admin/users/index.html.erb
+++ b/gotodo/app/views/admin/users/index.html.erb
@@ -1,0 +1,17 @@
+<table class="table table-striped text-center">
+  <thead class="thead-dark">
+    <tr>
+      <th><%= sortable :name %></th>
+      <th><%= sortable :email %></th>
+      <th><%= sortable :tasks_count %></th>
+      <th><%= sortable :created_at %></th>
+      <th><%= sortable :updated_at %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'user', collection: @users %>
+  </tbody>
+</table>
+<br>
+<%= paginate @users %>

--- a/gotodo/app/views/layouts/application.html.erb
+++ b/gotodo/app/views/layouts/application.html.erb
@@ -13,11 +13,11 @@
 <body>
 <div class="container mt-5">
   <div class="d-flex align-items-end">
-    <%= link_to (image_tag 'logo.png'), root_path %>
+    <%= link_to((image_tag 'logo.png'), root_path) %>
     <% if @current_user %>
       <div class="ml-auto">
-        <%= I18n.t('message.login_user', name: current_user.name) %>&emsp;
-        <%= link_to icon('fas', 'sign-out-alt'), logout_path, method: :delete %>
+        <%= link_to(I18n.t('message.login_user', name: current_user.name), profile_path) %>&emsp;
+        <%= link_to(icon('fas', 'sign-out-alt'), logout_path, method: :delete) %>
       </div>
     <% end %>
   </div>

--- a/gotodo/app/views/tasks/index.html.erb
+++ b/gotodo/app/views/tasks/index.html.erb
@@ -45,3 +45,9 @@
 </table>
 <br>
 <%= paginate @tasks %>
+<br>
+<div class="form-group d-flex">
+  <div class="ml-auto">
+    <%= link_to '管理画面', admin_users_path, { class: 'btn btn-outline-info' } %>
+  </div>
+</div>

--- a/gotodo/app/views/users/_form.html.erb
+++ b/gotodo/app/views/users/_form.html.erb
@@ -18,18 +18,22 @@
                            { disabled: disabled, placeholder: User.human_attribute_name(:email), class: 'form-control' }
       %>
     </div>
-    <div class="form-group">
-      <%= form.password_field :password,
-                              { disabled: disabled, placeholder: User.human_attribute_name(:password), class: 'form-control' }
-      %>
-    </div>
-    <div class="form-group">
-      <%= form.password_field :password_confirmation,
-                              { disabled: disabled, placeholder: User.human_attribute_name(:password_confirmation), class: 'form-control' }
-      %>
-    </div>
     <% unless disabled %>
+      <div class="form-group">
+        <%= form.password_field :password,
+                                { disabled: disabled, placeholder: User.human_attribute_name(:password), class: 'form-control' }
+        %>
+      </div>
+      <div class="form-group">
+        <%= form.password_field :password_confirmation,
+                                { disabled: disabled, placeholder: User.human_attribute_name(:password_confirmation), class: 'form-control' }
+        %>
+      </div>
       <%= form.submit class: 'btn btn-info' %>
     <% end %>
+  <% end %>
+  <%= link_to icon('fas', 'arrow-alt-circle-left'), profile_path %>
+  <% if disabled %>
+    <%= link_to(icon('fas', 'edit'), edit_user_path(@user)) if @user.id == @current_user.id %>
   <% end %>
 </div>

--- a/gotodo/app/views/users/edit.html.erb
+++ b/gotodo/app/views/users/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'form', locals: { user: @user, disabled: false } %>

--- a/gotodo/app/views/users/show.html.erb
+++ b/gotodo/app/views/users/show.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'form', locals: { user: @user, disabled: true } %>

--- a/gotodo/config/application.rb
+++ b/gotodo/config/application.rb
@@ -22,5 +22,7 @@ module Myapp
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :ja
+
+    config.action_controller.include_all_helpers = false
   end
 end

--- a/gotodo/config/locales/ja.yml
+++ b/gotodo/config/locales/ja.yml
@@ -7,10 +7,13 @@ ja:
         status: ステータス
         end_date: 終了期限
       user:
-        name: ユーザー名
+        name: ユーザ名
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード（確認）
+        tasks_count: タスク数
+  errors:
+    validation: '%{count}つの項目に不備が見つかりました。'
   helpers:
     submit:
       create: 登録する
@@ -18,6 +21,13 @@ ja:
       submit: 保存する
       search: 検索
       login: ログイン
+  date:
+    formats:
+      default: ! '%Y/%m/%d'
+  time:
+    formats:
+      default: ! '%Y/%m/%d %H:%M:%S'
+
   flash:
     create_success: '新しい%{model}が登録されました！'
     update_success: '%{model}が更新されました！'
@@ -37,11 +47,4 @@ ja:
     delete: 本当に削除して良いですか？
   message:
     login_user: '%{name}さん'
-  errors:
-    validation: '%{count}つの項目に不備が見つかりました。'
-  date:
-    formats:
-      default: ! '%Y/%m/%d'
-  time:
-    formats:
-      default: ! '%Y/%m/%d %H:%M:%S'
+

--- a/gotodo/config/locales/views/users/ja.yml
+++ b/gotodo/config/locales/views/users/ja.yml
@@ -1,7 +1,7 @@
 ja:
   activerecord:
     models:
-      user: ユーザー
+      user: ユーザ
     errors:
       models:
         user:

--- a/gotodo/config/routes.rb
+++ b/gotodo/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  root 'tasks#index'
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
-  resources :users
-  resources :tasks
-  root 'tasks#index'
+  resources :users, :tasks
+  namespace :admin do
+    resources :users, :tasks
+  end
 end

--- a/gotodo/config/routes.rb
+++ b/gotodo/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users, :tasks
   end
+  get '/profile', to: 'users#show'
 end

--- a/gotodo/config/routes.rb
+++ b/gotodo/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
   resources :users, :tasks
   namespace :admin do
-    resources :users, :tasks
+    get '/users', to: 'users#index'
   end
   get '/profile', to: 'users#show'
 end

--- a/gotodo/spec/models/user_spec.rb
+++ b/gotodo/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User, type: :model do
       let(:name) { 'a' * 0 }
       it 'バリデーションを通過しないこと' do
         expect(user).to_not be_valid
-        expect(user.errors.full_messages).to match_array('ユーザー名が空です')
+        expect(user.errors.full_messages).to match_array('ユーザ名が空です')
       end
     end
     context '1文字の場合' do
@@ -29,7 +29,7 @@ RSpec.describe User, type: :model do
       let(:name) { 'a' * 11 }
       it 'バリデーションを通過しないこと' do
         expect(user).to_not be_valid
-        expect(user.errors.full_messages).to match_array('ユーザー名は10文字以内で入力してください')
+        expect(user.errors.full_messages).to match_array('ユーザ名は10文字以内で入力してください')
       end
     end
   end

--- a/gotodo/spec/system/admin_users_spec.rb
+++ b/gotodo/spec/system/admin_users_spec.rb
@@ -176,4 +176,28 @@ RSpec.describe 'AdminUsers', type: :system do
       end
     end
   end
+
+  describe '#destroy(user_id)' do
+    let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com') }
+    let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com') }
+    let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com') }
+    let!(:task1) { FactoryBot.create(:task, user: login_user) }
+    let!(:task2) { FactoryBot.create(:task, user: user1) }
+    let!(:task3) { FactoryBot.create(:task, user: user2) }
+    let!(:task4) { FactoryBot.create(:task, user: user2) }
+
+    it '削除したユーザが表示されず、削除していないユーザが表示されること' do
+      visit admin_users_path
+      click_link nil, href: user_path(user1), class: 'delete-link'
+      is_expected.to have_current_path admin_users_path
+      is_expected.to have_selector('.alert-success', text: 'ユーザが削除されました！')
+      is_expected.to have_no_content user1.email
+      is_expected.to have_content login_user.email
+      is_expected.to have_content user2.email
+    end
+
+    it 'ユーザを削除すると、関連したタスクも削除されること' do
+      expect{ user2.destroy }.to change{ Task.count }.by(-2)
+    end
+  end
 end

--- a/gotodo/spec/system/admin_users_spec.rb
+++ b/gotodo/spec/system/admin_users_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pp'
+
+RSpec.describe 'AdminUsers', type: :system do
+  subject { page }
+
+  before 'ログイン' do
+    visit login_path
+    fill_in 'email', with: login_user.email
+    fill_in 'password', with: login_user.password
+    click_button 'ログイン'
+  end
+
+  describe 'アクセス権' do
+    let!(:login_user) { FactoryBot.create(:user) }
+
+    context 'ログイン状態の時' do
+      it '#indexにアクセスできること' do
+        visit admin_users_path
+        is_expected.to have_current_path admin_users_path
+      end
+    end
+
+    context '未ログイン状態の時' do
+      before do
+        click_link nil, href: logout_path
+      end
+      it '#indexにアクセスできないこと' do
+        visit admin_users_path
+        is_expected.to have_current_path login_path
+      end
+    end
+  end
+
+  describe '#index (/admin/users)' do
+    shared_examples '期待した順番で表示されること' do
+      it do
+        users_list = all('tbody tr')
+        expected_list.each_with_index do |user, i|
+          expect(users_list[i].all('td')[1].text).to eq user.email
+        end
+      end
+    end
+
+    describe '表示項目' do
+      let!(:login_user) { FactoryBot.create(:user, name: '夏目', email: 'natsume@example.com') }
+      it '期待した項目が表示されること' do
+        visit admin_users_path
+        is_expected.to have_content login_user.name
+        is_expected.to have_content login_user.email
+        is_expected.to have_content login_user.created_at.strftime('%Y/%m/%d %H:%M:%S')
+        is_expected.to have_content login_user.updated_at.strftime('%Y/%m/%d %H:%M:%S')
+      end
+    end
+
+    describe 'ソート機能' do
+      describe 'ユーザ名' do
+        let!(:login_user) { FactoryBot.create(:user, name: '4夏目', email: 'natsume@example.com') }
+        let!(:user1) { FactoryBot.create(:user, name: '1田沼', email: 'tanuma@example.com') }
+        let!(:user2) { FactoryBot.create(:user, name: '2多軌', email: 'taki@example.com') }
+        let!(:user3) { FactoryBot.create(:user, name: '3ニャンコ先生', email: 'nyanko@example.com') }
+        context '昇順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'name_asc'
+          end
+          let(:expected_list) { [user1, user2, user3, login_user] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+        context '降順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'name_desc'
+          end
+          let(:expected_list) { [login_user, user3, user2, user1] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+      end
+
+      describe 'メールアドレス' do
+        let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com') }
+        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com') }
+        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com') }
+        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com') }
+        context '昇順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'email_asc'
+          end
+          let(:expected_list) { [login_user, user3, user2, user1] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+        context '降順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'email_desc'
+          end
+          let(:expected_list) { [user1, user2, user3, login_user] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+      end
+
+      describe 'タスク数' do
+        let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com') }
+        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com') }
+        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com') }
+        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com') }
+        let!(:task1) { FactoryBot.create(:task, user: login_user) }
+        let!(:task2) { FactoryBot.create(:task, user: user1) }
+        let!(:task3) { FactoryBot.create(:task, user: user2) }
+        let!(:task4) { FactoryBot.create(:task, user: user2) }
+        context '昇順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'tasks_count_asc'
+          end
+          let(:expected_list) { [user3, user1, login_user, user2] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+        context '降順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'tasks_count_desc'
+          end
+          let(:expected_list) { [user2, user1, login_user, user3] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+      end
+
+      describe '作成日時' do
+        let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com', created_at: Time.current + 4.days) }
+        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', created_at: Time.current + 1.day) }
+        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', created_at: Time.current + 3.days) }
+        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com', created_at: Time.current + 2.days) }
+        context '昇順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'created_at_asc'
+          end
+          let(:expected_list) { [user1, user3, user2, login_user] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+        context '降順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'created_at_desc'
+          end
+          let(:expected_list) { [login_user, user2, user3, user1] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+      end
+
+      describe '更新日時' do
+        let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com', updated_at: Time.current + 4.days) }
+        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', updated_at: Time.current + 1.day) }
+        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', updated_at: Time.current + 3.days) }
+        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com', updated_at: Time.current + 2.days) }
+        context '昇順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'updated_at_asc'
+          end
+          let(:expected_list) { [user1, user3, user2, login_user] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+        context '降順' do
+          before do
+            visit admin_users_path
+            click_link nil, id: 'updated_at_desc'
+          end
+          let(:expected_list) { [login_user, user2, user3, user1] }
+          it_behaves_like '期待した順番で表示されること'
+        end
+      end
+    end
+  end
+end

--- a/gotodo/spec/system/users_spec.rb
+++ b/gotodo/spec/system/users_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 require 'pp'
 
 RSpec.describe 'Users', type: :system do
-  let!(:user1) { FactoryBot.create(:user) }
+  let!(:login_user) { FactoryBot.create(:user) }
   subject { page }
 
   before 'ログイン' do
     visit login_path
-    fill_in 'email', with: user1.email
-    fill_in 'password', with: user1.password
+    fill_in 'email', with: login_user.email
+    fill_in 'password', with: login_user.password
     click_button 'ログイン'
   end
 
@@ -53,9 +53,9 @@ RSpec.describe 'Users', type: :system do
 
     it '新規作成したユーザでログインできること' do
       is_expected.to have_current_path root_path
-      is_expected.to have_selector('.alert-success', text: '新しいユーザーが登録されました！')
-
+      is_expected.to have_selector('.alert-success', text: '新しいユーザが登録されました！')
       click_link nil, href: logout_path
+
       is_expected.to have_current_path login_path
       fill_in 'email', with: new_user['email']
       fill_in 'password', with: new_user['password']
@@ -64,5 +64,107 @@ RSpec.describe 'Users', type: :system do
       is_expected.to have_current_path root_path
       is_expected.to have_selector('.alert-success', text: "ようこそ、#{new_user['name']}さん")
     end
+  end
+
+  describe '#edit(user_id)' do
+    let(:edited_user) {
+      {
+        'name' => '夏目',
+        'email' => 'natsume@example.com',
+        'password' => 'natsume'
+      } }
+
+    context 'パスワードのみ更新する' do
+      before do
+        visit edit_user_path login_user.id
+        fill_in 'user[password]', with: edited_user['password']
+        fill_in 'user[password_confirmation]', with: edited_user['password']
+        click_button '更新する'
+      end
+
+      it 'パスワード以外の情報が書き換わっていないこと' do
+        is_expected.to have_current_path profile_path
+        expect(find('#user_name').value).to eq login_user.name
+        expect(find('#user_email').value).to eq login_user.email
+        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+      end
+
+      it '元々のメールアドレスと更新したパスワードでログインできること' do
+        is_expected.to have_current_path profile_path
+        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+        click_link nil, href: logout_path
+
+        is_expected.to have_current_path login_path
+        fill_in 'email', with: login_user.email
+        fill_in 'password', with: edited_user['password']
+        click_button 'ログイン'
+
+        is_expected.to have_current_path root_path
+        is_expected.to have_selector('.alert-success', text: "ようこそ、#{login_user.name}さん")
+      end
+    end
+
+    context 'パスワード以外を更新する' do
+      before do
+        visit edit_user_path login_user.id
+        fill_in 'user[name]', with: edited_user['name']
+        fill_in 'user[email]', with: edited_user['email']
+        click_button '更新する'
+      end
+
+      it '情報が更新されていること' do
+        is_expected.to have_current_path profile_path
+        expect(find('#user_name').value).to eq edited_user['name']
+        expect(find('#user_email').value).to eq edited_user['email']
+        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+      end
+
+      it '更新したメールアドレスと元々のパスワードでログインできること' do
+        is_expected.to have_current_path profile_path
+        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+        click_link nil, href: logout_path
+
+        is_expected.to have_current_path login_path
+        fill_in 'email', with: edited_user['email']
+        fill_in 'password', with: login_user.password
+        click_button 'ログイン'
+
+        is_expected.to have_current_path root_path
+        is_expected.to have_selector('.alert-success', text: "ようこそ、#{edited_user['name']}さん")
+      end
+    end
+
+    context 'すべて更新する' do
+      before do
+        visit edit_user_path login_user.id
+        fill_in 'user[name]', with: edited_user['name']
+        fill_in 'user[email]', with: edited_user['email']
+        fill_in 'user[password]', with: edited_user['password']
+        fill_in 'user[password_confirmation]', with: edited_user['password']
+        click_button '更新する'
+      end
+
+      it '情報が更新されていること' do
+        is_expected.to have_current_path profile_path
+        expect(find('#user_name').value).to eq edited_user['name']
+        expect(find('#user_email').value).to eq edited_user['email']
+        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+      end
+
+      it '更新したメールアドレスとパスワードでログインできること' do
+        is_expected.to have_current_path profile_path
+        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+        click_link nil, href: logout_path
+
+        is_expected.to have_current_path login_path
+        fill_in 'email', with: edited_user['email']
+        fill_in 'password', with: edited_user['password']
+        click_button 'ログイン'
+
+        is_expected.to have_current_path root_path
+        is_expected.to have_selector('.alert-success', text: "ようこそ、#{edited_user['name']}さん")
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## 課題
- 画面上に管理メニューを追加しましょう
- 管理画面にはかならず `/admin` というURLを先頭につけるようにしましょう
  - `routes.rb` に追加する前に、あらかじめURLやルーティング名（ `*_path` となる名前）を想定して設計してみましょう
- ユーザ一覧・作成・更新・削除を実装しましょう
- ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう
- ~~ユーザが作成したタスクの一覧が見られるようにしてみましょう~~


## 実施事項
* 管理画面（ユーザ一覧）を作成
  * ユーザごとのタスク数を表示する機能を実装
* ユーザ更新機能を実装
* 並び替え機能を実装
* systemテストを追加

## 前ステップにて実施済事項
* ユーザ作成機能を実装（サインイン機能）
* ユーザ削除機能を実装
  * 関連するタスクも削除する機能を実装


## 次フェーズにて実施予定事項
- ユーザが作成したタスクの一覧が見られるようにしてみましょう



## 確認事項
<details>
<summary>systemテスト(tasks)</summary>

```spec
root@7e834b18d981:/myapp# bundle exec rspec spec/system/tasks_spec.rb 

Tasks
  アクセス権
    ログイン状態の時
      #indexにアクセスできること
      #show(task_id)にアクセスできること
      #edit(task_id)にアクセスできること
      #newにアクセスできること
    未ログイン状態の時
      #indexにアクセスできないこと
      #show(task_id)にアクセスできないこと
      #edit(task_id)にアクセスできないこと
      #newにアクセスできないこと
  #index
    表示項目
      期待した項目が表示されること
    ログイン機能
      ログインユーザのタスクのみが表示されること
    ソート機能
      タスク名
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "え　洗濯する"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "あ　料理をする"
      作成日時
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク14"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク15"
      終了期限
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク22"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク24"
      ステータス
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク27"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク33"
    検索機能
      タスク名を指定
        behaves like 期待した順番で表示されること
          is expected to eq "あ　料理をする"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "え　洗濯する"
      ステータスを指定
        behaves like 期待した順番で表示されること
          is expected to eq "う　買い物に行く"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "い　食べる"
      タスク名とステータスを指定
        behaves like 期待した順番で表示されること
          is expected to eq "え　洗濯する"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "い　食べる"
    検索機能 & ソート機能
      behaves like 期待した順番で表示されること
        is expected to eq "え　洗濯する"
      behaves like 期待しないタスクが表示されないこと
        is expected not to have text "う　買い物に行く"
    ページネーション機能
      1ページ目
        behaves like 期待した順番で表示されること
          is expected to eq "タスク37"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "タスク47"
      2ページ目
        behaves like 期待した順番で表示されること
          is expected to eq "タスク59"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "タスク73"
    検索機能 & ソート機能 & ページネーション機能
      1ページ目
        behaves like 期待した順番で表示されること
          is expected to eq "task12!"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "task10"
      2ページ目
        behaves like 期待した順番で表示されること
          is expected to eq "task14!"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "task10"
  #show(task_id)
    期待したタスクが表示されること
  #edit(task_id)
    期待したタスクが表示されること
  #new
    期待したタスクが表示されること
  #destroy(task_id)
    削除した登録済みタスクが表示されないこと

Finished in 26.19 seconds (files took 5.13 seconds to load)
38 examples, 0 failures
```
</details>

<details>
<summary>systemテスト(users)</summary>

```spec
root@7e834b18d981:/myapp# bundle exec rspec spec/system/users_spec.rb 

Users
  アクセス権
    ログイン状態の時
      #newにアクセスできること
    未ログイン状態の時
      #newにアクセスできること
  #new
    新規作成したユーザでログインできること
  #edit(user_id)
    パスワードのみ更新する
      パスワード以外の情報が書き換わっていないこと
      元々のメールアドレスと更新したパスワードでログインできること
    パスワード以外を更新する
      情報が更新されていること
      更新したメールアドレスと元々のパスワードでログインできること
    すべて更新する
      情報が更新されていること
      更新したメールアドレスとパスワードでログインできること

Finished in 6.82 seconds (files took 4.7 seconds to load)
9 examples, 0 failures
```
</details>

<details>
<summary>systemテスト(admin_user)</summary>

```spec
root@7e834b18d981:/myapp# bundle exec rspec spec/system/admin_users_spec.rb 

AdminUsers
  アクセス権
    ログイン状態の時
      #indexにアクセスできること
    未ログイン状態の時
      #indexにアクセスできないこと
  #index (/admin/users)
    表示項目
      期待した項目が表示されること
    ソート機能
      ユーザ名
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "natsume@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "tanuma@example.com"
      メールアドレス
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "tanuma@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "natsume@example.com"
      タスク数
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "taki@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "nyanko@example.com"
      作成日時
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "natsume@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "tanuma@example.com"
      更新日時
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "natsume@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "tanuma@example.com"
  #destroy(user_id)
    削除したユーザが表示されず、削除していないユーザが表示されること
    ユーザを削除すると、関連したタスクも削除されること

Finished in 12.41 seconds (files took 5.39 seconds to load)
15 examples, 0 failures
```
</details>