### PR TITLE
[MioArai] ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -2,4 +2,19 @@
 
 class ApplicationController < ActionController::Base
   include SessionsHelper
+
+  before_action :render503, if: :maintenance_mode?
+
+  def maintenance_mode?
+    Maintenance.status?
+  end
+
+  def render503
+    render(
+      file: Rails.public_path.join('503.html'),
+      content_type: 'text/html',
+      layout: false,
+      status: :service_unavailable,
+    )
+  end
 end

--- a/myapp/app/models/maintenance.rb
+++ b/myapp/app/models/maintenance.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 class Maintenance
-  MAINTENANCE_FILE_PATH = './config/maintanance.txt'
+  MAINTENANCE_FILE_PATH = Rails.root.join(Dir.tmpdir, 'maintenance.txt')
 
   def self.start
-    file = File.open(MAINTENANCE_FILE_PATH, 'w')
-    file.puts()
-    file.close
+    FileUtils.touch MAINTENANCE_FILE_PATH
   end
 
   def self.stop
-    File.delete(MAINTENANCE_FILE_PATH) if File.exist? MAINTENANCE_FILE_PATH
+    FileUtils.rm_f MAINTENANCE_FILE_PATH
   end
 
   def self.status?
-    File.exist?(MAINTENANCE_FILE_PATH)
+    File.exist? MAINTENANCE_FILE_PATH
   end
 end

--- a/myapp/app/models/maintenance.rb
+++ b/myapp/app/models/maintenance.rb
@@ -3,7 +3,7 @@
 require 'tmpdir'
 
 class Maintenance
-  MAINTENANCE_FILE_PATH = Rails.root.join(Dir.tmpdir, 'maintenance.txt')
+  MAINTENANCE_FILE_PATH = Rails.root.join('tmp/maintenance.txt')
 
   def self.start
     FileUtils.touch MAINTENANCE_FILE_PATH

--- a/myapp/app/models/maintenance.rb
+++ b/myapp/app/models/maintenance.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Maintenance
+  MAINTENANCE_FILE_PATH = './config/maintanance.txt'
+
+  def self.start
+    file = File.open(MAINTENANCE_FILE_PATH, 'w')
+    file.puts()
+    file.close
+  end
+
+  def self.stop
+    File.delete(MAINTENANCE_FILE_PATH) if File.exist? MAINTENANCE_FILE_PATH
+  end
+
+  def self.status?
+    File.exist?(MAINTENANCE_FILE_PATH)
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 20_211_208_030_118) do
   end
 
   create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', comment: 'Usesr ID'
+    t.bigint 'user_id', comment: 'User ID'
     t.string 'title', null: false, comment: 'タイトル'
     t.string 'description', limit: 768, comment: '内容'
     t.integer 'status', limit: 1, comment: 'ステータス'

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc 'メンテナンスモード設定'
+  task start: :environment do
+    Maintenance.start
+    puts 'メンテナンスにしました'
+  end
+
+  desc 'メンテナンスモード解除'
+  task stop: :environment do
+    Maintenance.stop
+    puts 'メンテナンス解除しました'
+  end
+
+  desc 'メンテナンスモード状態取得'
+  task status: :environment do
+    puts Maintenance.status? ? 'メンテナンス中です' : 'メンテナンス解除中です'
+  end
+end

