### PR TITLE
ステップ21: メンテナンス機能の実装

### DIFF
--- a/tasks/app/controllers/application_controller.rb
+++ b/tasks/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :render_maintenance
   include SessionsHelper
   rescue_from Exception,                      with: :render_500
   rescue_from ActiveRecord::RecordNotFound,   with: :render_404
@@ -32,5 +33,10 @@ class ApplicationController < ActionController::Base
 
   def logged_in_user
     redirect_to login_url unless logged_in?
+  end
+
+  def render_maintenance
+    maintenance = Mode.find_by(mode_name: 'maintenance')
+    redirect_to '/maintenance.html' if maintenance.present? && maintenance.value.present?
   end
 end

--- a/tasks/app/models/mode.rb
+++ b/tasks/app/models/mode.rb
@@ -1,0 +1,11 @@
+class Mode < ApplicationRecord
+  def self.maintenance_start
+    maintenance = find_by(mode_name: 'maintenance')
+    maintenance.present? && maintenance.update(value: true)
+  end
+
+  def self.maintenance_end
+    maintenance = find_by(mode_name: 'maintenance')
+    maintenance.present? && maintenance.update(value: false)
+  end
+end

--- a/tasks/config/application.rb
+++ b/tasks/config/application.rb
@@ -14,6 +14,7 @@ module Tasks
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
+    config.autoload_paths += Dir["#{config.root}/lib"]
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/tasks/db/migrate/20210806000804_create_modes.rb
+++ b/tasks/db/migrate/20210806000804_create_modes.rb
@@ -1,0 +1,10 @@
+class CreateModes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :modes, id: :integer do |t|
+      t.string :mode_name, null: false
+      t.boolean :value, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/tasks/db/schema.rb
+++ b/tasks/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_03_060703) do
+ActiveRecord::Schema.define(version: 2021_08_06_000804) do
 
   create_table "label_links", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "label_id", null: false
@@ -35,6 +35,13 @@ ActiveRecord::Schema.define(version: 2021_08_03_060703) do
 
   create_table "master_task_statuses", id: { type: :integer, limit: 1 }, charset: "utf8", force: :cascade do |t|
     t.string "status", limit: 64, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "modes", id: :integer, charset: "utf8", force: :cascade do |t|
+    t.string "mode_name", null: false
+    t.boolean "value", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/tasks/db/seeds.rb
+++ b/tasks/db/seeds.rb
@@ -8,3 +8,4 @@
 # coding: utf-8
 
 User.create(user_name: '初期ユーザ', email: 'hoge@fuga.jp', password_digest: 'password', role: 0)
+Mode.create(mode_name: 'maintenance', value: false)

--- a/tasks/lib/batch/maintenance_batch.rb
+++ b/tasks/lib/batch/maintenance_batch.rb
@@ -1,17 +1,17 @@
 class Batch::MaintenanceBatch
   def self.maintenance_start_batch
     if Mode.maintenance_start
-      puts 'メンテナンスモードを開始しました。'
+      puts 'Success maintenance mode start'
     else
-      puts 'メンテナンスモードの開始に失敗しました。'
+      puts 'Failure maintenance mode start'
     end
   end
 
   def self.maintenance_end_batch
     if Mode.maintenance_end
-      puts 'メンテナンスモードを終了しました。'
+      puts 'Success maintenance mode end'
     else
-      puts 'メンテナンスモードの終了に失敗しました。'
+      puts 'Failure maintenance mode end'
     end
   end
 end

--- a/tasks/lib/batch/maintenance_batch.rb
+++ b/tasks/lib/batch/maintenance_batch.rb
@@ -1,0 +1,17 @@
+class Batch::MaintenanceBatch
+  def self.maintenance_start_batch
+    if Mode.maintenance_start
+      puts 'メンテナンスモードを開始しました。'
+    else
+      puts 'メンテナンスモードの開始に失敗しました。'
+    end
+  end
+
+  def self.maintenance_end_batch
+    if Mode.maintenance_end
+      puts 'メンテナンスモードを終了しました。'
+    else
+      puts 'メンテナンスモードの終了に失敗しました。'
+    end
+  end
+end

--- a/tasks/public/maintenance.html
+++ b/tasks/public/maintenance.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, but something went wrong (503)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="content-type" charset="UTF-8">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body class="rails-default-error-page">
+  <div class="dialog">
+    <div>
+      <h1>503エラー</h1>
+      <p>Service Unavailable</p>
+    </div>
+    <p>現在メンテナンス中です</p>
+  </div>
+</body>
+</html>

--- a/tasks/spec/factories/label.rb
+++ b/tasks/spec/factories/label.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
-  ActiveRecord::Base.connection.execute('ALTER TABLE labels AUTO_INCREMENT = 1')
   factory :label, class: Label do
     label_name { 'テストラベル名' }
   end

--- a/tasks/spec/factories/label_links.rb
+++ b/tasks/spec/factories/label_links.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
-  ActiveRecord::Base.connection.execute('ALTER TABLE label_links AUTO_INCREMENT = 1')
   factory :label_link, class: LabelLink do
     label_id { 1 }
     task_id { 1 }

--- a/tasks/spec/factories/modes.rb
+++ b/tasks/spec/factories/modes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :mode, class: Mode do
+    mode_name { 'maintenance' }
+    value { false }
+  end
+end

