### PR TITLE
ステップ12: 終了期限のソート機能の実装

### DIFF
--- a/tasks/.rubocop.yml
+++ b/tasks/.rubocop.yml
@@ -1,6 +1,3 @@
-HashSyntax:
-  EnforcedStyle: ruby19
-
 require:
   - rubocop-rails
 
@@ -42,13 +39,16 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
-##################### Metrics ##################################
+##################### Layout ##################################
 
 # 1行の文字数
-Metrics/LineLength:
+Layout/LineLength:
   Max: 160
   Exclude:
     - "db/migrate/*.rb"
+
+##################### Metrics ##################################
+
 
 # ブロックの行数
 Metrics/BlockLength:

--- a/tasks/app/controllers/tasks_controller.rb
+++ b/tasks/app/controllers/tasks_controller.rb
@@ -1,8 +1,9 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
+  helper_method :sort_column, :sort_direction
 
   def index
-    @tasks = Task.without_deleted.created_at_desc
+    @tasks = Task.without_deleted.order("#{sort_column} #{sort_direction}")
   end
 
   def show; end
@@ -58,5 +59,13 @@ class TasksController < ApplicationController
 
   def task_params
     params.require(:task).permit(:task_name, :status_id, :priority_id, :label, :limit_date, :detail)
+  end
+
+  def sort_direction
+    params[:direction].in?(%w[asc desc]) ? params[:direction] : 'desc'
+  end
+
+  def sort_column
+    params[:sort].in?(Task.column_names) ? params[:sort] : 'created_at'
   end
 end

--- a/tasks/app/helpers/tasks_helper.rb
+++ b/tasks/app/helpers/tasks_helper.rb
@@ -1,6 +1,6 @@
 module TasksHelper
   def sort_order(column, title)
-    direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
+    direction = sort_column == column && sort_direction == 'asc' ? 'desc' : 'asc'
     link_to title, root_path({ sort: column, direction: direction })
   end
 end

--- a/tasks/app/helpers/tasks_helper.rb
+++ b/tasks/app/helpers/tasks_helper.rb
@@ -1,0 +1,6 @@
+module TasksHelper
+  def sort_order(column, title)
+    direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
+    link_to title, root_path({ sort: column, direction: direction })
+  end
+end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -7,7 +7,6 @@ class Task < ApplicationRecord
   belongs_to :priority, class_name: 'MasterTaskPriority'
   belongs_to :status, class_name: 'MasterTaskStatus'
   scope :without_deleted, -> { where(deleted_at: nil) }
-  scope :created_at_desc, -> { order(created_at: :desc) }
 
   def before_datetime
     return if limit_date.blank? || limit_date > Time.current

--- a/tasks/app/views/tasks/index.html.erb
+++ b/tasks/app/views/tasks/index.html.erb
@@ -12,7 +12,7 @@
       <th><%= Task.human_attribute_name(:priority) %></th>
       <th><%= Task.human_attribute_name(:label) %></th>
       <th><%= Task.human_attribute_name(:task_name) %></th>
-      <th><%= Task.human_attribute_name(:limit_date) %></th>
+      <th><%= sort_order 'limit_date', Task.human_attribute_name(:limit_date) %></th>
       <th><%= Task.human_attribute_name(:detail) %></th>
     </tr>
   </thead>

--- a/tasks/spec/controllers/tasks_controller_spec.rb
+++ b/tasks/spec/controllers/tasks_controller_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe TasksController, type: :controller do
       let(:task_list) do
         [
           create(:task_list_item),
-          create(:task_list_item, created_at: Time.current + 1.day),
-          create(:task_list_item, created_at: Time.current + 2.days),
-          create(:task_list_item, deleted_at: Time.current)
+          create(:task_list_item, created_at: Time.current + 1.day, limit_date: Time.current + 5.days),
+          create(:task_list_item, created_at: Time.current + 2.days, limit_date: Time.current + 3.days),
+          create(:task_list_item, deleted_at: Time.current, limit_date: Time.current + 2.days)
         ]
       end
       it 'HTTPステータスコードが200、テンプレートが表示されること' do
