### PR TITLE
ステップ12: 終了期限を追加しよう

### DIFF
--- a/myapp/.rubocop_todo.yml
+++ b/myapp/.rubocop_todo.yml
@@ -89,6 +89,10 @@ Layout/TrailingWhitespace:
 Metrics/AbcSize:
   Max: 18
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
@@ -125,6 +129,7 @@ Style/Documentation:
     - 'app/models/application_record.rb'
     - 'config/application.rb'
     - 'db/migrate/20220427005438_create_tasks.rb'
+  Enabled: false
 
 # Offense count: 3
 # This cop supports safe auto-correction (--auto-correct).

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: %i[show edit update destroy]
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
     @tasks = Task.all_sort_by(:created_at, :desc)
@@ -14,9 +14,7 @@ class TasksController < ApplicationController
     render :index
   end
 
-  def show
-    
-  end
+  def show; end
 
   def new
     @task = Task.new()
@@ -29,29 +27,26 @@ class TasksController < ApplicationController
     @task.user_id = 0
 
     if @task.save
-      redirect_to @task, notice: t("tasks.flash.new")
+      redirect_to @task, notice: t('tasks.flash.new')
     else
       render :new
     end
   end
 
-  def edit
-
-  end
+  def edit; end
 
   def update
     if @task.update(task_params)
-      redirect_to @task, notice: t("tasks.flash.update")
+      redirect_to @task, notice: t('tasks.flash.update')
     else
       render :edit
     end
   end
 
   def destroy
-
     return unless @task.destroy
     
-    redirect_to tasks_path, notice: t("tasks.flash.destroy")
+    redirect_to tasks_path, notice: t('tasks.flash.destroy')
   end
 
   private

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,16 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all.order('created_at DESC')
+    @tasks = Task.all_sort_by(:created_at, :desc)
+  end
+
+  def sort
+    if params[:termination_at_latest]
+      @tasks = Task.all_sort_by(:termination_at, :desc)
+    elsif params[:termination_at_oldest]
+      @tasks = Task.all_sort_by(:termination_at, :asc)
+    end
+    render :index
   end
 
   def show

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,55 +1,57 @@
 class Task < ApplicationRecord
-    validates :title, presence: true, length: { maximum: 50 }
-    validates :description, presence: true, length: { maximum: 255 }
-    validates :termination_at, presence: true
-    validate :termination_at_must_be_future
-    validate :validate_priority
-    validate :validate_status
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :description, presence: true, length: { maximum: 255 }
+  validates :termination_at, presence: true
+  validate :termination_at_must_be_future
+  validate :validate_priority
+  validate :validate_status
 
-    PRIORITY_LOW = 0
-    PRIORITY_MIDDLE = 1
-    PRIORITY_HIGH = 2
+  PRIORITY_LOW = 0
+  PRIORITY_MIDDLE = 1
+  PRIORITY_HIGH = 2
 
-    STATUS_NOT_STARTED = 0
-    STATUS_ON_PROGRESS = 1
-    STATUS_DONE = 2
+  STATUS_NOT_STARTED = 0
+  STATUS_ON_PROGRESS = 1
+  STATUS_DONE = 2
 
-    scope :all_sort_by, -> (target, sort_type){ order({"#{target}": sort_type})}
-    
-    enum priority: { low: PRIORITY_LOW, middle: PRIORITY_MIDDLE, high: PRIORITY_HIGH }
-    enum status: { not_started: STATUS_NOT_STARTED, on_progress: STATUS_ON_PROGRESS, done: STATUS_DONE }
+  scope :all_sort_by, ->(target, sort_type) { order({ "#{target}": sort_type }) }
 
-    def priority=(value)
-        super value
-        @priority_backup = nil
-    rescue ArgumentError => _
-        @priority_backup = value
-        self[:priority] = nil
-    end
+  enum priority: { low: PRIORITY_LOW, middle: PRIORITY_MIDDLE, high: PRIORITY_HIGH }
+  enum status: { not_started: STATUS_NOT_STARTED, on_progress: STATUS_ON_PROGRESS, done: STATUS_DONE }
 
-    def status=(value)
-        super value
-        @status_backup = nil
-    rescue ArgumentError => _
-        @status_backup = value
-        self[:status] = nil
-    end
+  def priority=(value)
+    super value
+    @priority_backup = nil
+  rescue ArgumentError => _e
+    @priority_backup = value
+    self[:priority] = nil
+  end
 
-    private
-    
-    def termination_at_must_be_future
-        return if termination_at.blank? || termination_at > Time.now
-        
-        errors.add(:termination_at, :termination_at_must_be_future)
-    end
+  def status=(value)
+    super value
+    @status_backup = nil
+  rescue ArgumentError => _e
+    @status_backup = value
+    self[:status] = nil
+  end
 
-    def validate_priority
-        return errors.add(:priority, :invalid_value) if @priority_backup.present?
-        errors.add(:priority, :blank) if priority.blank?
-    end
+  private
 
-    def validate_status
-        return errors.add(:status, :invalid_value) if @status_backup.present?
-        errors.add(:status, :blank) if status.blank?
-    end
+  def termination_at_must_be_future
+    return if termination_at.blank? || termination_at > Time.now
+
+    errors.add(:termination_at, :termination_at_must_be_future)
+  end
+
+  def validate_priority
+    return errors.add(:priority, :invalid_value) if @priority_backup.present?
+
+    errors.add(:priority, :blank) if priority.blank?
+  end
+
+  def validate_status
+    return errors.add(:status, :invalid_value) if @status_backup.present?
+
+    errors.add(:status, :blank) if status.blank?
+  end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -14,6 +14,8 @@ class Task < ApplicationRecord
     STATUS_ON_PROGRESS = 1
     STATUS_DONE = 2
 
