### PR TITLE
[yykamei] ステップ7: タスクを登録・更新・削除できるようにしよう

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,5 @@ jobs:
           working-directory: myapp
       - run: yarn install
       - run: bundle exec rails db:create db:migrate
+      - run: bundle exec rails webpacker:compile
       - run: bundle exec rails test

--- a/myapp/.gitignore
+++ b/myapp/.gitignore
@@ -28,6 +28,9 @@
 !/storage/.keep
 
 /public/assets
+/public/packs
+/public/packs-test
+
 .byebug_history
 
 # Ignore master key for decrypting credentials and more.

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -49,3 +49,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'http_accept_language'
+gem 'rails-i18n'

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    http_accept_language (2.1.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
@@ -130,6 +131,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.7)
       actionpack (= 6.0.3.7)
       activesupport (= 6.0.3.7)
@@ -197,11 +201,13 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  http_accept_language
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.7)
+  rails-i18n
   sass-rails (>= 6)
   selenium-webdriver
   turbolinks (~> 5)

--- a/myapp/app/assets/stylesheets/application.css
+++ b/myapp/app/assets/stylesheets/application.css
@@ -13,3 +13,10 @@
  *= require_tree .
  *= require_self
  */
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}

--- a/myapp/app/assets/stylesheets/mixins.scss
+++ b/myapp/app/assets/stylesheets/mixins.scss
@@ -1,0 +1,31 @@
+@import './variables';
+
+@mixin button {
+  display: inline-block;
+  font-family: sans-serif;
+  font-weight: 400;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  user-select: none;
+  border-radius: 4px;
+  padding: $space-s $space-m;
+}
+
+@mixin button-positive {
+  @include button;
+
+  color: $color-white;
+  background-color: $color-green-800;
+  text-decoration: none;
+
+  &:visited,
+  &:focus,
+  &:active {
+    color: $color-white;
+  }
+
+  &:hover {
+    background-color: $color-green-900;
+  }
+}

--- a/myapp/app/assets/stylesheets/tasks.scss
+++ b/myapp/app/assets/stylesheets/tasks.scss
@@ -1,0 +1,146 @@
+// Place all the styles related to the tasks controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/
+
+@import './variables';
+@import './mixins';
+
+// TODO: Is it more common? Is it be declared in `./mixins.scss`?
+@mixin tasks_container {
+  max-width: $page-max-width;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.tasks {
+  @include tasks_container;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-height: 3rem;
+  }
+
+  &__flash {
+    margin-left: auto;
+    padding: $space-m $space-l;
+    border-radius: 4px;
+
+    &--info {
+      border: 2px solid $color-blue-200;
+    }
+
+    &--error {
+      border: 2px solid $color-red-800;
+    }
+  }
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 2px solid $color-gray-400;
+    margin-top: $space-l;
+  }
+
+  &__thead {
+    background-color: $color-gray-400;
+    color: $color-black;
+  }
+
+  &__tbody {
+    background-color: $color-white;
+    color: $color-gray-900;
+  }
+
+  &__row {
+    border: 1px solid $color-gray-400;
+
+    &:hover {
+      background-color: $color-gray-100;
+    }
+
+    &--header {
+      &:hover {
+        background-color: $color-gray-400;
+      }
+    }
+  }
+
+  &__cell {
+    font-family: sans-serif;
+    padding: $space-m;
+    text-align: left;
+
+    &--right {
+      text-align: right;
+    }
+  }
+
+  &__new {
+    @include button-positive;
+  }
+
+  &__edit {
+    @include button;
+    color: $color-blue-400;
+    background-color: $color-white;
+    text-decoration: none;
+
+    &:visited,
+    &:focus,
+    &:active {
+      color: $color-blue-400;
+    }
+
+    &:hover {
+      background-color: $color-gray-200;
+    }
+  }
+
+  &__delete {
+    @include button;
+    color: $color-red-800;
+    background-color: $color-white;
+    text-decoration: none;
+
+    &:visited,
+    &:focus,
+    &:active {
+      color: $color-red-800;
+    }
+
+    &:hover {
+      background-color: $color-gray-200;
+    }
+  }
+}
+
+.edit-task {
+  @include tasks_container;
+
+  &__form {
+    width: 100%;
+  }
+
+  &__form-field {
+    width: 100%;
+    min-width: 480px; // TODO: Make it a variable
+    display: flex;
+    flex-direction: column;
+    font-family: sans-serif;
+
+    & + & {
+      margin-top: $space-l;
+    }
+  }
+
+  &__button {
+    @include button-positive;
+
+    margin-top: $space-l;
+  }
+}