--- a/tasks/spec/factories/task_links.rb
+++ b/tasks/spec/factories/task_links.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
-  ActiveRecord::Base.connection.execute('ALTER TABLE task_links AUTO_INCREMENT = 1')
   factory :task_link, class: TaskLink do
     task_id { 1 }
     user_id { 1 }

--- a/tasks/spec/factories/tasks.rb
+++ b/tasks/spec/factories/tasks.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
-  ActiveRecord::Base.connection.execute('ALTER TABLE tasks AUTO_INCREMENT = 1')
   factory :task, class: Task do
     initialize_with do
       Task.find_or_initialize_by(

--- a/tasks/spec/factories/users.rb
+++ b/tasks/spec/factories/users.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
-  ActiveRecord::Base.connection.execute('ALTER TABLE users AUTO_INCREMENT = 1')
   factory :user, class: User do
     user_name { 'テストユーザ' }
     email { Faker::Internet.email }

--- a/tasks/spec/models/mode_spec.rb
+++ b/tasks/spec/models/mode_spec.rb
@@ -5,8 +5,11 @@ RSpec.describe Mode, type: :model do
     let!(:other_mode) { create(:mode, mode_name: 'other') }
     context 'mode_name「maintenance」が存在する場合' do
       let!(:maintenance_mode) { create(:mode, mode_name: 'maintenance', value: false) }
-      it 'メンテナンスモードを開始できること' do
-        expect(Mode.maintenance_start).to eq true
+      it 'mode_name「maintenance」のvalueが「true」になり、メンテナンスモードを開始できること' do
+        maintenance_mode_start = Mode.maintenance_start
+        maintenance = Mode.find_by(mode_name: 'maintenance')
+        expect(maintenance_mode_start).to eq true
+        expect(maintenance.value).to eq true
       end
     end
     context 'mode_name「maintenance」が存在しない場合' do
@@ -19,9 +22,12 @@ RSpec.describe Mode, type: :model do
   describe 'maintenance_end' do
     let!(:other_mode) { create(:mode, mode_name: 'other') }
     context 'mode_name「maintenance」が存在する場合' do
-      let!(:maintenance_mode) { create(:mode, mode_name: 'maintenance', value: false) }
-      it 'メンテナンスモードを終了できること' do
-        expect(Mode.maintenance_end).to eq true
+      let!(:maintenance_mode) { create(:mode, mode_name: 'maintenance', value: true) }
+      it 'mode_name「maintenance」のvalueが「false」になり、メンテナンスモードを終了できること' do
+        maintenance_mode_end = Mode.maintenance_end
+        maintenance = Mode.find_by(mode_name: 'maintenance')
+        expect(maintenance_mode_end).to eq true
+        expect(maintenance.value).to eq false
       end
     end
     context 'mode_name「maintenance」が存在しない場合' do

--- a/tasks/spec/models/mode_spec.rb
+++ b/tasks/spec/models/mode_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Mode, type: :model do
+  describe 'maintenance_start' do
+    let!(:other_mode) { create(:mode, mode_name: 'other') }
+    context 'mode_name「maintenance」が存在する場合' do
+      let!(:maintenance_mode) { create(:mode, mode_name: 'maintenance', value: false) }
+      it 'メンテナンスモードを開始できること' do
+        expect(Mode.maintenance_start).to eq true
+      end
+    end
+    context 'mode_name「maintenance」が存在しない場合' do
+      it 'メンテナンスモードを開始できないこと' do
+        expect(Mode.maintenance_start).to eq false
+      end
+    end
+  end
+
+  describe 'maintenance_end' do
+    let!(:other_mode) { create(:mode, mode_name: 'other') }
+    context 'mode_name「maintenance」が存在する場合' do
+      let!(:maintenance_mode) { create(:mode, mode_name: 'maintenance', value: false) }
+      it 'メンテナンスモードを終了できること' do
+        expect(Mode.maintenance_end).to eq true
+      end
+    end
+    context 'mode_name「maintenance」が存在しない場合' do
+      it 'メンテナンスモードを終了できないこと' do
+        expect(Mode.maintenance_end).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
課題
https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86
上記リンクの「ステップ21: メンテナンス機能を作ろう」の箇所

実装内容
・rails runnerでメンテナンスバッチを実行できるように実装
・DBの値の切り替えでメンテナンスモードの切り替えができるように実装
・メンテナンス画面は、railsのエラー画面のデザインを使用しています。
・rspecの作成と修正（不具合が出たため、オートインクリメントを初期化する機能を一旦外しました。）

画面キャプチャ
【正常時】
<img width="1260" alt="正常時" src="https://user-images.githubusercontent.com/85857723/128486276-664ccdb4-6627-4c2d-af28-195611daf586.png">

【メンテナンスモード開始】
<img width="777" alt="修正後開始コード" src="https://user-images.githubusercontent.com/85857723/129655658-482cb57b-5dee-4118-8320-d23382c5cb8b.png">


<img width="1253" alt="開始時" src="https://user-images.githubusercontent.com/85857723/128486425-ddd2e776-ab87-44ba-988e-8244a0727c14.png">

【メンテナンスモード終了】
<img width="790" alt="修正後終了コード" src="https://user-images.githubusercontent.com/85857723/129655694-0a904f3e-4597-4934-94a3-5bcc13346f8b.png">


<img width="1266" alt="終了後" src="https://user-images.githubusercontent.com/85857723/128486530-d95cfd04-9d66-429d-bb02-b9daf428f5b6.png">

