### PR TITLE
Step16の要件にbullet導入を追加（docker版）

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ chrome://extensions/ を開いて右上のDeveloper modeをオンにして、RKG
 - ユーザとタスクが紐づくようにしましょう
   - 関連に対してインデックスを貼りましょう
   - N+1問題を回避するための仕組みを取り入れましょう
+    - N+1クエリを自動検出するbulletを導入してみましょう（[参考記事](https://fablic.qiita.com/craftcat/items/b181b67ddae0c7d0702a)）
 
 ### ステップ17: ログイン/ログアウト機能を実装しよう
 


### PR DESCRIPTION
元PR：https://github.com/Fablic/training/pull/1111
以下元PRと同じ内容。

## 概要
目的はレビューコスト削減。
現状はN+1クエリの検出はログをコードを読んだ上でログを目視で確認するしかない。
N+1問題は`fablicop`による文法のチェック同様、[`bullet`](https://github.com/flyerhzm/bullet)で自動検出できるのでモデルのアソシエーションの実装があるStep16にて導入するようにしたい。