### PR TITLE
ステップ19: ユーザにロールを追加しよう

### DIFF
--- a/tasks/app/controllers/admin/users_controller.rb
+++ b/tasks/app/controllers/admin/users_controller.rb
@@ -1,5 +1,7 @@
 class Admin::UsersController < ApplicationController
   before_action :logged_in_user
+  before_action :current_user
+  before_action :redirect_top_by_general_user
   before_action :set_user, only: %i[show edit update destroy]
 
   def index
@@ -18,6 +20,11 @@ class Admin::UsersController < ApplicationController
   def edit; end
 
   def update
+    if current_user.id == @user.id && user_params[:role] == 'false'
+      redirect_to admin_users_path, notice: 'ログイン中のユーザの管理者権限は変更できません。'
+      return
+    end
+
     if @user.update(user_params)
       redirect_to admin_user_path, notice: 'ユーザ情報を更新しました。'
     else
@@ -51,6 +58,10 @@ class Admin::UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:user_name, :email)
+    params.require(:user).permit(:user_name, :email, :role)
+  end
+
+  def redirect_top_by_general_user
+    redirect_to root_path unless current_user.role
   end
 end

--- a/tasks/app/views/admin/users/_form.html.erb
+++ b/tasks/app/views/admin/users/_form.html.erb
@@ -21,6 +21,15 @@
     <%= f.text_field :email, class: 'form-control' %>
   </div>
 
+  <div class="form-group">
+    <%= f.label :role, class: 'control-label text-primary' %>
+    <%= f.radio_button :role, :false %>
+    <%= f.label :role, t('item_value.false'), class: 'control-label' %>
+    <%= f.radio_button :role, :true %>
+    <%= f.label :role, t('item_value.true'), class: 'control-label' %>
+  </div>
+
+
   <div class="form-group row justify-content-center">
     <div>
       <%= link_to t('link.back'), admin_users_path, class: 'btn btn-outline-secondary btn-width' %>

--- a/tasks/app/views/admin/users/index.html.erb
+++ b/tasks/app/views/admin/users/index.html.erb
@@ -20,6 +20,7 @@
         <th class="text-primary"><%= User.human_attribute_name(:id) %></th>
         <th class="text-primary"><%= User.human_attribute_name(:user_name) %></th>
         <th class="text-primary"><%= t('item_name.task_count') %></th>
+        <th class="text-primary"><%= User.human_attribute_name(:role) %></th>
       </tr>
     </thead>
 
@@ -29,6 +30,7 @@
           <td class="list-item"><%= user.id %></td>
           <td class="list-item"><%= user.user_name %></td>
           <td class="list-item"><%= user.tasks_count %></td>
+          <td class="list-item"><% if user.role %><%= t('item_value.true') %><% else %><%= t('item_value.false') %><% end %></td>
           <td><%= link_to t('link.show'), admin_user_path(user), class: 'btn default-btn' %></td>
           <td><%= link_to t('link.edit'), edit_admin_user_path(user), class: 'btn default-btn' %></td>
           <td><%= link_to t('link.delete'), admin_user_path(user), method: :delete, data: { confirm: t('confirm.delete') }, class: 'btn default-btn' %></td>

--- a/tasks/app/views/admin/users/show.html.erb
+++ b/tasks/app/views/admin/users/show.html.erb
@@ -28,6 +28,10 @@
     <div class="h8 border-bottom"><%= @user.tasks.without_deleted.count %></div>
   </div>
   <div class="form-group">
+    <div class="h7 text-primary"><%= User.human_attribute_name(:role) %></div>
+    <div class="h8 border-bottom"><% if @user.role %><%= t('item_value.true') %><% else %><%= t('item_value.false') %><% end %></div>
+  </div>
+  <div class="form-group">
     <div class="h7 text-primary"><%= User.human_attribute_name(:created_at) %></div>
     <div class="h8 border-bottom"><%= l @user.created_at %></div>
   </div>

--- a/tasks/app/views/tasks/index.html.erb
+++ b/tasks/app/views/tasks/index.html.erb
@@ -3,9 +3,11 @@
     <div>
       <%= link_to t('link.new'), new_task_path, class: 'btn new-btn' %>
     </div>
+    <% if current_user.role %>
     <div>
       <%= link_to t('link.admin'), admin_users_path, class: 'btn btn-secondary text-white ml-2' %>
     </div>
