### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替えましょう ★ スキップ可能

### DIFF
--- a/OreNoTask/app/controllers/tasks_controller.rb
+++ b/OreNoTask/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.where(deleted: 0).order(due_date_at: :desc)
+    @tasks = Task.where(deleted: 0).order(created_at: :desc)
   end
 
   def new

--- a/OreNoTask/app/controllers/tasks_controller.rb
+++ b/OreNoTask/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.where(deleted: 0).order(created_at: :desc)
+    @tasks = Task.where(deleted: 0).order(due_date_at: :desc)
   end
 
   def new

--- a/OreNoTask/app/controllers/tasks_controller.rb
+++ b/OreNoTask/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.where(deleted: 0)
+    @tasks = Task.where(deleted: 0).order(created_at: :desc)
   end
 
   def new

--- a/OreNoTask/spec/system/tasks_spec.rb
+++ b/OreNoTask/spec/system/tasks_spec.rb
@@ -3,8 +3,18 @@
 require 'rails_helper'
 describe 'タスク管理機能', type: :system do
   before do
-    create(:task, name: '最初のタスク', description: '説明文', start_at: '2021/09/01 10:00', due_date_at: '2021/09/02 11:00')
-    create(:task, name: '２番目のタスク', description: '説明文２', start_at: '2021/09/02 10:00', due_date_at: '2021/09/03 11:00')
+    @task_a = create(:task, name: '最初のタスク', description: '説明文', start_at: '2021/09/01 10:00', due_date_at: '2021/09/02 11:00')
+    @task_b = create(:task, name: '２番目のタスク', description: '説明文２', start_at: '2021/09/02 10:00', due_date_at: '2021/09/03 11:00')
+  end
+
+  describe '呼び出しレコードの順番をチェックする' do
+    before do
+      @task_c = create(:task, name: '追加したタスク', description: '追加した説明文', start_at: '2021/08/01 10:00', due_date_at: '2021/08/03 11:00')
+      @task_d = create(:task, name: '最後のタスク', description: '最後の説明文', start_at: '2021/07/02 10:00', due_date_at: '2021/07/03 11:00')
+    end
+    it 'ランダムな情報を入力したレコードで順番を確認' do
+      Task.order('created_at desc').all.should == [@task_d, @task_c, @task_b, @task_a]
+    end
   end
 
   context 'タスク一覧を表示する' do

--- a/OreNoTask/spec/system/tasks_spec.rb
+++ b/OreNoTask/spec/system/tasks_spec.rb
@@ -2,27 +2,24 @@
 
 require 'rails_helper'
 describe 'タスク管理機能', type: :system do
-  let!(:task_a) {create(:task, name: '最初のタスク', description: '説明文', start_at: '2021/09/01 10:00', due_date_at: '2021/09/02 11:00')}
-  let!(:task_b) {create(:task, name: '２番目のタスク', description: '説明文２', start_at: '2021/09/02 10:00', due_date_at: '2021/09/03 11:00')}
-
-  describe '呼び出しレコードの順番をチェックする' do
-    let!(:task_c) {create(:task, name: '追加したタスク', description: '追加した説明文', start_at: '2021/08/01 10:00', due_date_at: '2021/08/03 11:00')}
-    let!(:task_d) {create(:task, name: '最後のタスク', description: '最後の説明文', start_at: '2021/07/02 10:00', due_date_at: '2021/07/03 11:00')}
-
-    it 'ランダムな情報を入力したレコードで順番を確認' do
-      Task.order('created_at desc').all.should == [task_d, task_c, task_b, task_a]
-    end
-  end
+  let!(:task_a) {create(:task, name: '最初のタスク', description: '説明文', start_at: '2021/09/01 10:00', due_date_at: '2021/09/02 11:00', created_at: '2021/07/01 09:00:04')}
+  let!(:task_b) {create(:task, name: '２番目のタスク', description: '説明文２', start_at: '2021/08/02 10:00', due_date_at: '2021/08/03 11:00', created_at: '2021/07/01 09:00:03')}
+  let!(:task_c) {create(:task, name: '追加したタスク', description: '追加した説明文', start_at: '2021/10/01 10:00', due_date_at: '2021/10/03 11:00', created_at: '2021/07/01 09:00:02')}
+  let!(:task_d) {create(:task, name: '最後のタスク', description: '最後の説明文', start_at: '2021/12/02 10:00', due_date_at: '2021/12/03 11:00', created_at: '2021/07/01 09:00:01')}
 
   context 'タスク一覧を表示する' do
     it '一覧画面の表示を確認する' do
       visit tasks_path
 
       # 既存のタスクが順番通り表示されている
