### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -14,6 +14,12 @@ class TasksController < ApplicationController
     render :index
   end
 
+  def search
+    @search_params = input_search_params
+    @tasks = Task.search(@search_params)
+    render :index
+  end
+
   def show; end
 
   def new
@@ -57,5 +63,9 @@ class TasksController < ApplicationController
 
     def set_task
       @task = Task.find(params[:id])
+    end
+
+    def input_search_params
+      params.fetch(:search, {}).permit(:title, :status)
     end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -15,6 +15,14 @@ class Task < ApplicationRecord
   STATUS_DONE = 2
 
   scope :all_sort_by, ->(target, sort_type) { order({ "#{target}": sort_type }) }
+  scope :search, lambda { |search_params|
+    return if search_params.blank?
+
+    extract_matched_title(search_params[:title])
+      .extract_matched_status(search_params[:status])
+  }
+  scope :extract_matched_title, ->(title) { where('title LIKE ?', "%#{title}%") if title.present? }
+  scope :extract_matched_status, ->(status) { where(status: status) if status.present? }
 
   enum priority: { low: PRIORITY_LOW, middle: PRIORITY_MIDDLE, high: PRIORITY_HIGH }
   enum status: { not_started: STATUS_NOT_STARTED, on_progress: STATUS_ON_PROGRESS, done: STATUS_DONE }

--- a/myapp/app/views/tasks/_search.html.erb
+++ b/myapp/app/views/tasks/_search.html.erb
@@ -1,0 +1,16 @@
+<h3><%= t("tasks.search.page_title") %></h3>
+<% if @search_params.present? %>
+    <a><%= t("tasks.search.search_condition") %> : <%= @search_params[:title] %><%= Task.human_attribute_name("status.#{@search_params[:status]}") %></a>
+<% end %>
+<div class='search-input-box'>
+    <%= form_with(scope: :search, url: search_tasks_path, method: :get, local: true) do |f| %>
+        <div class='search-input-column-box'>
+            <%= f.label :title, t("tasks.title") %> : <%= f.text_field :title, placeholder:t("tasks.title") %>
+            <%= f.label :status, t("tasks.status") %> : <%= f.select :status, Task.statuses.keys.map { |k| [Task.human_attribute_name("status.#{k}"), k] }, include_blank: t('tasks.form.status_select') %>
+        </div>
+        <div class='search-input-search-button'>
+            <%= f.submit t("tasks.search.search"), class: 'btn btn-outline-primary' %>
+        </div>
+    <% end %>
+    <br />
+</div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,6 +2,7 @@
 
 <h1><%= t "tasks.index.page_title" %></h1>
 <td><%= link_to t('tasks.index.new_link'), new_task_path %></td>
+<td><%= render partial: "search", locals: {task: @task} %></td>
 <td><li><%= link_to t('tasks.index.sort_termination_at_latest'), sort_tasks_path(termination_at_latest: 'true'), class:'link-info' %></li></td>
 <td><li><%= link_to t('tasks.index.sort_termination_at_oldest'), sort_tasks_path(termination_at_oldest: 'true'),class:'link-info' %></li></td>
 <table>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,6 +2,7 @@
 
 <h1><%= t "tasks.index.page_title" %></h1>
 <td><%= link_to t('tasks.index.new_link'), new_task_path %></td>
+<td><%= render partial: "search", locals: {task: @task} %></td>
 <td>
   <li><%= link_to t('tasks.index.sort_termination_at_latest'), sort_tasks_path(termination_at_latest: 'true'), class: 'link-info' %></li>
 </td>

--- a/myapp/config/locales/views/tasks/ja.yml
+++ b/myapp/config/locales/views/tasks/ja.yml
@@ -26,6 +26,10 @@ ja:
       priority_select: '選択して下さい(優先度)'
       status_select: '選択して下さい(ステータス)'
       register: '登録'
+    search:
+      page_title: '検索機能'
+      search_condition: '検索条件'
+      search: '検索'
     flash:
       new: 'タスクを作成しました！'
       update: 'タスクを更新しました！'

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resources :tasks, path: '/' do
     collection do
       get :sort
+      get :search
     end
   end
 end

--- a/myapp/db/migrate/20220510051753_add_index_tasks_status.rb
+++ b/myapp/db/migrate/20220510051753_add_index_tasks_status.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksStatus < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_09_050810) do
+ActiveRecord::Schema.define(version: 2022_05_10_051753) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2022_05_09_050810) do
     t.integer "status", limit: 1, default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -30,9 +30,11 @@ RSpec.describe TasksController, type: :controller do
   describe 'GET #index' do
     context 'メイン画面にアクセスした場合' do
       subject { proc { get :index } }
+
       let!(:tasks) { create_list(:task, number_of_multiple_data) }
 
       it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+
       it '作成日時(新しい順)で並び替えられた全てのデータを取得していること' do
         subject.call
         displayed_tasks = controller.instance_variable_get('@tasks')
@@ -49,12 +51,14 @@ RSpec.describe TasksController, type: :controller do
 
   describe 'GET #sort' do
     subject { proc { get :sort, params: param } }
+
     let!(:tasks) { create_list(:task, number_of_multiple_data) }
 
     context '終了期日(新しい順)が選択された場合' do
       let(:param) { { termination_at_latest: true } }
 
       it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+
       it '終了期日(新しい順)で並び替えられた全てのデータを取得していること' do
         subject.call
         displayed_tasks = controller.instance_variable_get('@tasks')
@@ -72,6 +76,7 @@ RSpec.describe TasksController, type: :controller do
       let(:param) { { termination_at_oldest: true } }
 
       it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+
       it '終了期日(古い順)で並び替えられた全てのデータを取得していること' do
         subject.call
         displayed_tasks = controller.instance_variable_get('@tasks')
@@ -88,12 +93,9 @@ RSpec.describe TasksController, type: :controller do
 
   describe 'GET #search' do
     subject { proc { get :search, params: params } }
+
     let!(:tasks) { create_list(:task, number_of_multiple_data) }
-    let(:params) do
-      {
-        search: input_value
-      }
-    end
+    let(:params) { { search: input_value } }
 
     context '検索条件に値が入力されている場合' do
       let(:search_text) { 'test_title_for_search' }
