### PR TITLE
ステップ14: メンテナンス機能を作ろう

### DIFF
--- a/minimini/app/controllers/application_controller.rb
+++ b/minimini/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  
+  before_action :render_503, if: :maintenance_mode?
   helper_method :current_user, :is_logged_in?
 
   rescue_from StandardError, with: :render_500
@@ -15,6 +15,14 @@ class ApplicationController < ActionController::Base
     render file: Rails.root.join('public/404.html'), status: 500, layout: false, content_type: 'text/html'
   end
 
+  def maintenance_mode?
+    File.exist?('tmp/maintenance.txt')
+  end
+
+  def render_503
+    render file: Rails.root.join('public/503.html'), status: 500, layout: false, content_type: 'text/html'
+  end
+  
   include SessionsHelper
 
   private

--- a/minimini/app/controllers/application_controller.rb
+++ b/minimini/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  
+
+  before_action :render_503, if: :is_maintenance_mode?
+
   helper_method :current_user, :is_logged_in?
 
   rescue_from StandardError, with: :render_500
@@ -13,6 +15,15 @@ class ApplicationController < ActionController::Base
 
   def render_500
     render file: Rails.root.join('public/404.html'), status: 500, layout: false, content_type: 'text/html'
+  end
+
+  def render_503
+    render file: Rails.root.join('public/503.html'), status: 503, layout: false, content_type: 'text/html'
+  end
+
+  def is_maintenance_mode?
+    # DBあり、DBなしメンテナンス
+    File.exist?('tmp/maintenance.txt') || MaintenanceSchedule.has_scheduled_maintenance?
   end
 
   private

--- a/minimini/app/controllers/tasks_controller.rb
+++ b/minimini/app/controllers/tasks_controller.rb
@@ -49,7 +49,6 @@ class TasksController < ApplicationController
     # ホワイトリスト
     def task_params
       params.require(:task).permit(
-        :user_id,
         :id,
         :name,
         :description,

--- a/minimini/app/models/maintenance_schedule.rb
+++ b/minimini/app/models/maintenance_schedule.rb
@@ -1,2 +1,12 @@
 class MaintenanceSchedule < ApplicationRecord
+  with_options presence: true do
+    validates :reason
+    validates :start_time
+    validates :end_time
+  end
+
+  def self.has_scheduled_maintenance?
+    now = Time.zone.now
+    MaintenanceSchedule.where('start_time <= ? and end_time >= ?', now, now).any?
+  end
 end

--- a/minimini/db/migrate/20210420071240_add_start_time_to_maintenance_schedules.rb
+++ b/minimini/db/migrate/20210420071240_add_start_time_to_maintenance_schedules.rb
@@ -1,0 +1,7 @@
+class AddStartTimeToMaintenanceSchedules < ActiveRecord::Migration[6.1]
+  def change
+    add_column :maintenance_schedules, :reason, :string
+    add_column :maintenance_schedules, :start_time, :datetime
+    add_column :maintenance_schedules, :end_time, :datetime
+  end
+end

--- a/minimini/db/schema.rb
+++ b/minimini/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_19_144409) do
+ActiveRecord::Schema.define(version: 2021_04_20_071240) do
 
   create_table "labels", charset: "utf8mb4", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
@@ -18,6 +18,9 @@ ActiveRecord::Schema.define(version: 2021_04_19_144409) do
   end
 
   create_table "maintenance_schedules", charset: "utf8mb4", force: :cascade do |t|
+    t.string "reason"
+    t.datetime "start_time"
+    t.datetime "end_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -31,6 +34,7 @@ ActiveRecord::Schema.define(version: 2021_04_19_144409) do
     t.date "due_date", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", charset: "utf8mb4", force: :cascade do |t|

--- a/minimini/lib/tasks/maintenance.rake
+++ b/minimini/lib/tasks/maintenance.rake
@@ -5,7 +5,7 @@ namespace :maintenance do
 
   task :on do
     unless File.exist?(MANINTENANCE_FILE)
-      File.open(MANINTENANCE_FILE, 'w') { |f| f.write "#{Time.now}"}
+      File.open(MANINTENANCE_FILE, 'w') { |f| f.write "#{Time.current}"}
       puts 'maintenance mode is on' 
     else
       puts 'maintenance mode is already on' 

