### PR TITLE
ステップ12: 終了期限を追加しよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,6 +1,8 @@
 class TasksController < ApplicationController
+  helper_method :sort_column, :sort_type
+
   def index
-    @tasks = Task.order(created_at: :desc)
+    @tasks = Task.order("#{sort_column} #{sort_type}")
   end
 
   def new
@@ -38,6 +40,14 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :description)
+    params.require(:task).permit(:title, :description, :due_date)
+  end
+
+  def sort_type
+    %w[asc desc].include?(params[:type]) ? params[:type] : 'desc'
+  end
+
+  def sort_column
+    Task.column_names.include?(params[:sort]) ? params[:sort] : 'created_at'
   end
 end

--- a/myapp/app/helpers/tasks_helper.rb
+++ b/myapp/app/helpers/tasks_helper.rb
@@ -1,2 +1,6 @@
 module TasksHelper
+  def sort_order(column, title)
+    type = column == sort_column && sort_type == 'asc' ? 'desc' : 'asc'
+    link_to title, { sort: column, type: type }
+  end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,5 +1,4 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
   validates :due_date, presence: true
-
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,3 +1,5 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
+  validates :due_date, presence: true
+
 end

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -5,6 +5,8 @@
   <div><%= f.text_field :title %></div>
   <div><%= f.label :description, t('tasks.description') %></div>
   <div><%= f.text_field :description %></div>
+  <div><%= f.label :due_date, t('tasks.due_date') %></div>
+  <div><%= f.date_field :due_date %></div>
   <div><%= f.submit t('.submit') %></div>
 <% end %>
 <%= link_to t('.back'), tasks_path %>

--- a/myapp/app/views/tasks/index.erb
+++ b/myapp/app/views/tasks/index.erb
@@ -7,6 +7,7 @@
     <tr>
       <th><%= t 'tasks.title' %></th>
       <th><%= t 'tasks.description' %></th>
+      <th><%= sort_order 'due_date', t('tasks.due_date') %></th>
       <th><%= t 'tasks.created_at' %></th>
       <th></th>
     </tr>
@@ -16,7 +17,8 @@
     <tr>
       <td><%= t.title %></td>
       <td><%= t.description %></td>
-      <td><%= l t.created_at, format: :long %></td>
+      <td><%= l t.due_date, format: :date_only %></td>
+      <td><%= l t.created_at, format: :date_only %></td>
       <td>
          <td><%= link_to t('.edit_task'), edit_task_path(t) %></td>
       </td>

--- a/myapp/app/views/tasks/new.html.erb
+++ b/myapp/app/views/tasks/new.html.erb
@@ -5,6 +5,8 @@
   <div><%= f.text_field :title %></div>
   <div><%= f.label :description, t('tasks.description') %></div>
   <div><%= f.text_field :description %></div>
+  <div><%= f.label :due_date, t('tasks.due_date') %></div>
+  <div><%= f.date_field :due_date, value: Time.now.strftime("%Y-%m-%d") %></div>
   <div><%= f.submit t('.submit') %></div>
 <% end %>
 <%= link_to t('.back'), tasks_path %>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -203,6 +203,7 @@ ja:
       default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
+      date_only: "%Y/%m/%d"
     pm: 午後
   errors:
     http_status:

--- a/myapp/config/locales/models/ja.yml
+++ b/myapp/config/locales/models/ja.yml
@@ -6,6 +6,7 @@ ja:
       task:
         title: 'タスク名'
         description: '説明'
+        due_date: '終了期限'
    # 全てのmodelで共通して使用するattributesを記載
   attributes:
     created_at: 作成日

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -3,6 +3,7 @@ ja:
     title: 'タスク名'
     description: '説明'
     created_at: '作成日時'
+    due_date: '終了期限'
     index:
       title: 'タスク一覧'
       add_new_task: 'タスク新規追加'

--- a/myapp/db/migrate/20220519053924_add_due_date_to_tasks.rb
+++ b/myapp/db/migrate/20220519053924_add_due_date_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDueDateToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :due_date, :datetime, null: false, default: -> { 'NOW()' }
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_19_010702) do
+ActiveRecord::Schema.define(version: 2022_05_19_053924) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 50, null: false
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "due_date", default: -> { "CURRENT_TIMESTAMP" }, null: false
   end
 
 end

--- a/myapp/spec/factories/tasks.rb
+++ b/myapp/spec/factories/tasks.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:title) { |n| "test_title#{n}" }
     sequence(:description) { |n| "test_description#{n}" }
     sequence(:created_at) { |n| "2022/05/18 00:00:#{n}" }
+    sequence(:due_date) { |n| "2022/05/#{n}" }
   end
 end

--- a/myapp/spec/factories/tasks.rb
+++ b/myapp/spec/factories/tasks.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     sequence(:title) { |n| "test_title#{n}" }
     sequence(:description) { |n| "test_description#{n}" }
     sequence(:created_at) { |n| "2022/05/18 00:00:#{n}" }
-    sequence(:due_date) { |n| "2022/05/#{n}" }
+    sequence(:due_date) { |n| "2022/05/18 00:00:#{n}" }
   end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'Taskモデルのテスト', type: :model do
 
   let(:title) {'test title'}
   let(:description) {'test description'}