+    scope :all_sort_by, -> (target, sort_type){ order({"#{target}": sort_type})}
+    
     enum priority: { low: PRIORITY_LOW, middle: PRIORITY_MIDDLE, high: PRIORITY_HIGH }
     enum status: { not_started: STATUS_NOT_STARTED, on_progress: STATUS_ON_PROGRESS, done: STATUS_DONE }
 

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,8 +2,12 @@
 
 <h1><%= t "tasks.index.page_title" %></h1>
 <td><%= link_to t('tasks.index.new_link'), new_task_path %></td>
-<td><li><%= link_to t('tasks.index.sort_termination_at_latest'), sort_tasks_path(termination_at_latest: 'true'), class:'link-info' %></li></td>
-<td><li><%= link_to t('tasks.index.sort_termination_at_oldest'), sort_tasks_path(termination_at_oldest: 'true'),class:'link-info' %></li></td>
+<td>
+  <li><%= link_to t('tasks.index.sort_termination_at_latest'), sort_tasks_path(termination_at_latest: 'true'), class: 'link-info' %></li>
+</td>
+<td>
+  <li><%= link_to t('tasks.index.sort_termination_at_oldest'), sort_tasks_path(termination_at_oldest: 'true'), class: 'link-info' %></li>
+</td>
 <table>
   <thead>
     <tr>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,6 +2,8 @@
 
 <h1><%= t "tasks.index.page_title" %></h1>
 <td><%= link_to t('tasks.index.new_link'), new_task_path %></td>
+<td><li><%= link_to t('tasks.index.sort_termination_at_latest'), sort_tasks_path(termination_at_latest: 'true'), class:'link-info' %></li></td>
+<td><li><%= link_to t('tasks.index.sort_termination_at_oldest'), sort_tasks_path(termination_at_oldest: 'true'),class:'link-info' %></li></td>
 <table>
   <thead>
     <tr>

--- a/myapp/config/locales/views/tasks/ja.yml
+++ b/myapp/config/locales/views/tasks/ja.yml
@@ -13,6 +13,8 @@ ja:
       show_link : '詳細'
       edit_link : '編集'
       delete_link : '削除'
+      sort_termination_at_latest: '終了期日(新しい順)'
+      sort_termination_at_oldest: '終了期日(古い順)'
     show:
       page_title: '「%{task_title}」のタスク情報詳細'
     edit:

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
-  resources :tasks, path: '/'
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :tasks, path: '/' do
+    collection do
+      get :sort
+    end
+  end
 end

--- a/myapp/db/migrate/20220506044625_change_column_default_to_tasks.rb
+++ b/myapp/db/migrate/20220506044625_change_column_default_to_tasks.rb
@@ -1,6 +1,6 @@
 class ChangeColumnDefaultToTasks < ActiveRecord::Migration[6.0]
   def change
-    change_column_default :tasks, :priority, from: nil, to: "0"
-    change_column_default :tasks, :status, from: nil, to: "0"
+    change_column_default :tasks, :priority, from: nil, to: '0'
+    change_column_default :tasks, :status, from: nil, to: '0'
   end
 end

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
 
+    NUMBER_OF_MULTIPLE_DATA = 5
+    
     shared_examples_for "レスポンス(HTTPステータスコード)が正しいこと" do |status|
         it { subject.call; expect(response).to have_http_status(status) }
     end
@@ -13,30 +15,55 @@ RSpec.describe TasksController, type: :controller do
         }
     end
 
-    describe "GET #index" do
-        subject {Proc.new { get :index }}
-        let!(:tasks) { create_list(:task, listnum) }
-        let(:listnum) { 5 }
-        it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
-
-        it "タスクが作成日時(降順)で並び替えられた状態で全件取得できていること" do
+    shared_examples_for "並び替えが正常に実行されていること" do |column, equals|
+        it{
             addDays = 0
             for task in tasks do
-                task.update(created_at: Date.today + addDays)
+                task.update({"#{column}": Date.today + addDays})
                 addDays += 1
             end
             
             subject.call
             displayed_tasks = controller.instance_variable_get('@tasks')
-            
-            expect(displayed_tasks.size).to be == listnum
+            expect(displayed_tasks.size).to be == NUMBER_OF_MULTIPLE_DATA
+
             before_task = nil
             for task in displayed_tasks do
                 if before_task then
-                    expect(task.created_at).to be <= before_task.created_at
+                    case equals
+                    when :asc then
+                        expect(task.send("#{column}")).to be >= before_task.send("#{column}")
+                    when :desc then
+                        expect(task.send("#{column}")).to be <= before_task.send("#{column}")
+                    end
                 end
                 before_task = task
             end
+        }
+    end
+
+    describe "GET #index" do
+        subject {Proc.new { get :index }}
+        let!(:tasks) { create_list(:task, listnum) }
+        let(:listnum) { NUMBER_OF_MULTIPLE_DATA }
+        it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
+        it_behaves_like "並び替えが正常に実行されていること", :created_at, :desc
+    end
+
+    describe "GET #sort" do
+        subject {Proc.new { get :sort, params: param }}
+        let!(:tasks) { create_list(:task, listnum) }
+        let(:listnum) { NUMBER_OF_MULTIPLE_DATA }
+
+        context "終了期日(新しい順)が選択された場合" do
+            let(:param){ {termination_at_latest: true} }
+            it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
+            it_behaves_like "並び替えが正常に実行されていること", :termination_at, :desc
+        end
+        context "終了期日(古い順)が選択された場合" do
+            let(:param){ {termination_at_oldest: true} }
+            it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
+            it_behaves_like "並び替えが正常に実行されていること", :termination_at, :asc
         end
     end
 

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -1,202 +1,203 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
+  number_of_multiple_data = 5
 
