### PR TITLE
READMEにrubocop導入手順を追加(use_dockerブランチ用)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ chrome://extensions/ を開いて右上のDeveloper modeをオンにして、RKG
   - コントローラとビューに必要な実装を追加しましょう
   - 作成、更新、削除後はそれぞれflashメッセージを画面に表示させましょう
 - `routes.rb` を編集して、 `http://localhost:3000/` でタスクの一覧画面が表示されるようにしましょう
+- `Gemfile` で [RuboCop](https://github.com/rubocop/rubocop)（Rubyの静的コード解析ツール） か [fablicop](https://github.com/Fablic/fablicop)をインストールしましょう。設定やコマンド実行方法は各READMEから確認しましょう。
 - GitHub上でPRを作成してレビューしてもらいましょう
   - 今後、PRが大きくなりそうだったらPRを2回以上に分けることを検討しましょう
 


### PR DESCRIPTION
元PR
https://github.com/Fablic/training/pull/1047
developへのバックマージPR
https://github.com/Fablic/training/pull/1049