### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替え、ステップ11: バリデーションを設定

### DIFF
--- a/tasks/.rubocop.yml
+++ b/tasks/.rubocop.yml
@@ -54,6 +54,9 @@ Metrics/LineLength:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/MethodLength:
+  Max: 20
+
 ##################### Naming ##################################
 
 # 「FactoryBot」をスネークケースにする警告を除外するため

--- a/tasks/app/controllers/tasks_controller.rb
+++ b/tasks/app/controllers/tasks_controller.rb
@@ -1,26 +1,24 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: %i[ show edit update destroy ]
+  before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.without_deleted
+    @tasks = Task.without_deleted.created_at_desc
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @task = Task.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     create_params = task_params.merge(status_id: MasterTaskStatus::NOT_STARTED)
     @task = Task.new(create_params)
     respond_to do |format|
       if @task.save
-        format.html { redirect_to @task, notice: "タスクを作成しました。" }
+        format.html { redirect_to @task, notice: 'タスクを作成しました。' }
         format.json { render :show, status: :created, location: @task }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -32,7 +30,7 @@ class TasksController < ApplicationController
   def update
     respond_to do |format|
       if @task.update(task_params)
-        format.html { redirect_to @task, notice: "タスクを更新しました。" }
+        format.html { redirect_to @task, notice: 'タスクを更新しました。' }
         format.json { render :show, status: :ok, location: @task }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -46,18 +44,19 @@ class TasksController < ApplicationController
     now = Time.current
     @task.update(deleted_at: now)
     respond_to do |format|
-      format.html { redirect_to tasks_url, notice: "タスクを削除しました。" }
+      format.html { redirect_to tasks_url, notice: 'タスクを削除しました。' }
       format.json { head :no_content }
     end
   end
 
   private
-    # 共通処理
-    def set_task
-      @task = Task.find(params[:id])
-    end
 
-    def task_params
-      params.require(:task).permit(:task_name, :status_id, :priority_id, :label, :limit_date, :detail)
-    end
+  # 共通処理
+  def set_task
+    @task = Task.find(params[:id])
+  end
+
+  def task_params
+    params.require(:task).permit(:task_name, :status_id, :priority_id, :label, :limit_date, :detail)
+  end
 end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -1,5 +1,6 @@
 class Task < ApplicationRecord
-    belongs_to :priority, class_name: "MasterTaskPriority"
-    belongs_to :status, class_name: "MasterTaskStatus"
-    scope :without_deleted, -> { where(deleted_at: nil) }
+  belongs_to :priority, class_name: 'MasterTaskPriority'
+  belongs_to :status, class_name: 'MasterTaskStatus'
+  scope :without_deleted, -> { where(deleted_at: nil) }
+  scope :created_at_desc, -> { order(created_at: :desc) }
 end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -1,6 +1,17 @@
 class Task < ApplicationRecord
+  validates :task_name, presence: true, length: { maximum: 60 }
+  validates :label, length: { maximum: 20 }
+  validates :detail, length: { maximum: 250 }
+  validate :before_datetime
+
   belongs_to :priority, class_name: 'MasterTaskPriority'
   belongs_to :status, class_name: 'MasterTaskStatus'
   scope :without_deleted, -> { where(deleted_at: nil) }
   scope :created_at_desc, -> { order(created_at: :desc) }
+
+  def before_datetime
+    # 期限がNULLでない＆期限の日時が変更されている＆現在日時より前の日時に期限を変更している場合、エラーになる
+    errors.add(:limit_date, :cannot_be_before_datetime)\
+      if !limit_date.nil? && limit_date_was != limit_date && limit_date <= Time.current
+  end
 end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -2,7 +2,7 @@ class Task < ApplicationRecord
   validates :task_name, presence: true, length: { maximum: 60 }
   validates :label, length: { maximum: 20 }
   validates :detail, length: { maximum: 250 }
-  validate :before_datetime, if: :change_limit_date?
+  validate :before_datetime, if: :will_save_change_to_limit_date?
 
   belongs_to :priority, class_name: 'MasterTaskPriority'
   belongs_to :status, class_name: 'MasterTaskStatus'
@@ -10,13 +10,9 @@ class Task < ApplicationRecord
   scope :created_at_desc, -> { order(created_at: :desc) }
 
   def before_datetime
-    return if limit_date > Time.current
+    return if limit_date.blank? || limit_date > Time.current
 
     # 現在日時より前の日時に期限を変更している場合、エラーになる
     errors.add(:limit_date, :cannot_be_before_datetime)
