### PR TITLE
ステップ20: タスクにラベルをつけられるようにしよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -4,16 +4,11 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
   before_action :logged_in_user
   def index
-    @tasks = if Task.statuses.keys.include?(params[:status])
-                current_user.tasks
-                            .task_name_partial_search(params[:task_name])
-                            .where(status: params[:status])
-                            .page(params[:page])
-             else
-                current_user.tasks
-                            .task_name_partial_search(params[:task_name])
-                            .page(params[:page])
-             end
+    @tasks = current_user.tasks.includes([:task_labels]).includes([:labels])
+                         .task_name_partial_search(params[:task_name])
+                         .status_search(params[:status])
+                         .label_name_search(params[:label_name])
+                         .page(params[:page])
   end
 
   def new
@@ -75,6 +70,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:task_name, :description, :starts_on, :ends_on, :priority, :label, :status)
+    params.require(:task).permit(:task_name, :description, :starts_on, :ends_on, :priority, { label_ids: [] }, :status)
   end
 end

--- a/myapp/app/models/label.rb
+++ b/myapp/app/models/label.rb
@@ -1,0 +1,4 @@
+class Label < ApplicationRecord
+  has_many :task_labels, dependent: :destroy
+  has_many :tasks, through: :task_labels
+end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -3,8 +3,9 @@
 class Task < ApplicationRecord
   enum status: { yet_started: 0, being_worked: 1, done: 2 }
 
-  scope :task_name_partial_search, -> (task_name) { where('task_name LIKE ?', "%#{task_name}%") }
-
+  scope :task_name_partial_search, -> (task_name) { where('task_name LIKE ?', "%#{task_name}%") if task_name.present? }
+  scope :status_search, -> (status) { where(status: status) if status.present? }
+  scope :label_name_search, -> (label_name) { joins(:labels).where('label_name LIKE ?', label_name.to_s) if label_name.present? }
   validates :task_name, presence: true, length: { maximum: 30 }
   validates :description, presence: true, length: { maximum: 100 }
   validates :status, presence: true
@@ -13,6 +14,8 @@ class Task < ApplicationRecord
   paginates_per 5
 
   belongs_to :user
+  has_many :task_labels, dependent: :destroy
+  has_many :labels, through: :task_labels
 
   private
 

--- a/myapp/app/models/task_label.rb
+++ b/myapp/app/models/task_label.rb
@@ -1,0 +1,4 @@
+class TaskLabel < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -32,7 +32,7 @@
     </div>
     <div class="field">
       <%= f.label :label %>
-      <%= f.text_field :label %>
+      <%= f.collection_check_boxes(:label_ids, Label.all, :id, :label_name) %>
     </div>
     <div class="field">
       <%= f.label :status %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,6 +2,7 @@
 <%= form_tag(tasks_path,:method => 'get') do %>
   <%= t '.status' %>:<%= select_tag(:status, options_for_select(Task.statuses.keys.map { |k| [t("activerecord.enums.task.status.#{k}"), k]}),:include_blank => "未選択") %>
   <%= t '.task_name' %>:<%= text_field_tag :task_name %>
+  <%= t '.label' %>:<%= select_tag(:label_name, options_for_select(Label.pluck(:label_name)),:include_blank => "未選択") %>
   <%= submit_tag :search %>
 <% end %>
 
@@ -28,7 +29,11 @@
         <td><%= task.starts_on %></td>
         <td><%= task.ends_on %></td>
         <td><%= task.priority %></td>
-        <td><%= task.label %></td>
+        <td>
+          <% task.labels.each do |label| %>
+            <%= label.label_name %>
+          <% end %>
+        </td>
         <td><%= t("activerecord.enums.task.status.#{task.status}") %></td>
         <td><%= link_to (t '.show'), task %></td>
         <td><%= link_to (t '.edit'), edit_task_path(task) %></td>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,8 +1,8 @@
 <h1><%= t '.title' %></h1>
 <%= form_tag(tasks_path,:method => 'get') do %>