@@ -23,7 +23,11 @@ RSpec.describe TasksController, type: :controller do
       end
       it '作成日時の降順かつ、論理削除されていないタスクのみの一覧が取得されること' do
         get :index
-        expect(Task.without_deleted.created_at_desc).to match [task_list[2], task_list[1], task_list[0], task]
+        expect(Task.without_deleted.order('created_at desc')).to match [task_list[2], task_list[1], task_list[0], task]
+      end
+      it '期限の降順かつ、論理削除されていないタスクのみの一覧が取得されること（期限が同じならIDの昇順）' do
+        get :index
+        expect(Task.without_deleted.order('limit_date desc')).to match [task_list[1], task_list[2], task, task_list[0]]
       end
     end
   end

--- a/tasks/spec/helpers/tasks_helper_spec.rb
+++ b/tasks/spec/helpers/tasks_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe TasksHelper, type: :helper do
+  describe 'sort_order' do
+    context 'リクエストが「期限」の「降順」場合' do
+      before do
+        def helper.sort_column; end
+
+        def helper.sort_direction; end
+
+        allow(helper).to receive(:sort_column).and_return('limit_date')
+        allow(helper).to receive(:sort_direction).and_return('desc')
+      end
+      it '「期限」の「昇順」のリンクが生成されること' do
+        expect(helper.sort_order('limit_date', Task.human_attribute_name(:limit_date))).to eq('<a href="/?direction=asc&amp;sort=limit_date">期限</a>')
+      end
+    end
+  end
+end

--- a/tasks/spec/helpers/tasks_helper_spec.rb
+++ b/tasks/spec/helpers/tasks_helper_spec.rb
@@ -15,5 +15,31 @@ RSpec.describe TasksHelper, type: :helper do
         expect(helper.sort_order('limit_date', Task.human_attribute_name(:limit_date))).to eq('<a href="/?direction=asc&amp;sort=limit_date">期限</a>')
       end
     end
+    context 'リクエストが「期限」の「昇順」場合' do
+      before do
+        def helper.sort_column; end
+
+        def helper.sort_direction; end
+
+        allow(helper).to receive(:sort_column).and_return('limit_date')
+        allow(helper).to receive(:sort_direction).and_return('asc')
+      end
+      it '「期限」の「降順」のリンクが生成されること' do
+        expect(helper.sort_order('limit_date', Task.human_attribute_name(:limit_date))).to eq('<a href="/?direction=desc&amp;sort=limit_date">期限</a>')
+      end
+    end
+    context 'リクエストが「作成日」の「昇順」場合' do
+      before do
+        def helper.sort_column; end
+
+        def helper.sort_direction; end
+
+        allow(helper).to receive(:sort_column).and_return('created_at')
+        allow(helper).to receive(:sort_direction).and_return('asc')
+      end
+      it '「期限」の「昇順」のリンクが生成されること' do
+        expect(helper.sort_order('limit_date', Task.human_attribute_name(:limit_date))).to eq('<a href="/?direction=asc&amp;sort=limit_date">期限</a>')
+      end
+    end
   end
 end

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -172,19 +172,4 @@ RSpec.describe Task, type: :model do
       end
     end
   end
-
-  describe 'scope' do
-    context 'created_at_desc' do
-      let(:task_list) do
-        [
-          create(:task_list_item),
-          create(:task_list_item, created_at: Time.current + 1.day),
-          create(:task_list_item, created_at: Time.current + 2.days)
-        ]
-      end
-      it '作成日時の降順で取得できる' do
-        expect(Task.created_at_desc).to match [task_list[2], task_list[1], task_list[0]]
-      end
-    end
-  end
 end


### PR DESCRIPTION
**課題**
https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E7%B5%82%E4%BA%86%E6%9C%9F%E9%99%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD
上記リンクの「ステップ12: 終了期限を追加しよう」

**実装内容**
・期限にソート機能を実装
・ソート機能実装により以前実装していた「一覧ページ表示時に作成日時の降順で表示」の実装が、今回の実装でまとめられたため、その機能を削除し、まとめました
（scope created_at_descの箇所を削除しました）
・ソート機能のrspecの実装
・tasks/.rubocop.ymlで不要な箇所などを一部修正しました

**共有事項**
・終了期限は「期限」としてすでに実装済みです