-      expect(find('li:nth-child(1)')).to have_content '２番目のタスク'
-      expect(find('li:nth-child(1)')).to have_content '2021年09月02日(木) 10:00 〜 2021年09月03日(金) 11:00'
-      expect(find('li:nth-child(2)')).to have_content '最初のタスク'
-      expect(find('li:nth-child(2)')).to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
+      expect(find('li:nth-child(1)')).to have_content '最初のタスク'
+      expect(find('li:nth-child(1)')).to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
+      expect(find('li:nth-child(2)')).to have_content '２番目のタスク'
+      expect(find('li:nth-child(2)')).to have_content '2021年08月02日(月) 10:00 〜 2021年08月03日(火) 11:00'
+      expect(find('li:nth-child(3)')).to have_content '追加したタスク'
+      expect(find('li:nth-child(3)')).to have_content '2021年10月01日(金) 10:00 〜 2021年10月03日(日) 11:00'
+      expect(find('li:nth-child(4)')).to have_content '最後のタスク'
+      expect(find('li:nth-child(4)')).to have_content '2021年12月02日(木) 10:00 〜 2021年12月03日(金) 11:00'
     end
   end
 
@@ -52,10 +49,14 @@ describe 'タスク管理機能', type: :system do
       expect(find('li:nth-child(1)')).to have_content '2021年10月01日(金) 01:02 〜 2021年10月02日(土) 03:04'
 
       # 既存のデータに影響がない
-      expect(find('li:nth-child(2)')).to have_content '２番目のタスク'
-      expect(find('li:nth-child(2)')).to have_content '2021年09月02日(木) 10:00 〜 2021年09月03日(金) 11:00'
-      expect(find('li:nth-child(3)')).to have_content '最初のタスク'
-      expect(find('li:nth-child(3)')).to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
+      expect(find('li:nth-child(2)')).to have_content '最初のタスク'
+      expect(find('li:nth-child(2)')).to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
+      expect(find('li:nth-child(3)')).to have_content '２番目のタスク'
+      expect(find('li:nth-child(3)')).to have_content '2021年08月02日(月) 10:00 〜 2021年08月03日(火) 11:00'
+      expect(find('li:nth-child(4)')).to have_content '追加したタスク'
+      expect(find('li:nth-child(4)')).to have_content '2021年10月01日(金) 10:00 〜 2021年10月03日(日) 11:00'
+      expect(find('li:nth-child(5)')).to have_content '最後のタスク'
+      expect(find('li:nth-child(5)')).to have_content '2021年12月02日(木) 10:00 〜 2021年12月03日(金) 11:00'
 
       # 詳細画面で作成したタスクの内容を確認
       click_link '作ったタスク'
@@ -68,7 +69,7 @@ describe 'タスク管理機能', type: :system do
   context 'タスクの編集' do
     it 'タスクを編集する' do
       visit tasks_path
-      find('li:nth-child(2)').click_link('編集')
+      find('li:nth-child(1)').click_link('編集')
       fill_in 'タスク名', with: '最初のタスクを編集'
       fill_in '内容', with: 'タスクの内容を編集'
       fill_in 'task[start_at]', with: '002021-10-11-11:12'
@@ -76,12 +77,16 @@ describe 'タスク管理機能', type: :system do
 
       click_button 'commit'
       # 編集されたタスクが表示されている
-      expect(page).to have_content '最初のタスクを編集'
-      expect(page).to have_content '2021年10月11日(月) 11:12 〜 2021年10月12日(火) 13:14'
+      expect(find('li:nth-child(1)')).to have_content '最初のタスクを編集'
+      expect(find('li:nth-child(1)')).to have_content '2021年10月11日(月) 11:12 〜 2021年10月12日(火) 13:14'
 
       # 既存のデータに影響がない
