### PR TITLE
ステップ20: タスクにラベルをつけられるようにしよう

### DIFF
--- a/tasks/app/controllers/tasks_controller.rb
+++ b/tasks/app/controllers/tasks_controller.rb
@@ -10,7 +10,8 @@ class TasksController < ApplicationController
                  .includes_status
                  .includes_priority
                  .includes_user(current_user.id)
-                 .search_task_name(params[:keyword])
+                 .search_label(params[:keyword])
+                 .or(Task.without_deleted.search_task_name(params[:keyword]))
                  .search_status(params[:statuses])
                  .sort_task("#{sort_column} #{sort_direction}")
                  .page(params[:page])
@@ -27,21 +28,34 @@ class TasksController < ApplicationController
 
   def create
     create_params = task_params.merge(status_id: MasterTaskStatus::NOT_STARTED)
+    label_list = params[:task][:label].split(',')
+    create_params.delete(:label)
     @task = Task.new(create_params)
-    if @task.save
+
+    ActiveRecord::Base.transaction do
+      @task.save!
+      @task.labels_save(label_list)
       current_user.add_task(@task)
-      redirect_to @task, notice: 'タスクを作成しました。'
-    else
-      render :new, status: :unprocessable_entity
     end
+    redirect_to @task, notice: 'タスクを作成しました。'
+  rescue StandardError => e
+    Rails.logger.error e
+    render :new, status: :unprocessable_entity
   end
 
   def update
-    if @task.update(task_params)
-      redirect_to @task, notice: 'タスクを更新しました。'
-    else
-      render :edit, status: :unprocessable_entity
+    label_list = params[:task][:label].split(',')
+    update_params = task_params
+    update_params.delete(:label)
+
+    ActiveRecord::Base.transaction do
+      @task.update!(update_params)
+      @task.labels_save(label_list)
     end
+    redirect_to @task, notice: 'タスクを更新しました。'
+  rescue StandardError => e
+    Rails.logger.error e
+    render :edit, status: :unprocessable_entity
   end
 
   # 論理削除
@@ -66,7 +80,13 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:task_name, :status_id, :priority_id, :label, :limit_date, :detail)
+    params.require(:task)
+          .permit(:task_name,
+                  :status_id,
+                  :priority_id,
+                  :limit_date,
+                  :detail,
+                  :label)
   end
 
   def sort_direction

--- a/tasks/app/controllers/tasks_controller.rb
+++ b/tasks/app/controllers/tasks_controller.rb
@@ -10,8 +10,7 @@ class TasksController < ApplicationController
                  .includes_status
                  .includes_priority
                  .includes_user(current_user.id)
-                 .search_label(params[:keyword])
-                 .or(Task.without_deleted.search_task_name(params[:keyword]))
+                 .search_keyword(params[:keyword])
                  .search_status(params[:statuses])
                  .sort_task("#{sort_column} #{sort_direction}")
                  .page(params[:page])
@@ -44,8 +43,8 @@ class TasksController < ApplicationController
   end
 
   def update
-    label_list = params[:task][:label].split(',')
     update_params = task_params
+    label_list = params[:task][:label].split(',')
     update_params.delete(:label)
 
     ActiveRecord::Base.transaction do

--- a/tasks/app/models/label.rb
+++ b/tasks/app/models/label.rb
@@ -1,0 +1,4 @@
+class Label < ApplicationRecord
+  has_many :label_links, dependent: :destroy
+  has_many :tasks, through: :label_links
+end

--- a/tasks/app/models/label_link.rb
+++ b/tasks/app/models/label_link.rb
@@ -1,0 +1,4 @@
+class LabelLink < ApplicationRecord
+  belongs_to :label
+  belongs_to :task
+end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -39,7 +39,7 @@ class Task < ApplicationRecord
 
     # 入力されたラベルがDBに存在するなら取得し、存在しないなら作成し、紐付けする
     label_list.each do |label|
-      inspected_label = labels.where(label_name: label).first_or_create!
+      inspected_label = Label.where(label_name: label).first_or_create!
       labels << inspected_label
     end
   end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -14,13 +14,12 @@ class Task < ApplicationRecord
   has_many :labels, through: :label_links
 
   scope :without_deleted, -> { where(deleted_at: nil) }
