### PR TITLE
step18-19 ユーザ管理画面、管理者処理追加

### DIFF
--- a/myapp/app/assets/stylesheets/application.scss
+++ b/myapp/app/assets/stylesheets/application.scss
@@ -5,7 +5,7 @@
   justify-content: center;
 }
 
-.beta {
+.title_header {
   color: $gray-600;
-  background-color: $green-100;
+  background-color: $yellow-300;
 }

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,0 +1,79 @@
+class Admin::UsersController < ApplicationController
+  ADMIN_USER_MIN = 1
+
+  before_action { _login_check || _check_role_admin }
+
+  def index
+    @users = User.preload(:tasks)
+  end
+
+  def show
+    @tasks = Task.where(user_id: params[:id])
+    @user = User.find params[:id]
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to admin_users_path, flash: { success: I18n.t('flash.new_user_success') }
+    else
+      flash[:danger] = I18n.t('flash.new_user_danger')
+      flash[:validation_error] = @user.errors.full_messages
+      redirect_to new_admin_user_path
+    end
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+
+    if _can_change_role? && @user.update(user_params)
+      redirect_to admin_users_path, flash: { success: I18n.t('flash.updated_user_success') }
+    else
+      flash[:danger] = I18n.t('flash.updated_user_danger')
+      flash[:validation_error] = @user.errors.full_messages
+      redirect_to edit_admin_user_path(@user)
+    end
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+
+    if current_user == @user
+      flash[:danger] = I18n.t('flash.user_destroy_danger')
+      flash[:info] = I18n.t('flash.cannot_update_admin', num: ADMIN_USER_MIN)
+    else
+      @user.destroy
+      flash[:success] = I18n.t('flash.user_destroy_success')
+    end
+
+    redirect_to admin_users_path
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :password, :role)
+  end
+
+  private
+
+  def _check_role_admin
+    redirect_to routing_error unless current_user.admin?
+  end
+
+  def _can_change_role?
+    return true unless @user.admin?
+    return true if user_params[:role].to_sym == :admin
+    return true if User.admin.count > ADMIN_USER_MIN
+
+    flash[:info] = I18n.t('flash.cannot_update_admin', num: ADMIN_USER_MIN)
+    false
+  end
+end

--- a/myapp/app/helpers/admin/users_helper.rb
+++ b/myapp/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/myapp/app/helpers/application_helper.rb
+++ b/myapp/app/helpers/application_helper.rb
@@ -1,10 +1,9 @@
 module ApplicationHelper
   def page_title(page_title = '')
-    base_title = 'タスク管理'
     if page_title.empty?
       base_title
     else
-      page_title + '  |  ' + base_title
+      "#{page_title} | #{I18n.t('title.base')}"
     end
   end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -4,4 +4,7 @@ class User < ApplicationRecord
   has_secure_password validations: true
 
   validates :name, presence: true, uniqueness: true
+
+  # ユーザ種別（0=一般 / 1=管理者）
+  enum role: { nomal: 0, admin: 1 }
 end

--- a/myapp/app/views/admin/users/edit.html.erb
+++ b/myapp/app/views/admin/users/edit.html.erb
@@ -1,0 +1,35 @@
+<% provide(:title, 'ユーザ管理：更新') %>
+
+<div class="d-flex justify-content-end">
+  <%= link_to 'ユーザ一覧に戻る', admin_users_path, class: 'btn btn-outline-primary' %>
+</div>
+
+<%= form_with model: [:admin, @user], local: true do |f| %>
+<%= render 'layouts/error_messages' %>
+<div class="row mb-3">
+  <%= f.label :name, class: "col-sm-2 col-form-label" %>
+  <div class="col-sm-5">
+    <%= f.text_field :name, class: "form-control" %>
+  </div>
+</div>
+<div class="row mb-3">
+  <%= f.label :password, class: "col-sm-2 col-form-label" %>
+  <div class="col-sm-5">
+    <%= f.password_field :password, :placeholder => "未入力の場合は更新されません" , class: "form-control" %>
+  </div>
+</div>
+<div class="row mb-3">
+  <%= f.label :role, class: "col-sm-2 col-form-label" %>
+  <div class="col-sm-2 d-flex align-items-center">
+    <%= f.radio_button :role, :admin %>
+    <%= f.label I18n.t('activerecord.attributes.user.roles.admin') %>
+  </div>
+  <div class="col-sm-2 d-flex align-items-center">
+    <%= f.radio_button :role, :nomal %>
+  <%= f.label I18n.t('activerecord.attributes.user.roles.nomal') %>
+  </div>
+</div>
+<div>
+<%= f.submit '更新', class: 'btn btn-secondary' %>
+</div>
+<% end %>

