### PR TITLE
ステップ16: 複数人で利用できるようにしよう（ユーザの導入）

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem "rspec-rails"
   gem 'factory_girl_rails'
+  gem 'bullet'
 end
 
 group :test do

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
     ast (2.4.2)
     bindex (0.8.1)
     builder (3.2.4)
+    bullet (7.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.35.3)
       addressable
@@ -228,6 +231,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.1.0)
+    uniform_notifier (1.14.2)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -243,6 +247,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bullet
   byebug
   capybara (>= 2.15)
   coffee-rails (~> 4.2)

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -4,9 +4,9 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
   def index
     @tasks = if Task.statuses.keys.include?(params[:status])
-               Task.where(status: params[:status]).task_name_partial_search(params[:task_name]).page(params[:page])
+               Task.includes([:user]).where(status: params[:status]).task_name_partial_search(params[:task_name]).page(params[:page])
              else
-               Task.all.task_name_partial_search(params[:task_name]).page(params[:page])
+               Task.includes([:user]).task_name_partial_search(params[:task_name]).page(params[:page])
              end
   end
 
@@ -16,6 +16,7 @@ class TasksController < ApplicationController
 
   def create
     @task = Task.new(task_params)
+    @task.user_id = User.first.id
     if @task.save
       redirect_to @task, notice: 'タスクを登録しました。'
     else

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -12,6 +12,8 @@ class Task < ApplicationRecord
 
   paginates_per 5
 
+  belongs_to :user
+
   def ends_on_must_be_after_starts_on
     return if starts_on.blank? || ends_on.blank?
 

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_many :tasks, dependent: :destroy
+end

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -10,6 +10,7 @@
 <table>
   <thead>
     <tr>
+      <th><%= t '.user_name' %></th>
       <th><%= t '.task_name' %></th>
       <th><%= t '.description' %></th>
       <th><%= t '.starts_on' %></th>
@@ -23,13 +24,14 @@
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
+        <td><%= task.user&.user_name %></td>
         <td><%= task.task_name %></td>
         <td><%= task.description %></td>
         <td><%= task.starts_on %></td>
         <td><%= task.ends_on %></td>
         <td><%= task.priority %></td>
         <td><%= task.label %></td>
-        <td><%= t("activerecord.enums.task.status.#{task.status}")  %></td>
+        <td><%= t("activerecord.enums.task.status.#{task.status}") %></td>
         <td><%= link_to (t '.show'), task %></td>
         <td><%= link_to (t '.edit'), edit_task_path(task) %></td>
         <td><%= link_to (t '.destory'), task, method: :delete, data: { confirm: (t '.Are you sure?') } %></td>

--- a/myapp/config/environments/development.rb
+++ b/myapp/config/environments/development.rb
@@ -51,4 +51,13 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true # Bulletを有効化する
+    Bullet.alert = true # JavaScriptのポップアップアラートを表示する
+    Bullet.bullet_logger = true # log/bullet.logに出力
+    Bullet.console = true # ブラウザのconsole.logに出力
+    Bullet.rails_logger = true # Railsのログに結果を出力
+    Bullet.add_footer = true # ページの左下に結果を表示
+  end
 end

--- a/myapp/config/locales/view/ja.yml
+++ b/myapp/config/locales/view/ja.yml
@@ -14,6 +14,7 @@ ja:
       priority: 優先度
       label: ラベル
       status: ステータス
+      user_name: 担当者
       title: タスク一覧
       show: 詳細
       edit: 編集

--- a/myapp/db/migrate/20220316065427_create_users.rb
+++ b/myapp/db/migrate/20220316065427_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[5.0]
     create_table :users do |t|
       t.string :user_name
       t.string :email
-      t.integer :password
+      t.string :password
 
       t.timestamps
     end

--- a/myapp/db/migrate/20220316065427_create_users.rb
+++ b/myapp/db/migrate/20220316065427_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :users do |t|
+      t.string :user_name
+      t.string :email
+      t.integer :password
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/migrate/20220316073815_add_references_to_tasks.rb
+++ b/myapp/db/migrate/20220316073815_add_references_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddReferencesToTasks < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+  end
+end