-  end
-
-  def change_limit_date?
-    limit_date.present? && will_save_change_to_limit_date?
   end
 end

--- a/tasks/app/views/tasks/_form.html.erb
+++ b/tasks/app/views/tasks/_form.html.erb
@@ -16,13 +16,13 @@
 
   <%= f.label :priority %>
   <% case controller.action_name
-  when 'new' %>
+  when 'new', 'create' %>
     <%= f.collection_select :priority_id, MasterTaskPriority.all, :id, :priority, :prompt => true %>
-  <% when 'edit' %>
+  <% when 'edit', 'update' %>
     <%= f.collection_select :priority_id, MasterTaskPriority.all, :id, :priority, :prompt => @task.priority.priority %>
   <% end %>
 
-  <% if controller.action_name == 'edit' %>
+  <% if controller.action_name == 'edit' || controller.action_name == 'update' %>
     <%= f.label :status %>
     <%= f.collection_select :status_id, MasterTaskStatus.all, :id, :status, :prompt => @task.status.status %>
   <% end %>

--- a/tasks/app/views/tasks/_form.html.erb
+++ b/tasks/app/views/tasks/_form.html.erb
@@ -22,7 +22,7 @@
     <%= f.collection_select :priority_id, MasterTaskPriority.all, :id, :priority, :prompt => @task.priority.priority %>
   <% end %>
 
-  <% if controller.action_name == 'edit' || controller.action_name == 'update' %>
+  <% if controller.action_name.in?(%w[edit update]) %>
     <%= f.label :status %>
     <%= f.collection_select :status_id, MasterTaskStatus.all, :id, :status, :prompt => @task.status.status %>
   <% end %>

--- a/tasks/config/locales/ja.yml
+++ b/tasks/config/locales/ja.yml
@@ -15,6 +15,12 @@ ja:
         label: ラベル
         limit_date: 期限
         detail: 詳細説明
+    errors:
+      models:
+        task:
+          attributes:
+            limit_date:
+              cannot_be_before_datetime: 現在時刻より前の日時は設定できません
   time:
     formats:
       default: "%Y/%m/%d %H:%M"

--- a/tasks/spec/controllers/tasks_controller_spec.rb
+++ b/tasks/spec/controllers/tasks_controller_spec.rb
@@ -7,11 +7,23 @@ RSpec.describe TasksController, type: :controller do
 
   describe '#index' do
     context 'レスポンスが正常の時' do
+      let(:task_list) do
+        [
+          create(:task_list_item),
+          create(:task_list_item, created_at: Time.current + 1.day),
+          create(:task_list_item, created_at: Time.current + 2.days),
+          create(:task_list_item, deleted_at: Time.current)
+        ]
+      end
       it 'HTTPステータスコードが200、テンプレートが表示されること' do
         get :index
         expect(response).to be_successful
         expect(response).to have_http_status :success
         expect(response).to render_template :index
+      end
+      it '作成日時の降順かつ、論理削除されていないタスクのみの一覧が取得されること' do
+        get :index
+        expect(Task.without_deleted.created_at_desc).to match [task_list[2], task_list[1], task_list[0], task]
       end
     end
   end

--- a/tasks/spec/factories/tasks.rb
+++ b/tasks/spec/factories/tasks.rb
@@ -10,4 +10,9 @@ FactoryBot.define do
       )
     end
   end
+  factory :task_list_item, class: Task do
+    task_name { 'テストタスク名' }
+    status { create(:notStarted) }
+    priority { create(:low) }
+  end
 end

--- a/tasks/spec/factories/tasks.rb
+++ b/tasks/spec/factories/tasks.rb
@@ -15,4 +15,10 @@ FactoryBot.define do
     status { create(:notStarted) }
     priority { create(:low) }
   end
+  factory :exist_limit_date_task, class: Task do
+    task_name { 'テストタスク名' }
+    status { create(:notStarted) }
+    priority { create(:low) }
+    limit_date { Time.current + 1.minute }
+  end
 end

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -40,11 +40,25 @@ RSpec.describe Task, type: :model do
       xit 'エラーになる' do
         task = Task.new(
           task_name: 'テストタスク',
-          status: lowTaskPriority,
+          status: notStartedTaskStatus,
           priority: nil
         )
         task.valid?
         expect(task.errors[:priority]).to include('must exist')