@@ -110,6 +112,7 @@ RSpec.describe TasksController, type: :controller do
           end
 
           it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+
           it 'input_search_paramsによるバリデーション後の値を使用し、検索条件に一致するデータを1件取得していること' do
             subject.call
             search_params = controller.instance_variable_get('@search_params')
@@ -124,11 +127,7 @@ RSpec.describe TasksController, type: :controller do
         end
 
         context 'タイトルのみ入力されている場合' do
-          let(:input_value) do
-            {
-              title: search_text
-            }
-          end
+          let(:input_value) { { title: search_text } }
 
           it 'input_search_paramsによるバリデーション後の値を使用し、検索条件に一致するデータを1件取得していること' do
             subject.call
@@ -144,11 +143,8 @@ RSpec.describe TasksController, type: :controller do
         end
 
         context 'ステータスのみ入力されている場合' do
-          let(:input_value) do
-            {
-              status: Task.statuses[:done]
-            }
-          end
+          let(:input_value) { { status: Task.statuses[:done] } }
+
           it 'input_search_paramsによるバリデーション後の値を使用し、検索条件に一致するデータを1件取得していること' do
             subject.call
             search_params = controller.instance_variable_get('@search_params')
@@ -172,62 +168,74 @@ RSpec.describe TasksController, type: :controller do
         end
 
         it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+
         it_behaves_like 'input_search_paramsでのバリデーションにより値が無効化され、検索条件の指定なく全てのデータを取得していること'
       end
     end
 
     context '検索条件に値が入力されていない場合' do
       let(:input_value) { {} }
+
       it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+
       it_behaves_like 'input_search_paramsでのバリデーションにより値が無効化され、検索条件の指定なく全てのデータを取得していること'
     end
   end
 
   describe 'GET #new' do
     subject { proc { get :new } }
+
     it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
   end
 
   describe 'GET #show' do
     subject { proc { get :show, params: { id: id } } }
+
     let!(:task) { create(:task) }
 
     context '該当するタスクが存在する場合' do
       context '有効なパラメータの場合' do
         let(:id) { task.id }
+
         it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
       end
 
       context '無効なパラメータの場合' do
         let(:id) { nil }
+
         it_behaves_like '想定エラーが発生すること', ActionController::UrlGenerationError
       end
     end
 
     context '該当するタスクが存在しない場合' do
       let(:id) { Task.last.id + 1 }
+
       it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
     end
   end
 
   describe 'GET #edit' do
     subject { proc { get :edit, params: { id: id } } }
+
     let!(:task) { create(:task) }
 
     context '該当するタスクが存在する場合' do
       context '有効なパラメータの場合' do
         let(:id) { task.id }
+
         it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
       end
 
       context '無効なパラメータの場合' do
         let(:id) { nil }
+
         it_behaves_like '想定エラーが発生すること', ActionController::UrlGenerationError
       end
     end
 
     context '該当するタスクが存在しない場合' do
       let(:id) { Task.last.id + 1 }
+
       it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
     end
   end
@@ -254,7 +262,9 @@ RSpec.describe TasksController, type: :controller do
 
     context '無効なパラメータの場合' do
       let(:task) { attributes_for(:task, title: nil) }
+
       it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+
       it 'タスクが作成されないこと' do
         expect { subject.call }.to change(Task, :count).by(0)
       end
@@ -263,6 +273,7 @@ RSpec.describe TasksController, type: :controller do
 
   describe 'PATCH #update' do
     subject { proc { patch :update, params: { id: id, task: { title: value } } } }
+
     let!(:task) { create(:task) }
 
     context '該当するタスクが存在する場合' do
@@ -270,6 +281,7 @@ RSpec.describe TasksController, type: :controller do
 
       context '有効なパラメータの場合' do
         let(:value) { 'updated_task' }
+
         it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 302
 
         it 'タスク情報が更新されること' do
@@ -286,6 +298,7 @@ RSpec.describe TasksController, type: :controller do
 
       context '無効なパラメータの場合' do
         let(:value) { nil }
+
         it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
 
         it 'タスク情報が更新されないこと' do
@@ -298,16 +311,19 @@ RSpec.describe TasksController, type: :controller do
     context '該当するタスクが存在しない場合' do
       let(:id) { Task.last.id + 1 }
       let(:value) { 'updated_task' }
+
       it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
     end
   end
 
   describe 'DELETE #destroy' do
     subject { proc { delete :destroy, params: { id: id } } }
+
     let!(:task) { create(:task) }
 
     context '該当するタスクが存在する場合' do
       let(:id) { task.id }
+
       it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 302
 
       it 'タスクが削除されること' do
@@ -324,6 +340,7 @@ RSpec.describe TasksController, type: :controller do
 
     context '該当するタスクが存在しない場合' do
       let(:id) { Task.last.id + 1 }
+
       it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
     end
   end

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe TasksController, type: :controller do
   number_of_multiple_data = 5
 
-  shared_examples_for 'レスポンス(HTTPステータスコード)が正しいこと' do |status|
+  shared_examples_for 'レスポンス(HTTPステータスコード)が想定通りであること' do |status|
     it {
       subject.call
       expect(response).to have_http_status(status)
@@ -17,70 +17,72 @@ RSpec.describe TasksController, type: :controller do
     }
   end
 
-  shared_examples_for '並び替えが正常に実行されていること' do |column, equals|
+  shared_examples_for 'input_search_paramsでのバリデーションにより値が無効化され、検索条件の指定なく全てのデータを取得していること' do
     it {
-      add_days = 0
-      tasks.each do |task|
-        task.update({ "#{column}": Date.today + add_days })
-        add_days += 1
-      end
-
-      subject.call
-      displayed_tasks = controller.instance_variable_get('@tasks')
-      expect(displayed_tasks.size).to be == number_of_multiple_data
-
-      before_task = nil
-      displayed_tasks.each do |task|
-        if before_task
-          case equals
-          when :asc
-            expect(task.send(column.to_s)).to be >= before_task.send(column.to_s)
-          when :desc
-            expect(task.send(column.to_s)).to be <= before_task.send(column.to_s)
-          end
-        end
-        before_task = task
-      end
-    }
-  end
-
-  shared_examples_for '検索が正常に実行されていること' do |present, matched_num|
-    it {
-      Task.find(Task.last.id).update_columns(input_value) if present
-
       subject.call
       search_params = controller.instance_variable_get('@search_params')
-      expect(search_params.present?).to eq present
-      if present
-        expect(search_params[:title]).to eq input_value[:title]
-        expect(search_params[:status]).to eq input_value[:status].to_s
-      end
+      expect(search_params.present?).to eq false
       displayed_tasks = controller.instance_variable_get('@tasks')
-      expect(displayed_tasks.size).to be == matched_num
+      expect(displayed_tasks.size).to be == number_of_multiple_data
     }
   end
 
   describe 'GET #index' do
