### PR TITLE
ステップ17: ログイン/ログアウト機能を実装しよう

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -33,6 +33,8 @@ gem 'rubocop-rails', require: false
 
 gem 'rails-i18n'
 
+gem 'bcrypt'
+
 gem 'bootstrap5-kaminari-views', '~> 0.0.1'
 gem 'kaminari'
 

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -33,7 +33,7 @@ gem 'rubocop-rails', require: false
 
 gem 'rails-i18n'
 
-gem 'bcrypt'
+gem 'bcrypt', '3.1.16'
 
 gem 'bootstrap5-kaminari-views', '~> 0.0.1'
 gem 'kaminari'

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
-    bcrypt (3.1.18)
+    bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
@@ -287,7 +287,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bcrypt
+  bcrypt (= 3.1.16)
   bootsnap (>= 1.4.2)
   bootstrap
   bootstrap5-kaminari-views (~> 0.0.1)

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
@@ -286,6 +287,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt
   bootsnap (>= 1.4.2)
   bootstrap
   bootstrap5-kaminari-views (~> 0.0.1)

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include SessionsHelper
+
   unless Rails.env.development?
     rescue_from Exception,                      with: :render500
     rescue_from ActiveRecord::RecordNotFound,   with: :render404
@@ -27,5 +29,10 @@ class ApplicationController < ActionController::Base
   def render500(err = nil)
     logger.error "Rendering 500 with excaption: #{err.message}" if err
     render 'errors/500.html', status: :internal_server_error
+  end
+
+  # ログイン状態のユーザーかどうか確認
+  def logged_in_user
+    redirect_to login_url unless logged_in?
   end
 end

--- a/myapp/app/controllers/sessions_controller.rb
+++ b/myapp/app/controllers/sessions_controller.rb
@@ -1,6 +1,4 @@
 class SessionsController < ApplicationController
-  def new; end
-
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user&.authenticate(params[:session][:password])

--- a/myapp/app/controllers/sessions_controller.rb
+++ b/myapp/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
 
   def create
     user = User.find_by(email: params[:session][:email].downcase)
-    if user && user.authenticate(params[:session][:password])
+    if user&.authenticate(params[:session][:password])
       log_in user
       flash[:success] = t('.success')
       redirect_to root_url

--- a/myapp/app/controllers/sessions_controller.rb
+++ b/myapp/app/controllers/sessions_controller.rb
@@ -1,0 +1,21 @@
+class SessionsController < ApplicationController
+  def new; end
+
+  def create
+    user = User.find_by(email: params[:session][:email].downcase)
+    if user && user.authenticate(params[:session][:password])
+      log_in user
+      flash[:success] = t('.success')
+      redirect_to root_url
+    else
+      flash[:danger] = t('.failed')
+      render 'new'
+    end
+  end
+
+  def destroy
+    log_out if logged_in?
+    flash[:success] = t('.success')
+    redirect_to root_url
+  end
+end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,4 +1,5 @@
 class TasksController < ApplicationController
+  before_action :logged_in_user, only: %i[index edit new update destroy]
   helper_method :sort_column, :sort_type
   PER_PAGE = 5
 
@@ -17,7 +18,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(task_params)
+    @task = current_user.tasks.new(task_params)
     if @task.save
       redirect_to tasks_path, flash: { success: t('.flash_success') }
     else
@@ -26,11 +27,15 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = Task.find(params[:id])
+    return redirect_to tasks_path unless login_user_task?
+
+    @task = current_user.tasks.find(params[:id])
   end
 
   def update
-    @task = Task.find(params[:id])
+    return redirect_to tasks_path unless login_user_task?
+
+    @task = current_user.tasks.find(params[:id])
     if @task.update(task_params)
       redirect_to tasks_path, flash: { success: t('.flash_success') }
     else
@@ -39,7 +44,9 @@ class TasksController < ApplicationController
   end
 
   def destroy
