### PR TITLE
ステップ10: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/minimini/app/controllers/tasks_controller.rb
+++ b/minimini/app/controllers/tasks_controller.rb
@@ -37,7 +37,7 @@ class TasksController < ApplicationController
     @search_param = SearchParam.new(user_search_param)
     # デフォルト値
     @search_param.status ||= "#{Task.statuses[:not_selected]}"
-    @search_param.sort_order ||= "#{Task.statuses[:asc]}"
+    @search_param.sort_order ||= "#{Task.sort_orders[:asc]}"
     @tasks = Task.search(@search_param, session[:current_user_id])
   end
 

--- a/minimini/app/controllers/tasks_controller.rb
+++ b/minimini/app/controllers/tasks_controller.rb
@@ -36,8 +36,8 @@ class TasksController < ApplicationController
   def index
     @search_param = SearchParam.new(user_search_param)
     # デフォルト値
-    @search_param.status ||= "-1"
-    @search_param.sort_order ||= "ASC"
+    @search_param.status ||= "#{Task.statuses[:not_selected]}"
+    @search_param.sort_order ||= "#{Task.statuses[:asc]}"
     @tasks = Task.search(@search_param, session[:current_user_id])
   end
 

--- a/minimini/app/controllers/tasks_controller.rb
+++ b/minimini/app/controllers/tasks_controller.rb
@@ -35,7 +35,10 @@ class TasksController < ApplicationController
 
   def index
     @search_param = SearchParam.new(user_search_param)
-    @tasks = Task.search(user_search_param, session[:current_user_id])
+    # デフォルト値
+    @search_param.status ||= "-1"
+    @search_param.sort_order ||= "ASC"
+    @tasks = Task.search(@search_param, session[:current_user_id])
   end
 
   private

--- a/minimini/app/controllers/tasks_controller.rb
+++ b/minimini/app/controllers/tasks_controller.rb
@@ -34,19 +34,15 @@ class TasksController < ApplicationController
   end
 
   def index
-    # 検索用
-    @task = Task.new
-    # 検索結果
-    @tasks = Task.preload(:user).where(user_id: session[:current_user_id])
+    @search_param = SearchParam.new(user_search_param)
+    @tasks = Task.search(user_search_param, session[:current_user_id])
   end
 
   private
-    # コールバック
     def set_task
       @task = current_user.tasks.find(params[:id])
     end
 
-    # ホワイトリスト
     def task_params
       params.require(:task).permit(
         :name,
@@ -55,5 +51,9 @@ class TasksController < ApplicationController
         :status,
         :due_date
       )
+    end
+
+    def user_search_param
+      params.fetch(:search, {}).permit(:status, :sort_order)
     end
 end

--- a/minimini/app/models/search_param.rb
+++ b/minimini/app/models/search_param.rb
@@ -1,0 +1,5 @@
+class SearchParam
+  include ActiveModel::Model
+  
+  attr_accessor :status, :sort_order
+end

--- a/minimini/app/models/task.rb
+++ b/minimini/app/models/task.rb
@@ -26,16 +26,16 @@ class Task < ApplicationRecord
     unless search_params.blank?
       sort_order = Task.human_attribute_enum_value(
         :sort_order,
-        search_params[:sort_order]).upcase
+        search_params.sort_order).upcase
 
         # ステータースが「選択なし」
-        if search_params[:status] == "-1"
+        if search_params.status == "-1"
           @tasks = Task.preload(:user).where(
             user_id: current_user_id).order(id: sort_order)
         else 
           @tasks = Task.preload(:user).where(
             user_id: current_user_id,
-            status: search_params[:status]).order(id: sort_order)
+            status: search_params.status).order(id: sort_order)
         end
     else
       @tasks = Task.preload(:user).where(user_id: current_user_id)

--- a/minimini/app/models/task.rb
+++ b/minimini/app/models/task.rb
@@ -9,7 +9,7 @@ class Task < ApplicationRecord
     not_selected: 1,
     not_started: 2,
     in_progress: 3,