-  scope :search_task_name, ->(keyword) { keyword.present? ? where('task_name like ?', "%#{keyword}%") : return }
-  scope :search_label, ->(keyword) { keyword.present? ? joins(:labels).where('labels.label_name like ?', "%#{keyword}%") : return }
+  scope :search_keyword, ->(keyword)\
+    { keyword.present? ? joins(:labels).where('task_name like ? or labels.label_name like ?', "%#{keyword}%", "%#{keyword}%") : return }
   scope :search_status, ->(statuses) { statuses.present? ? where(status_id: [statuses]) : return }
   scope :sort_task, ->(sort_conditions) { order(sort_conditions) }
   scope :includes_status, -> { includes(:status) }
   scope :includes_priority, -> { includes(:priority) }
-  scope :includes_label, -> { includes(:labels) }
   scope :includes_user, ->(user_id) { includes(:users).where(users: { id: user_id }) }
 
   def before_datetime

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -2,7 +2,6 @@ class Task < ApplicationRecord
   paginates_per 10
 
   validates :task_name, presence: true, length: { maximum: 60 }
-  validates :label, length: { maximum: 20 }
   validates :detail, length: { maximum: 250 }
   validate :before_datetime, if: :will_save_change_to_limit_date?
   validates :deleted_at_before_type_cast, presence: true, format: { with: Constants::VALID_DATETIME_REGEX }, allow_nil: true, on: :update
@@ -11,13 +10,17 @@ class Task < ApplicationRecord
   belongs_to :status, class_name: 'MasterTaskStatus'
   has_many :task_links, dependent: :destroy
   has_many :users, through: :task_links
+  has_many :label_links, dependent: :destroy
+  has_many :labels, through: :label_links
 
   scope :without_deleted, -> { where(deleted_at: nil) }
-  scope :search_task_name, ->(keyword) { where(['task_name like ?', "%#{keyword}%"]) }
+  scope :search_task_name, ->(keyword) { keyword.present? ? where('task_name like ?', "%#{keyword}%") : return }
+  scope :search_label, ->(keyword) { keyword.present? ? joins(:labels).where('labels.label_name like ?', "%#{keyword}%") : return }
   scope :search_status, ->(statuses) { statuses.present? ? where(status_id: [statuses]) : return }
   scope :sort_task, ->(sort_conditions) { order(sort_conditions) }
   scope :includes_status, -> { includes(:status) }
   scope :includes_priority, -> { includes(:priority) }
+  scope :includes_label, -> { includes(:labels) }
   scope :includes_user, ->(user_id) { includes(:users).where(users: { id: user_id }) }
 
   def before_datetime
@@ -25,5 +28,19 @@ class Task < ApplicationRecord
 
     # 現在日時より前の日時に期限を変更している場合、エラーになる
     errors.add(:limit_date, :cannot_be_before_datetime)
+  end
+
+  def labels_save(label_list)
+    # ラベルが変更された時、そのタスクと以前のラベルのとの紐付けを削除
+    unless labels.nil?
+      label_links_records = LabelLink.where(task_id: id)
+      label_links_records.destroy_all
+    end
+
+    # 入力されたラベルがDBに存在するなら取得し、存在しないなら作成し、紐付けする
+    label_list.each do |label|
+      inspected_label = labels.where(label_name: label).first_or_create!
+      labels << inspected_label
+    end
   end
 end

--- a/tasks/app/views/admin/users/show.html.erb
+++ b/tasks/app/views/admin/users/show.html.erb
@@ -63,7 +63,11 @@
           <td class="list-item"><%= task.id %></td>
           <td class="list-item"><%= task.status.status %></td>
           <td class="list-item"><%= task.priority.priority %></td>
-          <td class="list-item"><%= task.label %></td>
+          <td class="list-item">
+            <% task.labels.each do |label| %>
+              <%= label.label_name %>
+            <% end %>
+          </td>
           <td class="list-item"><%= task.task_name %></td>
           <td class="list-item">
             <% if task.limit_date != nil %>

--- a/tasks/app/views/tasks/_form.html.erb
+++ b/tasks/app/views/tasks/_form.html.erb
@@ -35,7 +35,7 @@
 
   <div class="form-group">
     <%= f.label :label, class: 'control-label text-primary' %>