--- a/myapp/app/assets/stylesheets/variables.scss
+++ b/myapp/app/assets/stylesheets/variables.scss
@@ -1,0 +1,18 @@
+$color-white: #fff;
+$color-black: #000;
+$color-gray-100: #efefef;
+$color-gray-200: #dbd8d9;
+$color-gray-300: #cfcfd6;
+$color-gray-400: #b9b9cf;
+$color-gray-900: #1c1f30;
+$color-blue-200: #90caf9;
+$color-blue-400: #1b74ff;
+$color-green-800: #2e7d32;
+$color-green-900: #1b5e20;
+$color-red-800: #c62828;
+
+$space-s: 0.25rem;
+$space-m: 0.5rem;
+$space-l: 1rem;
+
+$page-max-width: 1020px;

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  around_action :switch_locale
+
+  private
+
+  def switch_locale(&action)
+    locale = params[:locale] || http_accept_language.compatible_language_from(I18n.available_locales)
+    I18n.with_locale(locale, &action)
+  end
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,0 +1,42 @@
+class TasksController < ApplicationController
+  def index
+    @tasks = Task.all.order(:id)
+  end
+
+  def new
+    @task = Task.new(name: '', description: '', priority: :normal, status: :waiting)
+  end
+
+  def edit
+    # TODO: Check the task exactly belongs to the user.
+    @task = Task.find(params.require(:id))
+  end
+
+  def create
+    if Task.create(params.require(:task).permit(:name, :description, :due_date, :priority, :status))
+      redirect_to root_path, flash: { info: I18n.t('pages.tasks.flash.added') }
+    else
+      redirect_to root_path, flash: { error: I18n.t('pages.tasks.flash.fail') }
+    end
+  end
+
+  def update
+    # TODO: Check the task exactly belongs to the user.
+    task = Task.find(params.require(:id))
+    if task.update(params.require(:task).permit(:name, :description, :due_date, :priority, :status))
+      redirect_to root_path, flash: { info: I18n.t('pages.tasks.flash.edited') }
+    else
+      redirect_to root_path, flash: { error: I18n.t('pages.tasks.flash.fail') }
+    end
+  end
+
+  def destroy
+    # TODO: Check the task exactly belongs to the user.
+    task = Task.find(params.require(:id))
+    if task.destroy
+      redirect_to root_path, flash: { info: I18n.t('pages.tasks.flash.deleted') }
+    else
+      redirect_to root_path, flash: { error: I18n.t('pages.tasks.flash.fail') }
+    end
+  end
+end

--- a/myapp/app/helpers/tasks_helper.rb
+++ b/myapp/app/helpers/tasks_helper.rb
@@ -1,0 +1,27 @@
+module TasksHelper
+  def translate_priority(priority)
+    case priority
+    when 'low'
+      t('activerecord.enum.task.priority.low')
+    when 'normal'
+      t('activerecord.enum.task.priority.normal')
+    when 'high'
+      t('activerecord.enum.task.priority.high')
+    else
+      raise "Unexpected priority `#{priority}` is set."
+    end
+  end
+
+  def translate_status(status)
+    case status
+    when 'waiting'
+      t('activerecord.enum.task.status.waiting')
+    when 'doing'
+      t('activerecord.enum.task.status.doing')
+    when 'done'
+      t('activerecord.enum.task.status.done')
+    else
+      raise "Unexpected status `#{status}` is set."
+    end
+  end
+end

--- a/myapp/app/views/tasks/_form.erb
+++ b/myapp/app/views/tasks/_form.erb
@@ -1,0 +1,27 @@
+<div class="edit-task">
+  <h1><%= page_title %></h1>
+
+  <%= form_for @task, url: action_url, class: "edit-task__form" do |f| %>
+    <div class="edit-task__form-field">
+      <%= f.label :name %>
+      <%= f.text_field :name %>
+    </div>
+    <div class="edit-task__form-field">
+      <%= f.label :description %>
+      <%= f.text_area :description, rows: 5 %>
+    </div>
+    <div class="edit-task__form-field">
+      <%= f.label :due_date %>
+      <%= f.date_field :due_date %>
+    </div>
+    <div class="edit-task__form-field">
+      <%= f.label :priority %>
+      <%= f.collection_select :priority, Task.priorities.keys, :to_s, method(:translate_priority) %>
+    </div>
+    <div class="edit-task__form-field">
+      <%= f.label :status %>
+      <%= f.collection_select :status, Task.statuses.keys, :to_s, method(:translate_status) %>
+    </div>
+    <%= f.submit t('common.submit'), class: 'edit-task__button' %>
+  <% end %>
+</div>

--- a/myapp/app/views/tasks/edit.erb
+++ b/myapp/app/views/tasks/edit.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'tasks/form', locals: { page_title: t('pages.edit_task.page_title'), action_url: task_path(I18n.locale, @task) } %>