-    completed: 3,
+    completed: 4,
   }
   enum labels: {
     very_important: 1,

--- a/minimini/app/models/task.rb
+++ b/minimini/app/models/task.rb
@@ -6,19 +6,19 @@ class Task < ApplicationRecord
   end
 
   enum status: {
-    'not_selected': -1,
-    'not_started': 0,
-    'in_progress': 1,
-    'completed': 2
+    not_selected: 1,
+    not_started: 2,
+    in_progress: 3,
+    completed: 3
   }
   enum labels: {
-    'very_important': "1",
-    'important': "2",
-    'urgent': "3",
-    'normal': "4"
+    very_important: 1,
+    important: 2,
+    urgent: 3,
+    normal: 4
   }
 
-  enum sort_order: { 'asc': "ASC", 'desc': "DESC" }, _default: :desc
+  enum sort_order: { asc: "ASC", desc: "DESC" }, _default: :desc
 
   belongs_to :user
 

--- a/minimini/app/models/task.rb
+++ b/minimini/app/models/task.rb
@@ -12,10 +12,10 @@ class Task < ApplicationRecord
     completed: 4,
   }
   enum labels: {
-    very_important: 1,
-    important: 2,
-    urgent: 3,
-    normal: 4,
+    very_important: "1",
+    important: "2",
+    urgent: "3",
+    normal: "4",
   }
 
   enum sort_order: { asc: "ASC", desc: "DESC" }, _default: :desc

--- a/minimini/app/models/task.rb
+++ b/minimini/app/models/task.rb
@@ -29,7 +29,7 @@ class Task < ApplicationRecord
         search_params.sort_order).upcase
 
         # ステータースが「選択なし」
-        if search_params.status == "-1"
+        if search_params.status == "#{Task.statuses[:not_selected]}"
           @tasks = Task.preload(:user).where(
             user_id: current_user_id).order(id: sort_order)
         else 

--- a/minimini/app/models/task.rb
+++ b/minimini/app/models/task.rb
@@ -9,13 +9,13 @@ class Task < ApplicationRecord
     not_selected: 1,
     not_started: 2,
     in_progress: 3,
-    completed: 3
+    completed: 3,
   }
   enum labels: {
     very_important: 1,
     important: 2,
     urgent: 3,
-    normal: 4
+    normal: 4,
   }
 
   enum sort_order: { asc: "ASC", desc: "DESC" }, _default: :desc

--- a/minimini/app/models/task.rb
+++ b/minimini/app/models/task.rb
@@ -1,17 +1,44 @@
 class Task < ApplicationRecord
-    with_options presence: true do
-      validates :name
-      validates :description
-      validates :due_date
-    end
-    
-    enum status: { '未着手': 0, '着手中': 1, '完了': 2 }
-    enum labels: { 
-        'A: 重要度高': "1",
-        'B: 重要度低': "2",
-        'C: 緊急度高': "3",
-        'D: 緊急度低': "4"
-    }
+  with_options presence: true do
+    validates :name
+    validates :description
+    validates :due_date
+  end
 
-    belongs_to :user
+  enum status: {
+    'not_selected': -1,
+    'not_started': 0,
+    'in_progress': 1,
+    'completed': 2
+  }
+  enum labels: {
+    'very_important': "1",
+    'important': "2",
+    'urgent': "3",
+    'normal': "4"
+  }
+
+  enum sort_order: { 'asc': "ASC", 'desc': "DESC" }, _default: :desc
+
+  belongs_to :user
+
+  def self.search(search_params, current_user_id)
+    unless search_params.blank?
+      sort_order = Task.human_attribute_enum_value(
+        :sort_order,
+        search_params[:sort_order]).upcase
+
+        # ステータースが「選択なし」
+        if search_params[:status] == "-1"
+          @tasks = Task.preload(:user).where(
+            user_id: current_user_id).order(id: sort_order)
+        else 
+          @tasks = Task.preload(:user).where(
+            user_id: current_user_id,
+            status: search_params[:status]).order(id: sort_order)
+        end
+    else
+      @tasks = Task.preload(:user).where(user_id: current_user_id)
+    end
+  end
 end

--- a/minimini/app/views/tasks/edit.erb
+++ b/minimini/app/views/tasks/edit.erb
@@ -27,11 +27,11 @@
         </tr>
         <tr>
             <th width="150"><%= I18n.t('task.status') %></th>
