### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -2,6 +2,14 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :maintenance?
+
+  def maintenance?
+    maintenance = Constant.find_by(name: 'maintenance')
+    if maintenance&.value == 'on'
+      render file: Rails.root.join('public/503.html'), status: :service_unavailable, content_type: 'text/html'
+    end
+  end
 
   def current_user
     if session[:user_id]

--- a/myapp/app/models/constant.rb
+++ b/myapp/app/models/constant.rb
@@ -1,0 +1,2 @@
+class Constant < ApplicationRecord
+end

--- a/myapp/db/migrate/20220407071610_create_constants.rb
+++ b/myapp/db/migrate/20220407071610_create_constants.rb
@@ -1,0 +1,10 @@
+class CreateConstants < ActiveRecord::Migration[5.0]
+  def change
+    create_table :constants do |t|
+      t.string :name
+      t.string :value
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220329055454) do
+ActiveRecord::Schema.define(version: 20220407071610) do
+
+  create_table "constants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
+    t.string   "name"
+    t.string   "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "labels", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string   "label_name"

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -12,3 +12,5 @@ User.create(user_name: '太郎', email: 'bbb@example.co.jp', password: '1234567'
 5.times do |i|
   Label.create!(label_name: "sample#{i + 1}")
 end
+
+Constant.create(name: 'maintenance', value: 'off')

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,14 @@
+namespace :maintenance do
+  desc 'メンテナンスをオンにします'
+  task :on => :environment do
+    maintenance = Constant.find_by(name: 'maintenance')
+    maintenance.update(value: 'on')
+    puts 'update on'
+  end
+  desc 'メンテナンスをオフにします'
+  task :off => :environment do
+    maintenance = Constant.find_by(name: 'maintenance')
+    maintenance.update(value: 'off')
+    puts 'update off'
+  end
+end

--- a/myapp/public/503.html
+++ b/myapp/public/503.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, but something went wrong (500)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body class="rails-default-error-page">
+  <!-- This file lives in public/500.html -->
+  <div id="errors">
+    <h1>503 Service Unavailable</h1>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### **仕様書**
https://github.com/Fablic/training/blob/hayato-kudo/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86

### **追加点**
### **１、バッチ作成**
メンテナンスを開始（on）/終了（off）するバッチの作成しました。
### **２、メンテナンスページの作成**
メンテナンス中にlocalhostに接続するとメンテナンスページ（503.html）に遷移するよう設定しました。
<img width="1440" alt="スクリーンショット 2022-04-08 8 59 47" src="https://user-images.githubusercontent.com/99626087/162338004-8b31b39b-6cd8-41b7-aa37-7eec9931d62b.png">

以上が追加点になります。ご確認の程よろしくお願い致します。