-  let!(:task) {Task.new(title: title, description: description)}
+  let(:due_date) {'2022/05/10'}
+  let!(:task) {Task.new(title: title, description: description, due_date: due_date)}
 
   describe 'title' do
     context "#{ TITLE_MAX_LENGTH }文字以内" do
@@ -35,6 +36,15 @@ RSpec.describe 'Taskモデルのテスト', type: :model do
       let(:description) {''}
       it 'バリデーションが設定されていないこと' do
         expect(task).to be_valid
+      end
+    end
+  end
+
+  describe "due_date" do
+    context '入力が空の場合' do
+      let(:due_date) {''}
+      it 'バリデーションで弾かれること' do
+        expect(task).not_to be_valid
       end
     end
   end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
 
+    context '終了期限の並び替えが1回押された時' do
+      let!(:tasks_order_by_due_date_asc) { Task.order(due_date: :asc) }
+      it '終了期限の昇順にタスクが並んでいること' do
+        click_on '終了期限'
+        expect(page.text).to match(/#{ tasks_order_by_due_date_asc[0].title }.*#{ tasks_order_by_due_date_asc[1].title }.*#{ tasks_order_by_due_date_asc[2].title }/)
+      end
+    end
+
     context '新規作成ボタンが押された時' do
       it '正常に遷移すること' do
         click_on 'タスク新規追加'
@@ -49,6 +57,7 @@ RSpec.describe 'Tasks', type: :system do
       it 'タスク新規追加が正常に行われること' do
         fill_in 'task[title]',       with: 'new task'
         fill_in 'task[description]', with: 'new description'
+        fill_in 'task[due_date]', with: '2022/05/10'
         click_button '新規作成'
         expect(page).to have_content 'タスクを新規作成しました。'
       end
@@ -75,6 +84,7 @@ RSpec.describe 'Tasks', type: :system do
       it '正常に更新が行われること' do
         fill_in 'task[title]',       with: 'edit task'
         fill_in 'task[description]', with: 'edit description'
+        fill_in 'task[due_date]',    with: '2022/05/12'
         click_button '保存'
         expect(page).to have_content 'タスクの情報を更新しました。'
       end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
 
+    context '終了期限の並び替えが2回押された時' do
+      let!(:tasks_order_by_due_date_desc) { Task.order(due_date: :desc) }
+      it '終了期限の降順にタスクが並んでいること' do
+        click_on '終了期限'
+        click_on '終了期限'
+        expect(page.text).to match(/#{ tasks_order_by_due_date_desc[0].title }.*#{ tasks_order_by_due_date_desc[1].title }.*#{ tasks_order_by_due_date_desc[2].title }/)
+      end
+    end
+
     context '新規作成ボタンが押された時' do
       it '正常に遷移すること' do
         click_on 'タスク新規追加'


### PR DESCRIPTION
## 課題
・タスクに対して終了期限を登録できるようにする
・一覧画面にて終了期限でソートができるようにする
・RSpecテストの追加

## 対応内容
・tasksテーブルに対して終了期限を設定する`due_date` のカラムを追加
・modelにて空での入力を弾くバリデーションを設定
・タスク一覧画面にて終了期限が表示されるように改修。終了期限によるソートも実装

## テスト確認内容
### system test
・新規登録画面、編集画面にて終了期限を入れた状態でタスクが登録できることを確認
・一覧画面にて終了期限によるソートが正常に行えていることを確認

### model
・終了期限を空で登録しようとするとバリデーションに弾かれることを確認

## 画面
### タスク一覧画面
#### before
![Screen Shot 2022-05-20 at 12 24 55](https://user-images.githubusercontent.com/105190694/169444302-f0346ea2-6ff5-4f45-983e-feca5bb2e97a.png)

#### after
終了期限のカラムを追加。初期の並びはタスクの作成日時順
![Screen Shot 2022-05-20 at 12 19 10](https://user-images.githubusercontent.com/105190694/169443754-a63d259f-8a8c-4fab-afe8-44e905e20fdc.png)

終了期限のリンクを押すと、1回目は昇順。2回目は降順に並び替えされる
![Screen Shot 2022-05-20 at 12 20 50](https://user-images.githubusercontent.com/105190694/169443933-de7e39ca-3fac-4f06-a2a2-1bd526614bd8.png)

![Screen Shot 2022-05-20 at 12 20 57](https://user-images.githubusercontent.com/105190694/169443952-58542509-a2d4-4914-b35f-8cc2020abff5.png)

### 新規作成画面
終了期限がカレンダーで設定できるように追加
![Screen Shot 2022-05-20 at 12 22 28](https://user-images.githubusercontent.com/105190694/169444083-fa63afe9-d915-4007-bd2f-faaa3857a1cb.png)

### 編集画面
上記と同じく、終了期限の入力欄を追加
![Screen Shot 2022-05-20 at 12 23 18](https://user-images.githubusercontent.com/105190694/169444146-9c57ac86-3aca-45a2-b403-d7d6675879c0.png)
