### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/tasks/app/controllers/tasks_controller.rb
+++ b/tasks/app/controllers/tasks_controller.rb
@@ -3,7 +3,8 @@ class TasksController < ApplicationController
   helper_method :sort_column, :sort_direction
 
   def index
-    @tasks = Task.without_deleted.order("#{sort_column} #{sort_direction}")
+    @tasks = Task.search(params[:keyword], params[:statuses], "#{sort_column} #{sort_direction}")
+    @status_list = MasterTaskStatus.all
   end
 
   def show; end

--- a/tasks/app/controllers/tasks_controller.rb
+++ b/tasks/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
   helper_method :sort_column, :sort_direction
 
   def index
-    @tasks = Task.search(params[:keyword], params[:statuses], "#{sort_column} #{sort_direction}")
+    @tasks = Task.without_deleted.search_task_name(params[:keyword]).search_status(params[:statuses]).sort_task("#{sort_column} #{sort_direction}")
     @status_list = MasterTaskStatus.all
   end
 

--- a/tasks/app/helpers/tasks_helper.rb
+++ b/tasks/app/helpers/tasks_helper.rb
@@ -1,6 +1,6 @@
 module TasksHelper
   def sort_order(column, title)
     direction = sort_column == column && sort_direction == 'asc' ? 'desc' : 'asc'
-    link_to title, root_path({ sort: column, direction: direction })
+    link_to title, root_path({ keyword: params[:keyword], statuses: params[:statuses], sort: column, direction: direction })
   end
 end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -7,11 +7,20 @@ class Task < ApplicationRecord
   belongs_to :priority, class_name: 'MasterTaskPriority'
   belongs_to :status, class_name: 'MasterTaskStatus'
   scope :without_deleted, -> { where(deleted_at: nil) }
+  scope :search_task_name, ->(keyword) { where(['task_name like ?', "%#{keyword}%"]) }
+  scope :search_status, ->(statuses) { where(status_id: [statuses]) }
+  scope :sort_task, ->(sort_conditions) { order(sort_conditions) }
 
   def before_datetime
     return if limit_date.blank? || limit_date > Time.current
 
     # 現在日時より前の日時に期限を変更している場合、エラーになる
     errors.add(:limit_date, :cannot_be_before_datetime)
+  end
+
+  def self.search(keyword, statuses, sort_conditions)
+    search_keyward_ids = Task.without_deleted.search_task_name(keyword).pluck(:id)
+    search_status_ids = Task.without_deleted.search_status(statuses).pluck(:id).presence || Task.without_deleted.pluck(:id)
+    Task.where(id: [search_keyward_ids]).where(id: [search_status_ids]).sort_task(sort_conditions)
   end
 end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -8,7 +8,7 @@ class Task < ApplicationRecord
   belongs_to :status, class_name: 'MasterTaskStatus'
   scope :without_deleted, -> { where(deleted_at: nil) }
   scope :search_task_name, ->(keyword) { where(['task_name like ?', "%#{keyword}%"]) }
-  scope :search_status, ->(statuses) { where(status_id: [statuses]) }
+  scope :search_status, ->(statuses) { statuses.present? ? where(status_id: [statuses]) : return }
   scope :sort_task, ->(sort_conditions) { order(sort_conditions) }
 
   def before_datetime
@@ -16,11 +16,5 @@ class Task < ApplicationRecord
 
     # 現在日時より前の日時に期限を変更している場合、エラーになる
     errors.add(:limit_date, :cannot_be_before_datetime)
-  end
-
-  def self.search(keyword, statuses, sort_conditions)
-    search_keyward_ids = Task.without_deleted.search_task_name(keyword).pluck(:id)
-    search_status_ids = Task.without_deleted.search_status(statuses).pluck(:id).presence || Task.without_deleted.pluck(:id)
-    Task.where(id: [search_keyward_ids]).where(id: [search_status_ids]).sort_task(sort_conditions)
   end
 end

--- a/tasks/app/views/tasks/index.html.erb
+++ b/tasks/app/views/tasks/index.html.erb
@@ -3,6 +3,20 @@
 <h1>タスク一覧</h1>
 <%= link_to t('link.new'), new_task_path %>
 <br>