--- a/myapp/app/views/admin/users/edit.html.erb
+++ b/myapp/app/views/admin/users/edit.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, 'ユーザ管理：更新') %>
-
 <div class="d-flex justify-content-end">
   <%= link_to 'ユーザ一覧に戻る', admin_users_path, class: 'btn btn-outline-primary' %>
 </div>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,0 +1,40 @@
+<% provide(:title, 'ユーザ管理：一覧') %>
+
+<div class="d-flex justify-content-end ">
+  <div class='btn-toolbar' role="toolbar">
+    <%= link_to '新規ユーザ作成', new_admin_user_path, class: 'btn  btn-primary mx-1' %>
+    <%= link_to 'タスク一覧', root_path, class: 'btn btn-outline-primary mx-1' %>
+  </div>
+</div>
+
+
+<table class="table table-striped task_list">
+  <thead>
+    <tr>
+      <th scope="col">ID</th>
+      <th scope="col">ユーザ名</th>
+      <th scope="col">種別</th>
+      <th scope="col">タスク</th>
+      <th scope="col">作成日</th>
+      <th scope="col"></th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+<% @users.each do |user| %>
+    <tr>
+      <th scope="row"><%= user.id %></th>
+      <td><%= user.name %></td>
+      <td><%= I18n.t("activerecord.attributes.user.roles.#{user.role}") %></td>
+      <td><%= link_to user.tasks.count.to_s + '件', admin_user_path(user) %></td>
+      <td class="created"><%= I18n.l(user.created_at, format: :short) %></td>
+      <td><%= link_to '更新', edit_admin_user_path(user), class: 'btn btn-primary mx-1' %></td>
+      <td>
+        <% unless current_user == user %>
+          <%= link_to '削除', admin_user_path(user), method: :delete, data:{ confirm: '本当によろしいですか？'}, class: 'btn btn-dark mx-1' %>
+        <% end %>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, 'ユーザ管理：一覧') %>
-
 <div class="d-flex justify-content-end ">
   <div class='btn-toolbar' role="toolbar">
     <%= link_to '新規ユーザ作成', new_admin_user_path, class: 'btn  btn-primary mx-1' %>

--- a/myapp/app/views/admin/users/new.html.erb
+++ b/myapp/app/views/admin/users/new.html.erb
@@ -1,0 +1,35 @@
+<% provide(:title, 'ユーザ管理：新規') %>
+
+<div class="d-flex justify-content-end">
+  <%= link_to 'ユーザ一覧に戻る', admin_users_path, class: 'btn btn-outline-primary' %>
+</div>
+
+<%= form_with model: [:admin, @user], local: true do |f| %>
+<%= render 'layouts/error_messages' %>
+<div class="row mb-3">
+  <%= f.label :name, class: "col-sm-2 col-form-label" %>
+  <div class="col-sm-4">
+    <%= f.text_field :name, class: "form-control" %>
+  </div>
+</div>
+<div class="row mb-3">
+  <%= f.label :password, class: "col-sm-2 col-form-label" %>
+  <div class="col-sm-4">
+    <%= f.password_field :password, class: "form-control" %>
+  </div>
+</div>
+<div class="row mb-3">
+  <%= f.label :role, class: "col-sm-2 col-form-label" %>
+  <div class="col-sm-2 d-flex align-items-center">
+    <%= f.radio_button :role, :admin %>
+    <%= f.label I18n.t('activerecord.attributes.user.roles.admin') %>
+  </div>
+  <div class="col-sm-2 d-flex align-items-center">
+    <%= f.radio_button :role, :nomal %>
+  <%= f.label I18n.t('activerecord.attributes.user.roles.nomal') %>
+  </div>
+</div>
+<div>
+<%= f.submit '登録', class: 'btn btn-secondary' %>
+</div>
+<% end %>

