### PR TITLE
ステップ7: タスクを登録・更新・削除できるようにしよう

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*.{rb,rake}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.js]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/app/assets/stylesheets/modules/flash.scss
+++ b/app/assets/stylesheets/modules/flash.scss
@@ -1,12 +1,12 @@
 .notification {
-    .notice {
-      background-color: greenyellow;
-      color: white;
-      text-align: center;
-    }
-    .alert {
-      background-color: red;
-      color: white;
-      text-align: center;
-    }
+  .notice {
+    background-color: greenyellow;
+    color: white;
+    text-align: center;
+  }
+  .alert {
+    background-color: red;
+    color: white;
+    text-align: center;
+  }
 }

--- a/app/assets/stylesheets/modules/flash.scss
+++ b/app/assets/stylesheets/modules/flash.scss
@@ -1,0 +1,12 @@
+.notification {
+    .notice {
+      background-color: greenyellow;
+      color: white;
+      text-align: center;
+    }
+    .alert {
+      background-color: red;
+      color: white;
+      text-align: center;
+    }
+}

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Tasks controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,2 @@
+class TasksController < ApplicationController
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,27 +12,27 @@ class TasksController < ApplicationController
     def create
         @task = Task.new(task_params)
         if @task.save
-            redirect_to @task, notice: 'Successfully created a task'
+            redirect_to @task, notice: 'タスクの作成が完了しました'
         else
-            flash[:alert] = 'Failed to create a task'
+            flash.now[:alert] = 'タスクの作成に失敗しました'
             render :new
         end
     end
 
     def update
         if @task.update(task_params)
-            redirect_to @task, notice: 'Successfully updated a task'
+            redirect_to @task, notice: 'タスクの削除が完了しました'
         else
-            flash[:alert] = 'Failed to update a task'
+            flash.now[:alert] = 'タスクの更新に失敗しました'
             render :edit
         end
     end
 
     def destroy
         if @task.destroy
-            redirect_to root_path, notice: 'Successfully destroyed a task'
+            redirect_to root_path, notice: 'タスクの削除が完了しました'
         else
-            redirect_to root_path, alert: 'Failed to destroy a task'
+            redirect_to root_path, alert: 'タスクの削除に失敗しました'
         end
     end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,48 +1,48 @@
 class TasksController < ApplicationController
-    before_action :set_task, only: [:show, :edit, :update, :destroy]
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
 
-    def index
-        @tasks = Task.all
+  def index
+    @tasks = Task.all
+  end
+
+  def new
+    @task = Task.new
+  end
+
+  def create
+    @task = Task.new(task_params)
+    if @task.save
+      redirect_to @task, notice: t('message.task.create.succeeded')
+    else
+      flash.now[:alert] = t('message.task.create.failed')
+      render :new
     end
+  end
 
-    def new
-        @task = Task.new
+  def update
+    if @task.update(task_params)
+      redirect_to @task, notice: t('message.task.update.succeeded')
+    else
+      flash.now[:alert] = t('message.task.update.failed')
+      render :edit
     end
+  end
 
-    def create
-        @task = Task.new(task_params)
-        if @task.save
-            redirect_to @task, notice: t('message.task.create.succeeded')
-        else
-            flash.now[:alert] = t('message.task.create.failed')
-            render :new
-        end
+  def destroy
+    if @task.destroy
+      redirect_to root_path, notice: t('message.task.delete.succeeded')
+    else
+      redirect_to root_path, alert: t('message.task.delete.failed')
     end
+  end
 
-    def update
-        if @task.update(task_params)
-            redirect_to @task, notice: t('message.task.update.succeeded')
-        else
-            flash.now[:alert] = t('message.task.update.failed')
-            render :edit
-        end
-    end
+  private
 
-    def destroy
-        if @task.destroy
-            redirect_to root_path, notice: t('message.task.delete.succeeded')
-        else
-            redirect_to root_path, alert: t('message.task.delete.failed')
-        end
-    end
+  def set_task
+    @task = Task.find(params[:id])
+  end
 
-    private
-
-    def set_task
-        @task = Task.find(params[:id])
-    end
-
-    def task_params
-        params.require(:task).permit(:title, :description)
-    end
+  def task_params
+    params.require(:task).permit(:title, :description)
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,2 +1,48 @@
 class TasksController < ApplicationController
