### PR TITLE
Yuta d saito/step11

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -21,7 +21,6 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to root_path, flash: { info: I18n.t('pages.tasks.flash.added') }
     else
-      flash.now[:danger] = I18n.t('pages.tasks.flash.fail')
       render 'new'
     end
   end
@@ -32,7 +31,6 @@ class TasksController < ApplicationController
     if @task.update(task_params)
       redirect_to @task, flash: { info: I18n.t('pages.tasks.flash.edited') }
     else
-      flash.now[:danger] = I18n.t('pages.tasks.flash.fail')
       render 'edit'
     end
   end

--- a/myapp/app/views/shared/_error_messages.html.erb
+++ b/myapp/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if object.errors.any? %>
+  <div>
+    <div>
+      <%= I18n.t("form.error",smtg: object.errors.count)%>
+    </div>
+    <ul>
+    <% object.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,7 +1,7 @@
 <div>
   <div >
     <%= form_with(model: @task, local: true) do |f| %>
-
+        <%= render 'shared/error_messages', object: f.object %>
         <%= f.label :title %>
         <%= f.text_field :title, class: 'form-control' %>
         <br />

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -68,6 +68,8 @@ en:
     edit: Edit
     submit: Submit
     delete: Delete
+  form:
+    error: The form contains %{smtg} error
   pages:
     tasks:
       flash:

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -58,9 +58,9 @@ en:
         task:
           attributes:
             title:
-              blank: title is empty.
+              blank: is empty.
             due_date:
-              blank: due_date is empty.
+              blank: is empty.
               error: Incorrect due date.
 
   common:
@@ -78,3 +78,5 @@ en:
         deleted: Deleted the task.
         fail: Failed to register the task.
       confirm_deletion: Are you sure you want to delete the task?
+      search:
+        title: Search

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -58,9 +58,9 @@ ja:
         task:
           attributes:
             title:
-              blank: 名前は必須です
+              blank: は入力必須です
             due_date:
-              blank: 期限は必須です
+              blank: は入力必須です
               error: 期限が誤っています
   common:
     new: 新規作成

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -67,6 +67,8 @@ ja:
     edit: 編集
     submit: 送信
     delete: 削除
+  form:
+    error: 入力に誤りがあります(%{smtg}件)
   pages:
     tasks:
       flash:

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,105 +1,140 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
+  let(:task) { build(:task) }
   describe '#title' do
-    it 'with nil is not valid' do
-      task = build(:task, title: nil)
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:title)
+    context 'If nil is set' do
+      it 'Invalidated and returns an error message' do
+        task.title = nil
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:title)
+      end
     end
 
-    it 'with empty is not valid' do
-      task = build(:task, title: '')
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:title)
+    context 'If empty is set.' do
+      it 'Invalidated and returns an error message' do
+        task.title = ''
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:title)
+      end
     end
 
-    it 'Exceeds the specified number of characters' do
-      task = build(:task, title: 'a' * 21)
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:title)
+    context 'If the number of characters is set to be more than the specified number' do
+      it 'Invalidated and returns an error message' do
+        task.title = 'a' * 21
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:title)
+      end
     end
 
-    it 'Less than the specified number of characters' do
-      task = build(:task, title: 'a' * 2)
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:title)
+    context 'If the number of characters is set to less than the specified value' do
+      it 'Invalidated and returns an error message' do
+        task.title = 'a' * 2
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:title)
+      end
     end
   end
 
   describe '#detail' do
-    it 'with nil is valid' do
-      task = build(:task, detail: nil)
-      expect(task).to be_valid
-      expect(task.errors.messages).not_to include(:detail)
+    context 'If nil is set' do
+      it 'Invalidated and returns an error message' do
+        task.detail = nil
+        expect(task).to be_valid
+        expect(task.errors.messages).not_to include(:detail)
+      end
     end
 