-    <%= f.text_field :label, class: 'form-control' %>
+    <%= f.text_field :label, placeholder:",で区切ると複数設定できます", class: 'form-control', value: @task.labels.pluck(:label_name).join(',') %>
   </div>
 
   <div class="form-group">

--- a/tasks/app/views/tasks/index.html.erb
+++ b/tasks/app/views/tasks/index.html.erb
@@ -24,7 +24,7 @@
             <%= f.label status.status, { for: 'statuses_' + status.id.to_s } %>
           </div>
         <% end %>
-        <%= f.text_field :keyword, value: params[:keyword], class: 'form-control mr-sm-2', placeholder: 'タスク名で検索' %>
+        <%= f.text_field :keyword, value: params[:keyword], class: 'form-control mr-sm-2 small', placeholder: 'タスク名/ラベルで検索' %>
         <%= f.hidden_field :sort, value: params[:sort] %>
         <%= f.hidden_field :direction, value: params[:direction] %>
         <%= f.submit '検索', class: 'btn btn-outline-success my-2 my-sm-0' %>   
@@ -58,7 +58,11 @@
           <td class="list-item"><%= task.id %></td>
           <td class="list-item"><%= task.status.status %></td>
           <td class="list-item"><%= task.priority.priority %></td>
-          <td class="list-item"><%= task.label %></td>
+          <td class="list-item">
+            <% task.labels.each do |label| %>
+              <%= label.label_name %>
+            <% end %>
+          </td>
           <td class="list-item"><%= task.task_name %></td>
           <td class="list-item">
             <% if task.limit_date != nil %>

--- a/tasks/app/views/tasks/show.html.erb
+++ b/tasks/app/views/tasks/show.html.erb
@@ -29,7 +29,11 @@
   </div>
   <div class="form-group">
     <div class="h6 text-primary"><%= Task.human_attribute_name(:label) %></div>
-    <div class="h5 border-bottom"><%= @task.label %></div>
+    <div class="h5 border-bottom">
+      <% @task.labels.each do |label| %>
+        <%= label.label_name %>
+      <% end %>
+    </div>
   </div>
   <div class="form-group">
     <div class="h6 text-primary"><%= Task.human_attribute_name(:limit_date) %></div>

--- a/tasks/db/migrate/20210803010304_create_labels.rb
+++ b/tasks/db/migrate/20210803010304_create_labels.rb
@@ -1,0 +1,9 @@
+class CreateLabels < ActiveRecord::Migration[6.1]
+  def change
+    create_table :labels, id: :integer do |t|
+      t.string :label_name
+
+      t.timestamps
+    end
+  end
+end

--- a/tasks/db/migrate/20210803010420_create_label_links.rb
+++ b/tasks/db/migrate/20210803010420_create_label_links.rb
@@ -1,0 +1,10 @@
+class CreateLabelLinks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :label_links, id: :integer do |t|
+      t.references :label, null: false, foreign_key: true, type: :integer
+      t.references :task, null: false, foreign_key: true, type: :integer
+
+      t.timestamps
+    end
+  end
+end

--- a/tasks/db/migrate/20210803060703_remove_label_from_tasks.rb
+++ b/tasks/db/migrate/20210803060703_remove_label_from_tasks.rb
@@ -1,0 +1,5 @@
+class RemoveLabelFromTasks < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :tasks, :label, :string, limit: 64, default: nil
+  end
+end

--- a/tasks/db/schema.rb
+++ b/tasks/db/schema.rb
@@ -10,7 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_20_075904) do
+ActiveRecord::Schema.define(version: 2021_08_03_060703) do
+
+  create_table "label_links", id: :integer, charset: "utf8", force: :cascade do |t|
+    t.integer "label_id", null: false
+    t.integer "task_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["label_id"], name: "index_label_links_on_label_id"
+    t.index ["task_id"], name: "index_label_links_on_task_id"
+  end
+
+  create_table "labels", id: :integer, charset: "utf8", force: :cascade do |t|
+    t.string "label_name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "master_task_priorities", id: { type: :integer, limit: 1 }, charset: "utf8", force: :cascade do |t|
     t.string "priority", limit: 64, null: false