-  <%= t '.status' %>:<%= select_tag(:status, options_for_select(Task.statuses.keys.map { |k| [t("activerecord.enums.task.status.#{k}"), k]}),:include_blank => "未選択") %>
+  <%= t '.status' %>:<%= select_tag(:status, options_for_select(Task.statuses.keys.map { |k| [t("activerecord.enums.task.status.#{k}"), k]}),:include_blank => '未選択') %>
   <%= t '.task_name' %>:<%= text_field_tag :task_name %>
-  <%= t '.label' %>:<%= select_tag(:label_name, options_for_select(Label.pluck(:label_name)),:include_blank => "未選択") %>
+  <%= t '.label' %>:<%= select_tag(:label_name, options_for_select(Label.pluck(:label_name)),:include_blank => '未選択') %>
   <%= submit_tag :search %>
 <% end %>
 

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -27,7 +27,9 @@
 
 <p>
   <strong><%= t '.label' %></strong>
-  <%= @task.label %>
+  <% @task.labels.each do |label| %>
+    <%= label.label_name %>
+  <% end %>
 </p>
 
 <p>

--- a/myapp/db/migrate/20220329054709_create_labels.rb
+++ b/myapp/db/migrate/20220329054709_create_labels.rb
@@ -1,0 +1,9 @@
+class CreateLabels < ActiveRecord::Migration[5.0]
+  def change
+    create_table :labels do |t|
+      t.string :label_name
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/migrate/20220329055454_create_task_labels.rb
+++ b/myapp/db/migrate/20220329055454_create_task_labels.rb
@@ -1,0 +1,10 @@
+class CreateTaskLabels < ActiveRecord::Migration[5.0]
+  def change
+    create_table :task_labels do |t|
+      t.references :task, foreign_key: true
+      t.references :label, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220318025405) do
+ActiveRecord::Schema.define(version: 20220329055454) do
+
+  create_table "labels", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.string   "label_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "task_labels", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.integer  "task_id"
+    t.integer  "label_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["label_id"], name: "index_task_labels_on_label_id", using: :btree
+    t.index ["task_id"], name: "index_task_labels_on_task_id", using: :btree
+  end
 
   create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "task_name",   limit: 30,              null: false
@@ -35,5 +50,7 @@ ActiveRecord::Schema.define(version: 20220318025405) do
     t.datetime "updated_at",      null: false
   end
 
+  add_foreign_key "task_labels", "labels"
+  add_foreign_key "task_labels", "tasks"
   add_foreign_key "tasks", "users"
 end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -6,9 +6,3 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# User.create(user_name: 'hoge', email: 'aaa@example.co.jp', password: 'password')
-# User.create(user_name: '太郎', email: 'bbb@example.co.jp', password: '1234567')
-
-5.times do |i|
-    Label.create!(label_name: "sample#{i + 1}")
-end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -6,3 +6,9 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+User.create(user_name: 'hoge', email: 'aaa@example.co.jp', password: 'password')
+User.create(user_name: '太郎', email: 'bbb@example.co.jp', password: '1234567')
+
+5.times do |i|
+  Label.create!(label_name: "sample#{i + 1}")
+end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -6,5 +6,9 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-User.create(user_name: 'hoge', email: 'aaa@example.co.jp', password: 'password')
-User.create(user_name: '太郎', email: 'bbb@example.co.jp', password: '1234567')
+# User.create(user_name: 'hoge', email: 'aaa@example.co.jp', password: 'password')
+# User.create(user_name: '太郎', email: 'bbb@example.co.jp', password: '1234567')
+
+5.times do |i|
+    Label.create!(label_name: "sample#{i + 1}")
+end

--- a/myapp/spec/factories/labels.rb
+++ b/myapp/spec/factories/labels.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :label do
+    label_name "rails"
+  end
+end