-    it 'with empty is valid' do
-      task = build(:task, detail: '')
-      expect(task).to be_valid
-      expect(task.errors.messages).not_to include(:detail)
+    context 'If empty is set.' do
+      it 'Invalidated and returns an error message' do
+        task.detail = ''
+        expect(task).to be_valid
+        expect(task.errors.messages).not_to include(:detail)
+      end
     end
 
-    it 'Exceeds the specified number of characters' do
-      task = build(:task, detail: 'a' * 10_001)
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:detail)
+    context 'If the number of characters is set to be more than the specified number' do
+      it 'Invalidated and returns an error message' do
+        task.detail = 'a' * 10_001
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:detail)
+      end
     end
   end
 
   describe '#due_date' do
-    it 'with nil is valid' do
-      task = build(:task, due_date: nil)
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:due_date)
+    context 'If nil is set' do
+      it 'Invalidated and returns an error message' do
+        task.due_date = nil
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:due_date)
+      end
     end
 
-    it 'with empty is valid' do
-      task = build(:task, due_date: '')
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:due_date)
+    context 'If empty is set.' do
+      it 'Invalidated and returns an error message' do
+        task.due_date = ''
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:due_date)
+      end
     end
 
-    it 'Check the date now' do
-      task = build(:task, due_date: Time.zone.now)
-      expect(task).to be_valid
-      expect(task.errors.messages).not_to include(:due_date)
+    context 'If todays date is set' do
+      it 'Enabled, no error message returned' do
+        task.due_date = Time.zone.now
+        expect(task).to be_valid
+        expect(task.errors.messages).not_to include(:due_date)
+      end
     end
-    it 'Check the date tomorrow' do
-      task = build(:task, due_date: Time.zone.tomorrow)
-      expect(task).to be_valid
-      expect(task.errors.messages).not_to include(:due_date)
+
+    context 'If tomorrow date is set' do
+      it 'Invalidated and returns an error message' do
+        task.due_date = Time.zone.tomorrow
+        expect(task).to be_valid
+        expect(task.errors.messages).not_to include(:due_date)
+      end
     end
-    it 'Check the date yesterday' do
-      task = build(:task, due_date: Time.zone.yesterday)
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:due_date)
+
+    context 'If yesterday date is set' do
+      it 'Invalidated and returns an error message' do
+        task.due_date = Time.zone.yesterday
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:due_date)
+      end
     end
   end
 
   describe '#priority' do
-    it 'with nil is valid' do
-      task = build(:task, priority: nil)
-      expect(task).not_to be_valid
+    context 'If nil is set' do
+      it 'be invalidated' do
+        task.priority = nil
+        expect(task).not_to be_valid
+      end
     end
 
-    it 'If an out-of-specification value is received' do
-      task = build(:task, priority: [*0..100].delete_if { |n| Task.prioritys.values.include?(n) }.sample)
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:priority)
+    context 'If an unintended value is set' do
+      it 'Invalidated and returns an error message' do
+        task.priority = [*0..100].delete_if { |n| Task.prioritys.values.include?(n) }.sample
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:priority)
+      end
     end
   end
 
   describe '#status' do
-    it 'with nil is valid' do
-      task = build(:task, status: nil)
-      expect(task).not_to be_valid
+    context 'If nil is set' do
+      it 'be invalidated' do
+        task.status = nil
+        expect(task).not_to be_valid
+      end
     end
 
-    it 'If an out-of-specification value is received' do
-      task = build(:task, status: [*0..100].delete_if { |n| Task.statuses.values.include?(n) }.sample)
-      expect(task).not_to be_valid
-      expect(task.errors.messages).to include(:status)
+    context 'If an unintended value is set' do
+      it 'Invalidated and returns an error message' do
+        task.status = [*0..100].delete_if { |n| Task.statuses.values.include?(n) }.sample
+        expect(task).not_to be_valid
+        expect(task.errors.messages).to include(:status)
+      end
     end
   end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Task, type: :model do
       expect(task.errors.messages).to include(:title)
     end
 