-            <td width="400"><%= form.select :status, Task.statuses.map {|k, _| [Task.human_attribute_enum_value(:status, k), k] }.to_h, selected: @task.status %></td>
+            <td width="400"><%= form.select :status, Task.statuses.map {|k, _| [Task.human_attribute_enum_value(:statuses, k), k] }.to_h, selected: @task.status %></td>
         </tr>
         <tr>
             <th width="150"><%= I18n.t('task.label') %></th>
-            <td width="400"><%= form.select :labels, Task.labels.map {|k, _| [Task.human_attribute_enum_value(:label, k), k] }.to_h, selected: @task.labels %></td>
+            <td width="400"><%= form.select :labels, Task.labels.map {|k, _| [Task.human_attribute_enum_value(:labels, k), k] }.to_h, selected: @task.labels %></td>
         </tr>
         <tr>
             <th width="150"><%= I18n.t('task.due_date') %></th>

--- a/minimini/app/views/tasks/index.html.erb
+++ b/minimini/app/views/tasks/index.html.erb
@@ -4,7 +4,7 @@
     <%= content_tag(:div, value, :class => "flash #{key}") %>
   <% end %>
 </div>
-<% if @task.errors.any? %>
+<% if @task&.errors&.any? %>
   <div id="error_explanation">
     <h2><%= pluralize(@task.errors.count, "error") %></h2>
     <ul>
@@ -20,6 +20,14 @@
 <%= link_to I18n.t('task.title.login'), login_path %>
 <br>
 <%= link_to I18n.t('task.title.logout'), logout_path, method: 'delete' %>
+<%= form_with scope: :search, url: search_path, method: :get do |form| %>
+    <%= I18n.t('task.status') %>
+    <%= form.select :status, Task.statuses.map {|k, v| [Task.human_attribute_enum_value(:statuses, k), v] }.to_h, selected: @search_param.status %>
+    <%= form.select :sort_order, Task.sort_orders.map {|k, v| [Task.human_attribute_enum_value(:sort_orders, k), v] }.to_h, selected: @search_param.sort_order %>
+    <%= submit_tag(I18n.t('task.button.search'), name: nil) %>
+</div>
+<% end %>
+<br>
 <table border=2>
     <thead>
         <tr>
@@ -41,8 +49,8 @@
             <td><%= task.id %></td>
             <td><%= task.name %></td>
             <td><%= task.description %></td>
-            <td><%= task.status %></td>
-            <td><%= task.labels %></td>
+            <td><%= Task.human_attribute_enum_value(:statuses, task.status) %></td>
+            <td><%= Task.human_attribute_enum_value(:labels, task.labels) %></td>
             <td><%= task.due_date %></td>
             <td><%= task.created_at.strftime('%Y-%m-%d %H:%M:%S') %></td>
             <td><%= task.user.name %></td>

--- a/minimini/app/views/tasks/new.html.erb
+++ b/minimini/app/views/tasks/new.html.erb
@@ -27,7 +27,7 @@
         </tr>
         <tr>
             <th width="120"><%= I18n.t('task.status') %></th>
-            <td width="400"><%= form.select :status, Task.statuses.map {|k, _| [Task.human_attribute_enum_value(:status, k), k] }.to_h, selected: @task.status %></td>
+            <td width="400"><%= form.select :status, Task.statuses.map {|k, _| [Task.human_attribute_enum_value(:statuses, k), k] }.to_h, selected: @task.status %></td>
         </tr>
         <tr>
             <th width="120"><%= I18n.t('task.label') %></th>

--- a/minimini/config/locales/view/list/ja.yml
+++ b/minimini/config/locales/view/list/ja.yml
@@ -106,3 +106,4 @@ ja:
               too_long: "最大%{count}文字まで使えます"
             description:
               too_long: "最大%{count}文字まで使えます"
+

--- a/minimini/config/locales/view/list/ja.yml
+++ b/minimini/config/locales/view/list/ja.yml
@@ -50,11 +50,13 @@ ja:
       login: 'ログイン'
       logout: 'ログアウト'
     button:
+      search: '検索'
       create: '登録'
       update: '更新'
       delete: '削除'
     confirm:
       delete: 'ID:%{id}を削除します'
+    sort: ソート順
   flash:
     create: 作成しました！
     updated: 更新しました！
@@ -77,18 +79,25 @@ ja:
         id: 'ID'
         name: 'タスク名'
         description: 'タスク内容'
