### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/todo_app/README.md
+++ b/todo_app/README.md
@@ -4,14 +4,14 @@
 ## Setup
 
 
-1. Set up Ruby
+### 1. Set up Ruby
 
 ```
 rbenv install 3.0.1
 rbenv global 3.0.1
 ```
 
-2. Database Setup
+### 2. Database Setup
 
 ```
 cd docker
@@ -22,14 +22,13 @@ MySQL8のバージョンで失敗する場合
 
 - https://mebee.info/2020/07/25/post-15160/
 
-
-3. Bundle install
+### 3. Bundle install
 
 ```
 bundle install
 ```
 
-4. Setup webpacker
+### 4. Setup webpacker
 
 ```
 bundle exec rails webpacker:yarn_install
@@ -37,7 +36,7 @@ bundle exec rails assets:clobber
 bundle exec rails webpacker:compile
 ```
 
-5. Rails setup
+### 5. Rails setup
 
 ```
 bundle exec rails db:migrate
@@ -45,7 +44,7 @@ bundle exec rails db:seed
 bundle exec rails server
 ```
 
-5.1 Login App
+### 5.1 Login App
 
 ```
 ### Admin
@@ -57,7 +56,7 @@ email: normal@example.com
 password: AAAA1234
 ```
 
-6. Create test data
+### 6. Create test data
 
 ```
 bundle exec rails c
