### PR TITLE
[yykamei] ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/README.md
+++ b/myapp/README.md
@@ -7,7 +7,7 @@ You can check this program with this command:
 ```console
 $ docker-compose --file docker-compose.prod.yml --project-name myapp-prod build
 $ docker-compose --file docker-compose.prod.yml --project-name myapp-prod up -d db
-$ docker-compose --file docker-compose.prod.yml --project-name myapp-prod run --rm api bundle exec rails db:setup
+$ docker-compose --file docker-compose.prod.yml --project-name myapp-prod run --rm -e DISABLE_DATABASE_ENVIRONMENT_CHECK=1 api bundle exec rails db:create db:migrate
 $ docker-compose --file docker-compose.prod.yml --project-name myapp-prod up -d
 ```
 

--- a/myapp/config/initializers/maintenance.rb
+++ b/myapp/config/initializers/maintenance.rb
@@ -1,0 +1,3 @@
+require 'rack/maintenance'
+
+Rails.application.config.middleware.insert_after Rails::Rack::Logger, Rack::Maintenance

--- a/myapp/lib/rack/maintenance.rb
+++ b/myapp/lib/rack/maintenance.rb
@@ -2,6 +2,18 @@ class Rack::Maintenance
   MAINTENANCE_STATUS_CODE = 503
   MAINTENANCE_YAML = Rails.root.join('tmp', 'maintenance.yml')
 
+  def self.start(retry_after)
+    Rack::Maintenance::MAINTENANCE_YAML.write(
+      YAML.dump(
+        'retry_after' => retry_after,
+      ),
+    )
+  end
+
+  def self.finish
+    FileUtils.rm_f(Rack::Maintenance::MAINTENANCE_YAML)
+  end
+
   def initialize(app)
     @app = app
     @content = Rails.root.join('public', 'maintenance.html').read

--- a/myapp/lib/rack/maintenance.rb
+++ b/myapp/lib/rack/maintenance.rb
@@ -1,0 +1,27 @@
+class Rack::Maintenance
+  MAINTENANCE_STATUS_CODE = 503
+  MAINTENANCE_YAML = Rails.root.join('tmp', 'maintenance.yml')
+
+  def initialize(app)
+    @app = app
+    @content = Rails.root.join('public', 'maintenance.html').read
+  end
+
+  def call(env)
+    if MAINTENANCE_YAML.file?
+      opts = YAML.safe_load(MAINTENANCE_YAML.read, symbolize_names: true)
+      [MAINTENANCE_STATUS_CODE, headers(opts || {}), [@content]]
+    else
+      @app.call(env)
+    end
+  end
+
+  private
+
+  def headers(opts)
+    {
+      'Content-Type' => 'text/html',
+      'Retry-After' => opts.fetch(:retry_after).to_s,
+    }
+  end
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,16 @@
+namespace :maintenance do
+  desc 'Begin maintenance'
+  task :begin, [:retry_after] => :environment do |_t, args|
+    retry_after = args[:retry_after].then { |v| v ? Integer(v) : 3600 }
+    Rack::Maintenance::MAINTENANCE_YAML.write(
+      YAML.dump(
+        'retry_after' => retry_after,
+      ),
+    )
+  end
+
+  desc 'End maintenance'
+  task :end => :environment do
+    FileUtils.rm_f(Rack::Maintenance::MAINTENANCE_YAML)
+  end
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -2,15 +2,11 @@ namespace :maintenance do
   desc 'Begin maintenance'
   task :begin, [:retry_after] => :environment do |_t, args|
     retry_after = args[:retry_after].then { |v| v ? Integer(v) : 3600 }
-    Rack::Maintenance::MAINTENANCE_YAML.write(
-      YAML.dump(
-        'retry_after' => retry_after,
-      ),
-    )
+    Rack::Maintenance.start(retry_after)
   end
 
   desc 'End maintenance'
   task :end => :environment do
-    FileUtils.rm_f(Rack::Maintenance::MAINTENANCE_YAML)
+    Rack::Maintenance.finish
   end
 end

--- a/myapp/public/maintenance.html
+++ b/myapp/public/maintenance.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Sorry for your inconvenience, but we're in maintenance</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <style>
+      h1 {
+        font-size: 5rem;
+      }
+    </style>
+  </head>
+
+  <body class="rails-default-error-page">
+    <h1>Sorry for your inconvenience, but we're in maintenance 🚧⛑</h1>
+  </body>
+</html>