-    @task = Task.find(params[:id])
+    return redirect_to tasks_path unless login_user_task?
+
+    @task = current_user.tasks.find(params[:id])
     @task.destroy
     redirect_to tasks_path, flash: { success: t('.flash_success') }
   end
@@ -60,10 +67,14 @@ class TasksController < ApplicationController
 
   def tasks
     if params[:search_text].present? || params[:search_status].present?
-      Task.where('(title like ? or description like ?) and status = ?', "%#{params[:search_text]}%",
-                 "%#{params[:search_text]}%", params[:search_status]).order("#{sort_column} #{sort_type}")
+      current_user.tasks.where('(title like ? or description like ?) and status = ?', "%#{params[:search_text]}%",
+                               "%#{params[:search_text]}%", params[:search_status]).order("#{sort_column} #{sort_type}")
     else
-      Task.order("#{sort_column} #{sort_type}")
+      current_user.tasks.order("#{sort_column} #{sort_type}")
     end
+  end
+
+  def login_user_task?
+    current_user.tasks.exists?(id: params[:id])
   end
 end

--- a/myapp/app/helpers/sessions_helper.rb
+++ b/myapp/app/helpers/sessions_helper.rb
@@ -1,0 +1,24 @@
+module SessionsHelper
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
+
+  # 現在ログイン中のユーザーを返却
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  # 受け取ったユーザーがログイン中のユーザーと一致するかどうか
+  def current_user?(user)
+    user == current_user
+  end
+
+  def logged_in?
+    !current_user.nil?
+  end
+end

--- a/myapp/app/helpers/sessions_helper.rb
+++ b/myapp/app/helpers/sessions_helper.rb
@@ -5,17 +5,11 @@ module SessionsHelper
 
   def log_out
     session.delete(:user_id)
-    @current_user = nil
   end
 
   # 現在ログイン中のユーザーを返却
   def current_user
-    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
-  end
-
-  # 受け取ったユーザーがログイン中のユーザーと一致するかどうか
-  def current_user?(user)
-    user == current_user
+    User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
   def logged_in?

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
-  
+
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
 
   has_many :tasks, dependent: :destroy

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_secure_password
+  
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
 
   has_many :tasks, dependent: :destroy

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -37,26 +37,28 @@
     <div class="container-fluid">
       <nav id="sidebar" class="col-md-3 col-lg-2 d-md-block navbar-dark sidebar collapse">
         <div class="position-sticky pt-md-1">