-        status:
-          0: '未着手1'
-          1: '着手中2'
-          2: '完了3'
-        labels:
-          'A: 重要度高': "1"
-          'B: 重要度低': "2"
-          'C: 緊急度高': "3"
-          'D: 緊急度低': "4"
+        status: 'ステータース'
+        label: 'ラベル'
+        sort_order: 'ソート順'
         due_date: '期限'
         created_at: '作成日'
         create: '新規タスク登録'
+      task/statuses:
+        not_selected: '選択なし'
+        not_started: '未着手'
+        in_progress: '着手中'
+        completed: '完了'
+      task/labels:
+        very_important: 'A: 重要度高'
+        important: 'B: 重要度低'
+        urgent: 'C: 緊急度高'
+        normal: 'D: 緊急度低'
+      task/sort_orders:
+        asc: '昇順'
+        desc: '降順'
     errors:
       models:
         task:
@@ -97,3 +106,4 @@ ja:
               too_long: "最大%{count}文字まで使えます"
             description:
               too_long: "最大%{count}文字まで使えます"
+  

--- a/minimini/config/locales/view/list/ja.yml
+++ b/minimini/config/locales/view/list/ja.yml
@@ -106,4 +106,3 @@ ja:
               too_long: "最大%{count}文字まで使えます"
             description:
               too_long: "最大%{count}文字まで使えます"
-  

--- a/minimini/config/routes.rb
+++ b/minimini/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
   get    'login'   => 'sessions#new'
   post   'login'   => 'sessions#create'
   delete 'logout'  => 'sessions#destroy'
+
+  get    'search'  => 'tasks#index'
 end

--- a/minimini/db/migrate/20210423003011_add_index_tasks_status.rb
+++ b/minimini/db/migrate/20210423003011_add_index_tasks_status.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksStatus < ActiveRecord::Migration[6.1]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/minimini/db/schema.rb
+++ b/minimini/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_19_144409) do
+ActiveRecord::Schema.define(version: 2021_04_23_003011) do
 
   create_table "labels", charset: "utf8mb4", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2021_04_19_144409) do
     t.date "due_date", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status"], name: "index_tasks_on_status"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 

--- a/minimini/db/seeds.rb
+++ b/minimini/db/seeds.rb
@@ -13,8 +13,8 @@
     )
 end
 
-status = [ 0, 1, 2 ]
-labels = ["1", "2", "3", "4"]
+status = [ 1, 2, 3, 4 ]
+labels = [ 1, 2, 3, 4 ]
 
 10.times do |m|
     10.times do |n|

--- a/minimini/db/seeds.rb
+++ b/minimini/db/seeds.rb
@@ -14,7 +14,7 @@
 end
 
 status = [ 1, 2, 3, 4 ]
-labels = [ 1, 2, 3, 4 ]
+labels = [ "1", "2", "3", "4" ]
 
 10.times do |m|
     10.times do |n|

--- a/minimini/spec/controller/tasks_controller_spec.rb
+++ b/minimini/spec/controller/tasks_controller_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe TasksController, type: :controller do
         task: {
           name: "NEW タスク名1",
           description: "NEW タスク内容1",
-          status: "未着手",
-          labels: "1",
+          status: "not_started",
+          labels: "very_important",
           user_id: "9999",
           due_date: "2022-01-01"
         }
@@ -37,8 +37,8 @@ RSpec.describe TasksController, type: :controller do
     expect(Task.count).to eq 1
     post :create, params: {
         task: {
-          status: "未着手",
-          labels: "1",
+          status: "not_started",
+          labels: "very_important",
           user_id: "9999",
           due_date: "2022-01-01"
         }
@@ -69,8 +69,8 @@ RSpec.describe TasksController, type: :controller do
         id: "10000",
         name: "[updated]タスク名1",
         description: "[updated]タスク内容1",
-        status: "完了",
-        labels: "D: 緊急度低",
+        status: "completed",
+        labels: "normal",
         due_date: "2023-01-01"
       }
     }
@@ -89,5 +89,16 @@ RSpec.describe TasksController, type: :controller do
     delete :destroy, params: { id: "99999999"}
     expect(Task.count).to eq 1
     expect(response.status).to eq 404