-      expect(page).to have_content '２番目のタスク'
-      expect(page).to have_content '2021年09月02日(木) 10:00 〜 2021年09月03日(金) 11:00'
+      expect(find('li:nth-child(2)')).to have_content '２番目のタスク'
+      expect(find('li:nth-child(2)')).to have_content '2021年08月02日(月) 10:00 〜 2021年08月03日(火) 11:00'
+      expect(find('li:nth-child(3)')).to have_content '追加したタスク'
+      expect(find('li:nth-child(3)')).to have_content '2021年10月01日(金) 10:00 〜 2021年10月03日(日) 11:00'
+      expect(find('li:nth-child(4)')).to have_content '最後のタスク'
+      expect(find('li:nth-child(4)')).to have_content '2021年12月02日(木) 10:00 〜 2021年12月03日(金) 11:00'
 
       # 詳細画面で編集したタスクの内容を確認
       click_link '最初のタスクを編集'
@@ -94,15 +99,19 @@ describe 'タスク管理機能', type: :system do
   context 'タスクの削除' do
     it 'タスクを削除する' do
       visit tasks_path
-      find('li:nth-child(2)').click_button('削除')
+      find('li:nth-child(1)').click_button('削除')
 
       # 作成されたタスクが表示されてない
       expect(page).not_to have_content '最初のタスク'
       expect(page).not_to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
 
       # 既存のデータに影響がない
-      expect(page).to have_content '２番目のタスク'
-      expect(page).to have_content '2021年09月02日(木) 10:00 〜 2021年09月03日(金) 11:00'
+      expect(find('li:nth-child(1)')).to have_content '２番目のタスク'
+      expect(find('li:nth-child(1)')).to have_content '2021年08月02日(月) 10:00 〜 2021年08月03日(火) 11:00'
+      expect(find('li:nth-child(2)')).to have_content '追加したタスク'
+      expect(find('li:nth-child(2)')).to have_content '2021年10月01日(金) 10:00 〜 2021年10月03日(日) 11:00'
+      expect(find('li:nth-child(3)')).to have_content '最後のタスク'
+      expect(find('li:nth-child(3)')).to have_content '2021年12月02日(木) 10:00 〜 2021年12月03日(金) 11:00'
     end
   end
 end

--- a/OreNoTask/spec/system/tasks_spec.rb
+++ b/OreNoTask/spec/system/tasks_spec.rb
@@ -11,11 +11,11 @@ describe 'タスク管理機能', type: :system do
     it '一覧画面の表示を確認する' do
       visit tasks_path
 
-      # 既存のタスクが表示されている
-      expect(page).to have_content '最初のタスク'
-      expect(page).to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
-      expect(page).to have_content '２番目のタスク'
-      expect(page).to have_content '2021年09月02日(木) 10:00 〜 2021年09月03日(金) 11:00'
+      # 既存のタスクが順番通り表示されている
+      expect(find('li:nth-child(1)')).to have_content '２番目のタスク'
+      expect(find('li:nth-child(1)')).to have_content '2021年09月02日(木) 10:00 〜 2021年09月03日(金) 11:00'
+      expect(find('li:nth-child(2)')).to have_content '最初のタスク'
+      expect(find('li:nth-child(2)')).to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
     end
   end
 
@@ -41,14 +41,14 @@ describe 'タスク管理機能', type: :system do
       click_button 'commit'
 
       # 作成されたタスクが表示されている
-      expect(page).to have_content '作ったタスク'
-      expect(page).to have_content '2021年10月01日(金) 01:02 〜 2021年10月02日(土) 03:04'
+      expect(find('li:nth-child(1)')).to have_content '作ったタスク'
+      expect(find('li:nth-child(1)')).to have_content '2021年10月01日(金) 01:02 〜 2021年10月02日(土) 03:04'
 
       # 既存のデータに影響がない
-      expect(page).to have_content '最初のタスク'
-      expect(page).to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
-      expect(page).to have_content '２番目のタスク'
-      expect(page).to have_content '2021年09月02日(木) 10:00 〜 2021年09月03日(金) 11:00'
+      expect(find('li:nth-child(2)')).to have_content '２番目のタスク'
+      expect(find('li:nth-child(2)')).to have_content '2021年09月02日(木) 10:00 〜 2021年09月03日(金) 11:00'
+      expect(find('li:nth-child(3)')).to have_content '最初のタスク'
+      expect(find('li:nth-child(3)')).to have_content '2021年09月01日(水) 10:00 〜 2021年09月02日(木) 11:00'
 
       # 詳細画面で作成したタスクの内容を確認
       click_link '作ったタスク'
