### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/todo_app/app/controllers/application_controller.rb
+++ b/todo_app/app/controllers/application_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include ApplicationHelper
   include SessionsHelper
+
+  before_action :render_service_unavailable, if: :maintenance?
   before_action :authenticate_user
 
   unless Rails.env.development?
@@ -28,5 +31,9 @@ class ApplicationController < ActionController::Base
 
   def authenticate_user
     redirect_to login_path unless user_signed_in?
+  end
+
+  def render_service_unavailable
+    render all_maintenance? ? 'layouts/maintenance' : "#{request_path[:controller]}/maintenance", status: :service_unavailable
   end
 end

--- a/todo_app/app/helpers/application_helper.rb
+++ b/todo_app/app/helpers/application_helper.rb
@@ -1,4 +1,25 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def maintenance?
+    File.exist?(maintenance_file_path)
+  end
+
+  def request_path
+    Rails.application.routes.recognize_path(request.url)
+  end
+
+  def maintenance_file_path
+    return application_maintenance_file if all_maintenance?
+
+    Rails.root.join("app/views/#{request_path[:controller]}/maintenance.html.erb")
+  end
+
+  def application_maintenance_file
+    Rails.root.join('app/views/layouts/maintenance.html.erb')
+  end
+
+  def all_maintenance?
+    File.exist?(application_maintenance_file)
+  end
 end

--- a/todo_app/app/views/errors/maintenance.html.erb
+++ b/todo_app/app/views/errors/maintenance.html.erb
@@ -1,0 +1,5 @@
+<div class="alert alert-danger mt-3" role="alert">
+  <h4 class="alert-heading">メンテナンス中です</h4>
+  <hr>
+  REASON
+</div>

--- a/todo_app/app/views/layouts/application.html.erb
+++ b/todo_app/app/views/layouts/application.html.erb
@@ -11,28 +11,30 @@
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
   <body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light p-4 mb-3">
-      <div class="container-fluid">
-        <%= link_to 'TodoApp', root_path, class: 'navbar-brand' %>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-          <ul class="navbar-nav me-auto mb-2 mb-lg-0 mt-3 mt-lg-0">
-            <% unless maintenance? %>
-              <li class="nav-item">
-                <%= render 'tasks/search_form' %>
-              </li>
+    <% unless all_maintenance? %>
+      <nav class="navbar navbar-expand-lg navbar-light bg-light p-4 mb-3">
+        <div class="container-fluid">
+          <%= link_to 'TodoApp', root_path, class: 'navbar-brand' %>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0 mt-3 mt-lg-0">
+              <% unless maintenance? %>
+                <li class="nav-item">
+                  <%= render 'tasks/search_form' %>
+                </li>
+              <% end %>
+            </ul>
+            <% if user_signed_in? %>
+              <%= link_to Task.model_name.human, root_path, class: 'nav-link btn btn-outline-secondary btn-sm', 'aria-current' => 'page' %>
+              <%= link_to Label.model_name.human, labels_path, class: 'nav-link btn btn-outline-secondary btn-sm ms-0 ms-lg-3 mt-3 mt-lg-0', 'aria-current' => 'page' %>
             <% end %>
-          </ul>
-          <% if user_signed_in? %>
-            <%= link_to Task.model_name.human, root_path, class: 'nav-link btn btn-outline-secondary btn-sm', 'aria-current' => 'page' %>
-            <%= link_to Label.model_name.human, labels_path, class: 'nav-link btn btn-outline-secondary btn-sm ms-0 ms-lg-3 mt-3 mt-lg-0', 'aria-current' => 'page' %>
-          <% end %>
-            <%= render 'sessions/link' %>
+              <%= render 'sessions/link' %>
+          </div>
         </div>
-      </div>
-    </nav>
+      </nav>
+    <% end %>
     <div class="container-fluid mb-3">
       <div class="container">
         <%= yield %>

--- a/todo_app/app/views/layouts/application.html.erb
+++ b/todo_app/app/views/layouts/application.html.erb
@@ -19,9 +19,11 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0 mt-3 mt-lg-0">
-            <li class="nav-item">
-              <%= render 'tasks/search_form' %>
-            </li>
+            <% unless maintenance? %>
+              <li class="nav-item">
+                <%= render 'tasks/search_form' %>
+              </li>
+            <% end %>
           </ul>
           <% if user_signed_in? %>
             <%= link_to Task.model_name.human, root_path, class: 'nav-link btn btn-outline-secondary btn-sm', 'aria-current' => 'page' %>