+  end
+
+  it 'search with not_started status' do
+    get :index, params: {
+        search: {
+          status: "not_started",
+          sort_order: "ASC"
+        }
+      }
+
+    expect(response).to render_template(:index)
   end
 end

--- a/minimini/spec/factories/tasks.rb
+++ b/minimini/spec/factories/tasks.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
         id           {"10000"}
         name         {"タスク名1"}
         description  {"タスク内容1"}
-        status       {"未着手"}
-        labels       {"1"}
+        status       {"completed"}
+        labels       {"very_important"}
         user_id      {"9999"}
         due_date     {DateTime.now + 1.week}
         created_at   {DateTime.now}

--- a/minimini/spec/models/task_spec.rb
+++ b/minimini/spec/models/task_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   before(:each) do
-    @task = FactoryBot.build(:task)
+    @task = FactoryBot.create(:task)
   end
 
   it 'is valid with name, description, due_date' do
@@ -25,5 +25,34 @@ RSpec.describe Task, type: :model do
     @task.due_date = nil
     expect(@task).to be_invalid
     expect(@task.errors[:due_date]).to include(I18n.t('errors.messages.blank'))
+  end
+
+  it 'record found when search with default status and sort order' do
+    user_search_params = SearchParam.new
+    user_search_params.status = "-1"
+    user_search_params.sort_order = "ASC"
+
+    tasks = Task.search(user_search_params, "9999")
+    expect(tasks.size).to eq (1)
+    expect(tasks).to include(@task)
+  end
+
+  it 'record found when search with "completed" status' do
+    user_search_params = SearchParam.new
+    user_search_params.status = "2"
+    user_search_params.sort_order = "ASC"
+
+    tasks = Task.search(user_search_params, "9999")
+    expect(tasks.size).to eq (1)
+    expect(tasks).to include(@task)
+  end
+
+  it 'record not found when search with "not started" status' do
+    user_search_params = SearchParam.new
+    user_search_params.status = "0"
+    user_search_params.sort_order = "ASC"
+
+    tasks = Task.search(user_search_params, "9999")
+    expect(tasks.size).to eq (0)
   end
 end

--- a/minimini/spec/models/task_spec.rb
+++ b/minimini/spec/models/task_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Task, type: :model do
 
   it 'record found when search with default status and sort order' do
     user_search_params = SearchParam.new
-    user_search_params.status = "-1"
-    user_search_params.sort_order = "ASC"
+    user_search_params.status = "#{Task.statuses[:not_selected]}"
+    user_search_params.sort_order = "#{Task.sort_orders[:asc]}"
 
     tasks = Task.search(user_search_params, "9999")
     expect(tasks.size).to eq (1)
@@ -39,8 +39,8 @@ RSpec.describe Task, type: :model do
 
   it 'record found when search with "completed" status' do
     user_search_params = SearchParam.new
-    user_search_params.status = "2"
-    user_search_params.sort_order = "ASC"
+    user_search_params.status = "#{Task.statuses[:completed]}"
+    user_search_params.sort_order = "#{Task.sort_orders[:asc]}"
 
     tasks = Task.search(user_search_params, "9999")
     expect(tasks.size).to eq (1)
@@ -49,8 +49,8 @@ RSpec.describe Task, type: :model do
 
   it 'record not found when search with "not started" status' do
     user_search_params = SearchParam.new
-    user_search_params.status = "0"
-    user_search_params.sort_order = "ASC"
+    user_search_params.status = "#{Task.statuses[:not_started]}"
+    user_search_params.sort_order = "#{Task.sort_orders[:asc]}"
 
     tasks = Task.search(user_search_params, "9999")
     expect(tasks.size).to eq (0)


### PR DESCRIPTION
実施内容
--------
1.ステップ10: ステータスを追加して、検索できるようにしよう
ステータス（未着手・着手中・完了）を追加してみよう
一覧画面でタイトルとステータスで検索ができるようにしよう
絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
以降のステップでも必要に応じて確認する癖をつけましょう
検索インデックスを貼りましょう
検索に対してmodel specを追加してみよう（feature specも拡充しておきましょう）

2.select 日本語化対応：実装が間違ってたので修正
参考：Railsでgem無しに手軽にenumをi18nに対応させる
https://qiita.com/daichirata/items/9495e2548417a4507fec