--- a/myapp/spec/factories/task_labels.rb
+++ b/myapp/spec/factories/task_labels.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :task_label do
+    task_id nil
+    label_id nil
+  end
+end

--- a/myapp/spec/factories/task_labels.rb
+++ b/myapp/spec/factories/task_labels.rb
@@ -1,6 +1,4 @@
 FactoryGirl.define do
   factory :task_label do
-    task_id nil
-    label_id nil
   end
 end

--- a/myapp/spec/requests/sessions_spec.rb
+++ b/myapp/spec/requests/sessions_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Sessions', type: :request do
 
       it 'レスポンスが正しいこと' do
         login_user
-        expect(response).to redirect_to(login_form_path)
+        expect(response).to have_http_status(:ok)
       end
 
       it 'エラーメッセージが表示されていること' do

--- a/myapp/spec/requests/tasks_spec.rb
+++ b/myapp/spec/requests/tasks_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Tasks', type: :request do
       context 'ステータスのみで検索した時' do # rubocop:disable RSpec/NestedGroups
         subject(:task_name_status_search) { get tasks_path, params: { status: 1 } }
 
-        before { create(:task, task_name: 'piyo', status: 1) }
+        before { create(:task, task_name: 'テスト', status: 1, user: user) }
 
         it 'レスポンスが正しいこと' do
           task_name_status_search
@@ -48,14 +48,14 @@ RSpec.describe 'Tasks', type: :request do
 
         it '該当するタスク名が表示されること' do
           task_name_status_search
-          expect(response.body).to include 'piyo'
+          expect(response.body).to include 'テスト'
         end
       end
 
       context 'ステータスが一致していない時' do # rubocop:disable RSpec/NestedGroups
         subject(:task_name_status_search) { get tasks_path, params: { status: 2 } }
 
-        before { create(:task, task_name: 'あいうえお', status: 1) }
+        before { create(:task, task_name: 'あいうえお', status: 1, user: user) }
 
         it 'レスポンスが正しいこと' do
           task_name_status_search
@@ -89,7 +89,7 @@ RSpec.describe 'Tasks', type: :request do
       end
 
       context 'タスク名が一致していない時' do # rubocop:disable RSpec/NestedGroups
-        subject(:task_name_status_search) { get tasks_path, params: { task_name: 'piyo', status: '' } }
+        subject(:task_name_status_search) { get tasks_path, params: { task_name: 'aiueo', status: '' } }
 
         it '検索したタスク名が表示されていないこと' do
           task_name_status_search

--- a/myapp/spec/requests/tasks_spec.rb
+++ b/myapp/spec/requests/tasks_spec.rb
@@ -78,12 +78,23 @@ RSpec.describe 'Tasks', type: :request do
       end
     end
 
-    context 'タスク名のみで検索した時' do
-      subject(:task_name_status_search) { get tasks_path, params: { task_name: 'piyo', status: '' } }
+    context 'タスク名検索した時' do
+      context 'タスク名のみで検索した時' do # rubocop:disable RSpec/NestedGroups
+        subject(:task_name_status_search) { get tasks_path, params: { task_name: 'piyo', status: '' } }
 
-      it '該当するタスク名が表示されること' do
-        task_name_status_search
-        expect(response.body).to include 'piyo'
+        it '該当するタスク名が表示されること' do
+          task_name_status_search
+          expect(response.body).to include 'piyo'
+        end
+      end
+
+      context 'タスク名が一致していない時' do # rubocop:disable RSpec/NestedGroups
+        subject(:task_name_status_search) { get tasks_path, params: { task_name: 'piyo', status: '' } }
+
+        it '検索したタスク名が表示されていないこと' do
+          task_name_status_search
+          expect(response.body).not_to include 'aiueo'
+        end
       end
     end
 

--- a/myapp/spec/requests/tasks_spec.rb
+++ b/myapp/spec/requests/tasks_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Tasks', type: :request do
 
         it '検索したタスク名が表示されていないこと' do
           task_name_status_search