-    subject { proc { get :index } }
-    let!(:tasks) { create_list(:task, number_of_multiple_data) }
-    it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
-    it_behaves_like '並び替えが正常に実行されていること', :created_at, :desc
+    context 'メイン画面にアクセスした場合' do
+      subject { proc { get :index } }
+      let!(:tasks) { create_list(:task, number_of_multiple_data) }
+
+      it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+      it '作成日時(新しい順)で並び替えられた全てのデータを取得していること' do
+        subject.call
+        displayed_tasks = controller.instance_variable_get('@tasks')
+        expect(displayed_tasks.size).to be == number_of_multiple_data
+
+        before_task = nil
+        displayed_tasks.each do |task|
+          expect(task.send(:created_at)).to be <= before_task.send(:created_at) if before_task
+          before_task = task
+        end
+      end
+    end
   end
 
   describe 'GET #sort' do
     subject { proc { get :sort, params: param } }
-    let!(:tasks) { create_list(:task, listnum) }
-    let(:listnum) { number_of_multiple_data }
+    let!(:tasks) { create_list(:task, number_of_multiple_data) }
 
     context '終了期日(新しい順)が選択された場合' do
       let(:param) { { termination_at_latest: true } }
-      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
-      it_behaves_like '並び替えが正常に実行されていること', :termination_at, :desc
+
+      it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+      it '終了期日(新しい順)で並び替えられた全てのデータを取得していること' do
+        subject.call
+        displayed_tasks = controller.instance_variable_get('@tasks')
+        expect(displayed_tasks.size).to be == number_of_multiple_data
+
+        before_task = nil
+        displayed_tasks.each do |task|
+          expect(task.send(:termination_at)).to be <= before_task.send(:termination_at) if before_task
+          before_task = task
+        end
+      end
     end
+
     context '終了期日(古い順)が選択された場合' do
       let(:param) { { termination_at_oldest: true } }
-      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
-      it_behaves_like '並び替えが正常に実行されていること', :termination_at, :asc
+
+      it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+      it '終了期日(古い順)で並び替えられた全てのデータを取得していること' do
+        subject.call
+        displayed_tasks = controller.instance_variable_get('@tasks')
+        expect(displayed_tasks.size).to be == number_of_multiple_data
+
+        before_task = nil
+        displayed_tasks.each do |task|
+          expect(task.send(:termination_at)).to be >= before_task.send(:termination_at) if before_task
+          before_task = task
+        end
+      end
     end
   end
 
@@ -92,18 +94,75 @@ RSpec.describe TasksController, type: :controller do
         search: input_value
       }
     end
-    context '検索条件が入力されている場合' do
+
+    context '検索条件に値が入力されている場合' do
       let(:search_text) { 'test_title_for_search' }
+
       context '正しい値が入力されている場合' do
-        let(:input_value) do
-          {
-            title: search_text,
-            status: Task.statuses[:not_started]
-          }
+        let!(:for_seach_task) { create(:task, input_value) }
+
+        context 'タイトル、ステータスが入力されている場合' do
+          let(:input_value) do
+            {
+              title: search_text,
+              status: Task.statuses[:not_started]
+            }
+          end
+
+          it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+          it 'input_search_paramsによるバリデーション後の値を使用し、検索条件に一致するデータを1件取得していること' do
+            subject.call
+            search_params = controller.instance_variable_get('@search_params')
+            expect(search_params.present?).to eq true
+            expect(search_params[:title]).to eq input_value[:title]
+            expect(search_params[:status]).to eq input_value[:status].to_s
+            displayed_tasks = controller.instance_variable_get('@tasks')
+            expect(displayed_tasks.size).to be == 1
+            expect(displayed_tasks[0].title).to eq for_seach_task.title
+            expect(displayed_tasks[0].status).to eq for_seach_task.status
+          end
         end
-        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
-        it_behaves_like '検索が正常に実行されていること', true, 1
+
+        context 'タイトルのみ入力されている場合' do
+          let(:input_value) do
+            {
+              title: search_text
+            }
+          end
+
+          it 'input_search_paramsによるバリデーション後の値を使用し、検索条件に一致するデータを1件取得していること' do
+            subject.call
+            search_params = controller.instance_variable_get('@search_params')
+            expect(search_params.present?).to eq true
+            expect(search_params[:title]).to eq input_value[:title]
+            expect(search_params[:status]).to eq nil
+            displayed_tasks = controller.instance_variable_get('@tasks')
+            expect(displayed_tasks.size).to be == 1
+            expect(displayed_tasks[0].title).to eq for_seach_task.title
+            expect(displayed_tasks[0].status).to eq for_seach_task.status
+          end
+        end
+
+        context 'ステータスのみ入力されている場合' do
+          let(:input_value) do
+            {
+              status: Task.statuses[:done]
+            }
+          end
+          it 'input_search_paramsによるバリデーション後の値を使用し、検索条件に一致するデータを1件取得していること' do
+            subject.call
+            search_params = controller.instance_variable_get('@search_params')
+            expect(search_params.present?).to eq true
+            expect(search_params[:title]).to eq nil
+            expect(search_params[:status]).to eq input_value[:status].to_s
+            displayed_tasks = controller.instance_variable_get('@tasks')
+            expect(displayed_tasks.size).to be == 1
+            expect(displayed_tasks[0].title).to eq for_seach_task.title
+            expect(displayed_tasks[0].status).to eq for_seach_task.status
+          end
+        end
       end