+<%= form_with url: tasks_path, method: :get, local: true do |f| %>
+  <%= f.text_field :keyword, value: params[:keyword] %>
+  <%= f.hidden_field :sort, value: params[:sort] %>
+  <%= f.hidden_field :direction, value: params[:direction] %>
+  <%= f.submit '検索' %>
+  <br>
+  <br>
+  <p>絞り込み</p>
+  <% @status_list.each do |status| %>
+    <%= f.check_box :statuses, { multiple: true, include_hidden: false, checked: params[:statuses].present? ? status.id.to_s.in?(params[:statuses]) : false }, status.id %>
+    <%= f.label status.status %>
+  <% end %>
+<% end %>
+<br>
 
 <table>
   <thead>

--- a/tasks/db/migrate/20210712005853_add_index_tasks_status_id.rb
+++ b/tasks/db/migrate/20210712005853_add_index_tasks_status_id.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksStatusId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :tasks, %i[status_id limit_date created_at], name: 'index_tasks_on_status_id_and_limit_date_and_created_at'
+  end
+end

--- a/tasks/db/migrate/20210712005853_add_index_tasks_status_id.rb
+++ b/tasks/db/migrate/20210712005853_add_index_tasks_status_id.rb
@@ -1,5 +1,7 @@
 class AddIndexTasksStatusId < ActiveRecord::Migration[6.1]
   def change
-    add_index :tasks, %i[status_id limit_date created_at], name: 'index_tasks_on_status_id_and_limit_date_and_created_at'
+    add_index :tasks, :status_id
+    add_index :tasks, :limit_date
+    add_index :tasks, :created_at
   end
 end

--- a/tasks/db/schema.rb
+++ b/tasks/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_22_031106) do
+ActiveRecord::Schema.define(version: 2021_07_12_005853) do
 
   create_table "master_task_priorities", id: { type: :integer, limit: 1 }, charset: "utf8", force: :cascade do |t|
     t.string "priority", limit: 64, null: false
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2021_06_22_031106) do
     t.datetime "deleted_at", precision: 6
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status_id", "limit_date", "created_at"], name: "index_tasks_on_status_id_and_limit_date_and_created_at"
   end
 
   create_table "users", id: :integer, charset: "utf8", force: :cascade do |t|

--- a/tasks/db/schema.rb
+++ b/tasks/db/schema.rb
@@ -41,7 +41,9 @@ ActiveRecord::Schema.define(version: 2021_07_12_005853) do
     t.datetime "deleted_at", precision: 6
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["status_id", "limit_date", "created_at"], name: "index_tasks_on_status_id_and_limit_date_and_created_at"
+    t.index ["created_at"], name: "index_tasks_on_created_at"
+    t.index ["limit_date"], name: "index_tasks_on_limit_date"
+    t.index ["status_id"], name: "index_tasks_on_status_id"
   end
 
   create_table "users", id: :integer, charset: "utf8", force: :cascade do |t|

--- a/tasks/spec/controllers/tasks_controller_spec.rb
+++ b/tasks/spec/controllers/tasks_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TasksController, type: :controller do
 
   describe '#index' do
     context 'レスポンスが正常の時' do