-          <ul class="nav flex-column">
-            <li class="nav-item">
-              <a href="<%= tasks_path %>" id="sidebar-index-link" class="nav-link <%= 'active' if current_page?(tasks_path) ||  current_page?(root_path) %>">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-card-checklist" viewBox="0 0 16 16">
-                  <path d="M14.5 3a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h13zm-13-1A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-13z"/>
-                  <path d="M7 5.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5zm-1.496-.854a.5.5 0 0 1 0 .708l-1.5 1.5a.5.5 0 0 1-.708 0l-.5-.5a.5.5 0 1 1 .708-.708l.146.147 1.146-1.147a.5.5 0 0 1 .708 0zM7 9.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5zm-1.496-.854a.5.5 0 0 1 0 .708l-1.5 1.5a.5.5 0 0 1-.708 0l-.5-.5a.5.5 0 0 1 .708-.708l.146.147 1.146-1.147a.5.5 0 0 1 .708 0z"/>
-                </svg>
-                <span class="ml-2"><%= t 'sidebar.task_list' %></span>
-              </a>
-            </li>
-            <li class="nav-item">
-              <a href="<%= new_task_path %>" id="sidebar-new-link" class="nav-link <%= 'active' if current_page?(new_task_path) %>">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-circle" viewBox="0 0 16 16">
-                  <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
-                  <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
-                </svg>
-                <span class="ml-2"><%= t 'sidebar.new_task' %></span>
-              </a>
-            </li>
-          </ul>
+          <% if logged_in? %>
+            <ul class="nav flex-column">
+              <li class="nav-item">
+                <a href="<%= tasks_path %>" id="sidebar-index-link" class="nav-link <%= 'active' if current_page?(tasks_path) ||  current_page?(root_path) %>">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-card-checklist" viewBox="0 0 16 16">
+                    <path d="M14.5 3a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h13zm-13-1A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-13z"/>
+                    <path d="M7 5.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5zm-1.496-.854a.5.5 0 0 1 0 .708l-1.5 1.5a.5.5 0 0 1-.708 0l-.5-.5a.5.5 0 1 1 .708-.708l.146.147 1.146-1.147a.5.5 0 0 1 .708 0zM7 9.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5zm-1.496-.854a.5.5 0 0 1 0 .708l-1.5 1.5a.5.5 0 0 1-.708 0l-.5-.5a.5.5 0 0 1 .708-.708l.146.147 1.146-1.147a.5.5 0 0 1 .708 0z"/>
+                  </svg>
+                  <span class="ml-2"><%= t 'sidebar.task_list' %></span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="<%= new_task_path %>" id="sidebar-new-link" class="nav-link <%= 'active' if current_page?(new_task_path) %>">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-circle" viewBox="0 0 16 16">
+                    <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                    <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
+                  </svg>
+                  <span class="ml-2"><%= t 'sidebar.new_task' %></span>
+                </a>
+              </li>
+            </ul>
+          <% end %>
         </div>
       </nav>
       <main>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
             <%= t('header.user_menu') %>
           </a>
           <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-              <li><a class="dropdown-item" data-method="delete" href="<%= logout_path %>"><%= t 'header.logout' %></a></li>
+              <li><a class="dropdown-item" data-method="delete" id="logoutLink" href="<%= logout_path %>"><%= t 'header.logout' %></a></li>
           </ul>
         <% else %>
           <a class="btn btn-secondary" href="<% login_path %>">

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -20,15 +20,18 @@
         </button>
       </div>
       <div class="dropdown user-menu">
-        <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
-          User menu
-        </a>
-
-        <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-          <li><a class="dropdown-item" href="#">Action</a></li>
-          <li><a class="dropdown-item" href="#">Another</a></li>
-          <li><a class="dropdown-item" href="#">Something</a></li>
-        </ul>
+        <% if logged_in? %>
+          <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+            <%= t('header.user_menu', :name => @current_user.name) %>
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+              <li><a class="dropdown-item" data-method="delete" href="<%= logout_path %>"><%= t 'header.logout' %></a></li>
+          </ul>
+        <% else %>
+          <a class="btn btn-secondary" href="<% login_path %>">
+            <%= t 'header.login' %>
+          </a>
+        <% end %>
       </div>
     </nav>
     <div class="container-fluid">

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
       <div class="dropdown user-menu">
         <% if logged_in? %>
           <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
-            <%= t('header.user_menu', :name => @current_user.name) %>
+            <%= t('header.user_menu') %>
           </a>
           <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
               <li><a class="dropdown-item" data-method="delete" href="<%= logout_path %>"><%= t 'header.logout' %></a></li>

--- a/myapp/app/views/sessions/new.html.erb
+++ b/myapp/app/views/sessions/new.html.erb
@@ -1,0 +1,13 @@
+<%= render partial: 'layouts/page_title', locals: { title: t('.title') } %>
+<%= render partial: 'layouts/flash_messages', locals: { flash: flash } %>
+<%= form_for(:session, url: login_path) do |f| %>
+  <div class="mb-auto p-2 form-group w-50">
+    <%= f.label t('.email') %>
+    <%= f.email_field :email %>
+  </div>
+  <div class="p-2 form-group w-25">
+    <%= f.label t('.password') %>
+    <%= f.password_field :password %>
+  </div>
+  <%= f.submit t('.submit'), class: "btn btn-primary"  %>
+<% end %>