+
       context '不正な値が入力されている場合' do
         let(:input_value) do
           {
@@ -111,35 +170,40 @@ RSpec.describe TasksController, type: :controller do
             unknown02: Task.statuses[:not_started]
           }
         end
-        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
-        it_behaves_like '検索が正常に実行されていること', false, number_of_multiple_data
+
+        it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+        it_behaves_like 'input_search_paramsでのバリデーションにより値が無効化され、検索条件の指定なく全てのデータを取得していること'
       end
     end
-    context '検索条件が入力されていない場合' do
+
+    context '検索条件に値が入力されていない場合' do
       let(:input_value) { {} }
-      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
-      it_behaves_like '検索が正常に実行されていること', false, number_of_multiple_data
+      it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
+      it_behaves_like 'input_search_paramsでのバリデーションにより値が無効化され、検索条件の指定なく全てのデータを取得していること'
     end
   end
 
   describe 'GET #new' do
     subject { proc { get :new } }
-    it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+    it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
   end
 
   describe 'GET #show' do
     subject { proc { get :show, params: { id: id } } }
     let!(:task) { create(:task) }
+
     context '該当するタスクが存在する場合' do
       context '有効なパラメータの場合' do
         let(:id) { task.id }
-        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+        it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
       end
+
       context '無効なパラメータの場合' do
         let(:id) { nil }
         it_behaves_like '想定エラーが発生すること', ActionController::UrlGenerationError
       end
     end
+
     context '該当するタスクが存在しない場合' do
       let(:id) { Task.last.id + 1 }
       it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
@@ -149,16 +213,19 @@ RSpec.describe TasksController, type: :controller do
   describe 'GET #edit' do
     subject { proc { get :edit, params: { id: id } } }
     let!(:task) { create(:task) }
+
     context '該当するタスクが存在する場合' do
       context '有効なパラメータの場合' do
         let(:id) { task.id }
-        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+        it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
       end
+
       context '無効なパラメータの場合' do
         let(:id) { nil }
         it_behaves_like '想定エラーが発生すること', ActionController::UrlGenerationError
       end
     end
+
     context '該当するタスクが存在しない場合' do
       let(:id) { Task.last.id + 1 }
       it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound
@@ -167,10 +234,11 @@ RSpec.describe TasksController, type: :controller do
 
   describe 'POST #create' do
     subject { proc { post :create, params: { task: task } } }
+
     context '有効なパラメータの場合' do
       let(:task) { attributes_for(:task, title: 'test_title_create') }
 
-      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 302
+      it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 302
 
       it 'タスクが作成されること' do
         expect { subject.call }.to change(Task, :count).by(1)
@@ -183,9 +251,10 @@ RSpec.describe TasksController, type: :controller do
         expect(flash[:notice]).to match(/^タスクを作成しました！$/)
       end
     end
+
     context '無効なパラメータの場合' do
       let(:task) { attributes_for(:task, title: nil) }
-      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+      it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
       it 'タスクが作成されないこと' do
         expect { subject.call }.to change(Task, :count).by(0)
       end
@@ -195,12 +264,13 @@ RSpec.describe TasksController, type: :controller do
   describe 'PATCH #update' do
     subject { proc { patch :update, params: { id: id, task: { title: value } } } }
     let!(:task) { create(:task) }
+
     context '該当するタスクが存在する場合' do
       let(:id) { task.id }
 
       context '有効なパラメータの場合' do
         let(:value) { 'updated_task' }
-        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 302
+        it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 302
 
         it 'タスク情報が更新されること' do
           subject.call
@@ -213,9 +283,10 @@ RSpec.describe TasksController, type: :controller do
           expect(flash[:notice]).to match(/^タスクを更新しました！$/)
         end
       end
+
       context '無効なパラメータの場合' do
         let(:value) { nil }
-        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+        it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 200
 
         it 'タスク情報が更新されないこと' do
           subject.call
@@ -223,6 +294,7 @@ RSpec.describe TasksController, type: :controller do
         end
       end
     end
+
     context '該当するタスクが存在しない場合' do
       let(:id) { Task.last.id + 1 }
       let(:value) { 'updated_task' }
@@ -233,9 +305,10 @@ RSpec.describe TasksController, type: :controller do
   describe 'DELETE #destroy' do
     subject { proc { delete :destroy, params: { id: id } } }
     let!(:task) { create(:task) }
+
     context '該当するタスクが存在する場合' do
       let(:id) { task.id }
-      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 302
+      it_behaves_like 'レスポンス(HTTPステータスコード)が想定通りであること', 302
 
       it 'タスクが削除されること' do
         expect { subject.call }.to change(Task, :count).by(-1)
@@ -248,6 +321,7 @@ RSpec.describe TasksController, type: :controller do
         expect(flash[:notice]).to match(/^タスクを削除しました！$/)
       end
     end
+
     context '該当するタスクが存在しない場合' do
       let(:id) { Task.last.id + 1 }
       it_behaves_like '想定エラーが発生すること', ActiveRecord::RecordNotFound

--- a/myapp/spec/controllers/tasks_controller_spec.rb
+++ b/myapp/spec/controllers/tasks_controller_spec.rb
@@ -44,10 +44,25 @@ RSpec.describe TasksController, type: :controller do
     }
   end
 
+  shared_examples_for '検索が正常に実行されていること' do |present, matched_num|
+    it {
+      Task.find(Task.last.id).update_columns(input_value) if present
+
+      subject.call
+      search_params = controller.instance_variable_get('@search_params')
+      expect(search_params.present?).to eq present
+      if present
+        expect(search_params[:title]).to eq input_value[:title]
+        expect(search_params[:status]).to eq input_value[:status].to_s
+      end
+      displayed_tasks = controller.instance_variable_get('@tasks')
+      expect(displayed_tasks.size).to be == matched_num
+    }
+  end
+
   describe 'GET #index' do
     subject { proc { get :index } }
-    let!(:tasks) { create_list(:task, listnum) }
-    let(:listnum) { number_of_multiple_data }
+    let!(:tasks) { create_list(:task, number_of_multiple_data) }
     it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
     it_behaves_like '並び替えが正常に実行されていること', :created_at, :desc
   end