-    NUMBER_OF_MULTIPLE_DATA = 5
-    
-    shared_examples_for "レスポンス(HTTPステータスコード)が正しいこと" do |status|
-        it { subject.call; expect(response).to have_http_status(status) }
+  shared_examples_for 'レスポンス(HTTPステータスコード)が正しいこと' do |status|
+    it {
+      subject.call
+      expect(response).to have_http_status(status)
+    }
+  end
+
+  shared_examples_for '想定エラーが発生すること' do |error|
+    it {
+      expect { subject.call }.to raise_error(error)
+      expect(response.response_code).to eq(200)
+    }
+  end
+
+  shared_examples_for '並び替えが正常に実行されていること' do |column, equals|
+    it {
+      add_days = 0
+      tasks.each do |task|
+        task.update({ "#{column}": Date.today + add_days })
+        add_days += 1
+      end
+
+      subject.call
+      displayed_tasks = controller.instance_variable_get('@tasks')
+      expect(displayed_tasks.size).to be == number_of_multiple_data
+
+      before_task = nil
+      displayed_tasks.each do |task|
+        if before_task
+          case equals
+          when :asc
+            expect(task.send(column.to_s)).to be >= before_task.send(column.to_s)
+          when :desc
+            expect(task.send(column.to_s)).to be <= before_task.send(column.to_s)
+          end
+        end
+        before_task = task
+      end
+    }
+  end
+
+  describe 'GET #index' do
+    subject { proc { get :index } }
+    let!(:tasks) { create_list(:task, listnum) }
+    let(:listnum) { number_of_multiple_data }
+    it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+    it_behaves_like '並び替えが正常に実行されていること', :created_at, :desc
+  end
+
+  describe 'GET #sort' do
+    subject { proc { get :sort, params: param } }
+    let!(:tasks) { create_list(:task, listnum) }
+    let(:listnum) { number_of_multiple_data }
+
+    context '終了期日(新しい順)が選択された場合' do
+      let(:param) { { termination_at_latest: true } }
+      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+      it_behaves_like '並び替えが正常に実行されていること', :termination_at, :desc
     end
-
-    shared_examples_for "想定エラーが発生すること" do |error|
-        it { 
-            expect { subject.call }.to raise_error(error)
-            expect(response.response_code).to eq(200)
-        }
+    context '終了期日(古い順)が選択された場合' do
+      let(:param) { { termination_at_oldest: true } }
+      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+      it_behaves_like '並び替えが正常に実行されていること', :termination_at, :asc
     end
+  end
 
-    shared_examples_for "並び替えが正常に実行されていること" do |column, equals|
-        it{
-            addDays = 0
-            for task in tasks do
-                task.update({"#{column}": Date.today + addDays})
-                addDays += 1
-            end
-            
-            subject.call
-            displayed_tasks = controller.instance_variable_get('@tasks')
-            expect(displayed_tasks.size).to be == NUMBER_OF_MULTIPLE_DATA
+  describe 'GET #new' do
+    subject { proc { get :new } }
+    it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+  end
 
-            before_task = nil
-            for task in displayed_tasks do
-                if before_task then
-                    case equals
-                    when :asc then
-                        expect(task.send("#{column}")).to be >= before_task.send("#{column}")
-                    when :desc then
-                        expect(task.send("#{column}")).to be <= before_task.send("#{column}")
-                    end
-                end
-                before_task = task
-            end
-        }
+  describe 'GET #show' do
+    subject { proc { get :show, params: { id: id } } }
+    let!(:task) { create(:task) }
+    context '該当するタスクが存在する場合' do
+      context '有効なパラメータの場合' do
+        let(:id) { task.id }
+        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+      end
+      context '無効なパラメータの場合' do
+        let(:id) { nil }
+        it_behaves_like '想定エラーが発生すること', ActionController::UrlGenerationError
+      end
     end
-
-    describe "GET #index" do
-        subject {Proc.new { get :index }}
-        let!(:tasks) { create_list(:task, listnum) }
-        let(:listnum) { NUMBER_OF_MULTIPLE_DATA }
-        it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
-        it_behaves_like "並び替えが正常に実行されていること", :created_at, :desc
+    context '該当するタスクが存在しない場合' do
+      let(:id) { Task.last.id + 1 }
+      it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
     end
+  end
 
