### PR TITLE
Rails Training Step21 (Kinjo)

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :_render_503, if: :maintenance_mode?
+
+  def maintenance_mode?
+    File.exist?('tmp/maintenance.txt')
+  end
+
   unless Rails.env.development?
     rescue_from Exception,                      with: :_render_500
     rescue_from ActiveRecord::RecordNotFound,   with: :_render_404
@@ -39,6 +45,14 @@ class ApplicationController < ActionController::Base
       render json: { error: '500 Internal Server Error' }, status: :internal_server_error
     else
       render 'errors/500', status: :internal_server_error, layout: 'error'
+    end
+  end
+
+  def _render_503
+    if request.format.to_sym == :json
+      render json: { error: '503 Service Unavailable' }, status: :service_unavailable
+    else
+      render 'errors/503', status: :service_unavailable, layout: 'error'
     end
   end
 end

--- a/myapp/app/views/errors/503.html.erb
+++ b/myapp/app/views/errors/503.html.erb
@@ -1,0 +1,3 @@
+<div class="container">
+    <h1 class="display-4">ただいまメンテナンス中です。</h1>
+</div>

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 namespace :maintenance do
-    desc 'メンテナンスモード設定'
-    task start: :environment do
-        FileUtils.touch('tmp/maintenance.txt')
-        p 'メンテナンスモード設定完了'
-    end
-
-    desc 'メンテナンスモード解除'
-    task stop: :environment do
-        FileUtils.rm('tmp/maintenance.txt')
-        p 'メンテナンス解除完了'
-    end
+  desc 'メンテナンスモード設定'
+  task start: :environment do
+    FileUtils.touch('tmp/maintenance.txt')
+    p 'メンテナンスモード設定完了'
   end
+
+  desc 'メンテナンスモード解除'
+  task stop: :environment do
+    FileUtils.rm('tmp/maintenance.txt')
+    p 'メンテナンス解除完了'
+  end
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+    desc 'メンテナンスモード設定'
+    task start: :environment do
+        FileUtils.touch('tmp/maintenance.txt')
+        p 'メンテナンスモード設定完了'
+    end
+
+    desc 'メンテナンスモード解除'
+    task stop: :environment do
+        FileUtils.rm('tmp/maintenance.txt')
+        p 'メンテナンス解除完了'
+    end
+  end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -96,16 +96,6 @@ RSpec.describe 'Tasks System', type: :system, js: true do
       end
     end
 
-    context '終了期限のカラムを2回クリックした時' do
-      it '終了期限の降順になる' do
-        find('a', text: '終了期限').click
-        find('a', text: '終了期限').click
-        expect(find('#task_row_0').first('td').text).to eq task.name
-        expect(find('#task_row_1').first('td').text).to eq task_second.name
-        expect(find('#task_row_2').first('td').text).to eq task_third.name
-      end
-    end
-
     context 'タスクとステータスを埋めて検索ボタンを押した時' do
       it '条件に合致するタスクが一覧に表示される事' do
         fill_in 'search_content', with: task_third.name


### PR DESCRIPTION
## 確認方法
### アプリ起動
```bash
cd myapp
docker-compose up
```
※localhost:3001にアクセスして画面が正常に表示される

### メンテナンス開始
```bash
docker compose exec api rails maintenance:start
```
※↑のコマンドが流し終わりlocalhost:3001に再アクセスしてメンテナンス画面が表示される
![image](https://user-images.githubusercontent.com/93513616/147423925-4644de82-7931-4d19-8d7e-4ea62ad00ad8.png)

### メンテナンス終了
```bash
docker compose exec api rails maintenance:stop
```
※↑のコマンドが流し終わりlocalhost:3001に再アクセスしてメンテナンス画面が表示されない

### 初回のみ
```bash
docker compose exec api db:migrate:reset
docker compose exec api db:seed
```

##  対応内容
- Rails研修のStep21の項目を対応
### [Step21](https://github.com/Fablic/training/tree/use_docker#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)
- メンテナンスを開始／終了するバッチを作る
- メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせる

## 確認した事
-  `rubocop` での指摘がないこと
-  `rspec` コマンドを実行してテストが全て通ること 
- メンテナンスモードの切り替えをRails Serverを再起動せずにできているか

### テストユーザー
```bash
shogo.kinjo@example.com
password
```

## 確認してもらいたい事
以下をご確認いただきご意見をいただければと思います。
- タスクが全て網羅されているか
- ライブラリを使わないメンテナンスモードの切り替え方法として、懸念点や気になる点はないか
- もっとこうした方が良いなどのご意見もいただけるととても助かります。