+    <% end %>
     <h1 class="title">タスク一覧</h1>
     <div class="login-user"><%= current_user.user_name %></div>
     <div>

--- a/tasks/config/locales/ja.yml
+++ b/tasks/config/locales/ja.yml
@@ -21,6 +21,7 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード（確認）
+        role: 管理者権限
         created_at: 作成日時
     errors:
       models:
@@ -54,3 +55,6 @@ ja:
     invalid_email_or_password_combination: メールアドレスかパスワードが違います。   
   item_name:
     task_count: タスク数
+  item_value:
+    'true': '有効'
+    'false': '無効'

--- a/tasks/spec/controllers/admin_users_controller_spec.rb
+++ b/tasks/spec/controllers/admin_users_controller_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Admin::UsersController, type: :controller do
   let(:task) { create(:task_list_item) }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, role: true) }
+  let(:general_user) { create(:user, role: false) }
 
   shared_context 'login_and_create_task_link' do
     before do
@@ -12,13 +13,21 @@ RSpec.describe Admin::UsersController, type: :controller do
   end
 
   describe '#index' do
-    context 'ログイン状態の場合' do
+    context 'ログイン状態かつ、管理者権限を持つ場合' do
       before { log_in(user) }
       it 'HTTPステータスコードが200、テンプレートが表示されること' do
         get :index
         expect(response).to be_successful
         expect(response).to have_http_status :success
         expect(response).to render_template :index
+      end
+    end
+    context 'ログイン状態かつ、管理者権限を持たない場合' do
+      before { log_in(general_user) }
+      it 'タスク一覧ページにリダイレクトされること' do
+        get :index
+        expect(response).to have_http_status :redirect
+        expect(response).to redirect_to root_path
       end
     end
     context 'ログアウト状態の場合' do
@@ -31,13 +40,21 @@ RSpec.describe Admin::UsersController, type: :controller do
   end
 
   describe '#show' do
-    context 'ログイン状態の場合' do
+    context 'ログイン状態かつ、管理者権限を持つ場合' do
       include_context 'login_and_create_task_link'
       it 'HTTPステータスコードが200、テンプレートが表示されること' do
         get :show, params: { id: user.id }
         expect(response).to be_successful
         expect(response).to have_http_status :success
         expect(response).to render_template :show
+      end
+    end
+    context 'ログイン状態かつ、管理者権限を持たない場合' do
+      before { log_in(general_user) }
+      it 'タスク一覧ページにリダイレクトされること' do
+        get :show, params: { id: user.id }
+        expect(response).to have_http_status :redirect
+        expect(response).to redirect_to root_path
       end
     end
     context 'ログアウト状態の場合' do
@@ -80,13 +97,21 @@ RSpec.describe Admin::UsersController, type: :controller do
   end
 
   describe '#edit' do
-    context 'ログイン状態の場合' do
+    context 'ログイン状態かつ、管理者権限を持つ場合' do
       before { log_in(user) }
       it 'HTTPステータスコードが200、テンプレートが表示されること' do
         get :edit, params: { id: user.id }
         expect(response).to be_successful
         expect(response).to have_http_status :success
         expect(response).to render_template :edit
+      end
+    end
+    context 'ログイン状態かつ、管理者権限を持たない場合' do
+      before { log_in(general_user) }
+      it 'タスク一覧ページにリダイレクトされること' do
+        get :edit, params: { id: user.id }
+        expect(response).to have_http_status :redirect
+        expect(response).to redirect_to root_path
       end
     end
     context 'ログアウト状態の場合' do
@@ -101,7 +126,7 @@ RSpec.describe Admin::UsersController, type: :controller do
   describe '#update' do
     before { log_in(user) }
     context '正常な値' do
-      let(:normal_user_params) { { user_name: '変更後ユーザ名', email: 'update@user.com' } }
+      let(:normal_user_params) { { user_name: '変更後ユーザ名', email: 'update@user.com', role: true } }
       it '正常にタスクを更新できること' do
         patch :update, params: { id: user.id, user: normal_user_params }
         expect(user.reload.user_name).to eq '変更後ユーザ名'
@@ -112,9 +137,32 @@ RSpec.describe Admin::UsersController, type: :controller do
         expect(response).to redirect_to admin_user_path(id: user.id)
       end
     end