-          expect(response.body).not_to include 'aiueo'
+          expect(response.body).not_to include 'piyo'
         end
       end
     end

--- a/myapp/spec/requests/tasks_spec.rb
+++ b/myapp/spec/requests/tasks_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe 'Tasks', type: :request do
   before { post login_path, params: { session: { email: user.email, password: 'Passw0rd' } } }
 
   describe 'GET /index' do
-    before { create(:task, task_name: 'piyo', status: 1, user: user) }
+    before do
+      task = create(:task, task_name: 'piyo', status: 1, user: user)
+      label = create(:label, label_name: 'rails')
+      create(:task_label, task_id: task.id, label_id: label.id)
+    end
 
     context '一覧ページが存在する時' do
       it 'レスポンスが正しいこと' do
@@ -17,42 +21,40 @@ RSpec.describe 'Tasks', type: :request do
       end
     end
 
-    context 'タスク名とステータスを同時検索した時' do
-      subject(:task_name_status_search) { get tasks_path, params: { task_name: 'piyo', status: 1 } }
-
-      context '検索したステータスと一致する時' do # rubocop:disable RSpec/NestedGroups
-        it 'レスポンスが正しいこと' do
-          task_name_status_search
-          expect(response).to have_http_status(:ok)
-        end
-
-        it 'ステータスとタスク名が一致しているタスクが含まれていること' do
-          task_name_status_search
-          expect(response.body).to include('piyo', '着手')
-        end
-      end
-    end
-
-    context '一致するステータスを検索した時' do
-      subject(:task_name_status_search) { get tasks_path, params: { status: 1 } }
-
-      before { create(:task, task_name: 'piyo', status: 1) }
+    context 'タスク名とステータスとラベルを同時検索した時' do
+      subject(:task_name_status_search) { get tasks_path, params: { task_name: 'piyo', status: 1, label_name: 'rails' } }
 
       it 'レスポンスが正しいこと' do
         task_name_status_search
         expect(response).to have_http_status(:ok)
       end
 
-      it '一致するタスク名が表示されること' do
+      it 'ステータスとタスク名とラベルが一致しているタスクが含まれていること' do
         task_name_status_search
-        expect(response.body).to include 'piyo'
+        expect(response.body).to include('piyo', '着手', 'rails')
       end
     end
 
     context 'ステータスを検索した時' do
-      subject(:task_name_status_search) { get tasks_path, params: { status: 2 } }
+      context 'ステータスのみで検索した時' do # rubocop:disable RSpec/NestedGroups
+        subject(:task_name_status_search) { get tasks_path, params: { status: 1 } }
+
+        before { create(:task, task_name: 'piyo', status: 1) }
+
+        it 'レスポンスが正しいこと' do
+          task_name_status_search
+          expect(response).to have_http_status(:ok)
+        end
+
+        it '該当するタスク名が表示されること' do
+          task_name_status_search
+          expect(response.body).to include 'piyo'
+        end
+      end
 
       context 'ステータスが一致していない時' do # rubocop:disable RSpec/NestedGroups
+        subject(:task_name_status_search) { get tasks_path, params: { status: 2 } }
+
         before { create(:task, task_name: 'あいうえお', status: 1) }
 
         it 'レスポンスが正しいこと' do
@@ -76,12 +78,34 @@ RSpec.describe 'Tasks', type: :request do
       end
     end
 
-    context 'ステータスが未選択で、タスク名のみで検索した時' do
+    context 'タスク名のみで検索した時' do
       subject(:task_name_status_search) { get tasks_path, params: { task_name: 'piyo', status: '' } }
 
       it '該当するタスク名が表示されること' do
         task_name_status_search
         expect(response.body).to include 'piyo'
