### PR TITLE
ステップ19: ユーザにロールを追加しよう

### DIFF
--- a/gotodo/app/controllers/admin/admin_controller.rb
+++ b/gotodo/app/controllers/admin/admin_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  class AdminController < ApplicationController
+    before_action :admin_check
+
+    def admin_check
+      redirect_to login_path unless admin?
+    end
+  end
+end

--- a/gotodo/app/controllers/admin/tasks_controller.rb
+++ b/gotodo/app/controllers/admin/tasks_controller.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 module Admin
-  class TasksController < ApplicationController
+  class TasksController < AdminController
     helper TasksHelper
-    before_action :admin_check
 
     def index
       @tasks = Task.where(user_id: params[:id])

--- a/gotodo/app/controllers/admin/tasks_controller.rb
+++ b/gotodo/app/controllers/admin/tasks_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   class TasksController < ApplicationController
     helper TasksHelper
+    before_action :admin_check
 
     def index
       @tasks = Task.where(user_id: params[:id])

--- a/gotodo/app/controllers/admin/tasks_controller.rb
+++ b/gotodo/app/controllers/admin/tasks_controller.rb
@@ -6,7 +6,7 @@ module Admin
 
     def index
       @tasks = Task.where(user_id: params[:id])
-                   .task_search(title: params[:title], status: params[:status], sort: params[:sort], direction: params[:direction])
+                   .task_search(params)
                    .page(params[:page])
                    .per(10)
       @user = User.find(params[:id])

--- a/gotodo/app/controllers/admin/users_controller.rb
+++ b/gotodo/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::UsersController < ApplicationController
-  before_action :login_check
+  before_action :admin_check
 
   def index
     user_sort_params

--- a/gotodo/app/controllers/admin/users_controller.rb
+++ b/gotodo/app/controllers/admin/users_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module Admin
-  class UsersController < ApplicationController
-    before_action :admin_check
-
+  class UsersController < AdminController
     def index
       user_sort_params
       @users = User.users_with_tasks_count

--- a/gotodo/app/controllers/application_controller.rb
+++ b/gotodo/app/controllers/application_controller.rb
@@ -12,4 +12,13 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
+
+  def admin_check
+    redirect_to login_path unless is_admin?
+  end
+
+  helper_method :is_admin?
+  def is_admin?
+    @current_user.role.name == 'admin'
+  end
 end

--- a/gotodo/app/controllers/application_controller.rb
+++ b/gotodo/app/controllers/application_controller.rb
@@ -14,11 +14,11 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_check
-    redirect_to login_path unless is_admin?
+    redirect_to login_path unless admin?
   end
 
-  helper_method :is_admin?
-  def is_admin?
-    @current_user.role.name == 'admin'
+  helper_method :admin?
+  def admin?
+    @current_user.role.name == 'admin' if @current_user.role
   end
 end

--- a/gotodo/app/controllers/application_controller.rb
+++ b/gotodo/app/controllers/application_controller.rb
@@ -4,20 +4,19 @@ class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
 
   before_action :login_check
+
   def login_check
     redirect_to login_path unless current_user
   end
 
   helper_method :current_user
+
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
-  def admin_check
-    redirect_to login_path unless admin?
-  end
-
   helper_method :admin?
+
   def admin?
     @current_user.role.name == 'admin' if @current_user.role
   end

--- a/gotodo/app/controllers/tasks_controller.rb
+++ b/gotodo/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.where(user_id: @current_user.id)
-                 .task_search(title: params[:title], status: params[:status], sort: params[:sort], direction: params[:direction])
+                 .task_search(params)
                  .page(params[:page])
                  .per(10)
   end

--- a/gotodo/app/controllers/tasks_controller.rb
+++ b/gotodo/app/controllers/tasks_controller.rb
@@ -43,7 +43,7 @@ class TasksController < ApplicationController
     @task.destroy
     redirect_back(
       fallback_location: root_path,
-      success: I18n.t('flash.destroy_success', model: I18n.t('activerecord.models.task'))
+      success: I18n.t('flash.destroy_success', model: I18n.t('activerecord.models.task')),
     )
   end
 

--- a/gotodo/app/controllers/users_controller.rb
+++ b/gotodo/app/controllers/users_controller.rb
@@ -43,8 +43,15 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    @user.destroy
-    redirect_to admin_users_path, success: I18n.t('flash.destroy_success', model: I18n.t('activerecord.models.user'))
+    if User.eager_load(:role).where(role: { name: 'admin' }).count > 1
+      if @user.destroy
+        redirect_to admin_users_path, success: I18n.t('flash.destroy_success', model: I18n.t('activerecord.models.user'))
+      else
+        flash.now[:danger] = I18n.t('flash.destroy_error', model: I18n.t('activerecord.models.user'))
+      end
+    else
+      redirect_to admin_users_path, danger: I18n.t('flash.destroy_cancel', model: I18n.t('activerecord.models.user'))
+    end
   end
 
   private

--- a/gotodo/app/controllers/users_controller.rb
+++ b/gotodo/app/controllers/users_controller.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[edit update destroy]
   before_action :login_check, except: %i[new create]
+  before_action :set_user, only: %i[show edit update destroy]
 
   def index
     @users = User.all
   end
 
   def show
-    @user = User.find(@current_user.id)
   end
 
   def new
@@ -32,7 +31,11 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to profile_path, success: I18n.t('flash.update_success', model: I18n.t('activerecord.models.user'))
+      if @user.id == @current_user.id
+        redirect_to profile_path, success: I18n.t('flash.update_success', model: I18n.t('activerecord.models.user'))
+      else
+        redirect_to user_path(@user), success: I18n.t('flash.update_success', model: I18n.t('activerecord.models.user'))
+      end
     else
       flash.now[:danger] = I18n.t('flash.update_error', model: I18n.t('activerecord.models.user'))
       render :edit
@@ -48,7 +51,7 @@ class UsersController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_user
-    @user = User.find(params[:id])
+    @user = params[:id] ? User.find(params[:id]) : @current_user
   end
 
   # Only allow a list of trusted parameters through.

--- a/gotodo/app/controllers/users_controller.rb
+++ b/gotodo/app/controllers/users_controller.rb
@@ -53,6 +53,6 @@ class UsersController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :role_id)
   end
 end

--- a/gotodo/app/models/role.rb
+++ b/gotodo/app/models/role.rb
@@ -1,0 +1,2 @@
+class Role < ApplicationRecord
+end

--- a/gotodo/app/models/role.rb
+++ b/gotodo/app/models/role.rb
@@ -1,2 +1,3 @@
 class Role < ApplicationRecord
+  has_many :users
 end

--- a/gotodo/app/models/role.rb
+++ b/gotodo/app/models/role.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
 class Role < ApplicationRecord
-  has_many :users
+  has_many :users, dependent: :destroy
+
+  def translated_name
+    I18n.t(name, scope: 'roles')
+  end
 end

--- a/gotodo/app/models/user.rb
+++ b/gotodo/app/models/user.rb
@@ -3,6 +3,7 @@
 class User < ApplicationRecord
   has_secure_password
 
+  belongs_to :role
   has_many :tasks, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 10 }

--- a/gotodo/app/views/admin/users/_user.html.erb
+++ b/gotodo/app/views/admin/users/_user.html.erb
@@ -2,7 +2,17 @@
   <td><%= user.name %></td>
   <td><%= user.email %></td>
   <td><%= link_to(user.count_all, admin_path(user)) %></td>