--- a/myapp/app/views/admin/users/new.html.erb
+++ b/myapp/app/views/admin/users/new.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, 'ユーザ管理：新規') %>
-
 <div class="d-flex justify-content-end">
   <%= link_to 'ユーザ一覧に戻る', admin_users_path, class: 'btn btn-outline-primary' %>
 </div>

--- a/myapp/app/views/admin/users/show.html.erb
+++ b/myapp/app/views/admin/users/show.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, 'ユーザ管理：タスク一覧') %>
-
 <div class="d-flex justify-content-end">
   <%= link_to 'ユーザ一覧に戻る', admin_users_path, class: 'btn btn-outline-primary' %>
 </div>

--- a/myapp/app/views/admin/users/show.html.erb
+++ b/myapp/app/views/admin/users/show.html.erb
@@ -1,0 +1,29 @@
+<% provide(:title, 'ユーザ管理：タスク一覧') %>
+
+<div class="d-flex justify-content-end">
+  <%= link_to 'ユーザ一覧に戻る', admin_users_path, class: 'btn btn-outline-primary' %>
+</div>
+
+<h3 class="mb-1">ユーザ名<%= ' : ' + @user.name %></h3>
+<table class="table table-striped task_list">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">件名</th>
+      <th scope="col">終了期限</th>
+      <th scope="col">ステータス</th>
+      <th scope="col">作成日</th>
+    </tr>
+  </thead>
+  <tbody>
+<% @tasks.each do |task| %>
+    <tr>
+      <th scope="row"><%= task.id %></th>
+      <td><%= task.title %></td>
+      <td class="deadline"><%= I18n.l(task.deadline, format: :short, default: '') %></td>
+      <td><%= I18n.t("activerecord.attributes.task.statuses.#{task.status}") %></td>
+      <td class="created"><%= I18n.l(task.created_at, format: :short) %></td>
+    </tr>
+<% end %>
+  </tbody>
+</table>

--- a/myapp/app/views/layouts/_flash_tasks.html.erb
+++ b/myapp/app/views/layouts/_flash_tasks.html.erb
@@ -4,3 +4,6 @@
 <% if flash[:danger].present? %>
   <div class="alert alert-danger" role="alert"><%= flash[:danger] %></div>
 <% end %>
+<% if flash[:info].present? %>
+  <div class="alert alert-info" role="alert"><%= flash[:info] %></div>
+<% end %>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= page_title(yield(:title)) %></title>
+    <title><%= page_title(I18n.t("title.#{controller.controller_name}.#{controller.action_name}", default: '')) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/myapp/app/views/sessions/new.html.erb
+++ b/myapp/app/views/sessions/new.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, 'ログイン') %>
-
 <%= form_with scope: :session, url:login_path, local: true do |f| %>
 <%= render 'layouts/error_messages' %>
   <div class="row mb-3">

--- a/myapp/app/views/shared/_author.html.erb
+++ b/myapp/app/views/shared/_author.html.erb
@@ -1,4 +1,4 @@
-<header class="bd-header beta p-3 mb-3">
+<header class="bd-header title_header p-3 mb-3">
   <div class="d-flex justify-content-between">
     <h1 class="fs-4 mb-0">
       ToDo Task<%= ' : ' + @current_user.name if logged_in? %>

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -8,7 +8,7 @@
 <%= form_with model: @task, local: true do |f| %>
 <%= render 'layouts/error_messages' %>
 <div class="row mb-3">