-      let(:task_list) do
+      let!(:task_list) do
         [
           create(:task_list_item),
           create(:task_list_item, created_at: Time.current + 1.day, limit_date: Time.current + 5.days),
@@ -23,11 +23,11 @@ RSpec.describe TasksController, type: :controller do
       end
       it '作成日時の降順かつ、論理削除されていないタスクのみの一覧が取得されること' do
         get :index
-        expect(Task.without_deleted.order('created_at desc')).to match [task_list[2], task_list[1], task_list[0], task]
+        expect(Task.search(nil, nil, 'created_at desc')).to match [task_list[2], task_list[1], task_list[0], task]
       end
       it '期限の降順かつ、論理削除されていないタスクのみの一覧が取得されること（期限が同じならIDの昇順）' do
         get :index
-        expect(Task.without_deleted.order('limit_date desc')).to match [task_list[1], task_list[2], task, task_list[0]]
+        expect(Task.search(nil, nil, 'limit_date desc')).to match [task_list[1], task_list[2], task, task_list[0]]
       end
     end
   end

--- a/tasks/spec/controllers/tasks_controller_spec.rb
+++ b/tasks/spec/controllers/tasks_controller_spec.rb
@@ -3,31 +3,64 @@ require 'rails_helper'
 RSpec.describe TasksController, type: :controller do
   let(:lowTaskPriority) { create(:low) }
   let(:notStartedTaskStatus) { create(:notStarted) }
-  let!(:task) { create(:task) }
+  let(:task) { create(:task) }
 
   describe '#index' do
     context 'レスポンスが正常の時' do
-      let!(:task_list) do
-        [
-          create(:task_list_item),
-          create(:task_list_item, created_at: Time.current + 1.day, limit_date: Time.current + 5.days),
-          create(:task_list_item, created_at: Time.current + 2.days, limit_date: Time.current + 3.days),
-          create(:task_list_item, deleted_at: Time.current, limit_date: Time.current + 2.days)
-        ]
-      end
       it 'HTTPステータスコードが200、テンプレートが表示されること' do
         get :index
         expect(response).to be_successful
         expect(response).to have_http_status :success
         expect(response).to render_template :index
       end
-      it '作成日時の降順かつ、論理削除されていないタスクのみの一覧が取得されること' do
-        get :index
-        expect(Task.search(nil, nil, 'created_at desc')).to match [task_list[2], task_list[1], task_list[0], task]
+    end
+  end
+
+  describe '表示されるタスク一覧が、指定した条件に合っているかチェック（検索、絞り込み、ソートの複合処理）' do
+    let!(:task_list) do
+      [
+        create(:task_list_item),
+        create(:task_list_item, task_name: 'テスト1', status: create(:started), created_at: Time.current + 1.day, limit_date: Time.current + 5.days),
+        create(:task_list_item, task_name: 'タスク1', status: create(:finished), created_at: Time.current + 2.days, limit_date: Time.current + 3.days),
+        create(:task_list_item, task_name: 'テスト2', status: create(:notStarted), created_at: Time.current + 3.days, limit_date: Time.current + 6.days),
+        create(:task_list_item, task_name: 'タスク2', status: create(:started), created_at: Time.current + 4.days, limit_date: Time.current + 4.days),
+        create(:task_list_item, task_name: 'テストタスク1', deleted_at: Time.current, limit_date: Time.current + 2.days)
+      ]
+    end
+    context '何も指定がない場合（初期表示）' do
+      let(:task_list_default) do
+        expect_task_list = []
+        task_list.each do |task|
+          expect_task_list.push(task) if task.deleted_at.nil?
+        end
+        return expect_task_list.sort do |a, b|
+          b.created_at <=> a.created_at
+        end
       end
-      it '期限の降順かつ、論理削除されていないタスクのみの一覧が取得されること（期限が同じならIDの昇順）' do
+      it '論理削除されていない、全てのタスクが、作成日時の降順で取得されること' do
         get :index
-        expect(Task.search(nil, nil, 'limit_date desc')).to match [task_list[1], task_list[2], task, task_list[0]]
+        expect(assigns(:tasks)).to match task_list_default
+      end
+    end
+    context '検索欄に「テス」を入力、絞り込みを「未着手」「着手」を選択し、期限の昇順を指定した場合' do
+      let(:task_list_search_and_sort) do
+        expect_task_list = []
+        task_list.each do |task|
+          expect_task_list.push(task) if task.deleted_at.nil? && task.task_name.include?('テス') && (task.status_id == 1 || task.status_id == 2)
+        end
+        return expect_task_list.sort do |a, b|
+          if a.limit_date.nil?
+            -1
+          elsif b.limit_date.nil?
+            1
+          else
+            a.limit_date <=> b.limit_date
+          end
+        end
+      end
+      it '論理削除されていない、タスク名に「テス」を含む、ステータスが「未着手」と「着手」の全てのタスクが、期限の昇順で取得されること' do
+        get :index, params: { keyword: 'テス', statuses: %w[1 2], direction: 'asc', sort: 'limit_date' }
+        expect(assigns(:tasks)).to match task_list_search_and_sort
       end
     end
   end
@@ -67,7 +100,7 @@ RSpec.describe TasksController, type: :controller do
 
   describe '#create' do
     context '正常な値' do
-      let(:newTask) { { task_name: '新規作成テストタスク', priority_id: lowTaskPriority } }
+      let(:newTask) { { task_name: '新規作成テストタスク', priority_id: lowTaskPriority, status_id: notStartedTaskStatus, label: nil, limit_date: nil, detail: nil } }
       it '正常にタスクを作成できること' do
         expect { post :create, params: { task: newTask } }.to change(Task, :count).by(1)
       end
@@ -77,7 +110,7 @@ RSpec.describe TasksController, type: :controller do
       end
     end
     context '不正な値' do
-      let(:unjustNewTask) { { task_name: '新規作成テストタスク', priority: nil } }
+      let(:unjustNewTask) { { task_name: '新規作成テストタスク', priority: nil, status_id: notStartedTaskStatus, label: nil, limit_date: nil, detail: nil } }
       it 'タスクが作成されないこと' do
         expect { post :create, params: { task: unjustNewTask } }.to change(Task, :count).by(0)
       end

--- a/tasks/spec/controllers/tasks_controller_spec.rb
+++ b/tasks/spec/controllers/tasks_controller_spec.rb
@@ -29,11 +29,8 @@ RSpec.describe TasksController, type: :controller do
     end
     context '何も指定がない場合（初期表示）' do
       let(:task_list_default) do
-        expect_task_list = []
-        task_list.each do |task|
-          expect_task_list.push(task) if task.deleted_at.nil?
-        end
-        return expect_task_list.sort do |a, b|
+        expect_task_list = task_list.select { |task| task.deleted_at.nil? }
+        expect_task_list.sort do |a, b|
           b.created_at <=> a.created_at
         end
       end
@@ -44,11 +41,8 @@ RSpec.describe TasksController, type: :controller do
     end
     context '検索欄に「テス」を入力、絞り込みを「未着手」「着手」を選択し、期限の昇順を指定した場合' do
       let(:task_list_search_and_sort) do
-        expect_task_list = []
-        task_list.each do |task|
-          expect_task_list.push(task) if task.deleted_at.nil? && task.task_name.include?('テス') && (task.status_id == 1 || task.status_id == 2)
-        end
-        return expect_task_list.sort do |a, b|
+        expect_task_list = task_list.select { |task| task.deleted_at.nil? && task.task_name.include?('テス') && (task.status_id == 1 || task.status_id == 2) }
+        expect_task_list.sort do |a, b|
           if a.limit_date.nil?
             -1
           elsif b.limit_date.nil?

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -172,4 +172,52 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe '検索・絞り込み・ソート機能' do
+    let!(:task_list) do
+      [
+        create(:task_list_item),
+        create(:task_list_item, task_name: 'テスト1', status: create(:started), created_at: Time.current + 1.day, limit_date: Time.current + 5.days),
+        create(:task_list_item, task_name: 'タスク1', status: create(:finished), created_at: Time.current + 2.days, limit_date: Time.current + 3.days),
+        create(:task_list_item, task_name: 'テスト2', status: create(:notStarted), created_at: Time.current + 3.days, limit_date: Time.current + 6.days),
+        create(:task_list_item, task_name: 'タスク2', status: create(:started), created_at: Time.current + 4.days, limit_date: Time.current + 4.days),
+        create(:task_list_item, task_name: 'テストタスク1', deleted_at: Time.current, limit_date: Time.current + 2.days)
+      ]
+    end
+    context '検索文字が空欄で、絞り込みの指定がなく、ソートを行っていない場合' do
+      it '論理削除されていない、タスクを全て、作成日時の降順で取得する' do
+        expect(Task.search(nil, nil, 'created_at desc')).to match [task_list[4], task_list[3], task_list[2], task_list[1], task_list[0]]
+      end
+    end
+    context '検索文字が「タス」で、絞り込みの指定がなく、ソートを行っていない場合' do
+      it '論理削除されていない、タスク名に「タス」を含むタスクを全て、作成日時の降順で取得する' do
+        expect(Task.search('タス', nil, 'created_at desc')).to match [task_list[4], task_list[2], task_list[0]]
+      end
+    end
+    context '検索文字が空欄で、絞り込みが「着手」を指定、ソートを行っていない場合' do
+      it '論理削除されていない、ステータスが「着手」のタスクを全て、作成日時の降順で取得する' do
+        expect(Task.search(nil, ['2'], 'created_at desc')).to match [task_list[4], task_list[1]]
+      end
+    end
+    context '検索文字が空欄で、絞り込みが「着手」と「完了」を指定、ソートを行っていない場合' do
+      it '論理削除されていない、ステータスが「着手」と「完了」のタスクを全て、作成日時の降順で取得する' do
+        expect(Task.search(nil, %w[2 3], 'created_at desc')).to match [task_list[4], task_list[2], task_list[1]]
+      end
+    end
+    context '検索文字が空欄で、絞り込みが「未着手」と「着手」と「完了」の全てを指定、ソートを行っていない場合' do
+      it '論理削除されていない、タスクを全て、作成日時の降順で取得する' do
+        expect(Task.search(nil, %w[1 2 3], 'created_at desc')).to match [task_list[4], task_list[3], task_list[2], task_list[1], task_list[0]]
+      end
+    end
+    context '検索文字が空欄で、絞り込みの指定がなく、期限の昇順でソートを行っていた場合' do
+      it '論理削除されていない、タスクを全て、期限の昇順で取得する' do
+        expect(Task.search(nil, nil, 'limit_date asc')).to match [task_list[0], task_list[2], task_list[4], task_list[1], task_list[3]]
+      end
+    end
+    context '検索文字が「テス」で、絞り込みの「未着手」を指定、期限の降順でソートを行っていた場合' do
+      it '論理削除されていない、タスク名に「テス」を含み、ステータスが「未着手」のタスクを全て、期限の降順で取得する' do
+        expect(Task.search('テス', ['1'], 'limit_date desc')).to match [task_list[3], task_list[0]]
+      end
+    end
+  end
 end

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -185,68 +185,38 @@ RSpec.describe Task, type: :model do
       ]
     end
     context '論理削除されたタスクが存在する場合' do