+  <td><%= I18n.t("roles.#{user.role.name}") %></td>
   <td><%= I18n.l(user.created_at) %></td>
   <td><%= I18n.l(user.updated_at) %></td>
-  <td><%= link_to(icon('fas', 'trash-alt'), user, { method: :delete, data: { confirm: I18n.t('confirms.delete') }, class: 'delete-link' }) %></td>
+  <td>
+    <%= link_to(icon('fas', 'edit'),
+                edit_user_path(user),
+                { class: 'edit-link' }) %>
+  </td>
+  <td>
+    <%= link_to(icon('fas', 'trash-alt'),
+                user,
+                { method: :delete, data: { confirm: I18n.t('confirms.delete') }, class: 'delete-link' }) %>
+  </td>
 </tr>

--- a/gotodo/app/views/admin/users/_user.html.erb
+++ b/gotodo/app/views/admin/users/_user.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= user.name %></td>
   <td><%= user.email %></td>
-  <td><%= link_to(user.count_all, admin_path(user)) %></td>
+  <td><%= link_to(user.count_all, tasks_admin_user_path(user)) %></td>
   <td><%= I18n.t("roles.#{user.role.name}") %></td>
   <td><%= I18n.l(user.created_at) %></td>
   <td><%= I18n.l(user.updated_at) %></td>

--- a/gotodo/app/views/admin/users/index.html.erb
+++ b/gotodo/app/views/admin/users/index.html.erb
@@ -4,8 +4,10 @@
       <th><%= sortable :name %></th>
       <th><%= sortable :email %></th>
       <th><%= sortable :tasks_count %></th>
+      <th><%= User.human_attribute_name(:role) %></th>
       <th><%= sortable :created_at %></th>
       <th><%= sortable :updated_at %></th>
+      <th></th>
       <th></th>
     </tr>
   </thead>

--- a/gotodo/app/views/tasks/index.html.erb
+++ b/gotodo/app/views/tasks/index.html.erb
@@ -53,8 +53,10 @@
 <br>
 <%= paginate @tasks %>
 <br>
-<div class="form-group d-flex">
-  <div class="ml-auto">
-    <%= link_to '管理画面', admin_users_path, { class: 'btn btn-outline-info' } %>
+<% if is_admin? %>
+  <div class="form-group d-flex">
+    <div class="ml-auto">
+      <%= link_to '管理画面', admin_users_path, { class: 'btn btn-outline-info' } %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/gotodo/app/views/tasks/index.html.erb
+++ b/gotodo/app/views/tasks/index.html.erb
@@ -53,7 +53,7 @@
 <br>
 <%= paginate @tasks %>
 <br>
-<% if is_admin? %>
+<% if admin? %>
   <div class="form-group d-flex">
     <div class="ml-auto">
       <%= link_to '管理画面', admin_users_path, { class: 'btn btn-outline-info' } %>

--- a/gotodo/app/views/users/_form.html.erb
+++ b/gotodo/app/views/users/_form.html.erb
@@ -45,7 +45,7 @@
 
   <% if controller.action_name == 'show' %>
     <%= link_to(icon('fas', 'arrow-alt-circle-left'), root_path, { class: 'back-link' }) %>
-    <%= link_to(icon('fas', 'edit'), edit_user_path(@user), { class: 'edit-link' }) if @user.id == @current_user.id %>
+    <%= @user.id == @current_user.id ? link_to(icon('fas', 'edit'), profile_edit_path, { class: 'edit-link' }) : link_to(icon('fas', 'edit'), edit_user_path(@user), { class: 'edit-link' }) %>
   <% elsif controller.action_name == 'new' %>
     <%= link_to(icon('fas', 'arrow-alt-circle-left'), login_path, { class: 'back-link' }) %>
   <% elsif controller.action_name == 'edit' %>

--- a/gotodo/app/views/users/_form.html.erb
+++ b/gotodo/app/views/users/_form.html.erb
@@ -18,6 +18,15 @@
                            { disabled: disabled, placeholder: User.human_attribute_name(:email), class: 'form-control' }
       %>
     </div>
+    <div class="form-group">
+      <%= form.collection_select :role_id,
+                                 Role.all.order('no desc'),
+                                 :id,
+                                 :translated_name,
+                                 {},
+                                 { disabled: disabled, class: 'form-control' }
+      %>
+    </div>
 
     <% unless disabled %>
       <div class="form-group">
@@ -35,11 +44,11 @@
   <% end %>
 
   <% if controller.action_name == 'show' %>
-    <%= link_to(icon('fas', 'arrow-alt-circle-left'), root_path, {class: 'back-link'}) %>
-    <%= link_to(icon('fas', 'edit'), edit_user_path(@user), {class: 'edit-link'}) if @user.id == @current_user.id %>
-    <% elsif controller.action_name == 'new' %>
-    <%= link_to(icon('fas', 'arrow-alt-circle-left'), login_path, {class: 'back-link'}) %>
+    <%= link_to(icon('fas', 'arrow-alt-circle-left'), root_path, { class: 'back-link' }) %>
+    <%= link_to(icon('fas', 'edit'), edit_user_path(@user), { class: 'edit-link' }) if @user.id == @current_user.id %>
+  <% elsif controller.action_name == 'new' %>
+    <%= link_to(icon('fas', 'arrow-alt-circle-left'), login_path, { class: 'back-link' }) %>
   <% elsif controller.action_name == 'edit' %>
-    <%= link_to(icon('fas', 'arrow-alt-circle-left'), profile_path, {class: 'back-link'}) %>
+    <%= link_to(icon('fas', 'arrow-alt-circle-left'), profile_path, { class: 'back-link' }) %>
   <% end %>
 </div>

--- a/gotodo/config/locales/ja.yml
+++ b/gotodo/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
         password: パスワード
         password_confirmation: パスワード（確認）
         tasks_count: タスク数
+        role: 権限
   errors:
     validation: '%{count}つの項目に不備が見つかりました。'
   helpers:

--- a/gotodo/config/locales/ja.yml
+++ b/gotodo/config/locales/ja.yml
@@ -14,7 +14,7 @@ ja:
         tasks_count: タスク数
         role: 権限
   errors:
-    validation: '%{count}つの項目に不備が見つかりました。'
+    validation: '%{count}つの項目に不備が見つかりました'
   helpers:
     submit:
       create: 登録する
@@ -33,8 +33,10 @@ ja:
     create_success: '新しい%{model}が登録されました！'
     update_success: '%{model}が更新されました！'
     destroy_success: '%{model}が削除されました！'
-    create_error: '%{model}の作成に失敗しました。'
-    update_error: '%{model}の更新に失敗しました。'
+    create_error: '%{model}の作成に失敗しました'
+    update_error: '%{model}の更新に失敗しました'
+    destroy_error: '%{model}の削除に失敗しました'
+    destroy_cancel: 'あなたは最後の%{model}なので削除できません'
     login_success: 'ようこそ、%{user}さん'
     login_error: ログインに失敗しました
     logout_success: ログアウトしました

--- a/gotodo/config/locales/views/users/ja.yml
+++ b/gotodo/config/locales/views/users/ja.yml
@@ -12,3 +12,7 @@ ja:
               blank: が空です
             password_confirmation:
               blank: もう一度入力してください
+
+  roles:
+    admin: 管理者
+    editor: 一般

--- a/gotodo/config/routes.rb
+++ b/gotodo/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :users, :tasks
   namespace :admin do
     get '/users', to: 'users#index'