-  <%= f.label :status, 'ステータス', class: "col-sm-1 col-form-label" %>
+  <%= f.label :status, class: "col-sm-1 col-form-label" %>
   <div class="col-sm-5">
   <%= f.select :status, options_for_select(
     Task.statuses.map { |k, _v| [I18n.t("activerecord.attributes.task.statuses.#{k}"), k] },
@@ -17,19 +17,19 @@
   </div>
 </div>
 <div class="row mb-3">
-  <%= f.label :title, '件名', class: "col-sm-1 col-form-label" %>
+  <%= f.label :title, class: "col-sm-1 col-form-label" %>
   <div class="col-sm-5">
     <%= f.text_field :title, class: "form-control" %>
   </div>
 </div>
 <div class="row mb-3">
-  <%= f.label :content, '詳細', class: "col-sm-1 col-form-label" %>
+  <%= f.label :content, class: "col-sm-1 col-form-label" %>
   <div class="col-sm-5">
     <%= f.text_area :content, class: "form-control" %>
   </div>
 </div>
 <div class="row mb-3">
-  <%= f.label :deadline, '終了期限', class: "col-sm-1 col-form-label" %>
+  <%= f.label :deadline, class: "col-sm-1 col-form-label" %>
   <div class="col-sm-3">
     <%= f.datetime_field :deadline, class: "form-control" %>
   </div>

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, '編集') %>
-
 <div class="d-flex justify-content-end ">
   <div class='btn-toolbar' role="toolbar">
     <%= link_to '詳細に戻る', task_path(@task.id), class: 'btn btn-outline-primary mx-1' %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, 'リスト') %>
-
 <div class="d-flex justify-content-end ">
   <div class='btn-toolbar' role="toolbar">
     <%= link_to '新規作成', new_task_path, class: 'btn btn-primary' %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,7 +1,10 @@
 <% provide(:title, 'リスト') %>
 
-<div class="d-flex justify-content-end">
-  <%= link_to '新規作成', new_task_path, class: 'btn btn-primary' %>
+<div class="d-flex justify-content-end ">
+  <div class='btn-toolbar' role="toolbar">
+    <%= link_to '新規作成', new_task_path, class: 'btn btn-primary' %>
+    <%= link_to 'ユーザ管理', admin_users_path, class: 'btn btn-outline-primary mx-1' if current_user.admin? %>
+  </div>
 </div>
 
 <%= search_form_for @q, url: root_path do |f| %>

--- a/myapp/app/views/tasks/new.html.erb
+++ b/myapp/app/views/tasks/new.html.erb
@@ -11,13 +11,13 @@
   </div>
 </div>
 <div class="row mb-3">
-  <%= f.label :content, '詳細', class: "col-sm-1 col-form-label" %>
+  <%= f.label :content, class: "col-sm-1 col-form-label" %>
   <div class="col-sm-5">
     <%= f.text_area :content, class: "form-control" %>
   </div>
 </div>
 <div class="row mb-3">
-  <%= f.label :deadline, '終了期限', class: "col-sm-1 col-form-label" %>
+  <%= f.label :deadline, class: "col-sm-1 col-form-label" %>
   <div class="col-sm-3">
     <%= f.datetime_field :deadline, class: "form-control" %>
   </div>

--- a/myapp/app/views/tasks/new.html.erb
+++ b/myapp/app/views/tasks/new.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, '新規') %>
-
 <div class="d-flex justify-content-end">
   <%= link_to '一覧に戻る', root_path, class: 'btn btn-outline-primary' %>
 </div>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, '詳細') %>
-
 <div class="d-flex justify-content-end ">
   <div class='btn-toolbar' role="toolbar">
     <%= link_to '一覧に戻る', root_path, class: 'btn btn-outline-primary mx-1' %>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -1,4 +1,19 @@
 ja:
+  title:
+    base: 'タスク管理'
+    sessions:
+      new: 'ログイン'
+    tasks:
+      index: 'リスト'
+      show: '詳細'
+      new: '新規'
+      edit: '編集'
+    users:
+      index: 'ユーザ管理：一覧'
+      show: 'ユーザ管理：タスク一覧'
+      new: 'ユーザ管理：新規'
+      edit: 'ユーザ管理：更新'
+
   activerecord:
     attributes:
       task:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -9,6 +9,13 @@ ja:
           not_started: 未着手
           in_progress: 進行中
           completed: 完了
+      user:
+        name: ユーザ名
+        password: パスワード
+        role: ユーザ種別
+        roles:
+          nomal: 一般
+          admin: 管理者
 
   flash:
     new_success: タスク投稿が成功しました
@@ -17,6 +24,13 @@ ja:
     updated_danger: タスク編集が失敗しました
     destroy: タスクが削除されました
     invalid_password: Name,Passwordが一致しません
+    new_user_success: ユーザ登録が成功しました
+    new_user_danger: ユーザ登録が失敗しました
+    updated_user_success: ユーザ更新が成功しました
+    updated_user_danger: ユーザ更新が失敗しました
+    user_destroy_success: ユーザが削除が成功しました
+    user_destroy_danger: ユーザが削除が失敗しました
+    cannot_update_admin: 管理者は%{num}人以上必要です
 
   time:
     formats:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -24,6 +24,7 @@ ja:
           not_started: 未着手
           in_progress: 進行中
           completed: 完了
+        deadline: 終了期限
       user:
         name: ユーザ名
         password: パスワード

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+  end
+
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'

--- a/myapp/db/migrate/20210913021743_add_admin_to_user.rb
+++ b/myapp/db/migrate/20210913021743_add_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer, after: :password_digest, null: false, default: 0
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_07_060933) do
+ActiveRecord::Schema.define(version: 2021_09_13_021743) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2021_09_07_060933) do
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.text "password_digest", null: false
+    t.integer "role", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_users_on_name", unique: true

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -1,6 +1,11 @@
 User.create!(
   [
     {
+      name: 'useradmin',
+      password: 'passwordadmin',
+      role: :admin,
+    },
+    {
       name: 'user1',
       password: 'password1',
     },

--- a/myapp/package.json
+++ b/myapp/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^4.2.0"
+    "webpack-dev-server": "^4.2.1"
   }
 }

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -3,4 +3,9 @@ FactoryBot.define do
     name { 'test_name' }
     password { 'password' }
   end
+  factory :admin_user, class: User do
+    name { 'admin_name' }
+    password { 'passwordadmin' }
+    role { :admin }
+  end
 end