-    describe "GET #sort" do
-        subject {Proc.new { get :sort, params: param }}
-        let!(:tasks) { create_list(:task, listnum) }
-        let(:listnum) { NUMBER_OF_MULTIPLE_DATA }
-
-        context "終了期日(新しい順)が選択された場合" do
-            let(:param){ {termination_at_latest: true} }
-            it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
-            it_behaves_like "並び替えが正常に実行されていること", :termination_at, :desc
-        end
-        context "終了期日(古い順)が選択された場合" do
-            let(:param){ {termination_at_oldest: true} }
-            it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
-            it_behaves_like "並び替えが正常に実行されていること", :termination_at, :asc
-        end
+  describe 'GET #edit' do
+    subject { proc { get :edit, params: { id: id } } }
+    let!(:task) { create(:task) }
+    context '該当するタスクが存在する場合' do
+      context '有効なパラメータの場合' do
+        let(:id) { task.id }
+        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+      end
+      context '無効なパラメータの場合' do
+        let(:id) { nil }
+        it_behaves_like '想定エラーが発生すること', ActionController::UrlGenerationError
+      end
     end
-
-    describe "GET #new" do
-        subject {Proc.new { get :new }}
-        it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
+    context '該当するタスクが存在しない場合' do
+      let(:id) { Task.last.id + 1 }
+      it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
     end
+  end
 
-    describe "GET #show" do
-        subject {Proc.new { get :show, params: { id: id } }}
-        let!(:task) { create(:task) }
-        context "該当するタスクが存在する場合" do
-            context "有効なパラメータの場合" do
-                let(:id) { task.id }
-                it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
-            end
-            context "無効なパラメータの場合" do
-                let(:id) { nil }
-                it_behaves_like "想定エラーが発生すること", ActionController::UrlGenerationError
-            end
-        end
-        context "該当するタスクが存在しない場合" do
-            let(:id) { Task.last.id + 1 }
-            it_behaves_like "想定エラーが発生すること", ActiveRecord::RecordNotFound
-        end
+  describe 'POST #create' do
+    subject { proc { post :create, params: { task: task } } }
+    context '有効なパラメータの場合' do
+      let(:task) { attributes_for(:task, title: 'test_title_create') }
+
+      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 302
+
+      it 'タスクが作成されること' do
+        expect { subject.call }.to change(Task, :count).by(1)
+        expect(Task.find(Task.last.id).title).to eq('test_title_create')
+      end
+
+      it '作成したタスク詳細画面へリダイレクトされ、フラッシュメッセージが表示されること' do
+        subject.call
+        expect(response).to redirect_to "/#{Task.last.id}"
+        expect(flash[:notice]).to match(/^タスクを作成しました！$/)
+      end
     end
-
-    describe "GET #edit" do
-        subject {Proc.new { get :edit, params: { id: id } }}
-        let!(:task) { create(:task) }
-        context "該当するタスクが存在する場合" do
-            context "有効なパラメータの場合" do
-                let(:id) { task.id }
-                it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
-            end
-            context "無効なパラメータの場合" do
-                let(:id) { nil }
-                it_behaves_like "想定エラーが発生すること", ActionController::UrlGenerationError
-            end
-        end
-        context "該当するタスクが存在しない場合" do
-            let(:id) { Task.last.id + 1 }
-            it_behaves_like "想定エラーが発生すること", ActiveRecord::RecordNotFound
-        end
+    context '無効なパラメータの場合' do
+      let(:task) { attributes_for(:task, title: nil) }
+      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+      it 'タスクが作成されないこと' do
+        expect { subject.call }.to change(Task, :count).by(0)
+      end
     end
+  end
 
-    describe "POST #create" do
-        subject {Proc.new { post :create, params: { task: task } }}
-        context "有効なパラメータの場合" do
-            let(:task){attributes_for(:task, title: "test_title_create")}
+  describe 'PATCH #update' do
+    subject { proc { patch :update, params: { id: id, task: { title: value } } } }
+    let!(:task) { create(:task) }
+    context '該当するタスクが存在する場合' do
+      let(:id) { task.id }
 
-            it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと",302
+      context '有効なパラメータの場合' do
+        let(:value) { 'updated_task' }
+        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 302
 
-            it "タスクが作成されること" do
-                expect { subject.call }.to change(Task, :count).by(1)
-                expect(Task.find(Task.last.id).title).to eq("test_title_create")
-            end
-
-            it "作成したタスク詳細画面へリダイレクトされ、フラッシュメッセージが表示されること" do
-                subject.call
-                expect(response).to redirect_to "/#{Task.last.id}"
-                expect(flash[:notice]).to match(/^タスクを作成しました！$/)
-            end
+        it 'タスク情報が更新されること' do
+          subject.call
+          expect(task.reload.title).to eq 'updated_task'
         end
-        context "無効なパラメータの場合" do
-            let(:task){attributes_for(:task, title: nil)}
-            it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
-            it "タスクが作成されないこと" do
-                expect { subject.call }.to change(Task, :count).by(0)
-            end
+
+        it '更新したタスク詳細画面へリダイレクトされ、フラッシュメッセージが表示されること' do
+          subject.call
+          expect(response).to redirect_to "/#{task.id}"
+          expect(flash[:notice]).to match(/^タスクを更新しました！$/)
         end
+      end
+      context '無効なパラメータの場合' do
+        let(:value) { nil }
+        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+
+        it 'タスク情報が更新されないこと' do
+          subject.call
+          expect(task.reload.title).not_to eq nil
+        end
+      end
     end