+      end
+    end
+  end
+  describe 'scope' do
+    context 'created_at_desc' do
+      let(:task_list) do
+        [
+          create(:task_list_item),
+          create(:task_list_item, created_at: Time.current + 1.day),
+          create(:task_list_item, created_at: Time.current + 2.days)
+        ]
+      end
+      it '作成日時の降順で取得できる' do
+        expect(Task.created_at_desc).to match [task_list[2], task_list[1], task_list[0]]
       end
     end
   end

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -152,25 +152,23 @@ RSpec.describe Task, type: :model do
   end
 
   describe 'すでに設定されている期限が現在時刻より前の日時のバリデーション' do
-    before do
-      @task = travel(-1.day) { create(:exist_limit_date_task) }
-    end
+    let(:task) { travel(-1.day) { create(:exist_limit_date_task) } }
     context '期限が変更されていない場合' do
       it '有効である' do
-        expect(@task).to be_valid
+        expect(task).to be_valid
       end
     end
     context '現在時刻より前の日時に期限が変更される場合' do
       it 'エラーになる' do
-        @task.limit_date = Time.current - 1.minute
-        expect(@task).to be_invalid
-        expect(@task.errors[:limit_date]).to include('現在時刻より前の日時は設定できません')
+        task.limit_date = Time.current - 1.minute
+        expect(task).to be_invalid
+        expect(task.errors[:limit_date]).to include('現在時刻より前の日時は設定できません')
       end
     end
     context '現在時刻より後の日時に期限が変更される場合' do
       it '有効である' do
-        @task.limit_date = Time.current + 1.minute
-        expect(@task).to be_valid
+        task.limit_date = Time.current + 1.minute
+        expect(task).to be_valid
       end
     end
   end

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -1,53 +1,180 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  describe 'バリデーション' do
-    let(:notStartedTaskStatus) { create(:notStarted) }
-    let(:lowTaskPriority) { create(:low) }
+  describe '正常系' do
     context 'タスク名、ステータス、優先度がある場合' do
+      let(:task) { build(:task) }
       it '有効である' do
-        task = Task.new(
-          task_name: 'テストタスク名',
-          status: notStartedTaskStatus,
-          priority: lowTaskPriority
-        )
         expect(task).to be_valid
       end
     end
+  end
+
+  describe 'タスク名バリデーション' do
+    let(:task) { build(:task, task_name: task_name) }
     context 'タスク名がない場合' do
-      xit 'エラーになる' do
-        task = Task.new(
-          task_name: nil,
-          status: notStartedTaskStatus,
-          priority: lowTaskPriority
-        )
-        task.valid?
-        expect(task.errors[:task_name]).to include('must exist')
+      let(:task_name) { '' }
+      it 'エラーになる' do
+        expect(task).to be_invalid
+        expect(task.errors[:task_name]).to include('を入力してください')
       end
     end
-    context 'ステータスがない場合' do
-      xit 'エラーになる' do
-        task = Task.new(
-          task_name: 'テストタスク',
-          status: nil,
-          priority: lowTaskPriority
-        )
-        task.valid?
-        expect(task.errors[:status]).to include('must exist')
+    context 'タスク名の文字数が上限未満の場合' do
+      let(:task_name) { 'a' * 59 }
+      it '有効である' do
+        expect(task).to be_valid
       end
     end
-    context '優先度がない場合' do
-      xit 'エラーになる' do
-        task = Task.new(
-          task_name: 'テストタスク',
-          status: notStartedTaskStatus,
-          priority: nil
-        )
-        task.valid?
-        expect(task.errors[:priority]).to include('must exist')
+    context 'タスク名の文字数が上限と同じ場合' do
+      let(:task_name) { 'a' * 60 }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context 'タスク名の文字数が上限を超える場合' do
+      let(:task_name) { 'a' * 61 }
+      it 'エラーになる' do
+        expect(task).to be_invalid
+        expect(task.errors[:task_name]).to include('は60文字以内で入力してください')
       end
     end
   end
