### PR TITLE
ステップ11: バリデーションを設定してみよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,10 +1,12 @@
 class TasksController < ApplicationController
+  before_action :set_task, only: %i[show edit update destroy]
+
   def index
     @tasks = Task.all.order('created_at DESC')
   end
 
   def show
-    @task = Task.find(params[:id])
+    
   end
 
   def new
@@ -17,24 +19,27 @@ class TasksController < ApplicationController
     # 現段階ではユーザーは考慮しないので、NOT NULL制約回避用にダミーデータ格納
     @task.user_id = 0
 
-    return unless @task.save
-
-    redirect_to @task, notice: t("tasks.flash.new")
+    if @task.save
+      redirect_to @task, notice: t("tasks.flash.new")
+    else
+      render :new
+    end
   end
 
   def edit
-    @task = Task.find(params[:id])
+
   end
 
   def update
-    @task = Task.find(params[:id])
-    return unless @task.update_attributes(task_params)
-
-    redirect_to @task, notice: t("tasks.flash.update")
+    if @task.update(task_params)
+      redirect_to @task, notice: t("tasks.flash.update")
+    else
+      render :edit
+    end
   end
 
   def destroy
-    @task = Task.find(params[:id])
+
     return unless @task.destroy
     
     redirect_to tasks_path, notice: t("tasks.flash.destroy")
@@ -44,5 +49,9 @@ class TasksController < ApplicationController
 
     def task_params
       params.require(:task).permit(:user_id, :title, :description, :termination_at, :priority, :status)
+    end
+
+    def set_task
+      @task = Task.find(params[:id])
     end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -3,6 +3,8 @@ class Task < ApplicationRecord
         validates :title
         validates :description
         validates :termination_at
+        validates :priority
+        validates :status
     end
     validates :title, length: { maximum: 50 }
     validates :description, length: { maximum: 255 }

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -8,7 +8,7 @@ class Task < ApplicationRecord
     validates :description, length: { maximum: 255 }
     validate :termination_at_must_be_greater_than_current_at
 
-    enum priority: { row: 0, middle: 1, high: 2 }
+    enum priority: { low: 0, middle: 1, high: 2 }
     enum status: { not_started: 0, on_progress: 1, done: 2 }
 
     private

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,23 +1,53 @@
 class Task < ApplicationRecord
-    with_options presence: true do
-        validates :title
-        validates :description
-        validates :termination_at
-        validates :priority
-        validates :status
-    end
-    validates :title, length: { maximum: 50 }
-    validates :description, length: { maximum: 255 }
-    validate :termination_at_must_be_greater_than_current_at
+    validates :title, presence: true, length: { maximum: 50 }
+    validates :description, presence: true, length: { maximum: 255 }
+    validates :termination_at, presence: true
+    validate :termination_at_must_be_future
+    validate :validate_priority
+    validate :validate_status
 
-    enum priority: { low: 0, middle: 1, high: 2 }
-    enum status: { not_started: 0, on_progress: 1, done: 2 }
+    PRIORITY_LOW = 0
+    PRIORITY_MIDDLE = 1
+    PRIORITY_HIGH = 2
+
+    STATUS_NOT_STARTED = 0
+    STATUS_ON_PROGRESS = 1
+    STATUS_DONE = 2
+
+    enum priority: { low: PRIORITY_LOW, middle: PRIORITY_MIDDLE, high: PRIORITY_HIGH }
+    enum status: { not_started: STATUS_NOT_STARTED, on_progress: STATUS_ON_PROGRESS, done: STATUS_DONE }
+
+    def priority=(value)
+        super value
+        @priority_backup = nil
+    rescue ArgumentError => _
+        @priority_backup = value
+        self[:priority] = nil
+    end
+
+    def status=(value)
+        super value
+        @status_backup = nil
+    rescue ArgumentError => _
+        @status_backup = value
+        self[:status] = nil
+    end
 
     private
     
-    def termination_at_must_be_greater_than_current_at
+    def termination_at_must_be_future
         return if termination_at.blank? || termination_at > Time.now
         
-        errors.add(:termination_at, :termination_at_must_be_greater_than_current_at)
+        errors.add(:termination_at, :termination_at_must_be_future)
+    end
+
+    def validate_priority
+        return errors.add(:priority, :invalid_value) if @priority_backup.present?
+        errors.add(:priority, :blank) if priority.blank?
+    end
+
+    def validate_status
+        return errors.add(:status, :invalid_value) if @status_backup.present?
+        errors.add(:status, :blank) if status.blank?
     end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,4 +1,21 @@
 class Task < ApplicationRecord