@@ -66,6 +81,44 @@ RSpec.describe TasksController, type: :controller do
       let(:param) { { termination_at_oldest: true } }
       it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
       it_behaves_like '並び替えが正常に実行されていること', :termination_at, :asc
+    end
+  end
+
+  describe 'GET #search' do
+    subject { proc { get :search, params: params } }
+    let!(:tasks) { create_list(:task, number_of_multiple_data) }
+    let(:params) do
+      {
+        search: input_value
+      }
+    end
+    context '検索条件が入力されている場合' do
+      let(:search_text) { 'test_title_for_search' }
+      context '正しい値が入力されている場合' do
+        let(:input_value) do
+          {
+            title: search_text,
+            status: Task.statuses[:not_started]
+          }
+        end
+        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+        it_behaves_like '検索が正常に実行されていること', true, 1
+      end
+      context '不正な値が入力されている場合' do
+        let(:input_value) do
+          {
+            unknown01: search_text,
+            unknown02: Task.statuses[:not_started]
+          }
+        end
+        it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+        it_behaves_like '検索が正常に実行されていること', false, number_of_multiple_data
+      end
+    end
+    context '検索条件が入力されていない場合' do
+      let(:input_value) { {} }
+      it_behaves_like 'レスポンス(HTTPステータスコード)が正しいこと', 200
+      it_behaves_like '検索が正常に実行されていること', false, number_of_multiple_data
     end
   end
 

--- a/myapp/spec/factories/task.rb
+++ b/myapp/spec/factories/task.rb
@@ -3,8 +3,9 @@ FactoryGirl.define do
     user_id 0
     sequence(:title) { |n| "test_title_#{n}" }
     sequence(:description) { |n| "test_description_#{n}" }
-    termination_at Date.today + 1
+    sequence(:termination_at) { |n| Date.today + n }
     priority Task.priorities.key(0)
     status Task.statuses.key(0)
+    sequence(:created_at) { |n| Date.today + n }
   end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,64 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  msg_no_value = 'を入力してください'.freeze
-  msg_invalid_value = 'に不正な値が入力されています'.freeze
+  msg_no_value = I18n.t('errors.messages.blank').freeze
+  msg_invalid_value = I18n.t('activerecord.errors.models.task.invalid_value').freeze
+  msg_invalid_termination_at = I18n.t('activerecord.errors.models.task.termination_at_must_be_future').freeze
   title_max_length = 50
   description_max_length = 255
+  number_of_multiple_data = 5
+  search_base_text = 'test_title_for_search'.freeze
 
   shared_examples_for 'バリデーションエラーとなり、想定するメッセージが表示されること' do |column, message|
     it {
       expect(task.valid?).to eq false
       task.valid?
       expect(task.errors.messages[column]).to include message
-    }
-  end
-
-  shared_examples_for '指定された任意のカラムに基づく並び替え順でデータが取得できていること' do |column, equals|
-    it {
-      add_days = 0
-      tasks.each do |task|
-        task.update({ "#{column}": Date.today + add_days })
-        add_days += 1
-      end
-
-      before_task = nil
-      subject.call.each do |task|
-        if before_task
-          case equals
-          when :asc
-            expect(task.send(column.to_s)).to be >= before_task.send(column.to_s)
-          when :desc
-            expect(task.send(column.to_s)).to be <= before_task.send(column.to_s)
-          end
-        end
-        before_task = task
-      end
-    }
-  end
-
-  shared_examples_for '検索条件に一致するデータが取得できていること' do |count, search_type|
-    it {
-      num = 0
-      tasks.first(2).each do |task|
-        task.update_columns(title: search_text, status: num)
-        num += 1
-      end
-
-      searched_tasks = subject.call
-      expect(searched_tasks.size).to eq count
-
-      searched_tasks.each do |task|
-        case search_type
-        when :title_and_status
-          expect(task.title).to eq search_text
-          expect(task.status).to eq Task.statuses.key(0)
-        when :title_only
-          expect(task.title).to eq search_text
-        when :status_only
-          expect(task.status).to eq Task.statuses.key(1)
-        end
-      end
     }
   end
 
@@ -75,6 +30,7 @@ RSpec.describe Task, type: :model do
           expect(task.valid?).to eq true
         end
       end
+
       context "タイトルが#{title_max_length + 1}文字以上の場合" do
         let(:num) { title_max_length + 1 }
 
@@ -87,15 +43,18 @@ RSpec.describe Task, type: :model do
         end
       end
     end