+    post '/users/:id/edit', to: 'users#edit'
     get '/users/:id/tasks', to: 'tasks#index'
   end
   get '/profile', to: 'users#show'

--- a/gotodo/config/routes.rb
+++ b/gotodo/config/routes.rb
@@ -13,6 +13,5 @@ Rails.application.routes.draw do
     end
   end
   get '/profile', to: 'users#show'
-  post '/profile', to: 'users#create'
   get '/profile/edit', to: 'users#edit'
 end

--- a/gotodo/config/routes.rb
+++ b/gotodo/config/routes.rb
@@ -6,9 +6,13 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
   resources :users, :tasks
   namespace :admin do
-    get '/users', to: 'users#index'
-    post '/users/:id/edit', to: 'users#edit'
-    get '/users/:id/tasks', to: 'tasks#index'
+    resources :users, only: [:index] do
+      member do
+        get '/tasks', to: 'tasks#index'
+      end
+    end
   end
   get '/profile', to: 'users#show'
+  post '/profile', to: 'users#create'
+  get '/profile/edit', to: 'users#edit'
 end

--- a/gotodo/db/migrate/20210126004822_create_roles.rb
+++ b/gotodo/db/migrate/20210126004822_create_roles.rb
@@ -1,0 +1,9 @@
+class CreateRoles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :roles do |t|
+      t.string :name, limit: 10, null: false
+      t.integer :no, limit: 1, null: false
+      t.timestamps
+    end
+  end
+end

--- a/gotodo/db/migrate/20210126004948_add_role_id_to_users.rb
+++ b/gotodo/db/migrate/20210126004948_add_role_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleIdToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :users, :role, foreign_key: true, index: true
+  end
+end

--- a/gotodo/db/schema.rb
+++ b/gotodo/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_13_065449) do
+ActiveRecord::Schema.define(version: 2021_01_26_004948) do
+
+  create_table "roles", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.string "name", limit: 10, null: false
+    t.integer "no", limit: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "title", limit: 50, null: false
@@ -33,8 +40,11 @@ ActiveRecord::Schema.define(version: 2021_01_13_065449) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "role_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["role_id"], name: "index_users_on_role_id"
   end
 
   add_foreign_key "tasks", "users"
+  add_foreign_key "users", "roles"
 end

--- a/gotodo/db/seeds.rb
+++ b/gotodo/db/seeds.rb
@@ -7,3 +7,4 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 User.first_or_create(name: 'TEST', email: 'test@example.com', password: 'p@sw0rd', password_confirmation: 'p@sw0rd')
+Role.first_or_create([{ name: 'admin', no: 0 }, { name: 'editor', no: 1 }])

--- a/gotodo/db/seeds.rb
+++ b/gotodo/db/seeds.rb
@@ -6,5 +6,5 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.first_or_create(name: 'TEST', email: 'test@example.com', password: 'p@sw0rd', password_confirmation: 'p@sw0rd')
 Role.first_or_create([{ name: 'admin', no: 0 }, { name: 'editor', no: 1 }])
+User.first_or_create(name: 'TEST', email: 'test@example.com', password: 'p@sw0rd', password_confirmation: 'p@sw0rd', role_id: 1)

--- a/gotodo/spec/factories/roles.rb
+++ b/gotodo/spec/factories/roles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :role do
+    
+  end
+end

--- a/gotodo/spec/factories/roles.rb
+++ b/gotodo/spec/factories/roles.rb
@@ -1,5 +1,15 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
-  factory :role do
-    
+  factory :role, class: Role do
+    trait :admin do
+      name { 'admin' }
+      no { 0 }
+    end
+
+    trait :editor do
+      name { 'editor' }
+      no { 1 }
+    end
   end
 end

--- a/gotodo/spec/factories/tasks.rb
+++ b/gotodo/spec/factories/tasks.rb
@@ -11,16 +11,9 @@ FactoryBot.define do
 
   factory :task, class: Task do
     title { generate :title }
-    # title { 'タスク' }
     detail { 'テスト' }
     end_date { generate :end_date }
     status { 'doing' }
     user
   end
-
-  # 今後使いたいためメモとしてコメントアウト
-  # trait :done do
-  #   status { :done }
-  #   completion_date { Time.current.yesterday }
-  # end
 end

--- a/gotodo/spec/factories/users.rb
+++ b/gotodo/spec/factories/users.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :user do
+  factory :user, class: User do
     name { '太郎' }
     email { 'test@example.com' }
     password { 'password' }
     password_confirmation { 'password' }
+    role
   end
 end

--- a/gotodo/spec/models/role_spec.rb
+++ b/gotodo/spec/models/role_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Role, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/gotodo/spec/models/role_spec.rb
+++ b/gotodo/spec/models/role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Role, type: :model do

--- a/gotodo/spec/models/role_spec.rb
+++ b/gotodo/spec/models/role_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe Role, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/gotodo/spec/models/task_spec.rb
+++ b/gotodo/spec/models/task_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe Task, type: :model do
   end
 
   describe '検索機能' do
-    let!(:user) { FactoryBot.create(:user) }
+    let!(:admin_role) { FactoryBot.create(:role, :admin) }
+    let!(:user) { FactoryBot.create(:user, role: admin_role) }
     let!(:task1) { FactoryBot.create(:task, title: '買い物に行く', status: 'done', user: user) }
     let!(:task2) { FactoryBot.create(:task, title: '料理をする', status: 'doing', user: user) }
     let!(:task3) { FactoryBot.create(:task, title: '食べる', status: 'todo', user: user) }

--- a/gotodo/spec/models/user_spec.rb
+++ b/gotodo/spec/models/user_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  let!(:admin_role) { FactoryBot.create(:role, :admin) }
+
   describe 'string "name", limit: 10, null: false' do
-    let(:user) { FactoryBot.build_stubbed(:user, name: name) }
+    let(:user) { FactoryBot.build_stubbed(:user, name: name, role: admin_role) }
 
     context '0文字の場合' do
       let(:name) { 'a' * 0 }
@@ -35,8 +37,8 @@ RSpec.describe User, type: :model do
   end
 
   describe 'string "email", limit: 30, null: false, unique: true' do
-    let(:user1) { FactoryBot.create(:user, name: 'Taro', email: 'taro@example.com') }
-    let(:user2) { FactoryBot.build_stubbed(:user, name: 'Jiro', email: email) }
+    let(:user1) { FactoryBot.create(:user, name: 'Taro', email: 'taro@example.com', role: admin_role) }
+    let(:user2) { FactoryBot.build_stubbed(:user, name: 'Jiro', email: email, role: admin_role) }
 
     context 'メールアドレス形式の場合' do
       context '30文字の場合' do
@@ -86,7 +88,7 @@ RSpec.describe User, type: :model do
   end
 
   describe 'string "password_digest", null: false' do
-    let(:user) { FactoryBot.build_stubbed(:user, password: password, password_confirmation: password_confirmation) }
+    let(:user) { FactoryBot.build_stubbed(:user, password: password, password_confirmation: password_confirmation, role: admin_role) }
 
     context '0文字の場合' do
       let(:password) { 'a' * 0 }

--- a/gotodo/spec/system/admin_tasks_spec.rb
+++ b/gotodo/spec/system/admin_tasks_spec.rb
@@ -5,9 +5,10 @@ require 'pp'
 
 RSpec.describe 'AdminTasks', type: :system do
   let!(:admin_role) { FactoryBot.create(:role, :admin) }