--- a/myapp/config/locales/controllers/ja.yml
+++ b/myapp/config/locales/controllers/ja.yml
@@ -8,3 +8,9 @@ ja:
       flash_success: 'タスクの情報を更新しました。'
     destroy:
       flash_success: 'タスクを削除しました。'
+  sessions_controller:
+    create: 
+      failed: 'メールアドレス、またはパスワードが間違っています。'
+      success: 'ログインしました。'
+    destroy:
+      success: 'ログアウトしました。'

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -210,7 +210,7 @@ ja:
       not_found: "お探しのページが見つかりませんでした。移動または削除された可能性があります。"
       server_error: "このページはご利用頂けません。"
   header:
-    user_menu: "%{name}さん、こんにちは"
+    user_menu: "ユーザーメニュー"
     login: "ログイン"
     logout: "ログアウト"
   sidebar:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -209,6 +209,10 @@ ja:
     http_status:
       not_found: "お探しのページが見つかりませんでした。移動または削除された可能性があります。"
       server_error: "このページはご利用頂けません。"
+  header:
+    user_menu: "%{name}さん、こんにちは"
+    login: "ログイン"
+    logout: "ログアウト"
   sidebar:
     task_list: "タスク一覧"
     new_task: "タスク新規追加"

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -20,3 +20,9 @@ ja:
       title: '新規タスク'
       submit: '新規作成'
       back: '戻る'
+  sessions:
+    new:
+      title: 'ログイン'
+      email: 'メールアドレス'
+      password: 'パスワード'
+      submit: 'ログイン'

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
   root "tasks#index"
   resources :tasks
 

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -7,7 +7,7 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 # Creating normal user
-User.create!(name: 'normal', email: 'normal@gmail.com' ,password_digest: 'passwordNormal', admin_flg: 0)
+User.create!(name: 'normal', email: 'normal@gmail.com' ,password: 'passwordNormal', password_confirmation: 'passwordNormal', admin_flg: 0)
 
 # Creating admin user
-User.create!(name: 'admin', email: 'admin@gmail.com' ,password_digest: 'passwordAdmin', admin_flg: 1)
+User.create!(name: 'admin', email: 'admin@gmail.com' ,password: 'passwordAdmin', password_confirmation: 'passwordAdmin', admin_flg: 1)

--- a/myapp/package.json
+++ b/myapp/package.json
@@ -10,6 +10,6 @@
     },
     "version": "0.1.0",
     "devDependencies": {
-        "webpack-dev-server": "^4.9.0"
+        "webpack-dev-server": "^4.9.1"
     }
 }

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -2,14 +2,24 @@ FactoryBot.define do
   factory :normal_user, class: User do
     name { "normal" }
     email { "normal@gmail.com" }
-    password_digest { "normal" }
+    password { "normal" }
+    password_confirmation { "normal" }
     admin_flg { 0 }
   end
 
   factory :admin_user, class: User do
     name { "admin" }
     email { "admin@gmail.com" }
-    password_digest { "admin" }
+    password { "admin" }
+    password_confirmation { "admin" }
     admin_flg { 1 }
+  end
+
+  factory :other_user, class: User do
+    name { "other" }
+    email { "other@gmail.com" }
+    password { "other" }
+    password_confirmation { "other" }
+    admin_flg { 0 }
   end
 end

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -47,13 +47,12 @@ RSpec.describe 'Userモデルのテスト', type: :model do
     end
   end
 
-  # 次のPRで実装するため一旦コメントアウト
-  # describe 'password' do 
-  #   context '入力が空の場合' do
-  #     let(:password_digest) { '' }
-  #     it 'バリデーションで弾かれること' do
-  #       expect(user).not_to be_valid
-  #     end
-  #   end
-  # end
+  describe 'password' do 
+    context '入力が空の場合' do
+      let(:password_digest) { '' }
+      it 'バリデーションで弾かれること' do
+        expect(user).not_to be_valid
+      end
+    end
+  end
 end