@@ -66,6 +65,21 @@ bundle exec rails c
 > (1..10).each{|n| Task.create(title: Faker::Alphanumeric.alpha(number: 10), task_status: :doing, user_id: User.find_by({ username: 'admin' }).id) }
 > (1..10).each{|n| Task.create(title: Faker::Alphanumeric.alpha(number: 10), task_status: :done, user_id: User.find_by({ username: 'admin' }).id) }
 ```
+
+### Other Maintenance Mode
+
+#### Start
+
+```
+bundle exec rake maintenance:start
+```
+
+#### End
+
+```
+bundle exec rake maintenance:end
+```
+
 
 ## ペーパープロトタイピング
 

--- a/todo_app/app/controllers/application_controller.rb
+++ b/todo_app/app/controllers/application_controller.rb
@@ -3,7 +3,8 @@
 class ApplicationController < ActionController::Base
   include SessionConcern
   before_action :authenticate_user
-  helper_method :current_user, :logged_in?
+  before_action :render503, if: :maintenance_mode?
+  helper_method :current_user, :logged_in?, :maintenance_mode?
 
   unless Rails.env.development?
     rescue_from StandardError, with: :render500
@@ -21,6 +22,14 @@ class ApplicationController < ActionController::Base
     logger.info "Rendering 500 with exception: #{err.message}" if err
 
     render file: Rails.root.join('public/500.html'), status: :internal_server_error
+  end
+
+  def render503
+    render file: Rails.root.join('public/503.html'), status: :service_unavailable
+  end
+
+  def maintenance_mode?
+    File.exist?(Constants::MAINTENANCE)
   end
 
   def authenticate_user

--- a/todo_app/app/controllers/application_controller.rb
+++ b/todo_app/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
   end
 
   def maintenance_mode?
-    File.exist?(Constants::MAINTENANCE)
+    File.exist?(Constants::MAINTENANCE_DIR)
   end
 
   def authenticate_user

--- a/todo_app/app/views/layouts/admin.html.erb
+++ b/todo_app/app/views/layouts/admin.html.erb
@@ -9,7 +9,11 @@
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
 </head>
-<body>
+
+<% if maintenance_mode? %>
+  <body><%= yield %></body>
+<% else %>
+  <body>
   <div class="d-flex flex-row justify-content-between align-items-center shadow-sm px-5 py-3 bg-dark">
     <h1><%= link_to 'TODO App Admin', admin_users_path %></h1>
 
@@ -30,5 +34,7 @@
   <div class="container mt-4">
     <%= yield %>
   </div>
-</body>
+  </body>
+
+<% end %>
 </html>

--- a/todo_app/app/views/layouts/application.html.erb
+++ b/todo_app/app/views/layouts/application.html.erb
@@ -10,7 +10,10 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body>
+  <% if maintenance_mode? %>
+    <body><%= yield %></body>
+  <% else %>
+    <body>
     <div class="d-flex flex-row justify-content-between align-items-center shadow-sm px-5 py-3">
       <h1><%= link_to 'TODO App', root_path %></h1>
       <div class="d-flex gap-2">
@@ -43,5 +46,6 @@
       <% end %>
       <%= yield %>
     </div>
-  </body>
+    </body>
+  <% end %>
 </html>

--- a/todo_app/config/initializers/constants.rb
+++ b/todo_app/config/initializers/constants.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Constants
+  MAINTENANCE = 'tmp/maintenance'
+end

--- a/todo_app/config/initializers/constants.rb
+++ b/todo_app/config/initializers/constants.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Constants
-  MAINTENANCE = 'tmp/maintenance'
+  MAINTENANCE_DIR = 'tmp/maintenance'
 end

--- a/todo_app/lib/tasks/maintenance.rake
+++ b/todo_app/lib/tasks/maintenance.rake
@@ -3,9 +3,9 @@
 namespace :maintenance do
   desc 'start maintenance'
   task start: :environment do
-    if File.exist?(Constants::MAINTENANCE)
+    if File.exist?(Constants::MAINTENANCE_DIR)
       puts 'すでにメンテナンスモードです'
-    elsif system("touch #{Constants::MAINTENANCE}")
+    elsif system("touch #{Constants::MAINTENANCE_DIR}")
       puts 'メンテナンスモードを開始します'
     else
       puts 'メンテナンスモード終了に失敗しました'
@@ -14,7 +14,7 @@ namespace :maintenance do
 
   desc 'end maintenance'
   task end: :environment do
-    if system("rm #{Constants::MAINTENANCE}")
+    if system("rm #{Constants::MAINTENANCE_DIR}")
       puts 'メンテナンスモードを終了します'
     else
       puts 'メンテナンスモード終了に失敗しました'

--- a/todo_app/lib/tasks/maintenance.rake
+++ b/todo_app/lib/tasks/maintenance.rake
@@ -4,20 +4,20 @@ namespace :maintenance do
   desc 'start maintenance'
   task start: :environment do
     if File.exist?(Constants::MAINTENANCE_DIR)
-      puts 'すでにメンテナンスモードです'
-    elsif FileUtils.touch(Constants::MAINTENANCE_DIR)
-      puts 'メンテナンスモードを開始します'
+      puts 'メンテナンスモードは既に開始済みです'
     else
-      puts 'メンテナンスモード終了に失敗しました'
+      FileUtils.touch(Constants::MAINTENANCE_DIR)
+      puts 'メンテナンスモードを開始します'
     end
   end
 
   desc 'end maintenance'
   task end: :environment do
-    if File.delete(Constants::MAINTENANCE_DIR)
+    if File.exist?(Constants::MAINTENANCE_DIR)
+      FileUtils.rm(Constants::MAINTENANCE_DIR)
       puts 'メンテナンスモードを終了します'
     else
-      puts 'メンテナンスモード終了に失敗しました'
+      puts 'メンテナンスモードは既に終了済みです'
     end
   end
 end

--- a/todo_app/lib/tasks/maintenance.rake
+++ b/todo_app/lib/tasks/maintenance.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc 'start maintenance'
+  task start: :environment do
+    if File.exist?(Constants::MAINTENANCE)
+      puts 'すでにメンテナンスモードです'
+    elsif system("touch #{Constants::MAINTENANCE}")
+      puts 'メンテナンスモードを開始します'
+    else
+      puts 'メンテナンスモード終了に失敗しました'
+    end
+  end
+
+  desc 'end maintenance'
+  task end: :environment do
+    if system("rm #{Constants::MAINTENANCE}")
+      puts 'メンテナンスモードを終了します'
+    else
+      puts 'メンテナンスモード終了に失敗しました'
+    end
+  end
+end

--- a/todo_app/lib/tasks/maintenance.rake
+++ b/todo_app/lib/tasks/maintenance.rake
@@ -5,7 +5,7 @@ namespace :maintenance do
   task start: :environment do
     if File.exist?(Constants::MAINTENANCE_DIR)
       puts 'すでにメンテナンスモードです'
-    elsif system("touch #{Constants::MAINTENANCE_DIR}")
+    elsif FileUtils.touch(Constants::MAINTENANCE_DIR)
       puts 'メンテナンスモードを開始します'
     else
       puts 'メンテナンスモード終了に失敗しました'
@@ -14,7 +14,7 @@ namespace :maintenance do
 
   desc 'end maintenance'
   task end: :environment do
-    if system("rm #{Constants::MAINTENANCE_DIR}")
+    if File.delete(Constants::MAINTENANCE_DIR)
       puts 'メンテナンスモードを終了します'
     else
       puts 'メンテナンスモード終了に失敗しました'

--- a/todo_app/public/503.html
+++ b/todo_app/public/503.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Maintenance 503</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+
+  <style>
+    .rails-default-error-page {
+      background-color: #EFEFEF;
+      color: #2E2F30;
+      text-align: center;
+      font-family: arial, sans-serif;
+      margin: 0;
+    }
+
+    .rails-default-error-page div.dialog {
+      width: 95%;
+      max-width: 33em;
+      margin: 4em auto 0;
+    }
+
+    .rails-default-error-page div.dialog > div {
+      border: 1px solid #CCC;
+      border-right-color: #999;
+      border-left-color: #999;
+      border-bottom-color: #BBB;
+      border-top: #0087b0 solid 4px;
+      border-radius: 9px;
+      background-color: white;
+      padding: 7px 12% 0;
+      box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    }
+
+    .rails-default-error-page h1 {
+      font-size: 100%;
+      color: #0b2f5c;
+      line-height: 1.5em;
+    }
+
+    .rails-default-error-page div.dialog > p {
+      margin: 0 0 1em;
+      padding: 1em;
+      background-color: #F7F7F7;
+      border: 1px solid #CCC;
+      border-right-color: #999;
+      border-left-color: #999;
+      border-bottom-color: #999;
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+      border-top-color: #DADADA;
+      color: #666;
+      box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    }
+    .rails-default-error-page img {
+      margin-bottom: 10px;
+      border-radius: 5px;
+      width: 400px;
+    }
+  </style>
+</head>
+
+<body class="rails-default-error-page">
+  <div class="dialog">
+    <div>
+      <h1>誠に申し訳ありません。ただいまメンテナンス中です。</h1>
+      <p>メンテナス終了を今しばらくお待ち下さい。</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/todo_app/spec/lib/tasks/maintenance_spec.rb
+++ b/todo_app/spec/lib/tasks/maintenance_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'maintenance' do
+  let(:file) { Rails.root.join(Constants::MAINTENANCE) }
+
+  before(:all) do
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake.application.rake_require 'tasks/maintenance'
+    Rake::Task.define_task(:environment)
+  end
+
+  before(:each) do
+    @rake[task_name].reenable
+  end
+
+  describe 'start' do
+    let(:task_name) { 'maintenance:start' }
+
+    context 'test start' do
+      it 'create file' do
+        @rake[task_name].invoke
+        visit login_path
+
+        expect(File).to exist file
+        expect(page).to have_content '誠に申し訳ありません。ただいまメンテナンス中です。'
+      end
+    end
+  end
+
+  describe 'finish' do
+    let(:task_name) { 'maintenance:end' }
+
+    context 'delete' do
+      it 'delete file' do
+        @rake[task_name].invoke
+        visit login_path
+
+        expect(File).not_to exist file
+        expect(page).to have_content 'TODO App'
+      end
+    end
+  end
+end

--- a/todo_app/spec/lib/tasks/maintenance_spec.rb
+++ b/todo_app/spec/lib/tasks/maintenance_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe 'Maintenance' do
+RSpec.describe 'Maintenance Batch' do
   let(:file) { Rails.root.join(Constants::MAINTENANCE_DIR) }
 
   before(:all) do
@@ -14,32 +14,36 @@ RSpec.describe 'Maintenance' do
   end
 
   before(:each) do
-    @rake[task_name].reenable
+    @rake[task_name].invoke
   end
 
   describe 'start' do
     let(:task_name) { 'maintenance:start' }
 
     context 'メンテナンスモードスタート時' do
+      it 'メンテナンスファイルが存在すること' do
+        expect(File).to exist file
+      end
+
       it '503のメンテナンスページが表示される' do
-        @rake[task_name].invoke
         visit login_path
 
-        expect(File).to exist file
         expect(page).to have_content '誠に申し訳ありません。ただいまメンテナンス中です。'
       end
     end
   end
 
-  describe 'finish' do
+  describe 'end' do
     let(:task_name) { 'maintenance:end' }
 
     context 'メンテナンスモード終了時' do
+      it 'メンテナンスファイルが存在しないこと' do
+        expect(File).not_to exist file
+      end
+
       it 'トップページが正常に表示される' do
-        @rake[task_name].invoke
         visit login_path
 
-        expect(File).not_to exist file
         expect(page).to have_content 'TODO App'
       end
     end

--- a/todo_app/spec/lib/tasks/maintenance_spec.rb
+++ b/todo_app/spec/lib/tasks/maintenance_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'rake'
 
 RSpec.describe 'maintenance' do
-  let(:file) { Rails.root.join(Constants::MAINTENANCE) }
+  let(:file) { Rails.root.join(Constants::MAINTENANCE_DIR) }
 
   before(:all) do
     @rake = Rake::Application.new

--- a/todo_app/spec/lib/tasks/maintenance_spec.rb
+++ b/todo_app/spec/lib/tasks/maintenance_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe 'maintenance' do
+RSpec.describe 'Maintenance' do
   let(:file) { Rails.root.join(Constants::MAINTENANCE_DIR) }
 
   before(:all) do
@@ -20,8 +20,8 @@ RSpec.describe 'maintenance' do
   describe 'start' do
     let(:task_name) { 'maintenance:start' }
 
-    context 'test start' do
-      it 'create file' do
+    context 'メンテナンスモードスタート時' do
+      it '503のメンテナンスページが表示される' do
         @rake[task_name].invoke
         visit login_path
 
@@ -34,8 +34,8 @@ RSpec.describe 'maintenance' do
   describe 'finish' do
     let(:task_name) { 'maintenance:end' }
 
-    context 'delete' do
-      it 'delete file' do
+    context 'メンテナンスモード終了時' do
+      it 'トップページが正常に表示される' do
         @rake[task_name].invoke
         visit login_path
 

--- a/todo_app/spec/system/maintenance_spec.rb
+++ b/todo_app/spec/system/maintenance_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Maintenance', type: :system do
+  describe 'メンテナンスファイルが存在する場合' do
+    it '503のメンテナンスページが表示される' do
+      FileUtils.touch(Constants::MAINTENANCE_DIR)
+      visit login_path
+
+      expect(page).to have_content '誠に申し訳ありません。ただいまメンテナンス中です。'
+    end
+  end
+
+  describe 'メンテナンスファイルが存在しない場合' do
+    it 'トップページが正常に表示される' do
+      FileUtils.rm(Constants::MAINTENANCE_DIR)
+      visit login_path
+
+      expect(page).to have_content 'TODO App'
+    end
+  end
+end


### PR DESCRIPTION
## 概要

ステップ21: メンテナンス機能を作ろう

## RSpec実行結果

![image](https://user-images.githubusercontent.com/85146460/125236618-45d4d700-e31f-11eb-9e53-35f5723f73de.png)

## やること

- [x] メンテナンスを開始／終了するバッチを作ってみましょう
  - rake taskコマンドで作成

```
bundle exec rake maintenance:start
bundle exec rake maintenance:end
```

- [x] メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
  - メンテナンスモードの開始
    - ![image](https://user-images.githubusercontent.com/85146460/125236405-dc54c880-e31e-11eb-801e-784078b7087e.png)
  - ルートページにアクセス
    - ![image](https://user-images.githubusercontent.com/85146460/125236427-e5de3080-e31e-11eb-974b-4130e8f4ffd8.png)
  - メンテナンスモードを終了
    - ![image](https://user-images.githubusercontent.com/85146460/125236505-11611b00-e31f-11eb-94a1-fbb7c37f95a1.png)
  - ルートページにアクセス
    - ![image](https://user-images.githubusercontent.com/85146460/125236534-22119100-e31f-11eb-8056-455c1d99d964.png)

- [x] 追加のGemを使わず、自分で実装してみましょう