+  let!(:editor_role) { FactoryBot.create(:role, :editor) }
   let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com', role: admin_role) }
-  let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', role: admin_role) }
-  let!(:task1) { FactoryBot.create(:task, user: user1) }
+  let!(:other_admin_user) { FactoryBot.create(:user, email: 'natori@example.com', role: admin_role) }
+  let!(:task1) { FactoryBot.create(:task, user: other_admin_user) }
   subject { page }
 
   before 'ログイン' do
@@ -17,13 +18,45 @@ RSpec.describe 'AdminTasks', type: :system do
     click_button 'ログイン'
   end
 
+  describe 'アクセス権' do
+    context 'ログイン状態の時' do
+      context 'admin権限の時' do
+        it 'admin/tasks#indexにアクセスできること' do
+          visit tasks_admin_user_path(other_admin_user)
+          is_expected.to have_current_path tasks_admin_user_path(other_admin_user)
+        end
+      end
+      context 'admin権限でない時' do
+        let!(:editor_user) { FactoryBot.create(:user, email: 'tanuma@example.com', role: editor_role) }
+        it 'admin/tasks#indexにアクセスできないこと' do
+          visit login_path
+          fill_in 'email', with: editor_user.email
+          fill_in 'password', with: editor_user.password
+          click_button 'ログイン'
+          visit tasks_admin_user_path(other_admin_user)
+          is_expected.to have_current_path login_path
+        end
+      end
+    end
+
+    context '未ログイン状態の時' do
+      before do
+        click_link nil, href: logout_path
+      end
+      it 'admin/tasks#indexにアクセスできないこと' do
+        visit tasks_admin_user_path(other_admin_user)
+        is_expected.to have_current_path login_path
+      end
+    end
+  end
+
   describe '#index [admin/users/*user_id*/tasks]' do
     describe '他人のタスクを編集する' do
       let(:edited_task) { { 'title' => '買い物に行く' } }
 
       it 'タスクが編集され、他人のタスクのままであること' do
         visit admin_users_path
-        click_link('1', { href: tasks_admin_user_path(user1) })
+        click_link('1', { href: tasks_admin_user_path(other_admin_user) })
         click_link(nil, { href: edit_task_path(task1), class: 'edit-link' })
 
         fill_in 'task[title]', with: edited_task['title']
@@ -34,7 +67,7 @@ RSpec.describe 'AdminTasks', type: :system do
         is_expected.to have_selector('.alert-success', text: 'タスクが更新されました！')
 
         visit admin_users_path
-        click_link('1', { href: tasks_admin_user_path(user1) })
+        click_link('1', { href: tasks_admin_user_path(other_admin_user) })
         is_expected.to have_content edited_task['title']
       end
     end
@@ -44,10 +77,10 @@ RSpec.describe 'AdminTasks', type: :system do
     describe '他人のタスクを削除する' do
       it '削除したタスクが表示されないこと' do
         visit admin_users_path
-        click_link('1', { href: tasks_admin_user_path(user1) })
+        click_link('1', { href: tasks_admin_user_path(other_admin_user) })
         click_link nil, href: task_path(task1), class: 'delete-link'
 
-        is_expected.to have_current_path tasks_admin_user_path(user1)
+        is_expected.to have_current_path tasks_admin_user_path(other_admin_user)
         is_expected.to have_selector('.alert-success', text: 'タスクが削除されました！')
         is_expected.to have_no_content task1.title
       end

--- a/gotodo/spec/system/admin_tasks_spec.rb
+++ b/gotodo/spec/system/admin_tasks_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 require 'pp'
 
 RSpec.describe 'AdminTasks', type: :system do
+  let!(:admin_role) { FactoryBot.create(:role, :admin) }
+  let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com', role: admin_role) }
+  let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', role: admin_role) }
+  let!(:task1) { FactoryBot.create(:task, user: user1) }
   subject { page }
 
   before 'ログイン' do
@@ -14,16 +18,12 @@ RSpec.describe 'AdminTasks', type: :system do
   end
 
   describe '#index [admin/users/*user_id*/tasks]' do
-    let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com') }
-    let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com') }
-    let!(:task1) { FactoryBot.create(:task, user: user1) }
-
     describe '他人のタスクを編集する' do
       let(:edited_task) { { 'title' => '買い物に行く' } }
 
       it 'タスクが編集され、他人のタスクのままであること' do
         visit admin_users_path
-        click_link('1', { href: admin_path(user1) })
+        click_link('1', { href: tasks_admin_user_path(user1) })
         click_link(nil, { href: edit_task_path(task1), class: 'edit-link' })
 
         fill_in 'task[title]', with: edited_task['title']
@@ -34,24 +34,20 @@ RSpec.describe 'AdminTasks', type: :system do
         is_expected.to have_selector('.alert-success', text: 'タスクが更新されました！')
 
         visit admin_users_path
-        click_link('1', { href: admin_path(user1) })
+        click_link('1', { href: tasks_admin_user_path(user1) })
         is_expected.to have_content edited_task['title']
       end
     end
   end
 
   describe '#destroy(task_id) [admin/users/*user_id*/tasks]' do
-    let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com') }
-    let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com') }
-    let!(:task1) { FactoryBot.create(:task, user: user1) }
-
     describe '他人のタスクを削除する' do
       it '削除したタスクが表示されないこと' do
         visit admin_users_path
-        click_link('1', { href: admin_path(user1) })
+        click_link('1', { href: tasks_admin_user_path(user1) })
         click_link nil, href: task_path(task1), class: 'delete-link'
 
-        is_expected.to have_current_path admin_path(user1)
+        is_expected.to have_current_path tasks_admin_user_path(user1)
         is_expected.to have_selector('.alert-success', text: 'タスクが削除されました！')
         is_expected.to have_no_content task1.title
       end

--- a/gotodo/spec/system/admin_users_spec.rb
+++ b/gotodo/spec/system/admin_users_spec.rb
@@ -18,9 +18,22 @@ RSpec.describe 'AdminUsers', type: :system do
 
   describe 'アクセス権' do
     context 'ログイン状態の時' do
-      it '#indexにアクセスできること' do
-        visit admin_users_path
-        is_expected.to have_current_path admin_users_path
+      context 'admin権限の時' do
+        it 'admin/users#indexにアクセスできること' do
+          visit admin_users_path
+          is_expected.to have_current_path admin_users_path
+        end
+      end
+      context 'admin権限でない時' do
+        let!(:editor_user) { FactoryBot.create(:user, email: 'tanuma@example.com', role: editor_role) }
+        it 'admin/users#indexにアクセスできないこと' do
+          visit login_path
+          fill_in 'email', with: editor_user.email
+          fill_in 'password', with: editor_user.password
+          click_button 'ログイン'
+          visit admin_users_path
+          is_expected.to have_current_path login_path
+        end
       end
     end
 
@@ -28,7 +41,7 @@ RSpec.describe 'AdminUsers', type: :system do
       before do
         click_link nil, href: logout_path
       end
-      it '#indexにアクセスできないこと' do
+      it 'admin/users#indexにアクセスできないこと' do
         visit admin_users_path
         is_expected.to have_current_path login_path
       end

--- a/gotodo/spec/system/admin_users_spec.rb
+++ b/gotodo/spec/system/admin_users_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 require 'pp'
 
 RSpec.describe 'AdminUsers', type: :system do