--- a/myapp/spec/system/users_spec.rb
+++ b/myapp/spec/system/users_spec.rb
@@ -1,0 +1,174 @@
+require 'rails_helper'
+
+RSpec.describe 'index', js: true, type: :system do
+  let!(:test_user) { create(:user) }
+  let!(:task) { create(:task) }
+  let!(:admin_user) { create(:admin_user) }
+  before do
+    visit login_path
+    fill_in 'Name', with: admin_user.name
+    fill_in 'Password', with: admin_user.password
+    click_button 'ログイン'
+  end
+
+  describe 'ユーザ一覧ページ' do
+    before { visit admin_users_path }
+    subject { page }
+
+    it '一覧が表示されている' do
+      is_expected.to have_title('ユーザ管理：一覧 | タスク管理')
+      is_expected.to have_content(admin_user.name)
+      is_expected.to have_content(test_user.name)
+    end
+    it 'ログインしているユーザ（管理者）の削除ボタンは表示されない' do
+      trs = page.all('tr')
+      expect(trs[1]).to have_content '削除'
+      expect(trs[2]).not_to have_content '削除'
+    end
+
+    it 'ユーザのタスク一覧へ遷移する' do
+      click_link '1件'
+      is_expected.to have_current_path admin_user_path(test_user.id)
+    end
+    it '新規作成へ遷移する' do
+      click_link '新規ユーザ作成'
+      is_expected.to have_current_path new_admin_user_path
+    end
+    it '更新へ遷移する' do
+      click_link '更新', match: :first
+      is_expected.to have_current_path edit_admin_user_path(test_user.id)
+    end
+    context '削除実行する' do
+      it '削除される' do
+        page.accept_confirm('本当によろしいですか？') do
+          click_link '削除', match: :first
+        end
+        is_expected.to have_content 'ユーザが削除が成功しました'
+        is_expected.to have_current_path admin_users_path
+        is_expected.not_to have_content(test_user.name)
+      end
+    end
+    context '削除実行しない' do
+      it '削除されない' do
+        page.dismiss_confirm('本当によろしいですか？') do
+          click_link '削除', match: :first
+        end
+        is_expected.to have_current_path admin_users_path
+        is_expected.to have_content(test_user.name)
+      end
+    end
+  end
+
+  describe 'ユーザタスク一覧ページ' do
+    before { visit admin_user_path(test_user.id) }
+    subject { page }
+
+    it 'ユーザのタスク一覧が表示されている' do
+      is_expected.to have_title('ユーザ管理：タスク一覧 | タスク管理')
+      is_expected.to have_content(task.title)
+    end
+    it 'ユーザ一覧へ遷移する' do
+      click_link 'ユーザ一覧に戻る'
+      is_expected.to have_current_path admin_users_path
+    end
+  end
+
+  describe '新規作成ページ' do
+    before { visit new_admin_user_path }
+    subject { page }
+    let(:params) { { name: 'newname', password: 'password', role: 'user_role_admin' } }
+
+    context '入力エラーなし' do
+      it 'ユーザが作成できる' do
+        is_expected.to have_title('ユーザ管理：新規 | タスク管理')
+        fill_in 'ユーザ名', with: params[:name]
+        fill_in 'パスワード', with: params[:password]
+        choose params[:role]
+        click_button '登録'
+        is_expected.to have_content 'ユーザ登録が成功しました'
+        is_expected.to have_content(params[:name])
+        is_expected.to have_content '管理者', count: 2
+        is_expected.to have_current_path admin_users_path
+      end
+    end
+    context 'ユーザ名が未入力' do
+      it 'エラーが表示される' do
+        fill_in 'ユーザ名', with: ''
+        fill_in 'パスワード', with: params[:password]
+        choose params[:role]
+        click_button '登録'
+        is_expected.to have_content 'ユーザ登録が失敗しました'
+        is_expected.to have_content 'ユーザ名を入力してください'
+        is_expected.to have_current_path new_admin_user_path
+      end
+    end
+    context 'パスワードが未入力' do
+      it 'エラーが表示される' do
+        fill_in 'ユーザ名', with: params[:name]
+        fill_in 'パスワード', with: ''
+        choose params[:role]
+        click_button '登録'
+        is_expected.to have_content 'ユーザ登録が失敗しました'
+        is_expected.to have_content 'パスワードを入力してください'
+        is_expected.to have_current_path new_admin_user_path
+      end
+    end
+  end
+
+  describe '更新ページ' do
+    before { visit edit_admin_user_path(admin_user.id) }
+    subject { page }
+    let(:params) { { name: 'updatename', password: 'password', role: 'user_role_admin' } }
+
+    it 'ユーザ名と種別が表示/選択され、パスワードは表示されない' do
+      is_expected.to have_title('ユーザ管理：更新 | タスク管理')
+      is_expected.to have_field 'ユーザ名', with: admin_user.name
+      is_expected.to have_field 'パスワード', with: ''
+      is_expected.to have_checked_field('user_role_admin')
+    end
+    context '入力エラーなし' do
+      it 'ユーザを更新できる' do
+        fill_in 'ユーザ名', with: params[:name]
+        fill_in 'パスワード', with: params[:password]
+        choose params[:role]
+        click_button '更新'
+        is_expected.to have_content 'ユーザ更新が成功しました'
+        is_expected.to have_content(params[:name])
+        is_expected.to have_current_path admin_users_path
+      end
+    end
+    context 'ユーザ名が未入力' do
+      it 'エラーが表示される' do
+        fill_in 'ユーザ名', with: ''
+        fill_in 'パスワード', with: params[:password]
+        choose params[:role]
+        click_button '更新'
+        is_expected.to have_content 'ユーザ更新が失敗しました'
+        is_expected.to have_content 'ユーザ名を入力してください'
+        is_expected.to have_current_path edit_admin_user_path(admin_user.id)
+      end
+    end
+    context 'パスワードが未入力' do
+      it 'エラーが表示されず更新される' do
+        fill_in 'ユーザ名', with: params[:name]
+        fill_in 'パスワード', with: ''
+        choose params[:role]
+        click_button '更新'
+        is_expected.to have_content 'ユーザ更新が成功しました'
+        is_expected.to have_content(params[:name])
+        is_expected.to have_current_path admin_users_path
+      end
+    end
+    context '管理者が１人のとき' do
+      it 'ユーザ種別を一般へ更新できない' do
+        fill_in 'ユーザ名', with: params[:name]
+        fill_in 'パスワード', with: params[:password]
+        choose 'user_role_nomal'
+        click_button '更新'
+        is_expected.to have_content 'ユーザ更新が失敗しました'
+        is_expected.to have_content '管理者は1人以上必要です'
+        is_expected.to have_current_path edit_admin_user_path(admin_user.id)
+      end
+    end
+  end
+end

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -7618,10 +7618,10 @@ webpack-dev-middleware@^5.1.0:
     range-parser "^1.2.1"
     schema-utils "^3.1.0"
 