@@ -36,7 +51,6 @@ ActiveRecord::Schema.define(version: 2021_07_20_075904) do
     t.string "task_name", limit: 64, null: false
     t.integer "status_id", limit: 1, null: false
     t.integer "priority_id", limit: 1, null: false
-    t.string "label", limit: 64
     t.datetime "limit_date", precision: 6
     t.string "detail"
     t.datetime "deleted_at", precision: 6
@@ -58,4 +72,6 @@ ActiveRecord::Schema.define(version: 2021_07_20_075904) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "label_links", "labels"
+  add_foreign_key "label_links", "tasks"
 end

--- a/tasks/spec/controllers/admin_users_controller_spec.rb
+++ b/tasks/spec/controllers/admin_users_controller_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Admin::UsersController, type: :controller do
       let!(:before_update_user) { user }
       let(:unjust_user_params) { { user_name: '変更後ユーザ名', email: nil } }
       it 'ユーザを更新できないこと' do
-        patch :update, params: { id: user.id, task: unjust_user_params }
+        patch :update, params: { id: user.id, user: unjust_user_params }
         expect(user.reload.user_name).to eq before_update_user.user_name
         expect(user.email).to eq before_update_user.email
       end

--- a/tasks/spec/controllers/tasks_controller_spec.rb
+++ b/tasks/spec/controllers/tasks_controller_spec.rb
@@ -45,12 +45,22 @@ RSpec.describe TasksController, type: :controller do
     end
     let!(:task_link) do
       [
-        create(:task_link, task_id: task_list[0].id, user_id: user.id),
-        create(:task_link, task_id: task_list[1].id, user_id: user.id),
-        create(:task_link, task_id: task_list[2].id, user_id: user.id),
-        create(:task_link, task_id: task_list[3].id, user_id: user.id),
-        create(:task_link, task_id: task_list[4].id, user_id: user.id),
-        create(:task_link, task_id: task_list[5].id, user_id: user.id)
+        create(:task_link, task: task_list[0], user: user),
+        create(:task_link, task: task_list[1], user: user),
+        create(:task_link, task: task_list[2], user: user),
+        create(:task_link, task: task_list[3], user: user),
+        create(:task_link, task: task_list[4], user: user),
+        create(:task_link, task: task_list[5], user: user)
+      ]
+    end
+    let!(:label_list) do
+      [
+        create(:label_link, label: create(:label, label_name: 'ああ'), task: task_list[0]),
+        create(:label_link, label: create(:label, label_name: 'いい'), task: task_list[1]),
+        create(:label_link, label: create(:label, label_name: 'テスト'), task: task_list[2]),
+        create(:label_link, label: create(:label, label_name: 'ええ'), task: task_list[3]),
+        create(:label_link, label: create(:label, label_name: 'あい'), task: task_list[4]),
+        create(:label_link, label: create(:label, label_name: 'うえ'), task: task_list[5])
       ]
     end
     before { log_in(user) }
@@ -66,7 +76,10 @@ RSpec.describe TasksController, type: :controller do
     end
     context '検索欄に「テス」を入力、絞り込みを「未着手」「着手」を選択し、期限の昇順を指定した場合' do
       let(:task_list_search_and_sort) do
-        expect_task_list = task_list.select { |task| task.deleted_at.nil? && task.task_name.include?('テス') && (task.status_id == 1 || task.status_id == 2) }
+        expect_task_list = task_list.select do |task|
+          @label = task.labels[0]
+          task.deleted_at.nil? && (task.task_name.include?('テス') || @label.label_name.include?('テス')) && (task.status_id == 1 || task.status_id == 2)
+        end
         expect_task_list.sort do |a, b|
           if a.limit_date.nil?
             -1
@@ -217,10 +230,11 @@ RSpec.describe TasksController, type: :controller do
   describe '#update' do
     include_context 'login_and_create_task_link'
     context '正常な値' do