+    context 'ログイン中の自身のユーザの管理者権限を無効にしようとした場合' do
+      let(:own_user_params) { { user_name: user.user_name, email: user.email, role: false } }
+      it 'ユーザを更新できないこと' do
+        get :update, params: { id: user.id, user: own_user_params }
+        expect(user.reload.role).to eq true
+      end
+      it 'ユーザ一覧ページにリダイレクトされること' do
+        get :update, params: { id: user.id, user: own_user_params }
+        expect(response).to redirect_to admin_users_path
+      end
+    end
+    context 'ログイン中以外の管理者権限が有効なユーザの管理者権限を無効にしようとした場合' do
+      let(:other_user) { create(:user, role: true) }
+      let(:other_user_params) { { user_name: other_user.user_name, email: other_user.email, role: false } }
+      it 'ユーザを更新できること' do
+        get :update, params: { id: other_user.id, user: other_user_params }
+        expect(other_user.reload.role).to eq false
+      end
+      it '更新後、詳細ページにリダイレクトされること' do
+        get :update, params: { id: other_user.id, user: other_user_params }
+        expect(response).to redirect_to redirect_to admin_user_path(id: other_user.id)
+      end
+    end
     context '不正な値' do
       let!(:before_update_user) { user }
-      let(:unjust_user_params) { { user_name: '変更後ユーザ名', email: nil } }
+      let(:unjust_user_params) { { user_name: '変更後ユーザ名', email: nil, role: true } }
       it 'ユーザを更新できないこと' do
         patch :update, params: { id: user.id, user: unjust_user_params }
         expect(user.reload.user_name).to eq before_update_user.user_name


### PR DESCRIPTION
**課題**
https://github.com/Fablic/training#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9719-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD
上記リンクの「ステップ19: ユーザにロールを追加しよう」の箇所


**実装内容**
・roleカラムによる管理者権限の有無の判定を行い、管理画面には、管理者権限を持つユーザのみ閲覧できるように実装
・タスク一覧画面で一般ユーザは管理者画面に遷移するボタンを非表示になるように実装
・ユーザ一覧、詳細画面でそのユーザの管理者権限を表示されるように実装
・編集画面で、そのユーザの管理者権限を変更できるように実装
・ログイン中の管理者権限を持つ自身のユーザの管理者権限を無効にできないように実装
（共有事項のユーザ削除時の制御も合わせて、管理者権限を持つユーザが0にならないようにしています）
・rspecの作成

**共有事項**
・roleカラムはすでにusersテーブルに作成済み
・ユーザ削除時、現在ログイン中のユーザは削除できないようにすでに実装済み

**画面キャプチャ**
【タスク一覧画面（一般ユーザ）】
<img width="1260" alt="一般_タスク一覧" src="https://user-images.githubusercontent.com/85857723/129674944-b0777222-b97a-4373-8242-3a04a903a369.png">


【タスク一覧画面（管理者ユーザ）】
<img width="1264" alt="管理者_タスク一覧" src="https://user-images.githubusercontent.com/85857723/129674652-ace1d028-b578-4cee-baf3-db021d0e9c7a.png">


【ユーザ一覧画面】
<img width="1262" alt="ユーザ一覧" src="https://user-images.githubusercontent.com/85857723/129674689-b56f13e2-a8f3-47e2-afb3-511f4a32706a.png">


【ユーザ詳細画面】
<img width="1263" alt="ユーザ詳細" src="https://user-images.githubusercontent.com/85857723/129674730-5515c54f-d198-44d1-a230-f3b785e82a71.png">


【ユーザ編集画面】
<img width="1266" alt="ユーザ編集" src="https://user-images.githubusercontent.com/85857723/129674745-57e9baf9-0e7b-4495-a74f-b2a6144062bb.png">


【ユーザ詳細画面（管理者権限の変更成功時）】
<img width="1270" alt="ユーザ詳細_変更後" src="https://user-images.githubusercontent.com/85857723/129675215-677dc6ef-bf86-4238-abbd-807d611263b8.png">


【ユーザ一覧画面（ログイン中のユーザの管理者権限を無効にした場合）】
<img width="1265" alt="ユーザ編集不可" src="https://user-images.githubusercontent.com/85857723/129674766-ae5134a4-5351-4605-8c5e-4ad5371a742f.png">


【ユーザ一覧画面（ログイン中のユーザを削除しようとした場合（すでに実装済み））】
<img width="1262" alt="ユーザ削除不可" src="https://user-images.githubusercontent.com/85857723/129674808-8b858fac-908c-4596-b6ef-73979a21c84a.png">