--- a/myapp/public/503.html
+++ b/myapp/public/503.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>Site Maintenance</title>
+<style>
+  body { text-align: center; padding: 150px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+</style>
+
+<article>
+    <h1>We&rsquo;ll be back soon!</h1>
+    <div>
+        <p>Sorry for the inconvenience but we&rsquo;re performing some maintenance at the moment. If you need to you can always <a href="mailto:#">contact us</a>, otherwise we&rsquo;ll be back online shortly!</p>
+        <p>&mdash; The Team</p>
+    </div>
+</article>

--- a/myapp/spec/models/maintenance_spec.rb
+++ b/myapp/spec/models/maintenance_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Maintenance, type: :model do
+  let(:maintenance) { described_class }
+  let(:maintenance_file_path) { maintenance::MAINTENANCE_FILE_PATH }
+
+  describe '#start' do
+    before {
+      maintenance.start
+    }
+
+    after { File.delete(maintenance_file_path) }
+
+    example 'Maintenance file is placed.' do
+      expect(File).to exist(maintenance_file_path)
+    end
+  end
+
+  describe '#stop' do
+    before {
+      File.open(maintenance_file_path, 'w')
+    }
+
+    example 'Maintenance file is deleted.' do
+      maintenance.stop
+      expect(File).not_to exist(maintenance_file_path)
+    end
+  end
+
+  describe '#status' do
+    context 'when in maintenance' do
+      example 'status is true' do
+        maintenance.start
+        expect(maintenance.status?).to eq true
+      end
+    end
+
+    context 'when out of maintenance' do
+      example 'status is false' do
+        maintenance.stop
+        expect(maintenance.status?).to eq false
+      end
+    end
+  end
+end

--- a/myapp/spec/models/maintenance_spec.rb
+++ b/myapp/spec/models/maintenance_spec.rb
@@ -3,28 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe Maintenance, type: :model do
-  let(:maintenance) { described_class }
-  let(:maintenance_file_path) { maintenance::MAINTENANCE_FILE_PATH }
+  let(:maintenance_file_path) { described_class::MAINTENANCE_FILE_PATH }
 
   describe '#start' do
-    before {
-      maintenance.start
-    }
-
-    after { File.delete(maintenance_file_path) }
+    after { FileUtils.rm_f maintenance_file_path }
 
     example 'Maintenance file is placed.' do
+      described_class.start
       expect(File).to exist(maintenance_file_path)
     end
   end
 
   describe '#stop' do
     before {
-      File.open(maintenance_file_path, 'w')
+      FileUtils.touch maintenance_file_path
     }
 
     example 'Maintenance file is deleted.' do
-      maintenance.stop
+      described_class.stop
       expect(File).not_to exist(maintenance_file_path)
     end
   end
@@ -32,15 +28,15 @@ RSpec.describe Maintenance, type: :model do
   describe '#status' do
     context 'when in maintenance' do
       example 'status is true' do
-        maintenance.start
-        expect(maintenance.status?).to eq true
+        described_class.start
+        expect(described_class.status?).to eq true
       end
     end
 
     context 'when out of maintenance' do
       example 'status is false' do
-        maintenance.stop
-        expect(maintenance.status?).to eq false
+        described_class.stop
+        expect(described_class.status?).to eq false
       end
     end
   end

--- a/myapp/spec/rake_helper.rb
+++ b/myapp/spec/rake_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    # Load all the tasks just as Rails does (`load 'Rakefile'` is another simple way)
+    Rails.application.load_tasks
+  end
+
+  config.before do
+    # suppres stdout while testing
+    allow($stdout).to receive(:write)
+
+    Rake.application.tasks.each(&:reenable) # Remove persistency between examples
+  end
+end

--- a/myapp/spec/system/application_spec.rb
+++ b/myapp/spec/system/application_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Errors', type: :system do
     }
 
     example 'Maintenance Page is shown' do
-        visit root_path
+      visit root_path
       expect(page).to have_http_status :service_unavailable
     end
   end

--- a/myapp/spec/system/error_spec.rb
+++ b/myapp/spec/system/error_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Errors', type: :system do
+  describe 'Set Maintainance Mode' do
+    before {
+      Maintenance.start
+    }
+
+    after {
+      Maintenance.stop
+    }
+
+    example 'Maintenance Page is shown' do
+        visit root_path
+      expect(page).to have_http_status :service_unavailable
+    end
+  end
+end

--- a/myapp/spec/tasks/maintenance_spec.rb
+++ b/myapp/spec/tasks/maintenance_spec.rb
@@ -8,42 +8,61 @@ describe 'MaintenanceTask' do
   describe 'maintainance:start' do
     subject(:task) { Rake.application['maintenance:start'] }
 
-    after { File.delete(Maintenance::MAINTENANCE_FILE_PATH) }
+    before {
+      allow(Maintenance).to receive(:start)
+    }
+
+    after { FileUtils.rm_f(Maintenance::MAINTENANCE_FILE_PATH) }
 
     example 'set maintenance mode' do
       expect { task.invoke }.to output("メンテナンスにしました\n").to_stdout