+    with_options presence: true do
+        validates :title
+        validates :description
+        validates :termination_at
+    end
+    validates :title, length: { maximum: 50 }
+    validates :description, length: { maximum: 255 }
+    validate :termination_at_must_be_greater_than_current_at
+
     enum priority: { row: 0, middle: 1, high: 2 }
     enum status: { not_started: 0, on_progress: 1, done: 2 }
+
+    private
+    
+    def termination_at_must_be_greater_than_current_at
+        return if termination_at.blank? || termination_at > Time.now
+        
+        errors.add(:termination_at, :termination_at_must_be_greater_than_current_at)
+    end
 end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,4 +1,12 @@
-<%= form_with model: task do |f| %>
+<% if task.errors.any? %>
+    <div>
+        <% task.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+        <% end %>
+    </div>
+<% end %>
+
+<%= form_with model: task, local: true do |f| %>
     <div><%= t "tasks.title" %></div>
     <%= f.text_field :title %>
     <div><%= t "tasks.description" %></div>

--- a/myapp/config/locales/model/ja.yml
+++ b/myapp/config/locales/model/ja.yml
@@ -3,6 +3,13 @@ ja:
     models:
       task: 'タスク'
     attributes:
+      task:
+        user_id: 'ユーザーID'
+        title: 'タイトル'
+        description: '説明'
+        termination_at: '終了期日'
+        priority: '優先度'
+        status: 'ステータス'
       task/priority:
         row: '低'
         middle: '中'
@@ -11,3 +18,7 @@ ja:
         not_started: '未着手'
         on_progress: '着手中'
         done: '完了'
+    errors:
+      models:
+        task:
+          termination_at_must_be_greater_than_current_at: 'は現在時刻より後の日付を指定してください'

--- a/myapp/config/locales/model/ja.yml
+++ b/myapp/config/locales/model/ja.yml
@@ -21,4 +21,5 @@ ja:
     errors:
       models:
         task:
-          termination_at_must_be_greater_than_current_at: 'は現在時刻より後の日付を指定してください'
+          termination_at_must_be_future: 'は現在時刻より後の日付を指定してください'
+          invalid_value: 'に不正な値が入力されています'

--- a/myapp/config/locales/model/ja.yml
+++ b/myapp/config/locales/model/ja.yml
@@ -11,7 +11,7 @@ ja:
         priority: '優先度'
         status: 'ステータス'
       task/priority:
-        row: '低'
+        low: '低'
         middle: '中'
         high: '高'
       task/status:

--- a/myapp/db/migrate/20220509050810_change_task_title_limit.rb
+++ b/myapp/db/migrate/20220509050810_change_task_title_limit.rb
@@ -1,0 +1,9 @@
+class ChangeTaskTitleLimit < ActiveRecord::Migration[6.0]
+  def up
+    change_column :tasks, :title, :string, limit: 50
+  end
+
+  def down
+    change_column :tasks, :title, :string
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_06_044625) do
+ActiveRecord::Schema.define(version: 2022_05_09_050810) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "title", null: false
+    t.string "title", limit: 50, null: false
     t.string "description", null: false
     t.datetime "termination_at", null: false
     t.integer "priority", limit: 1, default: 0, null: false

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -86,19 +86,13 @@ RSpec.describe TasksController, type: :controller do
     describe "POST #create" do
         subject {Proc.new { post :create, params: { task: task } }}
         context "有効なパラメータの場合" do
-            let(:task) { {
-                user_id: 1,
-                title: "test_title_02",
-                description: "test_description_02",
-                termination_at: '2022-01-01 00:00:00',
-                priority: "high",
-                status: "done"
-            } }
+            let(:task){attributes_for(:task, title: "test_title_update")}
+
             it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと",302
 
             it "タスクが作成されること" do
                 expect { subject.call }.to change(Task, :count).by(1)
-                expect(Task.find(Task.last.id).title).to eq("test_title_02")
+                expect(Task.find(Task.last.id).title).to eq("test_title_update")
             end
 
             it "作成したタスク詳細画面へリダイレクトされ、フラッシュメッセージが表示されること" do
@@ -106,16 +100,6 @@ RSpec.describe TasksController, type: :controller do
                 expect(response).to redirect_to "/#{Task.last.id}"
                 expect(flash[:notice]).to match(/^タスクを作成しました！$/)
             end
