### PR TITLE
STEP16：複数人で利用できるようにしよう（ユーザの導入）

### DIFF
--- a/tasks/.rubocop.yml
+++ b/tasks/.rubocop.yml
@@ -57,6 +57,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 20
 
+Metrics/AbcSize:
+  Max: 20
+
 ##################### Naming ##################################
 
 # 「FactoryBot」をスネークケースにする警告を除外するため

--- a/tasks/app/controllers/tasks_controller.rb
+++ b/tasks/app/controllers/tasks_controller.rb
@@ -4,6 +4,8 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.without_deleted
+                 .includes_status
+                 .includes_priority
                  .search_task_name(params[:keyword])
                  .search_status(params[:statuses])
                  .sort_task("#{sort_column} #{sort_direction}")
@@ -71,6 +73,6 @@ class TasksController < ApplicationController
   end
 
   def sort_column
-    params[:sort].in?(Task.column_names) ? params[:sort] : 'created_at'
+    params[:sort].in?(Task.column_names) ? params[:sort] : 'tasks.created_at'
   end
 end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -8,8 +8,8 @@ class Task < ApplicationRecord
 
   belongs_to :priority, class_name: 'MasterTaskPriority'
   belongs_to :status, class_name: 'MasterTaskStatus'
-  has_many :task_link, dependent: :destroy
-  has_many :user, through: :task_link
+  has_many :task_links, dependent: :destroy
+  has_many :users, through: :task_links
 
   scope :without_deleted, -> { where(deleted_at: nil) }
   scope :search_task_name, ->(keyword) { where(['task_name like ?', "%#{keyword}%"]) }
@@ -17,7 +17,7 @@ class Task < ApplicationRecord
   scope :sort_task, ->(sort_conditions) { order(sort_conditions) }
   scope :includes_status, -> { includes(:status) }
   scope :includes_priority, -> { includes(:priority) }
-  scope :includes_user, ->(user_id) { includes(:user).where(user: { id: user_id }) }
+  scope :includes_user, ->(user_id) { includes(:users).where(users: { id: user_id }) }
 
   def before_datetime
     return if limit_date.blank? || limit_date > Time.current

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -8,10 +8,16 @@ class Task < ApplicationRecord
 
   belongs_to :priority, class_name: 'MasterTaskPriority'
   belongs_to :status, class_name: 'MasterTaskStatus'
+  has_many :task_link, dependent: :destroy
+  has_many :user, through: :task_link
+
   scope :without_deleted, -> { where(deleted_at: nil) }
   scope :search_task_name, ->(keyword) { where(['task_name like ?', "%#{keyword}%"]) }
   scope :search_status, ->(statuses) { statuses.present? ? where(status_id: [statuses]) : return }
   scope :sort_task, ->(sort_conditions) { order(sort_conditions) }
+  scope :includes_status, -> { includes(:status) }
+  scope :includes_priority, -> { includes(:priority) }
+  scope :includes_user, ->(user_id) { includes(:user).where(user: { id: user_id }) }
 
   def before_datetime
     return if limit_date.blank? || limit_date > Time.current

--- a/tasks/app/models/task_link.rb
+++ b/tasks/app/models/task_link.rb
@@ -1,2 +1,4 @@
 class TaskLink < ApplicationRecord
+  belongs_to :user, class_name: 'User'
+  belongs_to :task, class_name: 'Task'
 end

--- a/tasks/app/models/user.rb
+++ b/tasks/app/models/user.rb
@@ -1,4 +1,4 @@
 class User < ApplicationRecord
-  has_many :task_link, dependent: :destroy
-  has_many :task, through: :task_link
+  has_many :task_links, dependent: :destroy
+  has_many :tasks, through: :task_links
 end

--- a/tasks/app/models/user.rb
+++ b/tasks/app/models/user.rb
@@ -1,2 +1,4 @@
 class User < ApplicationRecord
+  has_many :task_link, dependent: :destroy
+  has_many :task, through: :task_link
 end

--- a/tasks/db/migrate/20210719012517_add_index_task_links_user_id.rb
+++ b/tasks/db/migrate/20210719012517_add_index_task_links_user_id.rb
@@ -1,0 +1,5 @@
+class AddIndexTaskLinksUserId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :task_links, %i[user_id task_id]
+  end
+end

--- a/tasks/db/schema.rb
+++ b/tasks/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_12_005853) do
+ActiveRecord::Schema.define(version: 2021_07_19_012517) do
 
   create_table "master_task_priorities", id: { type: :integer, limit: 1 }, charset: "utf8", force: :cascade do |t|
     t.string "priority", limit: 64, null: false
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2021_07_12_005853) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id", "task_id"], name: "index_task_links_on_user_id_and_task_id"
   end
 
   create_table "tasks", id: :integer, charset: "utf8", force: :cascade do |t|