+    end
+
+    example 'Maintenance.start is called' do
+      task.invoke
+      expect(Maintenance).to have_received(:start).once
     end
   end
 
   describe 'maintainance:stop' do
     subject(:task) { Rake.application['maintenance:stop'] }
 
-    before { File.open(Maintenance::MAINTENANCE_FILE_PATH, 'w') }
+    before {
+      FileUtils.touch(Maintenance::MAINTENANCE_FILE_PATH)
+      allow(Maintenance).to receive(:stop)
+    }
 
     example 'unset maintenance mode' do
       expect { task.invoke }.to output("メンテナンス解除しました\n").to_stdout
+    end
+
+    example 'Maintenance.stop is called' do
+      task.invoke
+      expect(Maintenance).to have_received(:stop).once
     end
   end
 
   describe 'maintainance:status' do
     subject(:task) { Rake.application['maintenance:status'] }
 
-    before { File.delete(Maintenance::MAINTENANCE_FILE_PATH) if File.exist?(Maintenance::MAINTENANCE_FILE_PATH) }
-
-    after { File.delete(Maintenance::MAINTENANCE_FILE_PATH) if File.exist?(Maintenance::MAINTENANCE_FILE_PATH) }
-
     context 'when in maintenance' do
-      before { Maintenance.start }
+      before {
+        allow(Maintenance).to receive(:status?).and_return(true)
+      }
 
       example 'maintenance announcement is displayed' do
+        pp File.exist?(maintenance_file_path)
         expect { task.invoke }.to output("メンテナンス中です\n").to_stdout
       end
     end
 
     context 'when out of maintenance' do
-      before { Maintenance.stop }
+      before {
+        allow(Maintenance).to receive(:status?).and_return(false)
+      }
 
       example 'out of maintenance announcement is displayed' do
+        pp File.exist?(maintenance_file_path)
         expect { task.invoke }.to output("メンテナンス解除中です\n").to_stdout
       end
     end

--- a/myapp/spec/tasks/maintenance_spec.rb
+++ b/myapp/spec/tasks/maintenance_spec.rb
@@ -8,10 +8,6 @@ describe 'MaintenanceTask' do
   describe 'maintainance:start' do
     subject(:task) { Rake.application['maintenance:start'] }
 
-    before {
-      allow(Maintenance).to receive(:start)
-    }
-
     after { FileUtils.rm_f(Maintenance::MAINTENANCE_FILE_PATH) }
 
     example 'set maintenance mode' do
@@ -19,6 +15,7 @@ describe 'MaintenanceTask' do
     end
 
     example 'Maintenance.start is called' do
+      allow(Maintenance).to receive(:start)
       task.invoke
       expect(Maintenance).to have_received(:start).once
     end
@@ -29,7 +26,6 @@ describe 'MaintenanceTask' do
 
     before {
       FileUtils.touch(Maintenance::MAINTENANCE_FILE_PATH)
-      allow(Maintenance).to receive(:stop)
     }
 
     example 'unset maintenance mode' do
@@ -37,6 +33,7 @@ describe 'MaintenanceTask' do
     end
 
     example 'Maintenance.stop is called' do
+      allow(Maintenance).to receive(:stop)
       task.invoke
       expect(Maintenance).to have_received(:stop).once
     end
@@ -51,7 +48,6 @@ describe 'MaintenanceTask' do
       }
 
       example 'maintenance announcement is displayed' do
-        pp File.exist?(maintenance_file_path)
         expect { task.invoke }.to output("メンテナンス中です\n").to_stdout
       end
     end
@@ -62,7 +58,6 @@ describe 'MaintenanceTask' do
       }
 
       example 'out of maintenance announcement is displayed' do
-        pp File.exist?(maintenance_file_path)
         expect { task.invoke }.to output("メンテナンス解除中です\n").to_stdout
       end
     end