-        end
-        context "無効なパラメータの場合" do
-            let(:task) { {
-                user_id: 1,
-                description: "test_description_02",
-                termination_at: '2022-01-01 00:00:00',
-                priority: "high",
-                status: "done"
-            } }
-            it_behaves_like "想定エラーが発生すること", ActiveRecord::NotNullViolation
         end
     end
 

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe TasksController, type: :controller do
     describe "POST #create" do
         subject {Proc.new { post :create, params: { task: task } }}
         context "有効なパラメータの場合" do
-            let(:task){attributes_for(:task, title: "test_title_update")}
+            let(:task){attributes_for(:task, title: "test_title_create")}
 
             it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと",302
 
             it "タスクが作成されること" do
                 expect { subject.call }.to change(Task, :count).by(1)
-                expect(Task.find(Task.last.id).title).to eq("test_title_update")
+                expect(Task.find(Task.last.id).title).to eq("test_title_create")
             end
 
             it "作成したタスク詳細画面へリダイレクトされ、フラッシュメッセージが表示されること" do
@@ -101,14 +101,23 @@ RSpec.describe TasksController, type: :controller do
                 expect(flash[:notice]).to match(/^タスクを作成しました！$/)
             end
         end
+        context "無効なパラメータの場合" do
+            let(:task){attributes_for(:task, title: nil)}
+            it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
+            it "タスクが作成されないこと" do
+                expect { subject.call }.to change(Task, :count).by(0)
+            end
+        end
     end
 
     describe "PATCH #update" do
-        subject {Proc.new { patch :update, params: {id: id, task: {title: "updated_task"}} }}
+        subject {Proc.new { patch :update, params: {id: id, task: {title: value}} }}
         let!(:task) { create(:task) }
         context "該当するタスクが存在する場合" do
+            let(:id) { task.id }
+
             context "有効なパラメータの場合" do
-                let(:id) { task.id }
+                let(:value) { "updated_task" }
                 it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと",302
                 
                 it "タスク情報が更新されること" do
@@ -123,12 +132,18 @@ RSpec.describe TasksController, type: :controller do
                 end
             end
             context "無効なパラメータの場合" do
-                let(:id) { nil }
-                it_behaves_like "想定エラーが発生すること", ActionController::UrlGenerationError
+                let(:value){ nil }
+                it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
+                
+                it "タスク情報が更新されないこと" do
+                    subject.call
+                    expect(task.reload.title).not_to eq nil
+                end
             end
         end
         context "該当するタスクが存在しない場合" do
             let(:id) { Task.last.id + 1 }
+            let(:value) { "updated_task" }
             it_behaves_like "想定エラーが発生すること", ActiveRecord::RecordNotFound
         end
     end

--- a/myapp/spec/factories/task.rb
+++ b/myapp/spec/factories/task.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
         user_id 0
         sequence(:title) { |n| "test_title_#{n}" }
         sequence(:description) { |n| "test_description_#{n}" }
-        termination_at '2022-01-01 00:00:00'
+        termination_at Date.today + 1
         priority 0
         status 0
     end

--- a/myapp/spec/factories/task.rb
+++ b/myapp/spec/factories/task.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
         sequence(:title) { |n| "test_title_#{n}" }
         sequence(:description) { |n| "test_description_#{n}" }
         termination_at Date.today + 1
-        priority 0
-        status 0
+        priority Task.priorities.key(0)
+        status Task.statuses.key(0)
     end
   end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
 