+  let!(:admin_role) { FactoryBot.create(:role, :admin) }
+  let!(:editor_role) { FactoryBot.create(:role, :editor) }
+  let!(:login_user) { FactoryBot.create(:user, name: '夏目', email: 'natsume@example.com', role: admin_role) }
   subject { page }
 
   before 'ログイン' do
@@ -14,8 +17,6 @@ RSpec.describe 'AdminUsers', type: :system do
   end
 
   describe 'アクセス権' do
-    let!(:login_user) { FactoryBot.create(:user) }
-
     context 'ログイン状態の時' do
       it '#indexにアクセスできること' do
         visit admin_users_path
@@ -45,7 +46,6 @@ RSpec.describe 'AdminUsers', type: :system do
     end
 
     describe '表示項目' do
-      let!(:login_user) { FactoryBot.create(:user, name: '夏目', email: 'natsume@example.com') }
       it '期待した項目が表示されること' do
         visit admin_users_path
         is_expected.to have_content login_user.name
@@ -57,16 +57,15 @@ RSpec.describe 'AdminUsers', type: :system do
 
     describe 'ソート機能' do
       describe 'ユーザ名' do
-        let!(:login_user) { FactoryBot.create(:user, name: '4夏目', email: 'natsume@example.com') }
-        let!(:user1) { FactoryBot.create(:user, name: '1田沼', email: 'tanuma@example.com') }
-        let!(:user2) { FactoryBot.create(:user, name: '2多軌', email: 'taki@example.com') }
-        let!(:user3) { FactoryBot.create(:user, name: '3ニャンコ先生', email: 'nyanko@example.com') }
+        let!(:other_user) { FactoryBot.create(:user, name: '1田沼', email: 'tanuma@example.com', role: editor_role) }
+        let!(:user2) { FactoryBot.create(:user, name: '2多軌', email: 'taki@example.com', role: editor_role) }
+        let!(:user3) { FactoryBot.create(:user, name: '3ニャンコ先生', email: 'nyanko@example.com', role: editor_role) }
         context '昇順' do
           before do
             visit admin_users_path
             click_link nil, id: 'name_asc'
           end
-          let(:expected_list) { [user1, user2, user3, login_user] }
+          let(:expected_list) { [other_user, user2, user3, login_user] }
           it_behaves_like '期待した順番で表示されること'
         end
         context '降順' do
@@ -74,16 +73,15 @@ RSpec.describe 'AdminUsers', type: :system do
             visit admin_users_path
             click_link nil, id: 'name_desc'
           end
-          let(:expected_list) { [login_user, user3, user2, user1] }
+          let(:expected_list) { [login_user, user3, user2, other_user] }
           it_behaves_like '期待した順番で表示されること'
         end
       end
 
       describe 'メールアドレス' do
-        let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com') }
-        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com') }
-        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com') }
-        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com') }
+        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', role: editor_role) }
+        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', role: editor_role) }
+        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com', role: editor_role) }
         context '昇順' do
           before do
             visit admin_users_path
@@ -103,10 +101,9 @@ RSpec.describe 'AdminUsers', type: :system do
       end
 
       describe 'タスク数' do
-        let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com') }
-        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com') }
-        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com') }
-        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com') }
+        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', role: editor_role) }
+        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', role: editor_role) }
+        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com', role: editor_role) }
         let!(:task1) { FactoryBot.create(:task, user: login_user) }
         let!(:task2) { FactoryBot.create(:task, user: user1) }
         let!(:task3) { FactoryBot.create(:task, user: user2) }
@@ -130,16 +127,15 @@ RSpec.describe 'AdminUsers', type: :system do
       end
 
       describe '作成日時' do
-        let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com', created_at: Time.current + 4.days) }
-        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', created_at: Time.current + 1.day) }
-        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', created_at: Time.current + 3.days) }
-        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com', created_at: Time.current + 2.days) }
+        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', created_at: Time.current + 1.day, role: editor_role) }
+        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', created_at: Time.current + 3.days, role: editor_role) }
+        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com', created_at: Time.current + 2.days, role: editor_role) }
         context '昇順' do
           before do
             visit admin_users_path
             click_link nil, id: 'created_at_asc'
           end
-          let(:expected_list) { [user1, user3, user2, login_user] }
+          let(:expected_list) { [login_user, user1, user3, user2] }
           it_behaves_like '期待した順番で表示されること'
         end
         context '降順' do
@@ -147,22 +143,21 @@ RSpec.describe 'AdminUsers', type: :system do
             visit admin_users_path
             click_link nil, id: 'created_at_desc'
           end
-          let(:expected_list) { [login_user, user2, user3, user1] }
+          let(:expected_list) { [user2, user3, user1, login_user] }
           it_behaves_like '期待した順番で表示されること'
         end
       end
 
       describe '更新日時' do
-        let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com', updated_at: Time.current + 4.days) }
-        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', updated_at: Time.current + 1.day) }
-        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', updated_at: Time.current + 3.days) }
-        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com', updated_at: Time.current + 2.days) }
+        let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com', updated_at: Time.current + 1.day, role: editor_role) }
+        let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', updated_at: Time.current + 3.days, role: editor_role) }
+        let!(:user3) { FactoryBot.create(:user, email: 'nyanko@example.com', updated_at: Time.current + 2.days, role: editor_role) }
         context '昇順' do
           before do
             visit admin_users_path
             click_link nil, id: 'updated_at_asc'
           end
-          let(:expected_list) { [user1, user3, user2, login_user] }
+          let(:expected_list) { [login_user, user1, user3, user2] }
           it_behaves_like '期待した順番で表示されること'
         end
         context '降順' do
@@ -170,28 +165,140 @@ RSpec.describe 'AdminUsers', type: :system do
             visit admin_users_path
             click_link nil, id: 'updated_at_desc'
           end
-          let(:expected_list) { [login_user, user2, user3, user1] }
+          let(:expected_list) { [user2, user3, user1, login_user] }
           it_behaves_like '期待した順番で表示されること'
         end
       end
     end
   end
 
