### PR TITLE
Fix use_docker env

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ chrome://extensions/ を開いて右上のDeveloper modeをオンにして、RKG
     ```sh
     cd myapp
     ```
+- 自分の名前を`myapp/.env`に追加します
+    ```yml
+    COMPOSE_PROJECT_NAME=〇〇-training # 〇〇に自分の名前を入力
+    # ex) COMPOSE_PROJECT_NAME=Taro-training
+    ```
 - 下記コマンドでアプリケーションに最低限必要なディレクトリやファイルを作成しましょう
     ```sh
     docker-compose run api rails new . --force --database=mysql -G

--- a/myapp/.env
+++ b/myapp/.env
@@ -1,0 +1,13 @@
+# This file is automatically loaded and applied by docker-compose.
+# Reference: https://docs.docker.com/compose/env-file/
+
+# To set the docker-compose image prefix name as "rails-training".
+#
+# By default, docker-compose uses the parent directory name as the project name,
+# but it means the name will conflict if we copy "myapp" to another project.
+# To avoid the conflict, I set "taito-trainig" as the prefix.
+#
+
+# Reference: https://docs.docker.com/compose/reference/envvars/#compose_project_name
+# Please fill in your name to 〇〇 ↓
+COMPOSE_PROJECT_NAME=〇〇-training

--- a/myapp/.env
+++ b/myapp/.env
@@ -1,11 +1,9 @@
 # This file is automatically loaded and applied by docker-compose.
 # Reference: https://docs.docker.com/compose/env-file/
 
-# To set the docker-compose image prefix name as "rails-training".
-#
 # By default, docker-compose uses the parent directory name as the project name,
-# but it means the name will conflict if we copy "myapp" to another project.
-# To avoid the conflict, I set "taito-trainig" as the prefix.
+# but it means the name will conflict if we clone other training repo.
+# To avoid the conflict, please fill in "〇〇" and set prefix!
 #
 
 # Reference: https://docs.docker.com/compose/reference/envvars/#compose_project_name

--- a/myapp/Dockerfile
+++ b/myapp/Dockerfile
@@ -1,6 +1,5 @@
-FROM node:12-alpine AS node
-
 FROM ruby:2.6
+ENV NODE_VERSION 12
 
 ENV LANG C.UTF-8
 
@@ -9,14 +8,17 @@ RUN apt-get update -qq && \
       build-essential \
       libpq-dev \
       default-mysql-client \
+      nodejs \
       jq \
       git \
       curl \
       python3 \
       less
 
-COPY --from=node /usr/local/bin/ /usr/local/bin/
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+# node install
+RUN curl -SL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get -y remove nodejs-doc \
+    && apt-get install -y nodejs
 
 # yarn install
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/myapp/Dockerfile
+++ b/myapp/Dockerfile
@@ -1,13 +1,13 @@
+FROM node:12-alpine AS node
+
 FROM ruby:2.6
 
 ENV LANG C.UTF-8
-ENV NODE_VERSION 12
 
 RUN apt-get update -qq && \
     apt-get install -y \
       build-essential \
       libpq-dev \
-      nodejs \
       default-mysql-client \
       jq \
       git \
@@ -15,9 +15,8 @@ RUN apt-get update -qq && \
       python3 \
       less
 
-# node install
-RUN curl -SL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
-    && apt-get install -y nodejs
+COPY --from=node /usr/local/bin/ /usr/local/bin/
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 # yarn install
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
@@ -30,6 +29,7 @@ WORKDIR /$APP_ROOT
 
 COPY Gemfile /$APP_ROOT/Gemfile
 COPY Gemfile.lock /$APP_ROOT/Gemfile.lock
+
 ENV BUNDLE_PATH=/usr/local/bundle
 RUN bundle install
 

--- a/myapp/docker-compose.yml
+++ b/myapp/docker-compose.yml
@@ -13,7 +13,14 @@ services:
 
   api:
     build: .
-    command: bash -c "bundle install && yarn install && bundle exec rails webpacker:install && bundle exec rails db:create && bundle exec rails db:migrate && rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: >
+      bash -c "bundle install &&
+      yarn install &&
+      bundle exec rails webpacker:install &&
+      bundle exec rails db:create &&
+      bundle exec rails db:migrate &&
+      rm -f tmp/pids/server.pid &&
+      bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/myapp
       - bundle-install:/usr/local/bundle:delegated

--- a/myapp/docker-compose.yml
+++ b/myapp/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - .:/myapp
       - bundle-install:/usr/local/bundle:delegated
+      - node_modules:/myapp/node_modules:delegated
     ports:
       - "3001:3000"
     links:
@@ -39,3 +40,4 @@ volumes:
     driver: local
   bundle-install:
     driver: local
+  node_modules:


### PR DESCRIPTION
## 概要

自分がuse_docker利用時に気になったポイントである、use_docker環境におけるapiコンテナ起動時の高速化とエラー解消、container名にprefixの追加を行いました。

I speed up api container startup, fix node install error and added a prefix to the container name in the use_docker environment, which was a point I was concerned about when using use_docker.

## 実装内容

- Dockerfileにてnode install時に発生するエラーの解消と若干の高速化
  - nodeのversionは以前のまま12を利用しています
- container名にprefixを追加
  - trainingを受けている人が複数人いた場合に判別できるようにするため
- node_moduleに対してvolumesを利用
  - container立ち上げ時(初回除く)にかかる時間の削減のため
  
  ---

- Fixed an error that occurred when installing node in Dockerfile and slightly speeded up the process.
  - The version of node is still the same as before, 12.
- Add prefix to container name
  - To be able to identify if there is more than one person who is receiving training.
- Use volumes for node_module
  - To reduce the time required to start up the container (except for the first time)

## localでの確認内容
README.mdの手順通りに進めたところ、railsの初期画面が表示されることを確認しました。
ただ、それ以上はまだ確認していない状況です。

I followed the steps in README.md and confirmed that the initial screen of rails is displayed.
However, I have not yet confirmed anything further.

![image](https://user-images.githubusercontent.com/86704818/139387168-d9852d14-4962-4f71-a8f8-7d6ba34be03d.png)