-      let(:task_list_deleted_at_null) do
-        expect_task_list = []
-        task_list.each do |task|
-          expect_task_list.push(task) if task.deleted_at.nil?
-        end
-        return expect_task_list
-      end
+      let(:task_list_deleted_at_null) { task_list.select { |task| task.deleted_at.nil? } }
       it '論理削除されていないタスクを全て取得する' do
         expect(Task.without_deleted).to match_array task_list_deleted_at_null
       end
     end
     context '検索欄に「タス」を入力した場合' do
-      let(:task_list_search_task_name) do
-        expect_task_list = []
-        task_list.each do |task|
-          expect_task_list.push(task) if task.task_name.include?('タス')
-        end
-        return expect_task_list
-      end
+      let(:task_list_search_task_name) { task_list.select { |task| task.task_name.include?('タス') } }
       it 'タスク名に「タス」を含むタスクを全て取得する' do
         expect(Task.search_task_name('タス')).to match_array task_list_search_task_name
       end
     end
     context 'ステータスの絞り込みが「着手」を指定した場合' do
-      let(:task_list_search_status) do
-        expect_task_list = []
-        task_list.each do |task|
-          expect_task_list.push(task) if task.status_id == 2
-        end
-        return expect_task_list
-      end
+      let(:task_list_search_status) { task_list.select { |task| task.status_id == 2 } }
       it 'ステータスが「着手」のタスクを全て取得する' do
         expect(Task.search_status(['2'])).to match_array task_list_search_status
       end
     end
     context 'ステータスの絞り込みが「着手」と「完了」を指定した場合' do