-webpack-dev-server@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.2.0.tgz#f669117e97f0acbee447a5b2eb70060b03f39dcb"
-  integrity sha512-iBaDkHBLfW3cEITeJWNkjZBrm+b5A3YLg8XVdNOdjUNABdXJwcsJv4dzKSnVf1q4Ch489+6epWVW6OcOyVfG7w==
+webpack-dev-server@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.2.1.tgz#12e912b3cad8ddd5222a4ba2c41c6fc69d2545fb"
+  integrity sha512-SQrIyQDZsTaF84p/WMAXNRKxjTeIaewhDIiHYZ423ENhNAsQWyubvqPTn0IoLMGkbhWyWv8/GYnCjItt0ZNC5w==
   dependencies:
     ansi-html-community "^0.0.8"
     bonjour "^3.5.0"


### PR DESCRIPTION
レビューお願いします。
※こちらに沿って作業を進めています。
https://github.com/Fablic/training/tree/use_docker

## ステップ18: ユーザの管理画面を実装しよう
- ユーザ一覧・作成・更新・削除を実装
myapp/config/routes.rb
myapp/app/controllers/admin/users_controller.rb
myapp/app/views/admin/users　配下
- 管理画面への遷移ボタン追加
myapp/app/views/tasks/index.html.erb

## ステップ19: ユーザにロールを追加しよう
- ユーザに管理ユーザと一般ユーザの区別
myapp/db　配下
- 管理ユーザだけがユーザ管理画面にアクセスできる
myapp/app/controllers/admin/users_controller.rb
def _check_role_admin
- ユーザ管理画面でロールを選択
myapp/app/views/admin/users/edit.html.erb
ユーザ種別を更新項目に追加
- 管理ユーザが1人もいなくならないように削除の制御
myapp/app/views/admin/users/index.html.erb
管理者本人の場合、削除ボタン非表示
myapp/app/controllers/admin/users_controller.rb
def _can_change_role?

## 他
rspec追加、メッセージ文言追加、デザイン修正etc