--- a/myapp/spec/lib/rack/maintenance_spec.rb
+++ b/myapp/spec/lib/rack/maintenance_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe Rack::Maintenance do
+  let(:app) { ->(_env) { [200, {}, ['Hello']] } }
+  let(:request) { Rack::MockRequest.env_for }
+
+  def middleware(app)
+    Rack::Lint.new(described_class.new(app))
+  end
+
+  def start_maintenance(retry_after)
+    described_class::MAINTENANCE_YAML.write(
+      YAML.dump(
+        'retry_after' => retry_after,
+      ),
+    )
+  end
+
+  after do
+    FileUtils.rm_f(Rails.root.join('tmp', 'maintenance.yml'))
+  end
+
+  it 'calls the next middleware/app' do
+    response = middleware(app).call(request)
+    expect(response[0]).to eq 200
+    expect(response[1]).to eq({})
+  end
+
+  it 'does not call the next middleware/app and return the maintenance page' do
+    start_maintenance(1800)
+
+    response = middleware(app).call(request)
+    expect(response[0]).to eq 503
+    expect(response[1]).to eq({ 'Content-Type' => 'text/html', 'Retry-After' => '1800' })
+  end
+end

--- a/myapp/spec/lib/rack/maintenance_spec.rb
+++ b/myapp/spec/lib/rack/maintenance_spec.rb
@@ -10,15 +10,11 @@ RSpec.describe Rack::Maintenance do
   end
 
   def start_maintenance(retry_after)
-    described_class::MAINTENANCE_YAML.write(
-      YAML.dump(
-        'retry_after' => retry_after,
-      ),
-    )
+    Rack::Maintenance.start(retry_after)
   end
 
   after do
-    FileUtils.rm_f(Rails.root.join('tmp', 'maintenance.yml'))
+    Rack::Maintenance.finish
   end
 
   it 'calls the next middleware/app' do

--- a/myapp/spec/rails_helper.rb
+++ b/myapp/spec/rails_helper.rb
@@ -3,6 +3,9 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'rake'
+
+Rails.application.load_tasks
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 


### PR DESCRIPTION
**このプルリクエストはトレーニング用です。**

Rails研修の最後のステップです。ここでは以下の条件でメンテナンス機能を作ります。

1. メンテナンスを開始／終了するバッチを作ってみましょう
2. メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
3. 追加のGemを使わず、自分で実装してみましょう

`2.` についてはリダイレクトではなく、メンテナンスページを表示するだけの実装にしたので提示された課題通りではないかもしれません。しかし、メンテナンス機能を実装する、という目的は達成しているのでご容赦ください。ちなみにこんな画面がでます。

<img width="1120" alt="Screen Shot 2021-05-28 at 9 40 28" src="https://user-images.githubusercontent.com/13130705/119913440-e56d1e80-bf98-11eb-86eb-ab6007432843.png">


## 手元での動作確認方法

以下の手順で確認できると思いますが、もし失敗したらコメントを下さい 🙏 
(Git と Docker Compose が必要です。他に必要なものがあればコメントをください）

1. `git clone https://github.com/Fablic/training` で手元にソースコードを展開
2. `git checkout yykamei/step21` でこのプルリクエストの HEAD にチェックアウト
3. `cd myapp` で Rails アプリのディレクトリーに移動
4. `docker-compose build` で イメージを作成しておく
4. `docker-compose up -d db` を実行して mysqld を予め立ち上げておく
5. `docker-compose run api bundle exec rails db:setup` でスキーマ変更と seed の反映を行う
6. `docker-compose up -d` を実行してサービスを手元で走らせる
7. http://localhost:3001/login にブラウザーでアクセスしてログイン画面が表示されることを確認
8. `docker-compose exec api bundle exec rails maintenance:begin` を実行してメンテナンスモードへ
9. http://localhost:3001/login や他のページにアクセスしてメンテナンス画面が表示されることを確認
10. `docker-compose exec api bundle exec rails maintenance:end` を実行してメンテナンスモード終了
11. http://localhost:3001/login や他のページにアクセスして通常画面が表示されることを確認