+    it 'with empty is not valid' do
+      task = build(:task, title: '')
+      expect(task).not_to be_valid
+      expect(task.errors.messages).to include(:title)
+    end
+
     it 'Exceeds the specified number of characters' do
       task = build(:task, title: 'a' * 21)
       expect(task).not_to be_valid
@@ -25,6 +31,13 @@ RSpec.describe Task, type: :model do
     it 'with nil is valid' do
       task = build(:task, detail: nil)
       expect(task).to be_valid
+      expect(task.errors.messages).not_to include(:detail)
+    end
+
+    it 'with empty is valid' do
+      task = build(:task, detail: '')
+      expect(task).to be_valid
+      expect(task.errors.messages).not_to include(:detail)
     end
 
     it 'Exceeds the specified number of characters' do
@@ -41,10 +54,26 @@ RSpec.describe Task, type: :model do
       expect(task.errors.messages).to include(:due_date)
     end
 
-    it 'Check the date' do
-      expect(build(:task, due_date: Time.zone.now)).to be_valid
-      expect(build(:task, due_date: Time.zone.tomorrow)).to be_valid
-      expect(build(:task, due_date: Time.zone.yesterday)).not_to be_valid
+    it 'with empty is valid' do
+      task = build(:task, due_date: '')
+      expect(task).not_to be_valid
+      expect(task.errors.messages).to include(:due_date)
+    end
+
+    it 'Check the date now' do
+      task = build(:task, due_date: Time.zone.now)
+      expect(task).to be_valid
+      expect(task.errors.messages).not_to include(:due_date)
+    end
+    it 'Check the date tomorrow' do
+      task = build(:task, due_date: Time.zone.tomorrow)
+      expect(task).to be_valid
+      expect(task.errors.messages).not_to include(:due_date)
+    end
+    it 'Check the date yesterday' do
+      task = build(:task, due_date: Time.zone.yesterday)
+      expect(task).not_to be_valid
+      expect(task.errors.messages).to include(:due_date)
     end
   end
 

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe TasksController, type: :system do
     it 'Can not create tasks' do
       title = 'new Title'
       detail = 'new Detail'
-      flush = I18n.t('pages.tasks.flash.fail')
 
       fill_in I18n.t('activerecord.attributes.task.title'), with: title
       fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
@@ -78,7 +77,8 @@ RSpec.describe TasksController, type: :system do
       click_button I18n.t('common.submit')
 
       expect(page).to have_current_path(tasks_path)
-      expect(page).to have_content(flush)
+      expect(page).to have_content(I18n.t('form.error', smtg: 1))
+      expect(page).to have_content(I18n.t('activerecord.errors.models.task.attributes.due_date.error'))
     end
   end
 
@@ -104,7 +104,6 @@ RSpec.describe TasksController, type: :system do
     it 'Can not edit tasks' do
       title = 'edit Title'
       detail = 'edit Detail'
-      flush = I18n.t('pages.tasks.flash.fail')
 
       fill_in I18n.t('activerecord.attributes.task.title'), with: title
       fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
@@ -112,7 +111,8 @@ RSpec.describe TasksController, type: :system do
       click_button I18n.t('common.submit')
 
       expect(page).to have_current_path(task_path(tasks.last))
-      expect(page).to have_content(flush)
+      expect(page).to have_content(I18n.t('form.error', smtg: 1))
+      expect(page).to have_content(I18n.t('activerecord.errors.models.task.attributes.due_date.error'))
     end
   end
 

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -1,128 +1,146 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :system do
-  let!(:task_count) { 20 }
+  let(:task_count) { 20 }
   let!(:tasks) { FactoryBot.create_list(:task, task_count) }
 
-  describe 'Check the screen transitions' do
+  describe '#index' do
     before { visit root_path }