--- a/myapp/spec/tasks/maintenance_spec.rb
+++ b/myapp/spec/tasks/maintenance_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rake_helper'
+
+describe 'MaintenanceTask' do
+  let(:maintenance_file_path) { Maintenance::MAINTENANCE_FILE_PATH }
+
+  describe 'maintainance:start' do
+    subject(:task) { Rake.application['maintenance:start'] }
+
+    after { File.delete(Maintenance::MAINTENANCE_FILE_PATH) }
+
+    example 'set maintenance mode' do
+      task.invoke
+      expect(File).to exist(maintenance_file_path)
+    end
+  end
+
+  describe 'maintainance:stop' do
+    subject(:task) { Rake.application['maintenance:stop'] }
+
+    before { File.open(Maintenance::MAINTENANCE_FILE_PATH, 'w') }
+
+    example 'unset maintenance mode' do
+      task.invoke
+      expect(File).not_to exist(maintenance_file_path)
+    end
+  end
+
+  describe 'maintainance:status' do
+    subject(:task) { Rake.application['maintenance:status'] }
+
+    before { File.delete(Maintenance::MAINTENANCE_FILE_PATH) if File.exist?(Maintenance::MAINTENANCE_FILE_PATH) }
+
+    after { File.delete(Maintenance::MAINTENANCE_FILE_PATH) if File.exist?(Maintenance::MAINTENANCE_FILE_PATH) }
+
+    context 'when in maintenance' do
+      before { Maintenance.start }
+
+      example 'maintenance announcement is displayed' do
+        expect { task.invoke }.to output("メンテナンス中です\n").to_stdout
+      end
+    end
+
+    context 'when out of maintenance' do
+      before { Maintenance.stop }
+
+      example 'out of maintenance announcement is displayed' do
+        expect { task.invoke }.to output("メンテナンス解除中です\n").to_stdout
+      end
+    end
+  end
+end

--- a/myapp/spec/tasks/maintenance_spec.rb
+++ b/myapp/spec/tasks/maintenance_spec.rb
@@ -11,8 +11,7 @@ describe 'MaintenanceTask' do
     after { File.delete(Maintenance::MAINTENANCE_FILE_PATH) }
 
     example 'set maintenance mode' do
-      task.invoke
-      expect(File).to exist(maintenance_file_path)
+      expect { task.invoke }.to output("メンテナンスにしました\n").to_stdout
     end
   end
 
@@ -22,8 +21,7 @@ describe 'MaintenanceTask' do
     before { File.open(Maintenance::MAINTENANCE_FILE_PATH, 'w') }
 
     example 'unset maintenance mode' do
-      task.invoke
-      expect(File).not_to exist(maintenance_file_path)
+      expect { task.invoke }.to output("メンテナンス解除しました\n").to_stdout
     end
   end
 


### PR DESCRIPTION
# 【Rails研修】MioArai

## 概要
ステップ21: メンテナンス機能を作ろう

## 確認用環境構築手順
```
# training
git clone -b MioArai_step21 https://github.com/Fablic/training
cd training/myapp
docker-compose up --build -d
# access to http://localhost:3001
```

## 実装内容
### ステップ21: メンテナンス機能を作ろう
メンテナンスを開始／終了するタスクを作成
メンテナンス中にアクセスしたユーザはメンテナンスページを表示

## テスト結果(メンテナンス関連のみ)

```sh
root@40ae16c74618:/myapp# rspec --example "Maintenance"
Run options: include {:full_description=>/Maintenance/}

Maintenance
  #start
    Maintenance file is placed.
  #stop
    Maintenance file is deleted.
  #status
    when in maintenance
      status is true
    when out of maintenance
      status is false

Errors
  Set Maintainance Mode
    Maintenance Page is shown

MaintenanceTask
  maintainance:start
    set maintenance mode
  maintainance:stop
    unset maintenance mode
  maintainance:status
    when in maintenance
      maintenance announcement is displayed
    when out of maintenance
      out of maintenance announcement is displayed

Finished in 0.66772 seconds (files took 4.25 seconds to load)
9 examples, 0 failures
```

### メンテナンス画面
![image](https://user-images.githubusercontent.com/90371497/145923651-d00784b5-f70c-4f00-acab-659800878a08.png)