-      let(:task_list_search_statuses) do
-        expect_task_list = []
-        task_list.each do |task|
-          expect_task_list.push(task) if task.status_id == 2 || task.status_id == 3
-        end
-        return expect_task_list
-      end
+      let(:task_list_search_statuses) { task_list.select { |task| task.status_id == 2 || task.status_id == 3 } }
       it 'ステータスが「着手」と「完了」のタスクを全て取得する' do
         expect(Task.search_status(%w[2 3])).to match_array task_list_search_statuses
       end
     end
     context 'ステータス絞り込みが「未着手」と「着手」と「完了」の全てを指定した場合' do
-      let(:task_list_search_statuses_all) do
-        expect_task_list = []
-        task_list.each do |task|
-          expect_task_list.push(task) if task.status_id == 1 || task.status_id == 2 || task.status_id == 3
-        end
-        return expect_task_list
-      end
+      let(:task_list_search_statuses_all) { task_list.select { |task| task.status_id == 1 || task.status_id == 2 || task.status_id == 3 } }
       it 'タスクを全て取得する' do
         expect(Task.search_status(%w[1 2 3])).to match_array task_list_search_statuses_all
       end
     end
     context '期限を昇順になるようにした場合' do
       let(:task_list_sort_asc_limit_date) do
-        return task_list.sort do |a, b|
+        task_list.sort do |a, b|
           if a.limit_date.nil?
             -1
           elsif b.limit_date.nil?