+    before_action :set_task, only: [:show, :edit, :update, :destroy]
+
+    def index
+        @tasks = Task.all
+    end
+
+    def new
+        @task = Task.new
+    end
+
+    def create
+        @task = Task.new(task_params)
+        if @task.save
+            redirect_to @task, notice: 'Successfully created a task'
+        else
+            flash[:alert] = 'Failed to create a task'
+            render :new
+        end
+    end
+
+    def update
+        if @task.update(task_params)
+            redirect_to @task, notice: 'Successfully updated a task'
+        else
+            flash[:alert] = 'Failed to update a task'
+            render :edit
+        end
+    end
+
+    def destroy
+        if @task.destroy
+            redirect_to root_path, notice: 'Successfully destroyed a task'
+        else
+            redirect_to root_path, alert: 'Failed to destroy a task'
+        end
+    end
+
+    private
+
+    def set_task
+        @task = Task.find(params[:id])
+    end
+
+    def task_params
+        params.require(:task).permit(:title, :description)
+    end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,27 +12,27 @@ class TasksController < ApplicationController
     def create
         @task = Task.new(task_params)
         if @task.save
-            redirect_to @task, notice: 'タスクの作成が完了しました'
+            redirect_to @task, notice: t('message.task.create.succeeded')
         else
-            flash.now[:alert] = 'タスクの作成に失敗しました'
+            flash.now[:alert] = t('message.task.create.failed')
             render :new
         end
     end
 
     def update
         if @task.update(task_params)
-            redirect_to @task, notice: 'タスクの削除が完了しました'
+            redirect_to @task, notice: t('message.task.update.succeeded')
         else
-            flash.now[:alert] = 'タスクの更新に失敗しました'
+            flash.now[:alert] = t('message.task.update.failed')
             render :edit
         end
     end
 
     def destroy
         if @task.destroy
-            redirect_to root_path, notice: 'タスクの削除が完了しました'
+            redirect_to root_path, notice: t('message.task.delete.succeeded')
         else
-            redirect_to root_path, alert: 'タスクの削除に失敗しました'
+            redirect_to root_path, alert: t('message.task.delete.failed')
         end
     end
 

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,0 +1,2 @@
+module TasksHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+    <%= render 'shared/notification' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -1,0 +1,5 @@
+<div class="notification">
+  <% flash.each do |type, message| %>
+    <%= content_tag(:div, message, class: type) %> 
+  <% end %>
+</div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: task) do |form| %>
+  <% if task.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(task.errors.count, "error") %> prohibited this task from being saved:</h2>
+
+      <ul>
+        <% task.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :description %>
+    <%= form.text_field :description %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Task</h1>
+
+<%= render 'form', task: @task %>
+
+<%= link_to 'Show', @task %> |
+<%= link_to 'Back', tasks_path %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>Editing Task</h1>
+<h1>タスク編集</h1>
 
 <%= render 'form', task: @task %>
 
-<%= link_to 'Show', @task %> |
-<%= link_to 'Back', tasks_path %>
+<%= link_to '詳細', @task %> |
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', task: @task %>
 
-<%= link_to '詳細', @task %> |
-<%= link_to '戻る', tasks_path %>
+<%= link_to t('label.link.show'), @task %> |
+<%= link_to t('label.link.back'), tasks_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Tasks</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Description</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= task.title %></td>
+        <td><%= task.description %></td>
+        <td><%= link_to 'Show', task %></td>
+        <td><%= link_to 'Edit', edit_task_path(task) %></td>
+        <td><%= link_to 'Destroy', task, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Task', new_task_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,12 +1,12 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Tasks</h1>
+<h1>タスク一覧</h1>
 
-<table>
+<table border>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Description</th>
+      <th>タスク名</th>
+      <th>タスク説明</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -16,9 +16,9 @@
       <tr>
         <td><%= task.title %></td>
         <td><%= task.description %></td>