+  describe 'users#edit(users_id) [/users/*users_id*/edit]' do
+    let!(:other_user) { FactoryBot.create(:user, email: 'tanuma@example.com', role: editor_role) }
+    let(:edited_user) {
+      {
+        'name' => '的場',
+        'email' => 'matoba@example.com',
+        'role' => admin_role,
+        'password' => 'matoba',
+      }
+    }
+
+    describe '自分の情報を更新する' do
+      before do
+        visit edit_user_path(other_user.id)
+      end
+
+      shared_examples 'ユーザ詳細画面に遷移すること' do
+        it do
+          is_expected.to have_current_path user_path(other_user)
+          is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+        end
+      end
+
+      context 'パスワードのみ更新する' do
+        before do
+          fill_in 'user[password]', with: edited_user['password']
+          fill_in 'user[password_confirmation]', with: edited_user['password']
+          click_button '更新する'
+        end
+
+        it_behaves_like 'ユーザ詳細画面に遷移すること'
+
+        it 'パスワード以外の情報が書き換わっていないこと' do
+          expect(find('#user_name').value).to eq other_user.name
+          expect(find('#user_email').value).to eq other_user.email
+          expect(find('#user_role_id').value.to_i).to eq other_user.role.id
+        end
+
+        it '元々のメールアドレスと更新したパスワードでログインできること' do
+          click_link nil, href: logout_path
+
+          is_expected.to have_current_path login_path
+          fill_in 'email', with: other_user.email
+          fill_in 'password', with: edited_user['password']
+          click_button 'ログイン'
+
+          is_expected.to have_current_path root_path
+          is_expected.to have_selector('.alert-success', text: "ようこそ、#{other_user.name}さん")
+        end
+      end
+
+      context 'パスワード以外を更新する' do
+        before do
+          fill_in 'user[name]', with: edited_user['name']
+          fill_in 'user[email]', with: edited_user['email']
+          find('#user_role_id').find("option[value=#{edited_user['role'].id}]").select_option
+          click_button '更新する'
+        end
+
+        it_behaves_like 'ユーザ詳細画面に遷移すること'
+
+        it '情報が更新されていること' do
+          expect(find('#user_name').value).to eq edited_user['name']
+          expect(find('#user_email').value).to eq edited_user['email']
+          expect(find('#user_role_id').value.to_i).to eq edited_user['role'].id
+        end
+
+        it '更新したメールアドレスと元々のパスワードでログインできること' do
+          click_link nil, href: logout_path
+
+          is_expected.to have_current_path login_path
+          fill_in 'email', with: edited_user['email']
+          fill_in 'password', with: other_user.password
+          click_button 'ログイン'
+
+          is_expected.to have_current_path root_path
+          is_expected.to have_selector('.alert-success', text: "ようこそ、#{edited_user['name']}さん")
+        end
+      end
+
+      context 'すべて更新する' do
+        before do
+          fill_in 'user[name]', with: edited_user['name']
+          fill_in 'user[email]', with: edited_user['email']
+          find('#user_role_id').find("option[value=#{edited_user['role'].id}]").select_option
+          fill_in 'user[password]', with: edited_user['password']
+          fill_in 'user[password_confirmation]', with: edited_user['password']
+          click_button '更新する'
+        end
+
+        it_behaves_like 'ユーザ詳細画面に遷移すること'
+
+        it '情報が更新されていること' do
+          expect(find('#user_name').value).to eq edited_user['name']
+          expect(find('#user_email').value).to eq edited_user['email']
+          expect(find('#user_role_id').value.to_i).to eq edited_user['role'].id
+        end
+
+        it '更新したメールアドレスとパスワードでログインできること' do
+          click_link nil, href: logout_path
+
+          is_expected.to have_current_path login_path
+          fill_in 'email', with: edited_user['email']
+          fill_in 'password', with: edited_user['password']
+          click_button 'ログイン'
+
+          is_expected.to have_current_path root_path
+          is_expected.to have_selector('.alert-success', text: "ようこそ、#{edited_user['name']}さん")
+        end
+      end
+    end
+  end
+
   describe '#destroy(user_id)' do
-    let!(:login_user) { FactoryBot.create(:user, email: 'natsume@example.com') }
-    let!(:user1) { FactoryBot.create(:user, email: 'tanuma@example.com') }
-    let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com') }
+    let!(:other_user) { FactoryBot.create(:user, email: 'tanuma@example.com', role: editor_role) }
+    let!(:user2) { FactoryBot.create(:user, email: 'taki@example.com', role: editor_role) }
     let!(:task1) { FactoryBot.create(:task, user: login_user) }
-    let!(:task2) { FactoryBot.create(:task, user: user1) }
+    let!(:task2) { FactoryBot.create(:task, user: other_user) }
     let!(:task3) { FactoryBot.create(:task, user: user2) }
     let!(:task4) { FactoryBot.create(:task, user: user2) }
 
     it '削除したユーザが表示されず、削除していないユーザが表示されること' do
       visit admin_users_path
-      click_link nil, href: user_path(user1), class: 'delete-link'
+      click_link nil, href: user_path(other_user), class: 'delete-link'
       is_expected.to have_current_path admin_users_path
       is_expected.to have_selector('.alert-success', text: 'ユーザが削除されました！')
-      is_expected.to have_no_content user1.email
+      is_expected.to have_no_content other_user.email
       is_expected.to have_content login_user.email
       is_expected.to have_content user2.email
     end

--- a/gotodo/spec/system/tasks_spec.rb
+++ b/gotodo/spec/system/tasks_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 require 'pp'
 
 RSpec.describe 'Tasks', type: :system do
-  let!(:login_user) { FactoryBot.create(:user, name: '夏目', email: 'natsume@example.com') }
-  let!(:other_user) { FactoryBot.create(:user, name: 'ニャンコ先生', email: 'nyanko@example.com') }
+  let!(:editor_role) { FactoryBot.create(:role, :editor) }
+  let!(:login_user) { FactoryBot.create(:user, name: '夏目', email: 'natsume@example.com', role: editor_role) }
+  let!(:other_user) { FactoryBot.create(:user, name: 'ニャンコ先生', email: 'nyanko@example.com', role: editor_role) }
   subject { page }
 
   before 'ログイン' do

--- a/gotodo/spec/system/users_spec.rb
+++ b/gotodo/spec/system/users_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 require 'pp'
 
 RSpec.describe 'Users', type: :system do
-  let!(:login_user) { FactoryBot.create(:user) }
+  let!(:admin_role) { FactoryBot.create(:role, :admin) }
+  let!(:editor_role) { FactoryBot.create(:role, :editor) }
+  let!(:login_user) { FactoryBot.create(:user, email: 'login@example.com', role: admin_role) }
   subject { page }
 
   before 'ログイン' do
@@ -43,7 +45,7 @@ RSpec.describe 'Users', type: :system do
       it '編集ボタンで編集画面に遷移すること' do
         visit profile_path
         click_link nil, class: 'edit-link'
-        is_expected.to have_current_path edit_user_path(login_user.id)
+        is_expected.to have_current_path profile_edit_path
       end
     end
   end
@@ -55,6 +57,7 @@ RSpec.describe 'Users', type: :system do
         'email' => 'nyanko@example.com',
         'password' => 'xxx',
         'password_confirmation' => 'xxx',
+        'role' => admin_role,
       }
     }
     before do
@@ -63,6 +66,7 @@ RSpec.describe 'Users', type: :system do
       fill_in 'user[email]', with: new_user['email']
       fill_in 'user[password]', with: new_user['password']
       fill_in 'user[password_confirmation]', with: new_user['password_confirmation']
+      find('#user_role_id').find("option[value=#{new_user['role'].id}]").select_option
       click_button '登録する'
     end
 
@@ -92,10 +96,12 @@ RSpec.describe 'Users', type: :system do
   describe '#edit(user_id)' do
     let(:edited_user) {
       {
-        'name' => '夏目',
-        'email' => 'natsume@example.com',
-        'password' => 'natsume',
-      } }
+        'name' => '的場',
+        'email' => 'matoba@example.com',
+        'password' => 'matoba',
+        'role' => admin_role,
+      }
+    }
 
     describe 'ページ遷移' do
       it '戻るボタンでプロフィール画面に遷移すること' do
@@ -105,95 +111,104 @@ RSpec.describe 'Users', type: :system do
       end
     end
 
-    context 'パスワードのみ更新する' do
+    describe '自分の情報を更新する' do
       before do
-        visit edit_user_path login_user.id
-        fill_in 'user[password]', with: edited_user['password']
-        fill_in 'user[password_confirmation]', with: edited_user['password']
-        click_button '更新する'
+        visit edit_user_path(login_user.id)
       end
 