-
-    describe "PATCH #update" do
-        subject {Proc.new { patch :update, params: {id: id, task: {title: value}} }}
-        let!(:task) { create(:task) }
-        context "該当するタスクが存在する場合" do
-            let(:id) { task.id }
-
-            context "有効なパラメータの場合" do
-                let(:value) { "updated_task" }
-                it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと",302
-                
-                it "タスク情報が更新されること" do
-                    subject.call
-                    expect(task.reload.title).to eq "updated_task"
-                end
-
-                it "更新したタスク詳細画面へリダイレクトされ、フラッシュメッセージが表示されること" do
-                    subject.call
-                    expect(response).to redirect_to "/#{task.id}"
-                    expect(flash[:notice]).to match(/^タスクを更新しました！$/)
-                end
-            end
-            context "無効なパラメータの場合" do
-                let(:value){ nil }
-                it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 200
-                
-                it "タスク情報が更新されないこと" do
-                    subject.call
-                    expect(task.reload.title).not_to eq nil
-                end
-            end
-        end
-        context "該当するタスクが存在しない場合" do
-            let(:id) { Task.last.id + 1 }
-            let(:value) { "updated_task" }
-            it_behaves_like "想定エラーが発生すること", ActiveRecord::RecordNotFound
-        end
+    context '該当するタスクが存在しない場合' do
+      let(:id) { Task.last.id + 1 }
+      let(:value) { 'updated_task' }
+      it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
     end
+  end
 