--- a/todo_app/lib/tasks/maintenance.rake
+++ b/todo_app/lib/tasks/maintenance.rake
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc 'start maintenance'
+  task :start, %i[dir_name reason] => :environment do |task, args|
+    template(args[:dir_name], task) do |maintenance_file|
+      if File.exist?(maintenance_file)
+        puts '既に存在ファイルがします'
+      else
+        FileUtils.cp(origin_maintenance_file, maintenance_file)
+        read_file = File.open(maintenance_file, 'r', &:read)
+        reason = args[:reason] || '申し訳ございません'
+        read_file.gsub!('REASON', "<p class='mb-0'>#{reason}</p>")
+        File.open(maintenance_file, 'r+') do |f|
+          f.write(read_file)
+        end
+      end
+    end
+  end
+
+  desc 'finish maintenance'
+  task :finish, %i[dir_name] => :environment do |task, args|
+    template(args[:dir_name], task) do |maintenance_file|
+      if File.exist?(maintenance_file)
+        FileUtils.rm(maintenance_file)
+      else
+        puts '既にファイルが削除されています'
+      end
+    end
+  end
+
+  def template(dir_name, task)
+    maintenance_batch_start_notify(task)
+    if ensure_dir(dir_name)
+      maintenance_file = maintenance_file_path(dir_name)
+      yield(maintenance_file)
+    else
+      puts 'ディレクトリが存在しません'
+    end
+    maintenance_batch_finish_notify(task)
+  rescue StandardError => e
+    Rails.logger.error(e)
+    Rails.logger.error(e.backtrace.join("\n"))
+  end
+
+  def maintenance_file_path(dir_name)
+    Rails.root.join("app/views/#{dir_name}/maintenance.html.erb")
+  end
+
+  def origin_maintenance_file
+    Rails.root.join('app/views/errors/maintenance.html.erb')
+  end
+
+  def ensure_dir(dir_name)
+    Dir.exist?(Rails.root.join("app/views/#{dir_name}"))
+  end
+
+  def maintenance_batch_start_notify(task)
+    puts "メンテナンスバッチ #{task} を開始します"
+  end
+
+  def maintenance_batch_finish_notify(task)
+    puts "メンテナンスバッチ #{task} を終了します"
+  end
+end

--- a/todo_app/spec/lib/tasks/maintenance_spec.rb
+++ b/todo_app/spec/lib/tasks/maintenance_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'maintenance' do
+  let(:dir) { 'users' }
+  let(:file) { Rails.root.join("app/views/#{dir}/maintenance.html.erb") }
+
+  before(:all) do
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake.application.rake_require 'tasks/maintenance'
+    Rake::Task.define_task(:environment)
+  end
+
+  before(:each) do
+    @rake[task_name].reenable
+  end
+
+  describe 'start' do
+    let(:task_name) { 'maintenance:start' }
+    let(:reason) { 'hogehoge' }
+
+    context 'args are users directory and reason' do
+      it 'create file' do
+        @rake[task_name].invoke(dir, reason)
+        visit sign_up_path
+
+        expect(File).to exist(file)
+        expect(page).to have_content('hogehoge')
+      end
+    end
+  end
+
+  describe 'finish' do
+    let(:task_name) { 'maintenance:finish' }
+
+    context 'arg is users direcotry' do
+      it 'delete file' do
+        @rake[task_name].invoke(dir)
+        visit sign_up_path
+
+        expect(File).not_to exist(file)
+        expect(page).not_to have_content('hogehoge')
+      end
+    end
+  end
+end

--- a/todo_app/spec/rails_helper.rb
+++ b/todo_app/spec/rails_helper.rb
@@ -75,4 +75,7 @@ RSpec.configure do |config|
       end
     end
   end
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
 end


### PR DESCRIPTION
# 概要
## [ステップ21: メンテナンス機能を作ろう](https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)

# 詳細

- [x] メンテナンスを開始／終了するバッチを作ってみましょう
   - 開始時実行コマンド
 ```
  rake 'maintenance:start[画面ディレクトリ名, 理由]' 
```
```example
 rake 'maintenance:start[users, ユーザー登録周りで不具合が発生したためメンテナンスしております]' 
```

- 終了時実行コマンド
 ```
  rake 'maintenance:start[画面ディレクトリ名]' 
```
```example
 rake 'maintenance:start[users]' 
```
- [x] メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
- application全体(layouts) ヘッダーなし
![image](https://user-images.githubusercontent.com/85147122/124740240-90d4a000-df55-11eb-8f4e-daf1a863bee9.png)

- 画面ディレクトリ(ex: users)　ヘッダーあり
![image](https://user-images.githubusercontent.com/85147122/124740395-bb265d80-df55-11eb-8d7f-b7dea0df5cea.png)


- [x] 追加のGemを使わず、自分で実装してみましょう