--- a/myapp/app/views/tasks/index.erb
+++ b/myapp/app/views/tasks/index.erb
@@ -1,0 +1,51 @@
+<div class="tasks">
+  <h1><%= t('pages.tasks.page_title') %></h1>
+
+  <div class="tasks__header">
+    <%= link_to(t('common.new'), new_task_path(I18n.locale), class: 'tasks__new', title: t('pages.tasks.tooltip.new')) %>
+
+    <% if flash[:info] || flash[:error] %>
+      <% modifier = 'tasks__flash--info' if flash[:info] %>
+      <% modifier = 'tasks__flash--error' if flash[:error] %>
+      <div class="tasks__flash  <%= modifier %>"><%= flash[:info] || flash[:error] %></div>
+    <% end %>
+  </div>
+
+  <table class="tasks__table">
+    <thead class="tasks__thead">
+    <tr class="tasks__row tasks__row--header">
+      <th class="tasks__cell"><%= t('activerecord.attributes.task.id') %></th>
+      <th class="tasks__cell"><%= t('activerecord.attributes.task.name') %></th>
+      <th class="tasks__cell"><%= t('activerecord.attributes.task.description') %></th>
+      <th class="tasks__cell"><%= t('activerecord.attributes.task.due_date') %></th>
+      <th class="tasks__cell"><%= t('activerecord.attributes.task.priority') %></th>
+      <th class="tasks__cell"><%= t('activerecord.attributes.task.status') %></th>
+      <th class="tasks__cell"></th>
+    </tr>
+    </thead>
+    <tbody class="tasks__tbody">
+    <% @tasks.each do |task| %>
+      <tr class="tasks__row">
+        <td class="tasks__cell"><%= task.id %></td>
+        <td class="tasks__cell"><%= task.name %></td>
+        <td class="tasks__cell"><%= task.description %></td>
+        <td class="tasks__cell"><%= task.due_date ? distance_of_time_in_words(task.due_date - Time.current) : '' %></td>
+        <td class="tasks__cell"><%= translate_priority(task.priority) %></td>
+        <td class="tasks__cell"><%= translate_status(task.status) %></td>
+        <td class="tasks__cell tasks__cell--right">
+          <%= link_to(t('common.edit'), edit_task_path(I18n.locale, task), class: "tasks__edit", title: t('pages.tasks.tooltip.edit')) %>
+          <%= link_to(
+                t('common.delete'),
+                task_path(I18n.locale, task),
+                method: :delete,
+                class: "tasks__delete",
+                title: t('pages.tasks.tooltip.delete'),
+                data: { confirm: t('pages.tasks.confirm_deletion') },
+              )
+          %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/myapp/app/views/tasks/new.erb
+++ b/myapp/app/views/tasks/new.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'tasks/form', locals: { page_title: t('pages.new_task.page_title'), action_url: tasks_path(I18n.locale) } %>

--- a/myapp/config/initializers/locale.rb
+++ b/myapp/config/initializers/locale.rb
@@ -1,0 +1,2 @@
+I18n.available_locales = [:en, :ja]
+I18n.default_locale = :en

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -1,33 +1,41 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    attributes:
+      task:
+        name: Name
+        description: Description
+        due_date: Due date
+        priority: Priority
+        status: Status
+    enum:
+      task:
+        priority:
+          low: Low
+          normal: Normal
+          high: High
+        status:
+          waiting: Waiting
+          doing: Doing
+          done: Done
+  common:
+    new: New
+    edit: Edit
+    submit: Submit
+    delete: Delete
+  pages:
+    tasks:
+      page_title: The list of tasks
+      tooltip:
+        new: Add a new task
+        edit: Edit the task
+        delete: Delete the task
+      flash:
+        added: Succeeded to add the task!
+        edited: Succeeded to edit the task!
+        deleted: Succeeded to delete the task!
+        fail: Sorry, failed to proced the operation.
+      confirm_deletion: Are you sure you want to delete the task?
+    new_task:
+      page_title: Add a new task
+    edit_task:
+      page_title: Edit the task

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -1,0 +1,41 @@
+ja:
+  activerecord:
+    attributes:
+      task:
+        name: 名前
+        description: 説明
+        due_date: 期限
+        priority: 優先度
+        status: ステータス
+    enum:
+      task:
+        priority:
+          low: 低
+          normal: 中
+          high: 高
+        status:
+          waiting: 未着手
+          doing: 着手
+          done: 完了
+  common:
+    new: 新規作成
+    edit: 編集
+    submit: 送信
+    delete: 削除
+  pages:
+    tasks:
+      page_title: タスク一覧
+      tooltip:
+        new: タスクを新しく作成します
+        edit: タスクを編集します
+        delete: タスクを削除します
+      flash:
+        added: タスクを作成しました。
+        edited: タスクを編集しました。
+        deleted: タスクを削除しました。
+        fail: 操作に失敗しました。すみません
+      confirm_deletion: 本当にタスクを削除してよろしいですか？
+    new_task:
+      page_title: タスクの追加
+    edit_task:
+      page_title: タスクの編集

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  scope '(:locale)', locale: /en|ja/ do
+    root to: 'tasks#index'
+    resources :tasks, except: :index
+  end
 end

