### PR TITLE
ステップ10: タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order('created_at DESC')
   end
 
   def show

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -15,7 +15,23 @@ RSpec.describe TasksController, type: :controller do
 
     describe "GET #index" do
         subject {Proc.new { get :index }}
+        let!(:tasks) { create_list(:task, listnum) }
+        let(:listnum) { 5 }
         it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
+
+        it "タスクが作成日時(降順)で並び替えられた状態で全件取得できていること" do
+            subject.call
+            dislayed_tasks = controller.instance_variable_get('@tasks')
+            
+            expect(dislayed_tasks.size).to be == listnum
+            before_task = nil
+            for task in dislayed_tasks do
+                if before_task then
+                    expect(task.created_at).to be <= before_task.created_at
+                end
+                before_task = task
+            end
+        end
     end
 
     describe "GET #new" do

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -20,12 +20,18 @@ RSpec.describe TasksController, type: :controller do
         it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
 
         it "タスクが作成日時(降順)で並び替えられた状態で全件取得できていること" do
-            subject.call
-            dislayed_tasks = controller.instance_variable_get('@tasks')
+            addDays = 0
+            for task in tasks do
+                task.update(created_at: Date.today + addDays)
+                addDays += 1
+            end
             
-            expect(dislayed_tasks.size).to be == listnum
+            subject.call
+            displayed_tasks = controller.instance_variable_get('@tasks')
+            
+            expect(displayed_tasks.size).to be == listnum
             before_task = nil
-            for task in dislayed_tasks do
+            for task in displayed_tasks do
                 if before_task then
                     expect(task.created_at).to be <= before_task.created_at
                 end


### PR DESCRIPTION
## 要件（仕様書など）
タスク一覧を作成日時の順番で並び替えましょう
## 修正概要
タスク一覧画面上で、ID昇順から作成日時降順に並び替えて表示するよう変更
## 実装内容
修正概要と同じ
※テストも追加
## 動作確認（操作内容、画面キャプチャなど）
起動手順
```
bundle exec rake webpacker:compile
bundle exec rails s
```
■ 修正前(ID昇順で表示)
<img width="645" alt="スクリーンショット 2022-05-06 18 41 37" src="https://user-images.githubusercontent.com/103913705/167107670-3382849b-6cde-4c21-85b8-1e9d2732fe7d.png">
■ 修正後(作成日時降順で表示)
<img width="649" alt="スクリーンショット 2022-05-06 18 39 53" src="https://user-images.githubusercontent.com/103913705/167107480-3ff725a6-1e21-43a1-931b-4ee7c20c1a56.png">

※コンソール上でControllerアクション呼び出し時の動作確認(id, created_at, title のみ表示)
<img width="787" alt="スクリーンショット 2022-05-09 9 33 13" src="https://user-images.githubusercontent.com/103913705/167322485-1db89bfa-ff13-4ce1-8246-f68f27fcafae.png">