--- a/minimini/lib/tasks/maintenance.rake
+++ b/minimini/lib/tasks/maintenance.rake
@@ -1,0 +1,23 @@
+namespace :maintenance do
+  MANINTENANCE_FILE = 'tmp/maintenance.txt'
+
+  desc 'maintenance mode on/off'
+
+  task :on do
+    unless File.exist?(MANINTENANCE_FILE)
+      File.open(MANINTENANCE_FILE, 'w') { |f| f.write "#{Time.now}"}
+      puts 'maintenance mode is on' 
+    else
+      puts 'maintenance mode is already on' 
+    end
+  end
+
+  task :off do
+    if File.exist?(MANINTENANCE_FILE)
+      puts 'maintenance mode is off'
+      File.delete(MANINTENANCE_FILE)
+    else
+      puts 'no available maintenance'
+    end
+  end
+end

--- a/minimini/public/503.html
+++ b/minimini/public/503.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, but something went wrong (500)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body class="rails-default-error-page">
+  <!-- This file lives in public/503.html -->
+  <div class="dialog">
+    <div>
+      <h1>メンテナンスのお知らせ</h1>
+    </div>
+    <p>現在、システムの不具合のため、緊急メンテナンスを行っております。
+    </p>
+  </div>
+</body>
+</html>

--- a/minimini/spec/controller/sessions_controller_spec.rb
+++ b/minimini/spec/controller/sessions_controller_spec.rb
@@ -34,9 +34,15 @@ RSpec.describe SessionsController, type: :controller do
     expect(response).to redirect_to(login_path)
   end
 
-  it 'render the maintenance page after maintenance' do
+  it 'render the maintenance page during maintenance' do
     create(:maintenance_schedule)
     get :new
     expect(response.status).to eq 503
+  end
+
+  it 'render the login page after maintenance' do
+    create(:maintenance_schedule, :maintenance_schedule_over)
+    get :new
+    expect(response).to render_template(:new)
   end
 end

--- a/minimini/spec/controller/sessions_controller_spec.rb
+++ b/minimini/spec/controller/sessions_controller_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe SessionsController, type: :controller do
     expect(response.status).to eq 302
     expect(response).to redirect_to(login_path)
   end
+
+  it 'render the maintenance page after maintenance' do
+    create(:maintenance_schedule)
+    get :new
+    expect(response.status).to eq 503
+  end
 end

--- a/minimini/spec/factories/maintenance_schedules.rb
+++ b/minimini/spec/factories/maintenance_schedules.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :maintenance_schedule do
+    id         { 1000 }
+    reason     { "進行中-定期メンテナンス" }
+    start_time { Time.zone.now.ago(30.minutes) }
+    end_time   { Time.zone.now.since(10.minutes) }
+    created_at { Time.zone.now }
+    updated_at { Time.zone.now }
+  end
+end

--- a/minimini/spec/factories/maintenance_schedules.rb
+++ b/minimini/spec/factories/maintenance_schedules.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     end_time   { Time.zone.now.since(10.minutes) }
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
+
+    trait :maintenance_schedule_over do
+      end_time   { Time.zone.now.ago(1.minutes) }
+    end
   end
 end

--- a/minimini/spec/models/maintenance_schedule_spec.rb
+++ b/minimini/spec/models/maintenance_schedule_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe MaintenanceSchedule, type: :model do
+  before(:each) do
+    @maintenance_schedule = FactoryBot.build(:maintenance_schedule)
+  end
+
+  it 'is valid with reason, start_time, end_time' do
+    expect(@maintenance_schedule).to be_valid
+  end
+
+  it 'is invalid without a reason' do
+    @maintenance_schedule.reason = nil
+    expect(@maintenance_schedule).to be_invalid
+    expect(@maintenance_schedule.errors[:reason]).to include(I18n.t('errors.messages.blank'))
+  end
+
+  it 'is invalid without a start_time' do
+    @maintenance_schedule.start_time = nil
+    expect(@maintenance_schedule).to be_invalid
+    expect(@maintenance_schedule.errors[:start_time]).to include(I18n.t('errors.messages.blank'))
+  end
+
+  it 'is invalid without a end_time' do
+    @maintenance_schedule.end_time = nil
+    expect(@maintenance_schedule).to be_invalid
+    expect(@maintenance_schedule.errors[:end_time]).to include(I18n.t('errors.messages.blank'))
+  end
+end


### PR DESCRIPTION
1.実装内容
ステップ14: メンテナンス機能を作ろう
  メンテナンスを開始／終了するバッチを作ってみましょう
  メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう

2.テスト方法
DBを使わないメンテナンス
  rake maintenance:on
  rake maintenance:off
DBを使うメンテナンス
  maintenance_schedulesに有効なレコード追加

* 今回のPull Requestではメンテナンスの管理機能はスコープ外です。