+
     context 'タイトルに正常な値が入力されていない場合' do
       context 'タイトルが空の場合' do
         let(:title) { '' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
       end
+
       context 'タイトルが空白の場合' do
         let(:title) { ' ' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
       end
+
       context 'タイトルがnilの場合' do
         let(:title) { nil }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
@@ -116,6 +75,7 @@ RSpec.describe Task, type: :model do
           expect(task.valid?).to eq true
         end
       end
+
       context "説明が#{description_max_length + 1}文字以上の場合" do
         let(:num) { description_max_length + 1 }
 
@@ -128,15 +88,18 @@ RSpec.describe Task, type: :model do
         end
       end
     end
+
     context '説明に正常な値が入力されていない場合' do
       context '説明が空の場合' do
         let(:description) { '' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
       end
+
       context '説明が空白の場合' do
         let(:description) { ' ' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
       end
+
       context '説明がnilの場合' do
         let(:description) { nil }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
@@ -154,6 +117,7 @@ RSpec.describe Task, type: :model do
           expect(task.valid?).to eq true
         end
       end
+
       context '終了期日が現在日時以前の日付である場合' do
         let(:termination_at) { Time.now }
 
@@ -162,19 +126,22 @@ RSpec.describe Task, type: :model do
         end
         it 'エラーメッセージが表示されること' do
           task.valid?
-          expect(task.errors.messages[:termination_at]).to include 'は現在時刻より後の日付を指定してください'
+          expect(task.errors.messages[:termination_at]).to include msg_invalid_termination_at
         end
       end
     end
+
     context '終了期日に正常な値が入力されていない場合' do
       context '終了期日が空の場合' do
         let(:termination_at) { '' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
       end
+
       context '終了期日が空白の場合' do
         let(:termination_at) { ' ' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
       end
+
       context '終了期日がnilの場合' do
         let(:termination_at) { nil }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
@@ -193,21 +160,25 @@ RSpec.describe Task, type: :model do
           expect(task.valid?).to eq true
         end
       end
+
       context 'Enumで定義されていない値の場合' do
         let(:priority) { 'unknown_priority' }
 
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_invalid_value
       end
     end
+
     context '優先度に正常な値が入力されていない場合' do
       context '優先度が空の場合' do
         let(:priority) { '' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
       end
+
       context '優先度が空白の場合' do
         let(:priority) { ' ' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
       end
+
       context '優先度がnilの場合' do
         let(:priority) { nil }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
@@ -217,6 +188,7 @@ RSpec.describe Task, type: :model do
 
   describe 'status' do
     let(:task) { build(:task, status: status) }
+
     context 'ステータスに正常な値が入力されている場合' do
       context 'Enumで定義されている値の場合' do
         let(:status) { Task.statuses.key(0) }
@@ -225,21 +197,25 @@ RSpec.describe Task, type: :model do
           expect(task.valid?).to eq true
         end
       end
+
       context 'Enumで定義されていない値の場合' do
         let(:status) { 'unknown_status' }
 
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_invalid_value
       end
     end
+
     context 'ステータスに正常な値が入力されていない場合' do
       context 'ステータスが空の場合' do
         let(:status) { '' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
       end
+
       context 'ステータスが空白の場合' do
         let(:status) { ' ' }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
       end
+
       context 'ステータスがnilの場合' do
         let(:status) { nil }
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
@@ -248,56 +224,197 @@ RSpec.describe Task, type: :model do
   end
 
   describe 'scope' do
-    let!(:tasks) { create_list(:task, listnum) }
-    let(:listnum) { 5 }
+    let!(:tasks) { create_list(:task, number_of_multiple_data) }
 
     describe 'all_sort_by' do
       subject { proc { Task.all_sort_by(column, order) } }
+
       context '終了期日が指定された場合' do
         let(:column) { :termination_at }
+
         context '昇順が指定された場合' do
           let(:order) { :asc }
-          it_behaves_like '指定された任意のカラムに基づく並び替え順でデータが取得できていること', :termination_at, :asc
+          it '終了期日(昇順)で並び替えられた全てのデータを取得していること' do
+            before_task = nil
+            get_tasks = subject.call
+
+            expect(get_tasks.size).to eq(number_of_multiple_data)
+            get_tasks.each do |task|
+              expect(task.send(column.to_s)).to be >= before_task.send(column.to_s) if before_task
+              before_task = task
+            end
+          end
         end
+
         context '降順が指定された場合' do
           let(:order) { :desc }
-          it_behaves_like '指定された任意のカラムに基づく並び替え順でデータが取得できていること', :termination_at, :desc
+          it '終了期日(降順)で並び替えられた全てのデータを取得していること' do
+            before_task = nil
+            get_tasks = subject.call
+
+            expect(get_tasks.size).to eq(number_of_multiple_data)
+            get_tasks.each do |task|
+              expect(task.send(column.to_s)).to be <= before_task.send(column.to_s) if before_task
+              before_task = task
+            end
+          end
         end
       end
     end
 
     describe 'search' do
-      subject { proc { Task.search(params) } }
-      let(:search_text) { 'test_title_for_search' }
+      subject { proc { Task.search(search_params) } }
 
-      context 'タイトル、ステータス指定されている場合' do
-        let(:params) do
-          {
-            title: search_text,
-            status: Task.statuses[:not_started]
-          }
+      context '値が指定されている場合' do
+        let!(:for_search_task01) { create(:task, data01) }
+        let!(:for_search_task02) { create(:task, data02) }
+
+        context 'タイトル、ステータスが指定されている場合' do
+          let(:search_params) do
+            {
+              title: search_base_text,
+              status: Task.statuses[:not_started]
+            }
+          end
+
+          let(:data01) do
+            {
+              title: "#{search_base_text}_01",
+              status: Task.statuses[:not_started]
+            }
+          end
+
+          context '該当するタスクが1件存在する場合' do
+            # 検索不一致データ(ステータスが不一致)
+            let(:data02) do
+              {
+                title: "#{search_base_text}_02",
+                status: Task.statuses[:done]
+              }
+            end
+
+            it "検索条件(タイトル：「#{search_base_text}」部分一致, ステータス：#{Task.statuses[:not_started]})に一致するデータ1件を取得していること" do
+              searched_tasks = subject.call
+              expect(searched_tasks.size).to eq 1
+              expect(searched_tasks[0].title).to eq for_search_task01.title
+              expect(searched_tasks[0].status).to eq for_search_task01.status
+            end
+          end
+
+          context '該当するタスクが複数(2件)存在する場合' do
+            let(:data02) do
+              {
+                title: "#{search_base_text}_02",
+                status: Task.statuses[:not_started]
+              }
+            end
+
+            it "検索条件(タイトル：「#{search_base_text}」部分一致, ステータス：#{Task.statuses[:not_started]})に一致するデータ2件を取得していること" do
+              searched_tasks = subject.call
+              expect(searched_tasks.size).to eq 2
+              expect(searched_tasks[0].title).to eq for_search_task01.title
+              expect(searched_tasks[0].status).to eq for_search_task01.status
+              expect(searched_tasks[1].title).to eq for_search_task02.title
+              expect(searched_tasks[1].status).to eq for_search_task02.status
+            end
+          end
         end
-        it_behaves_like '検索条件に一致するデータが取得できていること', 1, :title_and_status
-      end
-      context 'タイトルのみ指定されている場合' do
-        let(:params) do
-          {
-            title: search_text
-          }
+
+        context 'タイトルのみ指定されている場合' do
+          let(:search_params) do
+            {
+              title: search_base_text
+            }
+          end
+
+          let(:data01) do
+            {
+              title: "#{search_base_text}_01",
+              status: Task.statuses[:not_started]
+            }
+          end
+
+          context '該当するタスクが1件存在する場合' do
+            # 検索不一致データ(タイトルが不一致)
+            let(:data02) {}
+            it "検索条件(タイトル：「#{search_base_text}」部分一致)に一致するデータ1件を取得していること" do
+              searched_tasks = subject.call
+              expect(searched_tasks.size).to eq 1
+              expect(searched_tasks[0].title).to eq for_search_task01.title
+              expect(searched_tasks[0].status).to eq for_search_task01.status
+            end
+          end
+
+          context '該当するタスクが複数(2件)存在する場合' do
+            let(:data02) do
+              {
+                title: "#{search_base_text}_02",
+                status: Task.statuses[:done]
+              }
+            end
+
+            it "検索条件(タイトル：「#{search_base_text}」部分一致)に一致するデータ2件を取得していること" do
+              searched_tasks = subject.call
+              expect(searched_tasks.size).to eq 2
+              expect(searched_tasks[0].title).to eq for_search_task01.title
+              expect(searched_tasks[0].status).to eq for_search_task01.status
+              expect(searched_tasks[1].title).to eq for_search_task02.title
+              expect(searched_tasks[1].status).to eq for_search_task02.status
+            end
+          end
         end
-        it_behaves_like '検索条件に一致するデータが取得できていること', 2, :title_only
-      end
-      context 'ステータスのみ指定されている場合' do
-        let(:params) do
-          {
-            status: Task.statuses[:on_progress]
-          }
+
+        context 'ステータスのみ指定されている場合' do
+          let(:search_params) do
+            {
+              status: Task.statuses[:on_progress]
+            }
+          end
+
+          let(:data01) do
+            {
+              title: "#{search_base_text}_01",
+              status: Task.statuses[:on_progress]
+            }
+          end
+
+          context '該当するタスクが1件存在する場合' do
+            # 検索不一致データ(ステータスが不一致)
+            let(:data02) {}
+            it "検索条件(ステータス：#{Task.statuses[:on_progress]})に一致するデータ1件を取得していること" do
+              searched_tasks = subject.call
+              expect(searched_tasks.size).to eq 1
+              expect(searched_tasks[0].title).to eq for_search_task01.title
+              expect(searched_tasks[0].status).to eq for_search_task01.status
+            end
+          end
+
+          context '該当するタスクが複数(2件)存在する場合' do
+            let(:data02) do
+              {
+                title: "#{search_base_text}_02",
+                status: Task.statuses[:on_progress]
+              }
+            end
+
+            it "検索条件(ステータス：#{Task.statuses[:on_progress]})に一致するデータ2件を取得していること" do
+              searched_tasks = subject.call
+              expect(searched_tasks.size).to eq 2
+              expect(searched_tasks[0].title).to eq for_search_task01.title
+              expect(searched_tasks[0].status).to eq for_search_task01.status
+              expect(searched_tasks[1].title).to eq for_search_task02.title
+              expect(searched_tasks[1].status).to eq for_search_task02.status
+            end
+          end
         end
-        it_behaves_like '検索条件に一致するデータが取得できていること', 1, :status_only
       end
-      context '何も指定されていない場合' do
-        let(:params) { {} }
-        it_behaves_like '検索条件に一致するデータが取得できていること', 5, :nothing
+
+      context '値が指定されていない場合' do
+        let(:search_params) { {} }
+        it '検索条件の指定なく、全てのデータを取得していること' do
+          searched_tasks = subject.call
+          expect(searched_tasks.size).to eq number_of_multiple_data
+        end
       end
     end
   end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Task, type: :model do
     }
   end
 
-  shared_examples_for '検索条件に一致するデータが取得できていること' do |count, sort_type|
+  shared_examples_for '検索条件に一致するデータが取得できていること' do |count, search_type|
     it {
       num = 0
       tasks.first(2).each do |task|
@@ -49,7 +49,7 @@ RSpec.describe Task, type: :model do
       expect(searched_tasks.size).to eq count
 
       searched_tasks.each do |task|
-        case sort_type
+        case search_type
         when :title_and_status
           expect(task.title).to eq search_text
           expect(task.status).to eq Task.statuses.key(0)

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -37,6 +37,31 @@ RSpec.describe Task, type: :model do
     }
   end
 
+  shared_examples_for '検索条件に一致するデータが取得できていること' do |count, sort_type|
+    it {
+      num = 0
+      tasks.first(2).each do |task|
+        task.update_columns(title: search_text, status: num)
+        num += 1
+      end
+
+      searched_tasks = subject.call
+      expect(searched_tasks.size).to eq count
+
+      searched_tasks.each do |task|
+        case sort_type
+        when :title_and_status
+          expect(task.title).to eq search_text
+          expect(task.status).to eq Task.statuses.key(0)
+        when :title_only
+          expect(task.title).to eq search_text
+        when :status_only
+          expect(task.status).to eq Task.statuses.key(1)
+        end
+      end
+    }
+  end
+
   describe 'title' do
     let(:task) { build(:task, title: title) }
 
@@ -238,6 +263,41 @@ RSpec.describe Task, type: :model do
           let(:order) { :desc }
           it_behaves_like '指定された任意のカラムに基づく並び替え順でデータが取得できていること', :termination_at, :desc
         end
+      end
+    end
+
+    describe 'search' do
+      subject { proc { Task.search(params) } }
+      let(:search_text) { 'test_title_for_search' }
+
+      context 'タイトル、ステータス指定されている場合' do
+        let(:params) do
+          {
+            title: search_text,
+            status: Task.statuses[:not_started]
+          }
+        end
+        it_behaves_like '検索条件に一致するデータが取得できていること', 1, :title_and_status
+      end
+      context 'タイトルのみ指定されている場合' do
+        let(:params) do
+          {
+            title: search_text
+          }
+        end
+        it_behaves_like '検索条件に一致するデータが取得できていること', 2, :title_only
+      end
+      context 'ステータスのみ指定されている場合' do
+        let(:params) do
+          {
+            status: Task.statuses[:on_progress]
+          }
+        end
+        it_behaves_like '検索条件に一致するデータが取得できていること', 1, :status_only
+      end
+      context '何も指定されていない場合' do
+        let(:params) { {} }
+        it_behaves_like '検索条件に一致するデータが取得できていること', 5, :nothing
       end
     end
   end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Task, type: :model do
         it 'バリデーションエラーになること' do
           expect(task.valid?).to eq false
         end
+
         it 'エラーメッセージが表示されること' do
           task.valid?
           expect(task.errors.messages[:title]).to include "は#{title_max_length}文字以内で入力してください"
@@ -47,16 +48,19 @@ RSpec.describe Task, type: :model do
     context 'タイトルに正常な値が入力されていない場合' do
       context 'タイトルが空の場合' do
         let(:title) { '' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
       end
 
       context 'タイトルが空白の場合' do
         let(:title) { ' ' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
       end
 
       context 'タイトルがnilの場合' do
         let(:title) { nil }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :title, msg_no_value
       end
     end
@@ -82,6 +86,7 @@ RSpec.describe Task, type: :model do
         it 'バリデーションエラーになること' do
           expect(task.valid?).to eq false
         end
+
         it 'エラーメッセージが表示されること' do
           task.valid?
           expect(task.errors.messages[:description]).to include "は#{description_max_length}文字以内で入力してください"
@@ -92,16 +97,19 @@ RSpec.describe Task, type: :model do
     context '説明に正常な値が入力されていない場合' do
       context '説明が空の場合' do
         let(:description) { '' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
       end
 
       context '説明が空白の場合' do
         let(:description) { ' ' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
       end
 
       context '説明がnilの場合' do
         let(:description) { nil }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :description, msg_no_value
       end
     end
@@ -113,6 +121,7 @@ RSpec.describe Task, type: :model do
     context '終了期日に正常な値が入力されている場合' do
       context '終了期日が現在日時よりも後の日付である場合' do
         let(:termination_at) { Time.now + 1 }
+
         it 'バリデーションエラーにならないこと' do
           expect(task.valid?).to eq true
         end
@@ -124,6 +133,7 @@ RSpec.describe Task, type: :model do
         it 'バリデーションエラーになること' do
           expect(task.valid?).to eq false
         end
+
         it 'エラーメッセージが表示されること' do
           task.valid?
           expect(task.errors.messages[:termination_at]).to include msg_invalid_termination_at
@@ -134,16 +144,19 @@ RSpec.describe Task, type: :model do
     context '終了期日に正常な値が入力されていない場合' do
       context '終了期日が空の場合' do
         let(:termination_at) { '' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
       end
 
       context '終了期日が空白の場合' do
         let(:termination_at) { ' ' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
       end
 
       context '終了期日がnilの場合' do
         let(:termination_at) { nil }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :termination_at, msg_no_value
       end
     end
@@ -171,16 +184,19 @@ RSpec.describe Task, type: :model do
     context '優先度に正常な値が入力されていない場合' do
       context '優先度が空の場合' do
         let(:priority) { '' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
       end
 
       context '優先度が空白の場合' do
         let(:priority) { ' ' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
       end
 
       context '優先度がnilの場合' do
         let(:priority) { nil }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :priority, msg_no_value
       end
     end
@@ -208,16 +224,19 @@ RSpec.describe Task, type: :model do
     context 'ステータスに正常な値が入力されていない場合' do
       context 'ステータスが空の場合' do
         let(:status) { '' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
       end
 
       context 'ステータスが空白の場合' do
         let(:status) { ' ' }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
       end
 
       context 'ステータスがnilの場合' do
         let(:status) { nil }
+
         it_behaves_like 'バリデーションエラーとなり、想定するメッセージが表示されること', :status, msg_no_value
       end
     end
@@ -234,6 +253,7 @@ RSpec.describe Task, type: :model do
 
         context '昇順が指定された場合' do
           let(:order) { :asc }
+
           it '終了期日(昇順)で並び替えられた全てのデータを取得していること' do
             before_task = nil
             get_tasks = subject.call
@@ -248,6 +268,7 @@ RSpec.describe Task, type: :model do
 
         context '降順が指定された場合' do
           let(:order) { :desc }
+
           it '終了期日(降順)で並び替えられた全てのデータを取得していること' do
             before_task = nil
             get_tasks = subject.call
@@ -337,6 +358,7 @@ RSpec.describe Task, type: :model do
           context '該当するタスクが1件存在する場合' do
             # 検索不一致データ(タイトルが不一致)
             let(:data02) {}
+
             it "検索条件(タイトル：「#{search_base_text}」部分一致)に一致するデータ1件を取得していること" do
               searched_tasks = subject.call
               expect(searched_tasks.size).to eq 1
@@ -381,6 +403,7 @@ RSpec.describe Task, type: :model do
           context '該当するタスクが1件存在する場合' do
             # 検索不一致データ(ステータスが不一致)
             let(:data02) {}
+
             it "検索条件(ステータス：#{Task.statuses[:on_progress]})に一致するデータ1件を取得していること" do
               searched_tasks = subject.call
               expect(searched_tasks.size).to eq 1
@@ -411,6 +434,7 @@ RSpec.describe Task, type: :model do
 
       context '値が指定されていない場合' do
         let(:search_params) { {} }
+
         it '検索条件の指定なく、全てのデータを取得していること' do
           searched_tasks = subject.call
           expect(searched_tasks.size).to eq number_of_multiple_data


### PR DESCRIPTION
## 要件（仕様書など）
ステータスを追加して、検索できるようにしよう
## 修正概要
検索機能の追加
## 実装内容
■ 検索機能
一覧画面で「タイトル」と「ステータス」で検索ができる機能を追加
上記対応に併せて検索インデックスも追加

## 動作確認（操作内容、画面キャプチャなど）
※Rsepc実施済(全てOK)
※rubocop実施済
※rails db:migrate:redo確認済

起動手順
```
bundle exec rake webpacker:compile
bundle exec rails s
```
■ 検索前の画面
<img width="1079" alt="スクリーンショット 2022-05-13 11 00 29" src="https://user-images.githubusercontent.com/103913705/168196425-57c0b21a-d33e-4974-838d-752a62d483ed.png">
■ 検索後の画面(タスク名：「task4」、ステータス：「着手中」で検索)
<img width="1079" alt="スクリーンショット 2022-05-13 11 00 53" src="https://user-images.githubusercontent.com/103913705/168196439-8c8996db-f1e7-435c-8a90-71f785b65ed1.png">