-      let(:normalTaskParams) { { task_name: '変更後テストタスク名', status_id: notStartedTaskStatus, priority_id: lowTaskPriority } }
+      let(:normalTaskParams) { { task_name: '変更後テストタスク名', status_id: notStartedTaskStatus, priority_id: lowTaskPriority, label: '変更後ラベル' } }
       it '正常にタスクを更新できること' do
         patch :update, params: { id: task.id, task: normalTaskParams }
         expect(task.reload.task_name).to eq '変更後テストタスク名'
+        expect(task.labels[0].label_name).to eq '変更後ラベル'
       end
       it '更新後、詳細ページにリダイレクトされること' do
         task_params = normalTaskParams
@@ -229,7 +243,7 @@ RSpec.describe TasksController, type: :controller do
       end
     end
     context '不正な値' do
-      let(:unjustTaskParams) { { task_name: '変更後テストタスク名', status_id: 4, priority_id: lowTaskPriority } }
+      let(:unjustTaskParams) { { task_name: '変更後テストタスク名', status_id: 4, priority_id: lowTaskPriority, label: nil } }
       it 'タスクを更新できないこと' do
         task_params = unjustTaskParams
         patch :update, params: { id: task.id, task: task_params }

--- a/tasks/spec/factories/label.rb
+++ b/tasks/spec/factories/label.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  ActiveRecord::Base.connection.execute('ALTER TABLE labels AUTO_INCREMENT = 1')
+  factory :label, class: Label do
+    label_name { 'テストラベル名' }
+  end
+  factory :label_after_create_task, class: Label do
+    label_name { 'テストラベル名' }
+
+    after(:create) do |label|
+      create(:label_link, label: label, task: create(:task_list_item))
+    end
+  end
+end

--- a/tasks/spec/factories/label_links.rb
+++ b/tasks/spec/factories/label_links.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  ActiveRecord::Base.connection.execute('ALTER TABLE label_links AUTO_INCREMENT = 1')
+  factory :label_link, class: LabelLink do
+    label_id { 1 }
+    task_id { 1 }
+  end
+end

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Task, type: :model do
     context '検索欄に「タス」を入力した場合' do
       let(:task_list_search_task_name) { task_list.select { |task| task.task_name.include?('タス') } }
       it 'タスク名に「タス」を含むタスクを全て取得する' do
-        expect(Task.search_task_name('タス')).to match_array task_list_search_task_name
+        expect(Task.search_keyword('タス')).to match_array task_list_search_task_name
       end
     end
     context '検索欄に「あ」を入力した場合' do
@@ -210,7 +210,7 @@ RSpec.describe Task, type: :model do
         end
       end
       it 'ラベル名に「あ」を含むタスクを全て取得する' do
-        expect(Task.search_label('あ')).to match_array task_list_search_label
+        expect(Task.search_keyword('あ')).to match_array task_list_search_label
       end
     end
     context 'ステータスの絞り込みが「着手」を指定した場合' do

--- a/tasks/spec/models/task_spec.rb
+++ b/tasks/spec/models/task_spec.rb
@@ -63,35 +63,6 @@ RSpec.describe Task, type: :model do
     end
   end
 
-  describe 'ラベルのバリデーション' do
-    let(:task) { build(:task, label: label) }
-    context '空文字の場合' do
-      let(:label) { '' }
-      it '有効である' do
-        expect(task).to be_valid
-      end
-    end
-    context '文字数が上限未満の場合' do
-      let(:label) { 'a' * 19 }
-      it '有効である' do
-        expect(task).to be_valid
-      end
-    end
-    context '文字数が上限と同じ場合' do
-      let(:label) { 'a' * 20 }
-      it '有効である' do
-        expect(task).to be_valid
-      end
-    end
-    context '文字数が上限を超える場合' do
-      let(:label) { 'a' * 21 }
-      it 'エラーになる' do
-        expect(task).to be_invalid
-        expect(task.errors[:label]).to include('は20文字以内で入力してください')
-      end
-    end
-  end
-
   describe '詳細説明のバリデーション' do
     let(:task) { build(:task, detail: detail) }
     context '空文字の場合' do
@@ -209,6 +180,16 @@ RSpec.describe Task, type: :model do
         create(:task_list_item, task_name: 'テストタスク1', deleted_at: Time.current.strftime('%Y-%m-%d %H:%M:%S'), limit_date: Time.current + 2.days)
       ]
     end