-      it 'パスワード以外の情報が書き換わっていないこと' do
-        is_expected.to have_current_path profile_path
-        expect(find('#user_name').value).to eq login_user.name
-        expect(find('#user_email').value).to eq login_user.email
-        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+      shared_examples 'プロフィール画面に遷移すること' do
+        it do
+          is_expected.to have_current_path profile_path
+          is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+        end
       end
 
-      it '元々のメールアドレスと更新したパスワードでログインできること' do
-        is_expected.to have_current_path profile_path
-        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
-        click_link nil, href: logout_path
+      context 'パスワードのみ更新する' do
+        before do
+          fill_in 'user[password]', with: edited_user['password']
+          fill_in 'user[password_confirmation]', with: edited_user['password']
+          click_button '更新する'
+        end
 
-        is_expected.to have_current_path login_path
-        fill_in 'email', with: login_user.email
-        fill_in 'password', with: edited_user['password']
-        click_button 'ログイン'
+        it_behaves_like 'プロフィール画面に遷移すること'
 
-        is_expected.to have_current_path root_path
-        is_expected.to have_selector('.alert-success', text: "ようこそ、#{login_user.name}さん")
-      end
-    end
+        it 'パスワード以外の情報が書き換わっていないこと' do
+          expect(find('#user_name').value).to eq login_user.name
+          expect(find('#user_email').value).to eq login_user.email
+          expect(find('#user_role_id').value.to_i).to eq login_user.role.id
+        end
 
-    context 'パスワード以外を更新する' do
-      before do
-        visit edit_user_path login_user.id
-        fill_in 'user[name]', with: edited_user['name']
-        fill_in 'user[email]', with: edited_user['email']
-        click_button '更新する'
-      end
+        it '元々のメールアドレスと更新したパスワードでログインできること' do
+          click_link nil, href: logout_path
 
-      it '情報が更新されていること' do
-        is_expected.to have_current_path profile_path
-        expect(find('#user_name').value).to eq edited_user['name']
-        expect(find('#user_email').value).to eq edited_user['email']
-        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+          is_expected.to have_current_path login_path
+          fill_in 'email', with: login_user.email
+          fill_in 'password', with: edited_user['password']
+          click_button 'ログイン'
+
+          is_expected.to have_current_path root_path
+          is_expected.to have_selector('.alert-success', text: "ようこそ、#{login_user.name}さん")
+        end
       end
 
-      it '更新したメールアドレスと元々のパスワードでログインできること' do
-        is_expected.to have_current_path profile_path
-        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
-        click_link nil, href: logout_path
+      context 'パスワード以外を更新する' do
+        before do
+          fill_in 'user[name]', with: edited_user['name']
+          fill_in 'user[email]', with: edited_user['email']
+          find('#user_role_id').find("option[value=#{edited_user['role'].id}]").select_option
+          click_button '更新する'
+        end
 
-        is_expected.to have_current_path login_path
-        fill_in 'email', with: edited_user['email']
-        fill_in 'password', with: login_user.password
-        click_button 'ログイン'
+        it_behaves_like 'プロフィール画面に遷移すること'
 
-        is_expected.to have_current_path root_path
-        is_expected.to have_selector('.alert-success', text: "ようこそ、#{edited_user['name']}さん")
-      end
-    end
+        it '情報が更新されていること' do
+          expect(find('#user_name').value).to eq edited_user['name']
+          expect(find('#user_email').value).to eq edited_user['email']
+          expect(find('#user_role_id').value.to_i).to eq edited_user['role'].id
+        end
 
-    context 'すべて更新する' do
-      before do
-        visit edit_user_path login_user.id
-        fill_in 'user[name]', with: edited_user['name']
-        fill_in 'user[email]', with: edited_user['email']
-        fill_in 'user[password]', with: edited_user['password']
-        fill_in 'user[password_confirmation]', with: edited_user['password']
-        click_button '更新する'
-      end
+        it '更新したメールアドレスと元々のパスワードでログインできること' do
+          click_link nil, href: logout_path
 
-      it '情報が更新されていること' do
-        is_expected.to have_current_path profile_path
-        expect(find('#user_name').value).to eq edited_user['name']
-        expect(find('#user_email').value).to eq edited_user['email']
-        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
+          is_expected.to have_current_path login_path
+          fill_in 'email', with: edited_user['email']
+          fill_in 'password', with: login_user.password
+          click_button 'ログイン'
+
+          is_expected.to have_current_path root_path
+          is_expected.to have_selector('.alert-success', text: "ようこそ、#{edited_user['name']}さん")
+        end
       end
 
-      it '更新したメールアドレスとパスワードでログインできること' do
-        is_expected.to have_current_path profile_path
-        is_expected.to have_selector('.alert-success', text: 'ユーザが更新されました！')
-        click_link nil, href: logout_path
+      context 'すべて更新する' do
+        before do
+          fill_in 'user[name]', with: edited_user['name']
+          fill_in 'user[email]', with: edited_user['email']
+          find('#user_role_id').find("option[value=#{edited_user['role'].id}]").select_option
+          fill_in 'user[password]', with: edited_user['password']
+          fill_in 'user[password_confirmation]', with: edited_user['password']
+          click_button '更新する'
+        end
 
-        is_expected.to have_current_path login_path
-        fill_in 'email', with: edited_user['email']
-        fill_in 'password', with: edited_user['password']
-        click_button 'ログイン'
+        it_behaves_like 'プロフィール画面に遷移すること'
 
-        is_expected.to have_current_path root_path
-        is_expected.to have_selector('.alert-success', text: "ようこそ、#{edited_user['name']}さん")
+        it '情報が更新されていること' do
+          expect(find('#user_name').value).to eq edited_user['name']
+          expect(find('#user_email').value).to eq edited_user['email']
+          expect(find('#user_role_id').value.to_i).to eq edited_user['role'].id
+        end
+
+        it '更新したメールアドレスとパスワードでログインできること' do
+          click_link nil, href: logout_path
+
+          is_expected.to have_current_path login_path
+          fill_in 'email', with: edited_user['email']
+          fill_in 'password', with: edited_user['password']
+          click_button 'ログイン'
+
+          is_expected.to have_current_path root_path
+          is_expected.to have_selector('.alert-success', text: "ようこそ、#{edited_user['name']}さん")
+        end
       end
     end
   end


### PR DESCRIPTION
## 課題
- ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
- 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
- ユーザ管理画面でロールを選択できるようにしましょう
- 管理ユーザが1人もいなくならないように削除の制御をしましょう
- ※ Gemの使用・不使用は自由です


## 環境構築追加手順
```console
x@x:training/gotodo$ docker exec -it gotodo_web_1 bundle exec rails db:migrate
x@x:training/gotodo$ docker exec -it gotodo_web_1 bundle exec rails db:seed
```

## 実施事項
* roleテーブル・モデルを作成
* 権限によるアクセス制限機能を実装
* ユーザ作成、編集時に権限を選択できるよう修正
* 管理ユーザの削除制御機能を実装


## 確認事項
<details>
<summary>テスト</summary>