--- a/tasks/db/seeds.rb
+++ b/tasks/db/seeds.rb
@@ -5,3 +5,6 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+# coding: utf-8
+
+User.create(user_name: '初期ユーザ', email: 'hoge@fuga.jp', password: 'password', role: 0)

--- a/tasks/spec/factories/task_links.rb
+++ b/tasks/spec/factories/task_links.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  ActiveRecord::Base.connection.execute('ALTER TABLE task_links AUTO_INCREMENT = 1')
+  factory :task_link, class: TaskLink do
+    task_id { 1 }
+    user_id { 1 }
+  end
+end

--- a/tasks/spec/factories/users.rb
+++ b/tasks/spec/factories/users.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  ActiveRecord::Base.connection.execute('ALTER TABLE users AUTO_INCREMENT = 1')
+  factory :user, class: User do
+    user_name { 'テストユーザ' }
+    email { 'test@test.jp' }
+    password { 'password' }
+    role { 0 }
+  end
+  factory :user_after_create_task, class: User do
+    user_name { 'テストユーザ' }
+    email { 'test@test.jp' }
+    password { 'password' }
+    role { 0 }
+
+    after(:create) do |user|
+      create(:task_link, task: create(:task_list_item), user: user)
+    end
+  end
+end

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -247,4 +247,14 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe 'ユーザとタスクの紐付け' do
+    context 'ユーザを作成し、その後タスクを作成した場合' do
+      let(:user) { create(:user_after_create_task) }
+      let!(:other_user) { create(:user_after_create_task, email: 'other@test.jp') }
+      it 'そのユーザに紐づくタスクのみを取得できること' do
+        expect(user.task).to match Task.includes_user(user.id)
+      end
+    end
+  end
 end

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe Task, type: :model do
       let(:user) { create(:user_after_create_task) }
       let!(:other_user) { create(:user_after_create_task, email: 'other@test.jp') }
       it 'そのユーザに紐づくタスクのみを取得できること' do
-        expect(user.task).to match Task.includes_user(user.id)
+        expect(user.tasks).to match Task.includes_user(user.id)
       end
     end
   end

--- a/tasks/spec/models/user_spec.rb
+++ b/tasks/spec/models/user_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'ユーザとタスクの紐付け' do
+    context 'ユーザを作成し、その後タスクを作成した場合' do
+      let(:user) { create(:user_after_create_task) }
+      let!(:other_user) { create(:user_after_create_task, email: 'other@test.jp') }
+      it 'そのタスクに紐づくユーザを取得できること' do
+        expect([user]).to match User.includes(:task).where(task: { id: user.task.ids })
+      end
+    end
+  end
+end

--- a/tasks/spec/models/user_spec.rb
+++ b/tasks/spec/models/user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe User, type: :model do
       let(:user) { create(:user_after_create_task) }
       let!(:other_user) { create(:user_after_create_task, email: 'other@test.jp') }
       it 'そのタスクに紐づくユーザを取得できること' do
-        expect([user]).to match User.includes(:task).where(task: { id: user.task.ids })
+        expect([user]).to match User.includes(:tasks).where(tasks: { id: user.tasks.ids })
       end
     end
   end


### PR DESCRIPTION
**課題**
https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9716-%E8%A4%87%E6%95%B0%E4%BA%BA%E3%81%A7%E5%88%A9%E7%94%A8%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E5%B0%8E%E5%85%A5
上記リンクの「ステップ16: 複数人で利用できるようにしよう（ユーザの導入）」

**実装内容**
・seedでユーザを作成
・users、tasks, task_linksテーブルが関連するようにインデックスを貼りました。
（task_linksテーブルがusers、tasksテーブルをつなぐ、中間テーブルとなります）
・N+1問題の修正（statusとpriority）
・rubocop.ymlの修正（コントローラのindexメソッドがMetrics/AbcSizeのデフォルトの17を超えたため、上限を20に変更）

**共有事項**
・今回のステップでは、画面上で対象ユーザとタスクを紐づけるようにしておりません。
（タスク新規作成時にユーザと紐づけやタスク一覧でユーザのタスクのみ表示など）
（ログイン中のユーザIDを現段階では取得できないため、ステップ17で実装します）
・モデルの`scope :includes_user`はテストでのみ使用しているが、ログイン機能実装の際に、コントローラに組み込む予定です。