+    let!(:label_list) do
+      [
+        create(:label_link, label: create(:label, label_name: 'ああ'), task: task_list[0]),
+        create(:label_link, label: create(:label, label_name: 'いい'), task: task_list[1]),
+        create(:label_link, label: create(:label, label_name: 'うう'), task: task_list[2]),
+        create(:label_link, label: create(:label, label_name: 'ええ'), task: task_list[3]),
+        create(:label_link, label: create(:label, label_name: 'あい'), task: task_list[4]),
+        create(:label_link, label: create(:label, label_name: 'うえ'), task: task_list[5])
+      ]
+    end
     context '論理削除されたタスクが存在する場合' do
       let(:task_list_deleted_at_null) { task_list.select { |task| task.deleted_at.nil? } }
       it '論理削除されていないタスクを全て取得する' do
@@ -219,6 +200,17 @@ RSpec.describe Task, type: :model do
       let(:task_list_search_task_name) { task_list.select { |task| task.task_name.include?('タス') } }
       it 'タスク名に「タス」を含むタスクを全て取得する' do
         expect(Task.search_task_name('タス')).to match_array task_list_search_task_name
+      end
+    end
+    context '検索欄に「あ」を入力した場合' do
+      let!(:task_list_search_label) do
+        task_list.select do |task|
+          @label = task.labels[0]
+          @label.label_name.include?('あ')
+        end
+      end
+      it 'ラベル名に「あ」を含むタスクを全て取得する' do
+        expect(Task.search_label('あ')).to match_array task_list_search_label
       end
     end
     context 'ステータスの絞り込みが「着手」を指定した場合' do


### PR DESCRIPTION
**課題**
https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9720-%E3%82%BF%E3%82%B9%E3%82%AF%E3%81%AB%E3%83%A9%E3%83%99%E3%83%AB%E3%82%92%E3%81%A4%E3%81%91%E3%82%89%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86
上記リンクの「ステップ20: タスクにラベルをつけられるようにしよう」の箇所

**実装内容**
・新たに「labels」「label_links」テーブルを作成（タスク1つに対して複数ラベルを設定できるようにするため）
・「tasks」テーブルのラベルカラムを削除（複数設定の対応ができないため）
・タスクの新規作成、編集時にラベルを「,」で区切って作成すると複数のラベルを設定できるように実装
・ラベルはすでに「labels」テーブルに存在する場合は取得し、存在しない場合は作成してから紐付けするように実装
・ラベル編集時、一度ラベルの紐付けを削除し、新しいラベルと紐付けするように実装
・タスクとラベルで検索できるように実装
・検索時、検索欄が空文字なら検索せず、全件表示するように修正（以前までは空文字でも検索してから全件表示してました）
・rspecの作成と修正

画面キャプチャ
【一覧画面（検索なし）】
<img width="1254" alt="一覧" src="https://user-images.githubusercontent.com/85857723/128284782-a45ceb18-beb9-48b5-b150-36e35fc50868.png">

【一覧画面（検索後）】
<img width="1262" alt="検索" src="https://user-images.githubusercontent.com/85857723/128284875-6cbd2900-1bc1-4473-b03f-8f5a455fca93.png">

【新規作成画面】
<img width="1261" alt="新規作成" src="https://user-images.githubusercontent.com/85857723/128284946-0d7d0fe4-4988-40b5-901b-dd66966edbc9.png">

【詳細画面（新規作成後）】
<img width="1260" alt="新規作成後" src="https://user-images.githubusercontent.com/85857723/128285063-cc942c8b-83ce-441d-b68e-6c00c1054368.png">

【編集画面（編集前）】
<img width="1259" alt="編集" src="https://user-images.githubusercontent.com/85857723/128285079-013c8235-16ce-4b1b-940f-572552d6def4.png">

【詳細画面（編集後）】
<img width="1262" alt="編集後" src="https://user-images.githubusercontent.com/85857723/128285102-dc439be6-ab06-4b78-ad72-a791d3a44093.png">

【一覧がめん（編集後）】
<img width="1263" alt="編集後一覧" src="https://user-images.githubusercontent.com/85857723/128285147-fb0c6a4e-edad-42c3-a14c-41f81e7e2f99.png">