```spec
root@7e834b18d981:/myapp# bundle exec rspec spec/

Task
  string "title", limit: 50, null: false
    0文字の場合
      バリデーションを通過しないこと
    10文字の場合
      バリデーションを通過すること
    50文字の場合
      バリデーションを通過すること
    51文字の場合
      バリデーションを通過しないこと
  string "detail", limit: 200
    0文字の場合
      バリデーションを通過すること
    10文字の場合
      バリデーションを通過すること
    200文字の場合
      バリデーションを通過すること
    201文字の場合
      バリデーションを通過しないこと
  検索機能
    title
      検索条件を含むタスクが表示され、含まないタスクは表示されないこと
    status
      検索条件を含むタスクが表示され、含まないタスクは表示されないこと

User
  string "name", limit: 10, null: false
    0文字の場合
      バリデーションを通過しないこと
    1文字の場合
      バリデーションを通過すること
    10文字の場合
      バリデーションを通過すること
    11文字の場合
      バリデーションを通過しないこと
  string "email", limit: 30, null: false, unique: true
    メールアドレス形式の場合
      30文字の場合
        バリデーションを通過すること
      31文字の場合
        バリデーションを通過しないこと
      登録済みのメールアドレスの場合
        バリデーションを通過しないこと
    メールアドレス形式でない場合
      0文字の場合
        バリデーションを通過しないこと
      30文字の場合
        バリデーションを通過しないこと
      31文字の場合
        バリデーションを通過しないこと
  string "password_digest", null: false
    0文字の場合
      バリデーションを通過しないこと
    再確認用のパスワードと一致しない場合
      バリデーションを通過しないこと
    再確認用のパスワードと一致する場合
      バリデーションを通過すること

AdminTasks
  アクセス権
    ログイン状態の時
      admin権限の時
        admin/tasks#indexにアクセスできること
      admin権限でない時
        admin/tasks#indexにアクセスできないこと
    未ログイン状態の時
      admin/tasks#indexにアクセスできないこと
  #index [admin/users/*user_id*/tasks]
    他人のタスクを編集する
      タスクが編集され、他人のタスクのままであること
  #destroy(task_id) [admin/users/*user_id*/tasks]
    他人のタスクを削除する
      削除したタスクが表示されないこと

AdminUsers
  アクセス権
    ログイン状態の時
      admin権限の時
        admin/users#indexにアクセスできること
      admin権限でない時
        admin/users#indexにアクセスできないこと
    未ログイン状態の時
      admin/users#indexにアクセスできないこと
  #index (/admin/users)
    表示項目
      期待した項目が表示されること
    ソート機能
      ユーザ名
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "natsume@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "tanuma@example.com"
      メールアドレス
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "tanuma@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "natsume@example.com"
      タスク数
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "taki@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "nyanko@example.com"
      作成日時
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "taki@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "natsume@example.com"
      更新日時
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "taki@example.com"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "natsume@example.com"
  users#edit(users_id) [/users/*users_id*/edit]
    自分の情報を更新する
      パスワードのみ更新する
        パスワード以外の情報が書き換わっていないこと
        元々のメールアドレスと更新したパスワードでログインできること
        behaves like ユーザ詳細画面に遷移すること
          is expected to have visible css ".alert-success" with text "ユーザが更新されました！"
      パスワード以外を更新する
        情報が更新されていること
        更新したメールアドレスと元々のパスワードでログインできること
        behaves like ユーザ詳細画面に遷移すること
          is expected to have visible css ".alert-success" with text "ユーザが更新されました！"
      すべて更新する
        情報が更新されていること
        更新したメールアドレスとパスワードでログインできること
        behaves like ユーザ詳細画面に遷移すること
          is expected to have visible css ".alert-success" with text "ユーザが更新されました！"
  #destroy(user_id)
    adminユーザの削除
      adminユーザが2人の時
        削除したユーザが表示されず、削除していないユーザが表示されること
      自分自身を削除した時
        adminユーザが2人の時
          ログイン画面に遷移すること
        adminユーザが1人の時
          ユーザが削除されないこと
    関連タスクの削除
      ユーザを削除すると、関連したタスクも削除されること

Tasks
  アクセス権
    ログイン状態の時
      #indexにアクセスできること
      #show(task_id)にアクセスできること
      #edit(task_id)にアクセスできること
      #newにアクセスできること
    未ログイン状態の時
      #indexにアクセスできないこと
      #show(task_id)にアクセスできないこと
      #edit(task_id)にアクセスできないこと
      #newにアクセスできないこと
  #index
    表示項目
      期待した項目が表示されること
    ログイン機能
      ログインユーザのタスクのみが表示されること
    ソート機能
      タスク名
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "え　洗濯する"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "あ　料理をする"
      作成日時
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク35"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク36"
      終了期限
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク43"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク45"
      ステータス
        昇順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク48"
        降順
          behaves like 期待した順番で表示されること
            is expected to eq "タスク54"
    検索機能
      タスク名を指定
        behaves like 期待した順番で表示されること
          is expected to eq "あ　料理をする"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "え　洗濯する"
      ステータスを指定
        behaves like 期待した順番で表示されること
          is expected to eq "う　買い物に行く"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "い　食べる"
      タスク名とステータスを指定
        behaves like 期待した順番で表示されること
          is expected to eq "え　洗濯する"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "い　食べる"
    検索機能 & ソート機能
      behaves like 期待した順番で表示されること
        is expected to eq "え　洗濯する"
      behaves like 期待しないタスクが表示されないこと
        is expected not to have text "う　買い物に行く"
    ページネーション機能
      1ページ目
        behaves like 期待した順番で表示されること
          is expected to eq "タスク58"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "タスク68"
      2ページ目
        behaves like 期待した順番で表示されること
          is expected to eq "タスク80"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "タスク94"
    検索機能 & ソート機能 & ページネーション機能
      1ページ目
        behaves like 期待した順番で表示されること
          is expected to eq "task12!"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "task10"
      2ページ目
        behaves like 期待した順番で表示されること
          is expected to eq "task14!"
        behaves like 期待しないタスクが表示されないこと
          is expected not to have text "task10"
  #show(task_id)
    期待したタスクが表示されること
    ページ遷移
      戻るボタンでトップ画面に遷移すること
  #edit(task_id)
    期待したタスクが表示されること
    ページ遷移
      戻るボタンでトップ画面に遷移すること
  #new
    期待したタスクが表示されること
    ページ遷移
      戻るボタンでトップ画面に遷移すること
  #destroy(task_id)
    削除した登録済みタスクが表示されないこと

Users
  アクセス権
    ログイン状態の時
      #newにアクセスできること
    未ログイン状態の時
      #newにアクセスできること
  #show(user_id)
    ページ遷移
      戻るボタンでトップ画面に遷移すること
      編集ボタンで編集画面に遷移すること
  #new
    新規作成したユーザでログインできること
    ページ遷移
      戻るボタンでログイン画面に遷移すること
  #edit(user_id)
    ページ遷移
      戻るボタンでプロフィール画面に遷移すること
    自分の情報を更新する
      パスワードのみ更新する
        パスワード以外の情報が書き換わっていないこと
        元々のメールアドレスと更新したパスワードでログインできること
        behaves like プロフィール画面に遷移すること
          is expected to have visible css ".alert-success" with text "ユーザが更新されました！"
      パスワード以外を更新する
        情報が更新されていること
        更新したメールアドレスと元々のパスワードでログインできること
        behaves like プロフィール画面に遷移すること
          is expected to have visible css ".alert-success" with text "ユーザが更新されました！"
      すべて更新する
        情報が更新されていること
        更新したメールアドレスとパスワードでログインできること
        behaves like プロフィール画面に遷移すること
          is expected to have visible css ".alert-success" with text "ユーザが更新されました！"

Finished in 55.28 seconds (files took 5.41 seconds to load)
112 examples, 0 failures
```
</details>