--- a/myapp/spec/system/sessions_spec.rb
+++ b/myapp/spec/system/sessions_spec.rb
@@ -48,4 +48,21 @@ RSpec.describe 'Sessions', type: :system do
       end
     end
   end
+
+  describe "ログアウト処理" do
+    context "ログアウトボタンがクリックされた時" do
+      it 'ログアウトが正常に行えること' do
+        visit login_path
+        fill_in 'session_email', with: user.email
+        fill_in 'session_password', with: user.password
+        click_button 'ログイン'
+        find('#dropdownMenuLink').click
+        find('#logoutLink').click
+        expect(current_path).to eq login_path
+        visit new_task_path
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+  
 end

--- a/myapp/spec/system/sessions_spec.rb
+++ b/myapp/spec/system/sessions_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'Sessions', type: :system do
+  let!(:user) { FactoryBot.create(:normal_user) }
+
+  describe 'ログイン処理' do
+    before {visit login_path}
+    context '登録済みのemail、正しいパスワードを入力' do
+      it '正常にログインが行われ、トップページが表示されること' do
+        fill_in 'session_email', with: user.email
+        fill_in 'session_password', with: user.password
+        click_button 'ログイン'
+        expect(current_path).to eq root_path
+      end
+    end
+
+    context '登録していないメールアドレスを入力' do
+      it 'ログインが行われないこと' do
+        fill_in 'session_email', with: 'sample@gmail.com'
+        fill_in 'session_password', with: user.password
+        click_button 'ログイン'
+        expect(current_path).to eq login_path
+      end
+    end
+
+    context '間違ったパスワードを入力' do
+      it 'ログインが行われないこと' do
+        fill_in 'session_email', with: user.email
+        fill_in 'session_password', with: 'samplepass'
+        click_button 'ログイン'
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+
+  describe 'ログインしていないユーザー' do
+    context 'タスク一覧のパスにアクセスした時' do
+      it 'アクセスできず、ログインページに遷移させられること' do
+        visit tasks_path
+        expect(current_path).to eq login_path
+      end
+    end
+
+    context 'タスク新規作成のパスにアクセスした時' do
+      it 'アクセスできず、ログインページに遷移させられること' do
+        visit new_task_path
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+end

--- a/myapp/spec/system/sessions_spec.rb
+++ b/myapp/spec/system/sessions_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Sessions', type: :system do
   let!(:user) { FactoryBot.create(:normal_user) }
 
   describe 'ログイン処理' do
-    before {visit login_path}
+    before { visit login_path }
     context '登録済みのemail、正しいパスワードを入力' do
       it '正常にログインが行われ、トップページが表示されること' do
         fill_in 'session_email', with: user.email
@@ -49,8 +49,8 @@ RSpec.describe 'Sessions', type: :system do
     end
   end
 
-  describe "ログアウト処理" do
-    context "ログアウトボタンがクリックされた時" do
+  describe 'ログアウト処理' do
+    context 'ログアウトボタンがクリックされた時' do
       it 'ログアウトが正常に行えること' do
         visit login_path
         fill_in 'session_email', with: user.email
@@ -63,6 +63,5 @@ RSpec.describe 'Sessions', type: :system do
         expect(current_path).to eq login_path
       end
     end
-  end
-  
+  end  
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -3,6 +3,16 @@ require 'rails_helper'
 RSpec.describe 'Tasks', type: :system do
   let!(:normal_user) { create(:normal_user) }
   let!(:task) { create(:task, user: normal_user) }
+
+  let!(:other_user) { create(:other_user) }
+  let!(:other_user_task) { create(:task, user: other_user) }
+
+  before do
+    visit login_path
+    fill_in 'session_email', with: normal_user.email
+    fill_in 'session_password', with: normal_user.password
+    click_button 'ログイン'
+  end
   
 
   describe 'サイドバー' do