@@ -262,7 +232,7 @@ RSpec.describe Task, type: :model do
     end
     context '期限を降順になるようにした場合' do
       let(:task_list_sort_desc_limit_date) do
-        return task_list.sort do |a, b|
+        task_list.sort do |a, b|
           if a.limit_date.nil?
             1
           elsif b.limit_date.nil?


### PR DESCRIPTION
**課題**
https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86
上記リンクの「ステップ13: ステータスを追加して、検索できるようにしよう」

**実装内容**
・一覧画面で、タスク名検索機能とステータス絞り込み機能実装。
・タスク名検索機能は、部分一致で検索できます。
・ステータス絞り込み機能は、全て指定されていない場合は、全て選択されているとして扱います。
　また、複数のステータスを選択して、絞り込みができます。
・「検索」ボタンを押すことで、検索と絞り込みを実行します。
・検索、絞り込み、ソートのいずれかを実行しても、前の状態（検索欄の記載や絞り込みの指定、ソートの状態）を維持できるようにしております。
・絞り込みやソートで使用するカラムに対してindexを貼りました。（status_id, limit_date, created_at）
（task_nameに関しては、部分一致の検索のためindexを貼っていません）
・rspec作成

**共有事項**
・ステータス（未着手・着手中・完了）を追加はすでに実施済みで、「着手中」は「着手」として実装しています。

【初期状態】
<img width="871" alt="元の状態" src="https://user-images.githubusercontent.com/85857723/125261616-61020f80-e33c-11eb-9993-89bc096d1e53.png">

【タスク名検索のみ】
<img width="902" alt="タスク名検索のみ" src="https://user-images.githubusercontent.com/85857723/125261675-7414df80-e33c-11eb-99bd-d7628d9aecea.png">

【一つ絞り込みのみ】
<img width="921" alt="絞り込みのみ" src="https://user-images.githubusercontent.com/85857723/125261731-83942880-e33c-11eb-9354-a55af82c4254.png">

【複数絞り込みのみ】
<img width="897" alt="複数絞り込み" src="https://user-images.githubusercontent.com/85857723/125261790-91e24480-e33c-11eb-98e9-f9326a7c1431.png">

【タスク名検索、絞り込み「未着手」「着手」、期限降順ソート】
<img width="911" alt="タスク名検索、絞り込み「未着手」「着手」、期限降順ソート" src="https://user-images.githubusercontent.com/85857723/125261875-a45c7e00-e33c-11eb-8a7c-61a9428eb76a.png">

【タスク名検索、絞り込み全て指定、期限降順ソート】
<img width="910" alt="タスク名検索、絞り込み全て指定、期限降順ソート" src="https://user-images.githubusercontent.com/85857723/125261958-b807e480-e33c-11eb-9910-b7292093d7cf.png">