-        <td><%= link_to 'Show', task %></td>
-        <td><%= link_to 'Edit', edit_task_path(task) %></td>
-        <td><%= link_to 'Destroy', task, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to '詳細', task %></td>
+        <td><%= link_to '編集', edit_task_path(task) %></td>
+        <td><%= link_to '削除', task, method: :delete, data: { confirm: '削除してもよいですか?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -26,4 +26,4 @@
 
 <br>
 
-<%= link_to 'New Task', new_task_path %>
+<%= link_to '新規作成', new_task_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>タスク一覧</h1>
 
 <table border>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -12,7 +12,7 @@
   </thead>
 
   <tbody>
-    <% @tasks.each do |task| %>
+    <% @tasks&.each do |task| %>
       <tr>
         <td><%= task.title %></td>
         <td><%= task.description %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,8 +3,8 @@
 <table border>
   <thead>
     <tr>
-      <th>タスク名</th>
-      <th>タスク説明</th>
+      <th><%= Task.human_attribute_name(:title) %></th>
+      <th><%= Task.human_attribute_name(:description) %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -14,9 +14,9 @@
       <tr>
         <td><%= task.title %></td>
         <td><%= task.description %></td>
-        <td><%= link_to '詳細', task %></td>
-        <td><%= link_to '編集', edit_task_path(task) %></td>
-        <td><%= link_to '削除', task, method: :delete, data: { confirm: '削除してもよいですか?' } %></td>
+        <td><%= link_to t('label.link.show'), task %></td>
+        <td><%= link_to t('label.link.edit'), edit_task_path(task) %></td>
+        <td><%= link_to t('label.link.delete'), task, method: :delete, data: { confirm: t('message.delete.confirm') } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -24,4 +24,4 @@
 
 <br>
 
-<%= link_to '新規作成', new_task_path %>
+<%= link_to t('label.link.create'), new_task_path %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Task</h1>
+
+<%= render 'form', task: @task %>
+
+<%= link_to 'Back', tasks_path %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Task</h1>
+<h1>タスク作成</h1>
 
 <%= render 'form', task: @task %>
 
-<%= link_to 'Back', tasks_path %>
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', task: @task %>
 
-<%= link_to '戻る', tasks_path %>
+<%= link_to t('label.link.back'), tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @task.title %>
+</p>
+
+<p>
+  <strong>Description:</strong>
+  <%= @task.description %>
+</p>
+
+<%= link_to 'Edit', edit_task_path(@task) %> |
+<%= link_to 'Back', tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong>タスク名:</strong>
   <%= @task.title %>
 </p>
 
 <p>
-  <strong>Description:</strong>
+  <strong>タスク説明:</strong>
   <%= @task.description %>
 </p>
 
-<%= link_to 'Edit', edit_task_path(@task) %> |
-<%= link_to 'Back', tasks_path %>
+<%= link_to '編集する', edit_task_path(@task) %> |
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,12 +1,14 @@
+<h1>タスク詳細</h1>
+
 <p>
-  <strong>タスク名:</strong>
+  <strong><%= Task.human_attribute_name(:title) %>:</strong>
   <%= @task.title %>
 </p>
 
 <p>
-  <strong>タスク説明:</strong>
+  <strong><%= Task.human_attribute_name(:description) %>:</strong>
   <%= @task.description %>
 </p>
 
-<%= link_to '編集する', edit_task_path(@task) %> |
-<%= link_to '戻る', tasks_path %>
+<%= link_to t('label.link.edit'), edit_task_path(@task) %> |
+<%= link_to t('label.link.back'), tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>タスク名:</strong>
   <%= @task.title %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Training
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,12 @@
+ja:
+  helpers:
+    submit:
+      create: "作成する"
+      update: "更新する"
+  activerecord:
+    models:
+      task: タスク
+    attributes:
+      task:
+        title: タスク名
+        description: タスク詳細

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,8 +1,8 @@
 ja:
   helpers:
     submit:
-      create: "作成する"
-      update: "更新する"
+      create: 作成する
+      update: 更新する
   activerecord:
     models:
       task: タスク
@@ -10,3 +10,23 @@ ja:
       task:
         title: タスク名
         description: タスク詳細
+  label:
+    link:
+      create: 新規作成
+      show: 詳細
+      edit: 編集
+      delete: 削除
+      back: 戻る
+  message:
+    delete:
+      confirm: 削除してもよいですか？
+    task:
+      create:
+        succeeded: タスクの作成が完了しました
+        failed: タスクの作成に失敗しました
+      update:
+        succeeded: タスクの更新が完了しました
+        failed: タスクの更新に失敗しました
+      delete:
+        succeeded: タスクの削除が完了しました
+        failed: タスクの削除に失敗しました

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :tasks
+  root 'tasks#index'
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TasksControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- [ステップ7: タスクを登録・更新・削除できるようにしよう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%977-%E3%82%BF%E3%82%B9%E3%82%AF%E3%82%92%E7%99%BB%E9%8C%B2%E6%9B%B4%E6%96%B0%E5%89%8A%E9%99%A4%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)にしたがって、タスクの一覧画面、作成画面、詳細画面、編集画面をつくりました。
- 作成、更新、削除後にそれぞれflashメッセージを画面に表示させています。
- [コーディングルールを統一する](https://confluence.rakuten-it.com/confluence/pages/viewpage.action?pageId=1981547704)の設定を入れて、インデントを修正しました。