-    it 'check show page' do
-      click_link tasks.last.title
-      expect(current_path).to eq task_path(tasks.last.id)
-    end
-    it 'check new page' do
-      click_link I18n.t('common.new')
-      expect(current_path).to eq new_task_path
-    end
-  end
-
-  describe 'Check the index page' do
-    before { visit root_path }
-    it 'deital' do
-      expect(page).to have_content("Tasks (#{task_count})")
-      expect(page).to have_content(tasks.last.title)
+    context 'Go to the show page.' do
+      it 'Successful transition' do
+        click_link tasks.last.title
+        expect(current_path).to eq task_path(tasks.last.id)
+      end
     end
 
-    it 'Check the sort order' do
-      created_ats = page.all('.created_at')
-      expect(created_ats.count).to be > 0
-      created_ats.each.with_index(1) do |row, index|
-        expect(row.text).to eq I18n.l(tasks[task_count - index].created_at)
+    context 'Go to the new page.' do
+      it 'Successful transition' do
+        click_link I18n.t('common.new')
+        expect(current_path).to eq new_task_path
+      end
+    end
+
+    context 'Is the task list represented?' do
+      it 'Displayed.' do
+        expect(page).to have_content("Tasks (#{task_count})")
+        expect(page).to have_content(tasks.last.title)
+      end
+    end
+
+    context 'Is it sorted by created_at?' do
+      it 'Displayed.' do
+        created_ats = page.all('.created_at')
+        expect(created_ats.count).to be > 0
+        created_ats.each.with_index(1) do |row, index|
+          expect(row.text).to eq I18n.l(tasks[task_count - index].created_at)
+        end
       end
     end
   end
 
-  describe 'Check the show page' do
+  describe '#show' do
     before { visit task_path(tasks.last.id) }
-    it 'deital' do
-      expect(page).to have_content(tasks.last.title)
-      expect(page).to have_content(tasks.last.detail)
-      expect(page).to have_link I18n.t('common.edit'), href: edit_task_path(tasks.last)
-      expect(page).to have_link I18n.t('common.delete'), href: task_path(tasks.last.id)
+    context 'Is the task list represented?' do
+      it 'Displayed.' do
+        expect(page).to have_content(tasks.last.title)
+        expect(page).to have_content(tasks.last.detail)
+        expect(page).to have_link I18n.t('common.edit'), href: edit_task_path(tasks.last)
+        expect(page).to have_link I18n.t('common.delete'), href: task_path(tasks.last.id)
+      end
     end
   end
 
-  describe 'Check the new task' do
+  describe '#new' do
     before { visit new_task_path }
 
-    it 'Can create tasks' do
-      title = 'new Title'
-      detail = 'new Detail'
-      flush = I18n.t('pages.tasks.flash.added')
+    context 'If the task is registered successfully' do
+      it 'Screen transition.' do
+        title = 'new Title'
+        detail = 'new Detail'
+        flush = I18n.t('pages.tasks.flash.added')
 
-      fill_in I18n.t('activerecord.attributes.task.title'), with: title
-      fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
-      select I18n.t('activerecord.enum.task.priority.low'), from: I18n.t('activerecord.attributes.task.priority')
-      select I18n.t('activerecord.enum.task.status.done'), from: I18n.t('activerecord.attributes.task.status')
-      fill_in I18n.t('activerecord.attributes.task.due_date'), with: Time.zone.tomorrow.strftime('%Y-%m-%d')
-      click_button I18n.t('common.submit')
+        fill_in I18n.t('activerecord.attributes.task.title'), with: title
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
+        select I18n.t('activerecord.enum.task.priority.low'), from: I18n.t('activerecord.attributes.task.priority')
+        select I18n.t('activerecord.enum.task.status.done'), from: I18n.t('activerecord.attributes.task.status')
+        fill_in I18n.t('activerecord.attributes.task.due_date'), with: Time.zone.tomorrow.strftime('%Y-%m-%d')
+        click_button I18n.t('common.submit')
 
-      expect(page).to have_current_path(root_path)
-      expect(page).to have_content(flush)
+        expect(page).to have_current_path(root_path)
+        expect(page).to have_content(flush)
 