+
+  describe 'ステータスのバリデーション' do
+    let(:task) { build(:task, status_id: status) }
+    context 'ステータスがない場合' do
+      let(:status) { nil }
+      it 'エラーになる' do
+        task.status_id = status
+        expect(task).to be_invalid
+        expect(task.errors[:status]).to include('を入力してください')
+      end
+    end
+  end
+
+  describe '優先度のバリデーション' do
+    let(:task) { build(:task, priority_id: priority) }
+    context '優先度がない場合' do
+      let(:priority) { nil }
+      it 'エラーになる' do
+        expect(task).to be_invalid
+        expect(task.errors[:priority]).to include('を入力してください')
+      end
+    end
+  end
+
+  describe 'ラベルのバリデーション' do
+    let(:task) { build(:task, label: label) }
+    context '空文字の場合' do
+      let(:label) { '' }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context '文字数が上限未満の場合' do
+      let(:label) { 'a' * 19 }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context '文字数が上限と同じ場合' do
+      let(:label) { 'a' * 20 }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context '文字数が上限を超える場合' do
+      let(:label) { 'a' * 21 }
+      it 'エラーになる' do
+        expect(task).to be_invalid
+        expect(task.errors[:label]).to include('は20文字以内で入力してください')
+      end
+    end
+  end
+
+  describe '詳細説明のバリデーション' do
+    let(:task) { build(:task, detail: detail) }
+    context '空文字の場合' do
+      let(:detail) { '' }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context '文字数が上限未満の場合' do
+      let(:detail) { 'a' * 249 }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context '文字数が上限と同じ場合' do
+      let(:detail) { 'a' * 250 }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context '詳細説明の文字数が上限を超える場合' do
+      let(:detail) { 'a' * 251 }
+      it 'エラーになる' do
+        expect(task).to be_invalid
+        expect(task.errors[:detail]).to include('は250文字以内で入力してください')
+      end
+    end
+  end
+
+  describe '期限のバリデーション' do
+    let(:task) { build(:task, limit_date: limit_date) }
+    context '期限を設定していない場合' do
+      let(:limit_date) { nil }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context '期限が現在時刻より後に設定する場合' do
+      let(:limit_date) { Time.current + 1.minute }
+      it '有効である' do
+        expect(task).to be_valid
+      end
+    end
+    context '現在時刻と同じに設定する場合' do
+      let(:limit_date) { Time.current }
+      it 'エラーになる' do
+        expect(task).to be_invalid
+        expect(task.errors[:limit_date]).to include('現在時刻より前の日時は設定できません')
+      end
+    end
+    context '現在時刻より前に設定する場合' do
+      let(:limit_date) { Time.current - 1.minute }
+      it 'エラーになる' do
+        expect(task).to be_invalid
+        expect(task.errors[:limit_date]).to include('現在時刻より前の日時は設定できません')
+      end
+    end
+  end
+
+  describe 'すでに設定されている期限が現在時刻より前の日時のバリデーション' do
+    before do
+      @task = travel(-1.day) { create(:exist_limit_date_task) }
+    end
+    context '期限が変更されていない場合' do
+      it '有効である' do
+        expect(@task).to be_valid
+      end
+    end
+    context '現在時刻より前の日時に期限が変更される場合' do
+      it 'エラーになる' do
+        @task.limit_date = Time.current - 1.minute
+        expect(@task).to be_invalid
+        expect(@task.errors[:limit_date]).to include('現在時刻より前の日時は設定できません')
+      end
+    end
+    context '現在時刻より後の日時に期限が変更される場合' do
+      it '有効である' do
+        @task.limit_date = Time.current + 1.minute
+        expect(@task).to be_valid
+      end
+    end
+  end
+
   describe 'scope' do
     context 'created_at_desc' do
       let(:task_list) do

--- a/tasks/spec/rails_helper.rb
+++ b/tasks/spec/rails_helper.rb
@@ -62,4 +62,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
課題
https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD
上記のリンクの
「ステップ10: タスク一覧を作成日時の順番で並び替えましょう」
「ステップ11: バリデーションを設定してみよう」

実装内容
・タスク一覧が作成日時の降順になるように実装（rspecも実装）
・「タスク名」「ラベル」「詳細説明」にバリデーションを実装（rspecも実装）
・「期限」に対して、カスタムバリデーションを実装（rspecも実装）
　新規作成、編集時：現在時刻と同じか前の日時を選択するとエラーになる
　編集時：期限に変更ない場合、その期限が現在時刻より前の日時であってもエラーにならないようにする
・バリデーションエラー時、ステータスと優先度のセレクトボックスが非表示になる不具合を修正



共有事項
・ステップ10の実装コード数が少なかったため、ステップ11も同時に実装しております
・ステップ11のDB制約のマイグレーションファイル作成関連は、すでに作成済みの状態のため追加実装しておりません。
・ステップ11の画面にバリデーションエラーのメッセージを表示する実装もすでに実装済みです。（少し修正しております）