--- a/myapp/test/controllers/tasks_controller_test.rb
+++ b/myapp/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class TasksControllerTest < ActionDispatch::IntegrationTest
+  # TODO: Test whether certain elements and texts exist on pages later. So far, this just tests the page existence.
+
+  test '"GET /" returns success' do
+    get '/'
+    assert_response :success
+  end
+
+  test '"GET /tasks/new" returns success' do
+    get '/tasks/new'
+    assert_response :success
+  end
+
+  test '"GET /tasks/:id/edit" returns success' do
+    get "/tasks/#{tasks(:base).id}/edit"
+    assert_response :success
+  end
+
+  test '"POST /tasks" succeeds' do
+    assert_difference -> { Task.count } do
+      post '/tasks', params: { task: { name: 'New task!', description: 'Hey', priority: 'normal', status: 'waiting' } }
+    end
+    assert_response :redirect
+  end
+
+  test '"PATCH /tasks/:id" succeeds' do
+    assert_changes -> { tasks(:base).reload.name } do
+      patch "/tasks/#{tasks(:base).id}", params: { task: { name: 'Updated!' } }
+    end
+    assert_response :redirect
+  end
+
+  test '"DELETE /tasks/:id" succeeds' do
+    assert_difference -> { Task.count }, -1 do
+      delete "/tasks/#{tasks(:base).id}"
+    end
+    assert_response :redirect
+  end
+end

--- a/myapp/test/test_helper.rb
+++ b/myapp/test/test_helper.rb
@@ -10,4 +10,9 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+
+  setup do
+    # NOTE: Always assume the rendered views are translated in English.
+    I18n.locale = :en
+  end
 end


### PR DESCRIPTION
**このプルリクエストはトレーニング用です。**

[ステップ7](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%977-%E3%82%BF%E3%82%B9%E3%82%AF%E3%82%92%E7%99%BB%E9%8C%B2%E6%9B%B4%E6%96%B0%E5%89%8A%E9%99%A4%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)の実装になります。変更が大きくて恐縮ですが、以下のような実装を行っています。
## このプルリクエストの変更について

## # ページの追加

* URL: `(:locale)/` でタスク一覧を表示するように変更
* URL: `(:locale)/tasks/new` でタスクを登録できるページを追加
* URL: `(:locale)/tasks/:id/edit` でタスクの編集をできるようなページを追加

### CRUD 操作に対応してアクションの追加

`TasksController` を作成し以下のアクションを作成しました。いずれのアクションとも、操作後に雑ですが、タスク一覧ページにリダイレクトさせます。

* `create`: タスクの追加を行う。操作後、タスク一覧ページにリダイレクトを実施
* `update`: タスクの更新を行う。操作後、タスク一覧ページにリダイレクトを実施
* `destroy`: タスクの削除を行う。操作後、タスク一覧ページにリダイレクトを実施

### ページのデザインに関する変更

`app/assets` ディレクトリーと `config/locales` 以下の翻訳で実装しています。デザインについては専門家ではないので、あまりしっかりしたものができていません。以下に、どんな感じの画面なのか動画を貼るので参考にしてみてください。


https://user-images.githubusercontent.com/13130705/118592442-e8ba1a80-b7e0-11eb-94df-c53ffa94b41e.mov

### その他

ユーザーエージェントが期待する言語を考慮するために [`http_accept_language`](https://github.com/iain/http_accept_language) という Gem を追加しました。また、 Rails には `en` のロケールセットしか入っていないので、 `distance_of_time_in_words` などの Rails のヘルパーを呼び出すと `en` 以外への翻訳が失敗します。そのため、 [`rails-i18n`](https://github.com/svenfuchs/rails-i18n) という Gem を入れて対応しました。

また、念の為、それぞれのページへのリクエストが成功するかどうかだけのテストを追加しました。これは次のステップで書き換えます。

## 手元での動作確認方法

以下の手順で確認できると思いますが、もし失敗したらコメントを下さい 🙏 
(Git と Docker Compose が必要です。他に必要なものがあればコメントをください）

1. `git clone https://github.com/Fablic/training` で手元にソースコードを展開
2. `git checkout yykamei/step7` でこのプルリクエストの HEAD にチェックアウト
3. `cd myapp` で Rails アプリのディレクトリーに移動
4. `docker-compose up --build` を実行してサービスを手元で走らせる
5. http://localhost:3001 にブラウザーでアクセスして動作確認