-    MSG_INVALID_LENGHT = 'を入力してください'
+    MSG_INVALID_INPUT = 'を入力してください'
 
     shared_examples_for 'バリデーションエラーとなり、想定するメッセージが表示されること' do | column, message|
         it { expect(task.valid?).to eq false
@@ -40,15 +40,15 @@ RSpec.describe Task, type: :model do
         context 'タイトルに正常な値が入力されていない場合' do
             context 'タイトルが空の場合' do
                 let(:title) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_INPUT
             end
             context 'タイトルが空白の場合' do
                 let(:title) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_INPUT
             end
             context 'タイトルがnilの場合' do
                 let(:title) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_INPUT
             end
         end
     end
@@ -82,15 +82,15 @@ RSpec.describe Task, type: :model do
         context '説明に正常な値が入力されていない場合' do
             context '説明が空の場合' do
                 let(:description) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_INPUT
             end
             context '説明が空白の場合' do
                 let(:description) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_INPUT
             end
             context '説明がnilの場合' do
                 let(:description) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_INPUT
             end
         end
     end
@@ -120,15 +120,15 @@ RSpec.describe Task, type: :model do
         context "終了期日に正常な値が入力されていない場合" do
             context '終了期日が空の場合' do
                 let(:termination_at) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_INPUT
             end
             context '終了期日が空白の場合' do
                 let(:termination_at) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_INPUT
             end
             context '終了期日がnilの場合' do
                 let(:termination_at) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_LENGHT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_INPUT
             end
         end
     end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -132,4 +132,55 @@ RSpec.describe Task, type: :model do
             end
         end
     end
+
+    describe 'priority' do
+        let(:task) { build(:task, priority: priority) }
+
+        context '優先度に正常な値が入力されている場合' do
+            let(:priority) { Task.priorities.key(0) }
+
+            it 'バリデーションエラーにならないこと' do
+                expect(task.valid?).to eq true
+            end
+        end
+        context '優先度に正常な値が入力されていない場合' do
+            context '優先度が空の場合' do
+                let(:priority) { '' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_INVALID_INPUT
+            end
+            context '優先度が空白の場合' do
+                let(:priority) { ' ' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_INVALID_INPUT
+            end
+            context '優先度がnilの場合' do
+                let(:priority) { nil }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_INVALID_INPUT
+            end
+        end
+    end
+
+    describe 'status' do
+        let(:task) { build(:task, status: status) }
+        context 'ステータスに正常な値が入力されている場合' do
+            let(:status) { Task.statuses.key(0) }
+
+            it 'バリデーションエラーにならないこと' do
+                expect(task.valid?).to eq true
+            end
+        end
+        context 'ステータスに正常な値が入力されていない場合' do
+            context 'ステータスが空の場合' do
+                let(:status) { '' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_INVALID_INPUT
+            end
+            context 'ステータスが空白の場合' do
+                let(:status) { ' ' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_INVALID_INPUT
+            end
+            context 'ステータスがnilの場合' do
+                let(:status) { nil }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_INVALID_INPUT
+            end
+        end
+    end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+
+    MSG_INVALID_LENGHT = 'を入力してください'
+
+    shared_examples_for 'バリデーションエラーとなり、想定するメッセージが表示されること' do | column, message|
+        it { expect(task.valid?).to eq false
+            task.valid?
+            expect(task.errors.messages[column]).to include message
+        }
+    end
+
+    describe 'title' do
+        let(:task) { build(:task, title: title) }
+
+        context 'タイトルに正常な値が入力されている場合' do
+            let(:title) { 'あ' * num }
+            max_num = 50
+
+            context "タイトルが#{ max_num }文字の場合" do
+                let(:num) { max_num }
+
+                it 'バリデーションエラーにならないこと' do
+                    expect(task.valid?).to eq true
+                end
+            end
+            context "タイトルが#{ max_num+1 }文字以上の場合" do
+                let(:num) { max_num+1 }
+
+                it 'バリデーションエラーになること' do
+                    expect(task.valid?).to eq false
+                end
+                it 'エラーメッセージが表示されること' do
+                    task.valid?
+                    expect(task.errors.messages[:title]).to include "は#{ max_num }文字以内で入力してください"
+                end
+            end
+        end
+        context 'タイトルに正常な値が入力されていない場合' do
+            context 'タイトルが空の場合' do
+                let(:title) { '' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_LENGHT
+            end
+            context 'タイトルが空白の場合' do
+                let(:title) { ' ' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_LENGHT
+            end
+            context 'タイトルがnilの場合' do
+                let(:title) { nil }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_LENGHT
+            end
+        end
+    end
+  
+    describe 'description' do
+        let(:task) { build(:task, description: description) }
+
+        context '説明に正常な値が入力されている場合' do
+            let(:description) { 'あ' * num }
+            max_num = 255
+
+            context "説明が#{ max_num }文字の場合" do    
+                let(:num) { max_num }
+
+                it 'バリデーションエラーにならないこと' do
+                    expect(task.valid?).to eq true
+                end
+            end
+            context "説明が#{ max_num+1 }文字以上の場合" do
+                let(:num) { max_num+1 }
+        
+                it 'バリデーションエラーになること' do
+                    expect(task.valid?).to eq false
+                end
+                it 'エラーメッセージが表示されること' do
+                    task.valid?
+                    expect(task.errors.messages[:description]).to include "は#{ max_num }文字以内で入力してください"
+                end
+            end
+        end
+        context '説明に正常な値が入力されていない場合' do
+            context '説明が空の場合' do
+                let(:description) { '' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_LENGHT
+            end
+            context '説明が空白の場合' do
+                let(:description) { ' ' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_LENGHT
+            end
+            context '説明がnilの場合' do
+                let(:description) { nil }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_LENGHT
+            end
+        end
+    end
+  
+    describe 'termination_at' do
+        let(:task) { build(:task, termination_at: termination_at) }
+
+        context '終了期日に正常な値が入力されている場合' do
+            context '終了期日が現在日時よりも後の日付である場合' do
+                let(:termination_at) { Time.now + 1 }
+                it 'バリデーションエラーにならないこと' do
+                    expect(task.valid?).to eq true
+                end
+            end
+            context '終了期日が現在日時以前の日付である場合' do
+                let(:termination_at) { Time.now }
+
+                it 'バリデーションエラーになること' do
+                    expect(task.valid?).to eq false
+                end
+                it 'エラーメッセージが表示されること' do
+                    task.valid?
+                    expect(task.errors.messages[:termination_at]).to include 'は現在時刻より後の日付を指定してください'
+                end
+            end
+        end
+        context "終了期日に正常な値が入力されていない場合" do
+            context '終了期日が空の場合' do
+                let(:termination_at) { '' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_LENGHT
+            end
+            context '終了期日が空白の場合' do
+                let(:termination_at) { ' ' }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_LENGHT
+            end
+            context '終了期日がnilの場合' do
+                let(:termination_at) { nil }
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_LENGHT
+            end
+        end
+    end
+end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Task, type: :model do
 
     MSG_INVALID_INPUT = 'を入力してください'
+    TITLE_MAX_LENGHT = 50
+    DESCRIPTION_MAX_LENGHT = 255
 
     shared_examples_for 'バリデーションエラーとなり、想定するメッセージが表示されること' do | column, message|
         it { expect(task.valid?).to eq false
@@ -16,24 +18,23 @@ RSpec.describe Task, type: :model do
 
         context 'タイトルに正常な値が入力されている場合' do
             let(:title) { 'あ' * num }
-            max_num = 50
 
-            context "タイトルが#{ max_num }文字の場合" do
-                let(:num) { max_num }
+            context "タイトルが#{ TITLE_MAX_LENGHT }文字の場合" do
+                let(:num) { TITLE_MAX_LENGHT }
 
                 it 'バリデーションエラーにならないこと' do
                     expect(task.valid?).to eq true
                 end
             end
-            context "タイトルが#{ max_num+1 }文字以上の場合" do
-                let(:num) { max_num+1 }
+            context "タイトルが#{ TITLE_MAX_LENGHT+1 }文字以上の場合" do
+                let(:num) { TITLE_MAX_LENGHT+1 }
 
                 it 'バリデーションエラーになること' do
                     expect(task.valid?).to eq false
                 end
                 it 'エラーメッセージが表示されること' do
                     task.valid?
-                    expect(task.errors.messages[:title]).to include "は#{ max_num }文字以内で入力してください"
+                    expect(task.errors.messages[:title]).to include "は#{ TITLE_MAX_LENGHT }文字以内で入力してください"
                 end
             end
         end
@@ -58,24 +59,23 @@ RSpec.describe Task, type: :model do
 
         context '説明に正常な値が入力されている場合' do
             let(:description) { 'あ' * num }
-            max_num = 255
 
-            context "説明が#{ max_num }文字の場合" do    
-                let(:num) { max_num }
+            context "説明が#{ DESCRIPTION_MAX_LENGHT }文字の場合" do    
+                let(:num) { DESCRIPTION_MAX_LENGHT }
 
                 it 'バリデーションエラーにならないこと' do
                     expect(task.valid?).to eq true
                 end
             end
-            context "説明が#{ max_num+1 }文字以上の場合" do
-                let(:num) { max_num+1 }
+            context "説明が#{ DESCRIPTION_MAX_LENGHT+1 }文字以上の場合" do
+                let(:num) { DESCRIPTION_MAX_LENGHT+1 }
         
                 it 'バリデーションエラーになること' do
                     expect(task.valid?).to eq false
                 end
                 it 'エラーメッセージが表示されること' do
                     task.valid?
-                    expect(task.errors.messages[:description]).to include "は#{ max_num }文字以内で入力してください"
+                    expect(task.errors.messages[:description]).to include "は#{ DESCRIPTION_MAX_LENGHT }文字以内で入力してください"
                 end
             end
         end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
 
-    MSG_INVALID_INPUT = 'を入力してください'
+    MSG_NO_VALUE = 'を入力してください'
+    MSG_INVALID_VALUE = 'に不正な値が入力されています'
     TITLE_MAX_LENGHT = 50
     DESCRIPTION_MAX_LENGHT = 255
 
@@ -41,15 +42,15 @@ RSpec.describe Task, type: :model do
         context 'タイトルに正常な値が入力されていない場合' do
             context 'タイトルが空の場合' do
                 let(:title) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_NO_VALUE
             end
             context 'タイトルが空白の場合' do
                 let(:title) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_NO_VALUE
             end
             context 'タイトルがnilの場合' do
                 let(:title) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_NO_VALUE
             end
         end
     end
@@ -82,15 +83,15 @@ RSpec.describe Task, type: :model do
         context '説明に正常な値が入力されていない場合' do
             context '説明が空の場合' do
                 let(:description) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_NO_VALUE
             end
             context '説明が空白の場合' do
                 let(:description) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_NO_VALUE
             end
             context '説明がnilの場合' do
                 let(:description) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_NO_VALUE
             end
         end
     end
@@ -120,15 +121,15 @@ RSpec.describe Task, type: :model do
         context "終了期日に正常な値が入力されていない場合" do
             context '終了期日が空の場合' do
                 let(:termination_at) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_NO_VALUE
             end
             context '終了期日が空白の場合' do
                 let(:termination_at) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_NO_VALUE
             end
             context '終了期日がnilの場合' do
                 let(:termination_at) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_NO_VALUE
             end
         end
     end
@@ -137,24 +138,31 @@ RSpec.describe Task, type: :model do
         let(:task) { build(:task, priority: priority) }
 
         context '優先度に正常な値が入力されている場合' do
-            let(:priority) { Task.priorities.key(0) }
+            context 'Enumで定義されている値の場合' do
+                let(:priority) { Task.priorities.key(0) }
 
-            it 'バリデーションエラーにならないこと' do
-                expect(task.valid?).to eq true
+                it 'バリデーションエラーにならないこと' do
+                    expect(task.valid?).to eq true
+                end
+            end
+            context 'Enumで定義されていない値の場合' do
+                let(:priority) { "unknown_priority" }
+                
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_INVALID_VALUE
             end
         end
         context '優先度に正常な値が入力されていない場合' do
             context '優先度が空の場合' do
                 let(:priority) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_NO_VALUE
             end
             context '優先度が空白の場合' do
                 let(:priority) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_NO_VALUE
             end
             context '優先度がnilの場合' do
                 let(:priority) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_NO_VALUE
             end
         end
     end
@@ -162,24 +170,32 @@ RSpec.describe Task, type: :model do
     describe 'status' do
         let(:task) { build(:task, status: status) }
         context 'ステータスに正常な値が入力されている場合' do
-            let(:status) { Task.statuses.key(0) }
 
-            it 'バリデーションエラーにならないこと' do
-                expect(task.valid?).to eq true
+            context 'Enumで定義されている値の場合' do
+                let(:status) { Task.statuses.key(0) }
+
+                it 'バリデーションエラーにならないこと' do
+                    expect(task.valid?).to eq true
+                end
+            end
+            context 'Enumで定義されていない値の場合' do
+                let(:status) { "unknown_status" }
+
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_INVALID_VALUE
             end
         end
         context 'ステータスに正常な値が入力されていない場合' do
             context 'ステータスが空の場合' do
                 let(:status) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_NO_VALUE
             end
             context 'ステータスが空白の場合' do
                 let(:status) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_NO_VALUE
             end
             context 'ステータスがnilの場合' do
                 let(:status) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_INVALID_INPUT
+                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_NO_VALUE
             end
         end
     end


### PR DESCRIPTION
## 要件（仕様書など）
バリデーションを設定してみよう
## 修正概要
バリデーション追加
## 実装内容
■ バリデーション追加
以下のカラムに対するバリデーションを追加
・title
・description
・priority
・status
■ TasksControllerのリファクタリング
重複していた処理をprivateメソッドに集約

## 動作確認（操作内容、画面キャプチャなど）
※マイグレーションファイルに関して
`rails db:migtate:redo` 動作確認済

■ バリデーションエラー発生時
<img width="620" alt="スクリーンショット 2022-05-12 14 09 26" src="https://user-images.githubusercontent.com/103913705/167996358-3a4327f7-ec6a-4ed5-9f1c-d39a74da1579.png">