+      end
+    end
+
+    context 'ラベル検索した時' do
+      context 'ラベルのみで検索した時' do # rubocop:disable RSpec/NestedGroups
+        subject(:task_name_status_search) { get tasks_path, params: { task_name: '', status: '', label_name: 'rails' } }
+
+        it '該当するラベルが表示されること' do
+          task_name_status_search
+          expect(response.body).to include 'rails'
+        end
+      end
+
+      context 'ラベルが一致していない時' do # rubocop:disable RSpec/NestedGroups
+        subject(:task_name_status_search) { get tasks_path, params: { task_name: '', status: '', label_name: 'rails' } }
+
+        before { create(:task, task_name: 'かきくけこ', label: 'ruby') }
+
+        it '検索したタスク名が表示されていないこと' do
+          task_name_status_search
+          expect(response.body).not_to include 'かきくけこ'
+        end
       end
     end
   end
@@ -186,7 +210,7 @@ RSpec.describe 'Tasks', type: :request do
     context 'タスク更新が成功した時' do
       subject(:new_task) { put task_url task, params: { task: attributes_for(:task, task_name: 'hoge') } }
 
-      let(:task) { create(:task) }
+      let(:task) { create(:task, task_name: 'あいうえお', user: user) }
 
       it 'レスポンスが正しいこと' do
         new_task
@@ -215,7 +239,7 @@ RSpec.describe 'Tasks', type: :request do
     context 'タスク削除が成功した時' do
       subject(:new_task) { delete task_url task }
 
-      let(:task) { create(:task) }
+      let(:task) { create(:task, task_name: 'あいうえお', user: user) }
 
       it 'レスポンスが正しいこと' do
         new_task


### PR DESCRIPTION
## 仕様書
https://github.com/Fablic/training/blob/hayato-kudo/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9720-%E3%82%BF%E3%82%B9%E3%82%AF%E3%81%AB%E3%83%A9%E3%83%99%E3%83%AB%E3%82%92%E3%81%A4%E3%81%91%E3%82%89%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86

## 追加点
### **1、タスクに複数のラベルを追加**
### 1-1 labelテーブル作成
<img width="982" alt="スクリーンショット 2022-03-31 12 43 47" src="https://user-images.githubusercontent.com/99626087/160972156-4dd4526a-dd5a-4ef6-b052-a128a818900c.png">

タスクにラベルを追加する際に必要なテーブルを作成しました。
### 1-2 中間テーブルtask_labelsテーブルを作成
<img width="985" alt="スクリーンショット 2022-03-31 12 44 43" src="https://user-images.githubusercontent.com/99626087/160972232-10535a0c-a7d5-46be-a369-dfcbdfd1e57e.png">
こちらの中間テーブルはuserテーブルとtaskテーブルを紐付けるために作成しました。

### 1-3 チェックボックス追加
<img width="603" alt="スクリーンショット 2022-03-31 12 41 04" src="https://user-images.githubusercontent.com/99626087/160971891-8090e3c0-f3e6-4a7f-828e-b02c047299d1.png">

タスク作成時にラベル選択できるようにしております。

### **２、ラベル検索機能**
### 2-1 検索欄追加
<img width="837" alt="スクリーンショット 2022-03-31 12 36 13" src="https://user-images.githubusercontent.com/99626087/160972594-0709d5c7-086d-4647-be27-3deddf58fcf2.png">

タスクの一覧ページにラベル検索欄を追加しました。

### **３、spec追加**
### 3-1 request/tasks_specにテストケース追加
<img width="1049" alt="スクリーンショット 2022-03-30 16 00 08" src="https://user-images.githubusercontent.com/99626087/160973025-9b0b72b5-69bf-44a3-9cf5-82af1004d81e.png">
上記の画像の通りrequest/tasks_specにテストを追加しました。

### 3-2 request/sessions_specの追加
<img width="861" alt="スクリーンショット 2022-03-24 17 50 59" src="https://user-images.githubusercontent.com/99626087/160973154-9703cbaf-effe-4959-8d4c-d7952a3e3f09.png">
上記の画像の通りrequest/sessions_specにテストを追加しました。

以上が追加点になります。ご確認の程よろしくお願い致します。