### PR TITLE
Step6: add Task model

### DIFF
--- a/tasks_api/app/models/task.rb
+++ b/tasks_api/app/models/task.rb
@@ -1,0 +1,2 @@
+class Task < ApplicationRecord
+end

--- a/tasks_api/db/migrate/20210705060239_create_tasks.rb
+++ b/tasks_api/db/migrate/20210705060239_create_tasks.rb
@@ -1,0 +1,10 @@
+class CreateTasks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tasks do |t|
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/tasks_api/db/schema.rb
+++ b/tasks_api/db/schema.rb
@@ -1,0 +1,22 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_07_05_060239) do
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/tasks_api/test/fixtures/tasks.yml
+++ b/tasks_api/test/fixtures/tasks.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyText
+
+two:
+  name: MyString
+  description: MyText

--- a/tasks_api/test/models/task_test.rb
+++ b/tasks_api/test/models/task_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TaskTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This adds Task model.
migration:
```
user@ubuntu:~/rakuma/training/tasks_api$ rails db:migrate:redo VERSION=20210705060239
== 20210705060239 CreateTasks: reverting ======================================
-- drop_table(:tasks)
   -> 0.0044s
== 20210705060239 CreateTasks: reverted (0.0063s) =============================

== 20210705060239 CreateTasks: migrating ======================================
-- create_table(:tasks)
   -> 0.0046s
== 20210705060239 CreateTasks: migrated (0.0076s) =============================

user@ubuntu:~/rakuma/training/tasks_api$ 
```

ref. https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%976-%E3%82%BF%E3%82%B9%E3%82%AF%E3%83%A2%E3%83%87%E3%83%AB%E3%82%92%E4%BD%9C%E6%88%90%E3%81%97%E3%81%BE%E3%81%97%E3%82%87%E3%81%86