-      click_link title
-      expect(page).to have_content(detail)
-      expect(page).not_to have_content(flush)
+        click_link title
+        expect(page).to have_content(detail)
+        expect(page).not_to have_content(flush)
+      end
     end
 
-    it 'Can not create tasks' do
-      title = 'new Title'
-      detail = 'new Detail'
+    context 'If the registration of a task fails' do
+      it 'Display an error without transitioning.' do
+        title = 'new Title'
+        detail = 'new Detail'
 
-      fill_in I18n.t('activerecord.attributes.task.title'), with: title
-      fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
-      select I18n.t('activerecord.enum.task.priority.low'), from: I18n.t('activerecord.attributes.task.priority')
-      select I18n.t('activerecord.enum.task.status.done'), from: I18n.t('activerecord.attributes.task.status')
-      fill_in I18n.t('activerecord.attributes.task.due_date'), with: Time.zone.yesterday.strftime('%Y-%m-%d')
-      click_button I18n.t('common.submit')
+        fill_in I18n.t('activerecord.attributes.task.title'), with: title
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
+        select I18n.t('activerecord.enum.task.priority.low'), from: I18n.t('activerecord.attributes.task.priority')
+        select I18n.t('activerecord.enum.task.status.done'), from: I18n.t('activerecord.attributes.task.status')
+        fill_in I18n.t('activerecord.attributes.task.due_date'), with: Time.zone.yesterday.strftime('%Y-%m-%d')
+        click_button I18n.t('common.submit')
 
-      expect(page).to have_current_path(tasks_path)
-      expect(page).to have_content(I18n.t('form.error', smtg: 1))
-      expect(page).to have_content(I18n.t('activerecord.errors.models.task.attributes.due_date.error'))
+        expect(page).to have_current_path(tasks_path)
+        expect(page).to have_content(I18n.t('form.error', smtg: 1))
+        expect(page).to have_content(I18n.t('activerecord.errors.models.task.attributes.due_date.error'))
+      end
     end
   end
 
-  describe 'Check the edit task' do
+  describe '#edit' do
     before { visit edit_task_path(tasks.last.id) }
 
-    it 'Can edit tasks' do
-      title = 'edit Title'
-      detail = 'edit Detail'
-      flush = I18n.t('pages.tasks.flash.edited')
+    context 'If the task is edit successfully' do
+      it 'Screen transition.' do
+        title = 'edit Title'
+        detail = 'edit Detail'
+        flush = I18n.t('pages.tasks.flash.edited')
 
-      fill_in I18n.t('activerecord.attributes.task.title'), with: title
-      fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
-      fill_in I18n.t('activerecord.attributes.task.due_date'), with: Time.zone.now.tomorrow.strftime('%Y-%m-%d')
-      click_button I18n.t('common.submit')
+        fill_in I18n.t('activerecord.attributes.task.title'), with: title
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
+        fill_in I18n.t('activerecord.attributes.task.due_date'), with: Time.zone.now.tomorrow.strftime('%Y-%m-%d')
+        click_button I18n.t('common.submit')
 
-      expect(page).to have_current_path(task_path(tasks.last))
-      expect(page).to have_content(flush)
-      expect(page).to have_content(title)
-      expect(page).to have_content(detail)
+        expect(page).to have_current_path(task_path(tasks.last))
+        expect(page).to have_content(flush)
+        expect(page).to have_content(title)
+        expect(page).to have_content(detail)
+      end
     end
 
-    it 'Can not edit tasks' do
-      title = 'edit Title'
-      detail = 'edit Detail'
+    context 'If the edit of a task fails.' do
+      it 'Display an error without transitioning.' do
+        title = 'edit Title'
+        detail = 'edit Detail'
 