@@ -61,7 +61,7 @@ describe 'タスク管理機能', type: :system do
   context 'タスクの編集' do
     it 'タスクを編集する' do
       visit tasks_path
-      click_link '編集', match: :first
+      find('li:nth-child(2)').click_link('編集')
       fill_in 'タスク名', with: '最初のタスクを編集'
       fill_in '内容', with: 'タスクの内容を編集'
       fill_in 'task[start_at]', with: '002021-10-11-11:12'
@@ -87,7 +87,7 @@ describe 'タスク管理機能', type: :system do
   context 'タスクの削除' do
     it 'タスクを削除する' do
       visit tasks_path
-      click_button '削除', match: :first
+      find('li:nth-child(2)').click_button('削除')
 
       # 作成されたタスクが表示されてない
       expect(page).not_to have_content '最初のタスク'

--- a/OreNoTask/spec/system/tasks_spec.rb
+++ b/OreNoTask/spec/system/tasks_spec.rb
@@ -2,18 +2,15 @@
 
 require 'rails_helper'
 describe 'タスク管理機能', type: :system do
-  before do
-    @task_a = create(:task, name: '最初のタスク', description: '説明文', start_at: '2021/09/01 10:00', due_date_at: '2021/09/02 11:00')
-    @task_b = create(:task, name: '２番目のタスク', description: '説明文２', start_at: '2021/09/02 10:00', due_date_at: '2021/09/03 11:00')
-  end
+  let!(:task_a) {create(:task, name: '最初のタスク', description: '説明文', start_at: '2021/09/01 10:00', due_date_at: '2021/09/02 11:00')}
+  let!(:task_b) {create(:task, name: '２番目のタスク', description: '説明文２', start_at: '2021/09/02 10:00', due_date_at: '2021/09/03 11:00')}
 
   describe '呼び出しレコードの順番をチェックする' do
-    before do
-      @task_c = create(:task, name: '追加したタスク', description: '追加した説明文', start_at: '2021/08/01 10:00', due_date_at: '2021/08/03 11:00')
-      @task_d = create(:task, name: '最後のタスク', description: '最後の説明文', start_at: '2021/07/02 10:00', due_date_at: '2021/07/03 11:00')
-    end
+    let!(:task_c) {create(:task, name: '追加したタスク', description: '追加した説明文', start_at: '2021/08/01 10:00', due_date_at: '2021/08/03 11:00')}
+    let!(:task_d) {create(:task, name: '最後のタスク', description: '最後の説明文', start_at: '2021/07/02 10:00', due_date_at: '2021/07/03 11:00')}
+
     it 'ランダムな情報を入力したレコードで順番を確認' do
-      Task.order('created_at desc').all.should == [@task_d, @task_c, @task_b, @task_a]
+      Task.order('created_at desc').all.should == [task_d, task_c, task_b, task_a]
     end
   end
 


### PR DESCRIPTION
# ステップ10: タスク一覧を作成日時の順番で並び替えましょう ★ スキップ可能
## Jiraチケット
https://jira.rakuten-it.com/jira/browse/RAKUTRA-3718

## 行うこと
- 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
- 並び替えがうまく行っていることをsystem specで書いてみましょう

## 行ったこと
- Taskのレコードをcreated_at降順で取得するように変更
- テストを修正した
- rubocopでコードチェック＆修正

## 扱い方

画面の確認
`http://localhost:3000/`

## 現在のdbのスキーマやinstall方法など
https://github.com/Fablic/training/blob/ryo_ikebe_step9/OreNoTask/README.md

## リンク
[ステップ10: タスク一覧を作成日時の順番で並び替えましょう ★ スキップ可能]https://github.com/Fablic/training#ステップ10-タスク一覧を作成日時の順番で並び替えましょう--スキップ可能

## 動作確認
- 一覧画面
![index_order](https://user-images.githubusercontent.com/50345954/135214837-a960604f-42a9-456b-b638-79aa854f64db.jpeg)

- テスト結果
```
.....

Finished in 5.25 seconds (files took 1.61 seconds to load)
5 examples, 0 failures
```