@@ -26,7 +36,7 @@ RSpec.describe 'Tasks', type: :system do
   describe '一覧ページ' do
     describe '一覧表示機能' do
       let!(:task_list) { create_list(:task, 4, user: normal_user) }
-      let!(:tasks_order_by_created_at_desc) { Task.order(created_at: :desc) }
+      let!(:tasks_order_by_created_at_desc) { Task.where(user_id: normal_user.id).order(created_at: :desc) }
       let!(:first_task) { tasks_order_by_created_at_desc[0] }
 
       before { visit tasks_path }
@@ -38,10 +48,14 @@ RSpec.describe 'Tasks', type: :system do
         it '作成日時の降順でタスクが並んでいること' do
           expect(page.text).to match(/#{ tasks_order_by_created_at_desc[0].title }.*#{ tasks_order_by_created_at_desc[1].title }.*#{ tasks_order_by_created_at_desc[2].title }/)
         end
+
+        it 'ログインユーザーのタスクのみ表示されていること' do
+          expect(page).to have_no_content other_user_task.description
+        end
       end
 
       context '終了期限の並び替えが1回押された時' do
-        let!(:tasks_order_by_due_date_asc) { Task.order(due_date: :asc) }
+        let!(:tasks_order_by_due_date_asc) { Task.where(user_id: normal_user.id).order(due_date: :asc) }
         it '終了期限の昇順にタスクが並んでいること' do
           click_on '終了期限'
           expect(page.text).to match(/#{ tasks_order_by_due_date_asc[0].title }.*#{ tasks_order_by_due_date_asc[1].title }.*#{ tasks_order_by_due_date_asc[2].title }/)
@@ -49,7 +63,7 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       context '終了期限の並び替えが2回押された時' do
-        let!(:tasks_order_by_due_date_desc) { Task.order(due_date: :desc) }
+        let!(:tasks_order_by_due_date_desc) { Task.where(user_id: normal_user.id).order(due_date: :desc) }
         it '終了期限の降順にタスクが並んでいること' do
           click_on '終了期限'
           click_on '終了期限'
@@ -75,6 +89,14 @@ RSpec.describe 'Tasks', type: :system do
         it '削除が正常に行われること' do
           all('table tr')[1].click_on '削除'
           expect(page).to have_no_content first_task.description
+        end
+      end
+
+      context "他のユーザーのタスクのIDでリクエストが送られた時" do
+        it '削除が行われずに、一覧画面にリダイレクトされること' do
+          delete task_path other_user_task
+          expect(Task.where(id: other_user_task.id)).to exist
+          expect(current_path).to eq tasks_path
         end
       end
     end
@@ -152,16 +174,15 @@ RSpec.describe 'Tasks', type: :system do
   describe 'タスク新規作成ページ' do
     before { visit new_task_path }
 
-    # step17にて実装予定のため、一旦コメントアウト
-    # context 'タスク新規作成時' do
-    #   it 'タスク新規追加が正常に行われること' do
-    #     fill_in 'task[title]',       with: 'new task'
-    #     fill_in 'task[description]', with: 'new description'
-    #     fill_in 'task[due_date]', with: '2022/05/10'
-    #     click_button '保存'
-    #     expect(page).to have_content 'タスクを新規作成しました。'
-    #   end
-    # end
+    context 'タスク新規作成時' do
+      it 'タスク新規追加が正常に行われること' do
+        fill_in 'task[title]',       with: 'new task'
+        fill_in 'task[description]', with: 'new description'
+        fill_in 'task[due_date]', with: '2022/05/10'
+        click_button '保存'
+        expect(page).to have_content 'タスクを新規作成しました。'
+      end
+    end
 
     context '戻るボタンが押された時' do
       it '正常に遷移すること' do
@@ -188,6 +209,13 @@ RSpec.describe 'Tasks', type: :system do
         find('#task_status').find("option[value='in_progress']").select_option
         click_button '保存'
         expect(page).to have_content 'タスクの情報を更新しました。'
+      end
+    end
+
+    context "他のユーザーのタスクにアクセスした時" do
+      it 'アクセスできず、一覧画面にリダイレクトされること' do
+        visit edit_task_path other_user_task
+        expect(current_path).to eq tasks_path
       end
     end
   end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe 'Tasks', type: :system do
     fill_in 'session_email', with: normal_user.email
     fill_in 'session_password', with: normal_user.password
     click_button 'ログイン'
-  end
-  
+  end 
 
   describe 'サイドバー' do
     context 'タスク一覧をクリックした時' do
@@ -92,7 +91,7 @@ RSpec.describe 'Tasks', type: :system do
         end
       end
 
-      context "他のユーザーのタスクのIDでリクエストが送られた時" do
+      context '他のユーザーのタスクのIDでリクエストが送られた時' do
         it '削除が行われずに、一覧画面にリダイレクトされること' do
           delete task_path other_user_task
           expect(Task.where(id: other_user_task.id)).to exist
@@ -212,7 +211,7 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
 
-    context "他のユーザーのタスクにアクセスした時" do
+    context '他のユーザーのタスクにアクセスした時' do
       it 'アクセスできず、一覧画面にリダイレクトされること' do
         visit edit_task_path other_user_task
         expect(current_path).to eq tasks_path

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -6826,7 +6826,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sockjs@^0.3.21:
+sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
   integrity sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==
@@ -7683,10 +7683,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.0.tgz#737dbf44335bb8bde68f8f39127fc401c97a1557"
-  integrity sha512-+Nlb39iQSOSsFv0lWUuUTim3jDQO8nhK3E68f//J2r5rIcp4lULHXz2oZ0UVdEeWXEh5lSzYUlzarZhDAeAVQw==
+webpack-dev-server@^4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.1.tgz#184607b0287c791aeaa45e58e8fe75fcb4d7e2a8"
+  integrity sha512-CTMfu2UMdR/4OOZVHRpdy84pNopOuigVIsRbGX3LVDMWNP8EUgC5mUBMErbwBlHTEX99ejZJpVqrir6EXAEajA==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"
@@ -7712,7 +7712,7 @@ webpack-dev-server@^4.9.0:
     schema-utils "^4.0.0"
     selfsigned "^2.0.1"
     serve-index "^1.9.1"
-    sockjs "^0.3.21"
+    sockjs "^0.3.24"
     spdy "^4.0.2"
     webpack-dev-middleware "^5.3.1"
     ws "^8.4.2"


### PR DESCRIPTION
## 課題
- ログイン/ログアウト機能を実装(DeviseなどのGemを使わないこと)
- ログイン画面の実装
- ログインしていないユーザーはタスク管理のページに遷移できないようにする
- 自分が作成したタスクのみ一覧に表示するようにする

## 対応事項
- ログイン/ログアウト機能の実装
- ログイン画面の実装
- 未ログインユーザはタスク一覧、編集、新規作成画面に遷移できないように変更
- ログインユーザーに紐づくタスクのみが一覧に表示されるように修正
- ログインユーザーに紐づくタスクのみが編集、削除できるように修正
- タスクを新規作成した際に、ログインしているユーザーIDに紐づけられるように修正

## テスト事項
- ログイン、ログアウト処理
- 未ログインユーザーがタスク管理画面にアクセスできないこと
- ログインしているユーザー以外のタスクが一覧に表示されないこと
- ログインしているユーザー以外にタスクの編集、削除が行えないこと
- タスク新規作成が正常に行えること

## 画面
・ログイン画面
![Screen Shot 2022-05-31 at 15 24 18](https://user-images.githubusercontent.com/105190694/171106479-132907eb-ee6d-431f-a5a7-754f1d23e86b.png)

・ログイン後のユーザーメニューにてログアウトボタンを設置
![Screen Shot 2022-05-31 at 15 24 28](https://user-images.githubusercontent.com/105190694/171106529-baf9fd09-5571-42a8-86fa-21a80fc7465b.png)