--- a/myapp/db/migrate/20220318011424_change_date_password_to_users.rb
+++ b/myapp/db/migrate/20220318011424_change_date_password_to_users.rb
@@ -1,0 +1,11 @@
+class ChangeDatePasswordToUsers < ActiveRecord::Migration[5.0]
+  def up
+    rename_column :users, :password_digest, :password
+    change_column :users, :password, :string
+  end
+
+  def down
+    rename_column :users, :password, :password_digest
+    change_column :users, :password_digest, :integer
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220315064507) do
+ActiveRecord::Schema.define(version: 20220316073815) do
 
   create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "task_name",   limit: 30,              null: false
@@ -22,7 +22,18 @@ ActiveRecord::Schema.define(version: 20220315064507) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.integer  "status",                  default: 0, null: false
+    t.integer  "user_id"
     t.index ["status"], name: "index_tasks_on_status", using: :btree
+    t.index ["user_id"], name: "index_tasks_on_user_id", using: :btree
   end
 
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.string   "user_name"
+    t.string   "email"
+    t.integer  "password"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "tasks", "users"
 end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220316073815) do
+ActiveRecord::Schema.define(version: 20220318011424) do
 
   create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "task_name",   limit: 30,              null: false
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20220316073815) do
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "user_name"
     t.string   "email"
-    t.integer  "password"
+    t.string   "password"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+User.create(user_name: '太郎', email: 'aaa@example.co.jp', password: 1234567)

--- a/myapp/spec/factories/tasks.rb
+++ b/myapp/spec/factories/tasks.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     task_name 'MyString'
     description 'hogehoge'
     status 'being_worked'
+    user
   end
 end

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :user do
-    user_name "MyString"
-    email "MyString"
-    password 1
+    user_name "test_name"
+    email "test@example.com"
+    password "Passw0rd"
   end
 end

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :user do
+    user_name "MyString"
+    email "MyString"
+    password 1
+  end
+end

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/requests/tasks_spec.rb
+++ b/myapp/spec/requests/tasks_spec.rb
@@ -99,6 +99,8 @@ RSpec.describe 'Tasks', type: :request do
     context 'タスクが作成された時' do
       subject(:new_task) { post tasks_path, params: { task: attributes_for(:task) } }
 
+      before { create(:user) }
+
       it 'レスポンスが正しいこと' do
         new_task
         expect(response).to have_http_status(:found)


### PR DESCRIPTION
## 仕様書
https://github.com/Fablic/training/blob/hayato-kudo/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9716-%E8%A4%87%E6%95%B0%E4%BA%BA%E3%81%A7%E5%88%A9%E7%94%A8%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E5%B0%8E%E5%85%A5

### **追加仕様**
・タスク一覧に、ユーザー名の列を追加し、タスクに紐づいたユーザー名を表示する
・タスク作成時は、（step16の段階では）seedで作成したユーザーを固定で紐付けさせるような処理にしておく
　（次のstepでログイン機能を作るので、暫定的な処理）

## 追加点
### **１、ユーザーモデルの作成**
ユーザーモデルを作成しました。
user_name・・ユーザー名はタスクと紐付けタスク一覧に担当者の名前を表示する仕様だったので追加しました。
email・・次のステップ17でログイン機能を実装するところでメールアドレスが必要になるので追加致しました。
password・・こちらに関しても次のステップ17でログイン機能を実装する際に必要になるので追加致しました。
### **２、最初のユーザーをseedで作成**
初期データとしてseedでUserのデータを1つ作成致しました。
<img width="649" alt="スクリーンショット 2022-03-17 17 55 56" src="https://user-images.githubusercontent.com/99626087/158773377-874bb03f-098e-4c42-93ee-e76c0f571ac0.png">


### **３、ユーザーとタスクが紐付くようにする**
まず、tasksテーブルにuser_idを紐付かせ、それに対しインデックスを貼りました。
### **４、N+1問題解消**
N+1問題を回避するために、N+1のクエリを自動で検知するbulletを導入しました。
### **５、タスク一覧に、ユーザー名の列を追加し、タスクに紐づいたユーザー名を表示する**
現時点では、ユーザー名を固定して表示しております。
<img width="784" alt="スクリーンショット 2022-03-17 17 57 54" src="https://user-images.githubusercontent.com/99626087/158773953-466c5223-ba4c-4809-8aa3-22502612e597.png">

### **備考**
今回のステップの実装でspecは書かなくても良いとの、ご指示を「織田さん・稲崎さん」から頂きました。

以上が追加点になります。ご確認の程よろしくお願い致します。