-      fill_in I18n.t('activerecord.attributes.task.title'), with: title
-      fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
-      fill_in I18n.t('activerecord.attributes.task.due_date'), with: Time.zone.yesterday.strftime('%Y-%m-%d')
-      click_button I18n.t('common.submit')
+        fill_in I18n.t('activerecord.attributes.task.title'), with: title
+        fill_in I18n.t('activerecord.attributes.task.detail'), with: detail
+        fill_in I18n.t('activerecord.attributes.task.due_date'), with: Time.zone.yesterday.strftime('%Y-%m-%d')
+        click_button I18n.t('common.submit')
 
-      expect(page).to have_current_path(task_path(tasks.last))
-      expect(page).to have_content(I18n.t('form.error', smtg: 1))
-      expect(page).to have_content(I18n.t('activerecord.errors.models.task.attributes.due_date.error'))
+        expect(page).to have_current_path(task_path(tasks.last))
+        expect(page).to have_content(I18n.t('form.error', smtg: 1))
+        expect(page).to have_content(I18n.t('activerecord.errors.models.task.attributes.due_date.error'))
+      end
     end
   end
 
-  describe 'Check the delete' do
+  describe '#delete' do
     before { visit task_path(tasks.last.id) }
-    it 'Can delete tasks' do
-      click_link I18n.t('common.delete')
+    context 'If the task is delete successfully' do
+      it 'Screen transition.' do
+        click_link I18n.t('common.delete')
 
-      expect(page).to have_current_path(root_path)
-      expect(page).to have_content(I18n.t('pages.tasks.flash.deleted'))
+        expect(page).to have_current_path(root_path)
+        expect(page).to have_content(I18n.t('pages.tasks.flash.deleted'))
+      end
     end
   end
 end


### PR DESCRIPTION
********
### 【Rails研修】 yuta.d.saito
********

### 概要
本プルリクは[yuta.d.saito のRails研修](https://fablic.qiita.com/shared/items/658bd3bc023ee530c457) ステップ11の課題用です。

- ステップ10: タスク一覧を作成日時の順番で並び替えましょう
- **ステップ11: バリデーションを設定してみよう**
- ステップ12: 終了期限を追加しよう

********
###  確認用環境構築手順 
以下の手順で、Railsの動作が確認できます

**初めての場合**
1. [Dockerインストール](https://github.com/Fablic/training/tree/use_docker#1-1-docker%E3%81%AE%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB)
2. `git clone -b yuta-d-saito/step11 https://github.com/Fablic/training` で手元にソースコードを展開
3. `cd training/myapp` で Rails アプリのディレクトリーに移動
4. `docker-compose up --build` を実行してサービスを手元で走らせる(myapp-api-1  | Use Ctrl-C to stopが出たら起動完了)
5. http://localhost:3001 にブラウザーでアクセスして動作確認

**環境構築済みの場合**
1. dockerを停止する(`docker-compose stop`)
2. 該当ディレクトリに移動して、`git checkout yuta-d-saito/step11`
3. `docker-compose up `
4. http://localhost:3001 にブラウザーでアクセスして動作確認

********
###  開発資料

- [ER図](https://github.com/Fablic/training/blob/af36be47b1906d3f6d5f9f8275976e58b8f7b660/myapp/docs/ER_diagram.png)
- [画面遷移](https://github.com/Fablic/training/blob/af36be47b1906d3f6d5f9f8275976e58b8f7b660/myapp/docs/ScreenTransitionDiagram.png)

********
###  ステップ11: バリデーションを設定してみよう

以下を修正しました。

- バリデーションエラーの文言が表示されるように修正
- specでバリデーションの確認
- specでエラー文言のテスト

myapp/app/models/task.rb
に開発初期段階でバリデーションを入れてしまっていたため、今回のプルリク差分には表示されておりません。
[こちら](https://github.com/Fablic/training/blob/be0a12cae1d3a495b2ee8f9d61665b5fef78b90a/myapp/app/models/task.rb)から直接ファイルをご確認いただけますと幸いです。

ご確認よろしくお願いいたします。