-    describe "DELETE #destroy" do
-        subject {Proc.new { delete :destroy, params: {id: id} }}
-        let!(:task) { create(:task) }
-        context "該当するタスクが存在する場合" do
-            let(:id) { task.id }
-            it_behaves_like "レスポンス(HTTPステータスコード)が正しいこと", 302
-            
-            it "タスクが削除されること" do
-                expect { subject.call }.to change(Task, :count).by(-1)
-                expect { Task.find(task.id) }.to raise_error(ActiveRecord::RecordNotFound)
-            end
-            
-            it "タスク一覧画面へリダイレクトされ、フラッシュメッセージが表示されること" do
-                subject.call
-                expect(response).to redirect_to "/"
-                expect(flash[:notice]).to match(/^タスクを削除しました！$/)
-            end
-        end
-        context "該当するタスクが存在しない場合" do
-            let(:id) { Task.last.id + 1 }
-            it_behaves_like "想定エラーが発生すること", ActiveRecord::RecordNotFound
-        end
+  describe 'DELETE #destroy' do
+    subject { proc { delete :destroy, params: { id: id } } }
+    let!(:task) { create(:task) }
+    context '該当するタスクが存在する場合' do
+      let(:id) { task.id }
+      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 302
+
+      it 'タスクが削除されること' do
+        expect { subject.call }.to change(Task, :count).by(-1)
+        expect { Task.find(task.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'タスク一覧画面へリダイレクトされ、フラッシュメッセージが表示されること' do
+        subject.call
+        expect(response).to redirect_to '/'
+        expect(flash[:notice]).to match(/^タスクを削除しました！$/)
+      end
     end
-
+    context '該当するタスクが存在しない場合' do
+      let(:id) { Task.last.id + 1 }
+      it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
+    end
+  end
 end

--- a/myapp/spec/factories/task.rb
+++ b/myapp/spec/factories/task.rb
@@ -1,10 +1,10 @@
 FactoryGirl.define do
-    factory :task do
-        user_id 0
-        sequence(:title) { |n| "test_title_#{n}" }
-        sequence(:description) { |n| "test_description_#{n}" }
-        termination_at Date.today + 1
-        priority Task.priorities.key(0)
-        status Task.statuses.key(0)
-    end
+  factory :task do
+    user_id 0
+    sequence(:title) { |n| "test_title_#{n}" }
+    sequence(:description) { |n| "test_description_#{n}" }
+    termination_at Date.today + 1
+    priority Task.priorities.key(0)
+    status Task.statuses.key(0)
   end
+end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -14,6 +14,29 @@ RSpec.describe Task, type: :model do
         }
     end
 
+    shared_examples_for "指定された任意のカラムに基づく並び替え順でデータが取得できていること" do |column, equals|
+        it{
+            addDays = 0
+            for task in tasks do
+                task.update({"#{column}": Date.today + addDays})
+                addDays += 1
+            end
+
+            before_task = nil
+            for task in subject.call do
+                if before_task then
+                    case equals
+                    when :asc then
+                        expect(task.send("#{column}")).to be >= before_task.send("#{column}")
+                    when :desc then
+                        expect(task.send("#{column}")).to be <= before_task.send("#{column}")
+                    end
+                end
+                before_task = task
+            end
+        }
+    end
+
     describe 'title' do
         let(:task) { build(:task, title: title) }
 
@@ -196,6 +219,26 @@ RSpec.describe Task, type: :model do
             context 'ステータスがnilの場合' do
                 let(:status) { nil }
                 it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_NO_VALUE
+            end
+        end
+    end
+
+    describe 'scope' do
+        let!(:tasks) { create_list(:task, listnum) }
+        let(:listnum) { 5 }
+
+        describe 'all_sort_by' do
+            subject { Proc.new{Task.all_sort_by(column, order)} }
+            context "終了期日が指定された場合" do
+                let(:column){:termination_at}
+                context '昇順が指定された場合' do
+                    let(:order){:asc}
+                    it_behaves_like "指定された任意のカラムに基づく並び替え順でデータが取得できていること", :termination_at, :asc
+                end
+                context '降順が指定された場合' do
+                    let(:order){:desc}
+                    it_behaves_like "指定された任意のカラムに基づく並び替え順でデータが取得できていること", :termination_at, :desc
+                end
             end
         end
     end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,245 +1,244 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
+  msg_no_value = 'を入力してください'.freeze
+  msg_invalid_value = 'に不正な値が入力されています'.freeze
+  title_max_length = 50
+  description_max_length = 255
 
-    MSG_NO_VALUE = 'を入力してください'
-    MSG_INVALID_VALUE = 'に不正な値が入力されています'
-    TITLE_MAX_LENGHT = 50
-    DESCRIPTION_MAX_LENGHT = 255
+  shared_examples_for 'バリデーションエラーとなり、想定するメッセージが表示されること' do |column, message|
+    it {
+      expect(task.valid?).to eq false
+      task.valid?
+      expect(task.errors.messages[column]).to include message
+    }
+  end
 
-    shared_examples_for 'バリデーションエラーとなり、想定するメッセージが表示されること' do | column, message|
-        it { expect(task.valid?).to eq false
-            task.valid?
-            expect(task.errors.messages[column]).to include message
-        }
+  shared_examples_for '指定された任意のカラムに基づく並び替え順でデータが取得できていること' do |column, equals|
+    it {
+      add_days = 0
+      tasks.each do |task|
+        task.update({ "#{column}": Date.today + add_days })
+        add_days += 1
+      end
+
+      before_task = nil
+      subject.call.each do |task|
+        if before_task
+          case equals
+          when :asc
+            expect(task.send(column.to_s)).to be >= before_task.send(column.to_s)
+          when :desc
+            expect(task.send(column.to_s)).to be <= before_task.send(column.to_s)
+          end
+        end
+        before_task = task
+      end
+    }
+  end
+
+  describe 'title' do
+    let(:task) { build(:task, title: title) }
+
+    context 'タイトルに正常な値が入力されている場合' do
+      let(:title) { 'あ' * num }
+
+      context "タイトルが#{title_max_length}文字の場合" do
+        let(:num) { title_max_length }
+
+        it 'バリデーションエラーにならないこと' do
+          expect(task.valid?).to eq true
+        end
+      end
+      context "タイトルが#{title_max_length + 1}文字以上の場合" do
+        let(:num) { title_max_length + 1 }
+
+        it 'バリデーションエラーになること' do
+          expect(task.valid?).to eq false
+        end
+        it 'エラーメッセージが表示されること' do
+          task.valid?
+          expect(task.errors.messages[:title]).to include "は#{title_max_length}文字以内で入力してください"
+        end
+      end
     end
-
-    shared_examples_for "指定された任意のカラムに基づく並び替え順でデータが取得できていること" do |column, equals|
-        it{
-            addDays = 0
-            for task in tasks do
-                task.update({"#{column}": Date.today + addDays})
-                addDays += 1
-            end
-
-            before_task = nil
-            for task in subject.call do
-                if before_task then
-                    case equals
-                    when :asc then
-                        expect(task.send("#{column}")).to be >= before_task.send("#{column}")
-                    when :desc then
-                        expect(task.send("#{column}")).to be <= before_task.send("#{column}")
-                    end
-                end
-                before_task = task
-            end
-        }
+    context 'タイトルに正常な値が入力されていない場合' do
+      context 'タイトルが空の場合' do
+        let(:title) { '' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
+      end
+      context 'タイトルが空白の場合' do
+        let(:title) { ' ' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
+      end
+      context 'タイトルがnilの場合' do
+        let(:title) { nil }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
+      end
     end
+  end
 
-    describe 'title' do
-        let(:task) { build(:task, title: title) }
+  describe 'description' do
+    let(:task) { build(:task, description: description) }
 
-        context 'タイトルに正常な値が入力されている場合' do
-            let(:title) { 'あ' * num }
+    context '説明に正常な値が入力されている場合' do
+      let(:description) { 'あ' * num }
 
-            context "タイトルが#{ TITLE_MAX_LENGHT }文字の場合" do
-                let(:num) { TITLE_MAX_LENGHT }
+      context "説明が#{description_max_length}文字の場合" do
+        let(:num) { description_max_length }
 
-                it 'バリデーションエラーにならないこと' do
-                    expect(task.valid?).to eq true
-                end
-            end
-            context "タイトルが#{ TITLE_MAX_LENGHT+1 }文字以上の場合" do
-                let(:num) { TITLE_MAX_LENGHT+1 }
-
-                it 'バリデーションエラーになること' do
-                    expect(task.valid?).to eq false
-                end
-                it 'エラーメッセージが表示されること' do
-                    task.valid?
-                    expect(task.errors.messages[:title]).to include "は#{ TITLE_MAX_LENGHT }文字以内で入力してください"
-                end
-            end
+        it 'バリデーションエラーにならないこと' do
+          expect(task.valid?).to eq true
         end
-        context 'タイトルに正常な値が入力されていない場合' do
-            context 'タイトルが空の場合' do
-                let(:title) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_NO_VALUE
-            end
-            context 'タイトルが空白の場合' do
-                let(:title) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_NO_VALUE
-            end
-            context 'タイトルがnilの場合' do
-                let(:title) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:title, MSG_NO_VALUE
-            end
+      end
+      context "説明が#{description_max_length + 1}文字以上の場合" do
+        let(:num) { description_max_length + 1 }
+
+        it 'バリデーションエラーになること' do
+          expect(task.valid?).to eq false
         end
+        it 'エラーメッセージが表示されること' do
+          task.valid?
+          expect(task.errors.messages[:description]).to include "は#{description_max_length}文字以内で入力してください"
+        end
+      end
     end
-  
-    describe 'description' do
-        let(:task) { build(:task, description: description) }
-
-        context '説明に正常な値が入力されている場合' do
-            let(:description) { 'あ' * num }
-
-            context "説明が#{ DESCRIPTION_MAX_LENGHT }文字の場合" do    
-                let(:num) { DESCRIPTION_MAX_LENGHT }
-
-                it 'バリデーションエラーにならないこと' do
-                    expect(task.valid?).to eq true
-                end
-            end
-            context "説明が#{ DESCRIPTION_MAX_LENGHT+1 }文字以上の場合" do
-                let(:num) { DESCRIPTION_MAX_LENGHT+1 }
-        
-                it 'バリデーションエラーになること' do
-                    expect(task.valid?).to eq false
-                end
-                it 'エラーメッセージが表示されること' do
-                    task.valid?
-                    expect(task.errors.messages[:description]).to include "は#{ DESCRIPTION_MAX_LENGHT }文字以内で入力してください"
-                end
-            end
-        end
-        context '説明に正常な値が入力されていない場合' do
-            context '説明が空の場合' do
-                let(:description) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_NO_VALUE
-            end
-            context '説明が空白の場合' do
-                let(:description) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_NO_VALUE
-            end
-            context '説明がnilの場合' do
-                let(:description) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:description, MSG_NO_VALUE
-            end
-        end
+    context '説明に正常な値が入力されていない場合' do
+      context '説明が空の場合' do
+        let(:description) { '' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
+      end
+      context '説明が空白の場合' do
+        let(:description) { ' ' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
+      end
+      context '説明がnilの場合' do
+        let(:description) { nil }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
+      end
     end
-  
-    describe 'termination_at' do
-        let(:task) { build(:task, termination_at: termination_at) }
+  end
 
-        context '終了期日に正常な値が入力されている場合' do
-            context '終了期日が現在日時よりも後の日付である場合' do
-                let(:termination_at) { Time.now + 1 }
-                it 'バリデーションエラーにならないこと' do
-                    expect(task.valid?).to eq true
-                end
-            end
-            context '終了期日が現在日時以前の日付である場合' do
-                let(:termination_at) { Time.now }
+  describe 'termination_at' do
+    let(:task) { build(:task, termination_at: termination_at) }
 
-                it 'バリデーションエラーになること' do
-                    expect(task.valid?).to eq false
-                end
-                it 'エラーメッセージが表示されること' do
-                    task.valid?
-                    expect(task.errors.messages[:termination_at]).to include 'は現在時刻より後の日付を指定してください'
-                end
-            end
+    context '終了期日に正常な値が入力されている場合' do
+      context '終了期日が現在日時よりも後の日付である場合' do
+        let(:termination_at) { Time.now + 1 }
+        it 'バリデーションエラーにならないこと' do
+          expect(task.valid?).to eq true
         end
-        context "終了期日に正常な値が入力されていない場合" do
-            context '終了期日が空の場合' do
-                let(:termination_at) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_NO_VALUE
-            end
-            context '終了期日が空白の場合' do
-                let(:termination_at) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_NO_VALUE
-            end
-            context '終了期日がnilの場合' do
-                let(:termination_at) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:termination_at, MSG_NO_VALUE
-            end
+      end
+      context '終了期日が現在日時以前の日付である場合' do
+        let(:termination_at) { Time.now }
+
+        it 'バリデーションエラーになること' do
+          expect(task.valid?).to eq false
         end
+        it 'エラーメッセージが表示されること' do
+          task.valid?
+          expect(task.errors.messages[:termination_at]).to include 'は現在時刻より後の日付を指定してください'
+        end
+      end
     end
-
-    describe 'priority' do
-        let(:task) { build(:task, priority: priority) }
-
-        context '優先度に正常な値が入力されている場合' do
-            context 'Enumで定義されている値の場合' do
-                let(:priority) { Task.priorities.key(0) }
-
-                it 'バリデーションエラーにならないこと' do
-                    expect(task.valid?).to eq true
-                end
-            end
-            context 'Enumで定義されていない値の場合' do
-                let(:priority) { "unknown_priority" }
-                
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_INVALID_VALUE
-            end
-        end
-        context '優先度に正常な値が入力されていない場合' do
-            context '優先度が空の場合' do
-                let(:priority) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_NO_VALUE
-            end
-            context '優先度が空白の場合' do
-                let(:priority) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_NO_VALUE
-            end
-            context '優先度がnilの場合' do
-                let(:priority) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:priority, MSG_NO_VALUE
-            end
-        end
+    context '終了期日に正常な値が入力されていない場合' do
+      context '終了期日が空の場合' do
+        let(:termination_at) { '' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
+      end
+      context '終了期日が空白の場合' do
+        let(:termination_at) { ' ' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
+      end
+      context '終了期日がnilの場合' do
+        let(:termination_at) { nil }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
+      end
     end
+  end
 
-    describe 'status' do
-        let(:task) { build(:task, status: status) }
-        context 'ステータスに正常な値が入力されている場合' do
+  describe 'priority' do
+    let(:task) { build(:task, priority: priority) }
 
-            context 'Enumで定義されている値の場合' do
-                let(:status) { Task.statuses.key(0) }
+    context '優先度に正常な値が入力されている場合' do
+      context 'Enumで定義されている値の場合' do
+        let(:priority) { Task.priorities.key(0) }
 
-                it 'バリデーションエラーにならないこと' do
-                    expect(task.valid?).to eq true
-                end
-            end
-            context 'Enumで定義されていない値の場合' do
-                let(:status) { "unknown_status" }
-
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_INVALID_VALUE
-            end
+        it 'バリデーションエラーにならないこと' do
+          expect(task.valid?).to eq true
         end
-        context 'ステータスに正常な値が入力されていない場合' do
-            context 'ステータスが空の場合' do
-                let(:status) { '' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_NO_VALUE
-            end
-            context 'ステータスが空白の場合' do
-                let(:status) { ' ' }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_NO_VALUE
-            end
-            context 'ステータスがnilの場合' do
-                let(:status) { nil }
-                it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること',:status, MSG_NO_VALUE
-            end
-        end
+      end
+      context 'Enumで定義されていない値の場合' do
+        let(:priority) { 'unknown_priority' }
+
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_invalid_value
+      end
     end
-
-    describe 'scope' do
-        let!(:tasks) { create_list(:task, listnum) }
-        let(:listnum) { 5 }
-
-        describe 'all_sort_by' do
-            subject { Proc.new{Task.all_sort_by(column, order)} }
-            context "終了期日が指定された場合" do
-                let(:column){:termination_at}
-                context '昇順が指定された場合' do
-                    let(:order){:asc}
-                    it_behaves_like "指定された任意のカラムに基づく並び替え順でデータが取得できていること", :termination_at, :asc
-                end
-                context '降順が指定された場合' do
-                    let(:order){:desc}
-                    it_behaves_like "指定された任意のカラムに基づく並び替え順でデータが取得できていること", :termination_at, :desc
-                end
-            end
-        end
+    context '優先度に正常な値が入力されていない場合' do
+      context '優先度が空の場合' do
+        let(:priority) { '' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
+      end
+      context '優先度が空白の場合' do
+        let(:priority) { ' ' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
+      end
+      context '優先度がnilの場合' do
+        let(:priority) { nil }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
+      end
     end
+  end
+
+  describe 'status' do
+    let(:task) { build(:task, status: status) }
+    context 'ステータスに正常な値が入力されている場合' do
+      context 'Enumで定義されている値の場合' do
+        let(:status) { Task.statuses.key(0) }
+
+        it 'バリデーションエラーにならないこと' do
+          expect(task.valid?).to eq true
+        end
+      end
+      context 'Enumで定義されていない値の場合' do
+        let(:status) { 'unknown_status' }
+
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_invalid_value
+      end
+    end
+    context 'ステータスに正常な値が入力されていない場合' do
+      context 'ステータスが空の場合' do
+        let(:status) { '' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
+      end
+      context 'ステータスが空白の場合' do
+        let(:status) { ' ' }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
+      end
+      context 'ステータスがnilの場合' do
+        let(:status) { nil }
+        it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
+      end
+    end
+  end
+
+  describe 'scope' do
+    let!(:tasks) { create_list(:task, listnum) }
+    let(:listnum) { 5 }
+
+    describe 'all_sort_by' do
+      subject { proc { Task.all_sort_by(column, order) } }
+      context '終了期日が指定された場合' do
+        let(:column) { :termination_at }
+        context '昇順が指定された場合' do
+          let(:order) { :asc }
+          it_behaves_like '指定された任意のカラムに基づく並び替え順でデータが取得できていること', :termination_at, :asc
+        end
+        context '降順が指定された場合' do
+          let(:order) { :desc }
+          it_behaves_like '指定された任意のカラムに基づく並び替え順でデータが取得できていること', :termination_at, :desc
+        end
+      end
+    end
+  end
 end

--- a/myapp/spec/rails_helper.rb
+++ b/myapp/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/myapp/spec/spec_helper.rb
+++ b/myapp/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
## 要件（仕様書など）
終了期日を追加しよう
## 修正概要
画面上から終了期日でタスク一覧をソートできるようにする
## 実装内容
■ ソート機能(終了期日)の追加
■ rubocop対応

前ステップ時にrubocop実行を失念しており今回実施した為、今回修正対象であるファイル以外の解析・自動修正が行われております。
該当コミット：https://github.com/Fablic/training/pull/1294/commits/e2d06aa347f2457c77f6ea20049482d83a936df3

その為差分ファイルが多くなってしまっております、申し訳ありません。
上記を除く今回の修正内容としては以下となります。
該当コミット：https://github.com/Fablic/training/pull/1294/commits/884e26737bd4c40367e775c5ba6cee825bf07a7d

## 動作確認（操作内容、画面キャプチャなど）
※Rsepc実施済(全てOK)
※rubocop実施済

起動手順
```
bundle exec rake webpacker:compile
bundle exec rails s
```
■ [終了期日(新しい順)]押下時
<img width="805" alt="スクリーンショット 2022-05-13 9 36 41" src="https://user-images.githubusercontent.com/103913705/168188931-49503b2d-8785-4e46-b317-68e7e465c321.png">
■ [終了期日(古い順)]押下時
<img width="804" alt="スクリーンショット 2022-05-13 9 36 51" src="https://user-images.githubusercontent.com/103913705/168188944-e0c28d42-f639-4713-b22b-a656faddb59f.png">