### PR TITLE
ステップ19: ユーザにロールを追加しよう

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -38,6 +38,8 @@ gem 'bcrypt', '3.1.16'
 gem 'bootstrap5-kaminari-views', '~> 0.0.1'
 gem 'kaminari'
 
+gem 'draper'
+
 gem 'bootstrap'
 gem 'jquery-rails'
 gem 'uglifier'

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -42,6 +42,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.0.5)
       activesupport (= 6.0.5)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.0.5)
       activemodel (= 6.0.5)
       activesupport (= 6.0.5)
@@ -98,6 +102,13 @@ GEM
     crass (1.0.6)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     erubi (1.10.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -197,6 +208,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rexml (3.2.5)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
@@ -233,6 +246,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -304,6 +318,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 2.15)
+  draper
   factory_bot_rails
   jbuilder (~> 2.7)
   jquery-rails

--- a/myapp/app/controllers/admin/tasks_controller.rb
+++ b/myapp/app/controllers/admin/tasks_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class TasksController < ApplicationController
+    before_action :logged_in_admin_user
     def show
       @tasks = Task.where(user_id: params[:id])
     end

--- a/myapp/app/controllers/admin/tasks_controller.rb
+++ b/myapp/app/controllers/admin/tasks_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class TasksController < ApplicationController
     before_action :logged_in_admin_user
+
     def show
       @tasks = Task.where(user_id: params[:id])
     end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -37,7 +37,7 @@ module Admin
       if user.destroy
         redirect_to admin_users_path, flash: { success: t('.flash_success') }
       else
-        redirect_to admin_users_path, flash: { danger: user.errors.full_messages.first}
+        redirect_to admin_users_path, flash: { danger: user.errors.full_messages.first }
       end
     end
 

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -4,7 +4,6 @@ module Admin
 
     def index
       logged_in_admin_user
-      pp('aaa')
       @users = User.all
     end
 
@@ -30,14 +29,21 @@ module Admin
       if @user.update(user_params)
         redirect_to admin_users_path, flash: { success: t('.flash_success') }
       else
-        render :admin_user_edit
+        render :edit
       end
     end
 
     def destroy
       user = User.find(params[:id])
-      user.destroy
-      redirect_to admin_users_path, flash: { success: t('.flash_success') }
+      if user.destroy
+        redirect_to admin_users_path, flash: { success: t('.flash_success') }
+      else
+        flash[:danger] = ""
+        user.errors.full_messages.each do |message|
+          flash[:danger] << message
+        end
+        redirect_to admin_users_path
+      end
     end
 
     private

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -3,7 +3,6 @@ module Admin
     before_action :logged_in_admin_user, only: %i[index new create edit update destroy]
 
     def index
-      logged_in_admin_user
       @users = User.all
     end
 

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class UsersController < ApplicationController
-    before_action :logged_in_admin_user, only: %i[index new create edit update destroy]
+    before_action :logged_in_admin_user
 
     def index
       @users = User.all
@@ -37,11 +37,7 @@ module Admin
       if user.destroy
         redirect_to admin_users_path, flash: { success: t('.flash_success') }
       else
-        flash[:danger] = ''
-        user.errors.full_messages.each do |message|
-          flash[:danger] << message
-        end
-        redirect_to admin_users_path
+        redirect_to admin_users_path, flash: { danger: user.errors.full_messages.first}
       end
     end
 

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,6 +1,10 @@
 module Admin
   class UsersController < ApplicationController
+    before_action :logged_in_admin_user, only: %i[index new create edit update destroy]
+
     def index
+      logged_in_admin_user
+      pp('aaa')
       @users = User.all
     end
 

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -38,7 +38,7 @@ module Admin
       if user.destroy
         redirect_to admin_users_path, flash: { success: t('.flash_success') }
       else
-        flash[:danger] = ""
+        flash[:danger] = ''
         user.errors.full_messages.each do |message|
           flash[:danger] << message
         end

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -35,4 +35,10 @@ class ApplicationController < ActionController::Base
   def logged_in_user
     redirect_to login_url unless logged_in?
   end
+
+  # 管理権限を持つユーザーかどうか確認
+  def logged_in_admin_user
+    return logged_in_user unless logged_in?
+    redirect_to tasks_path unless admin_user?
+  end
 end

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -39,6 +39,7 @@ class ApplicationController < ActionController::Base
   # 管理権限を持つユーザーかどうか確認
   def logged_in_admin_user
     return logged_in_user unless logged_in?
+
     redirect_to tasks_path unless admin_user?
   end
 end

--- a/myapp/app/decorators/application_decorator.rb
+++ b/myapp/app/decorators/application_decorator.rb
@@ -1,0 +1,8 @@
+class ApplicationDecorator < Draper::Decorator
+  # Define methods for all decorated objects.
+  # Helpers are accessed through `helpers` (aka `h`). For example:
+  #
+  #   def percent_amount
+  #     h.number_to_percentage object.amount, precision: 2
+  #   end
+end

--- a/myapp/app/decorators/user_decorator.rb
+++ b/myapp/app/decorators/user_decorator.rb
@@ -1,0 +1,11 @@
+class UserDecorator < Draper::Decorator
+  delegate_all
+
+  def admin_flg_show
+    if admin_flg == 1
+      I18n.t('admin.users.admin_flg.true')
+    else
+      I18n.t('admin.users.admin_flg.false')
+    end
+  end
+end

--- a/myapp/app/decorators/user_decorator.rb
+++ b/myapp/app/decorators/user_decorator.rb
@@ -2,7 +2,7 @@ class UserDecorator < Draper::Decorator
   delegate_all
 
   def admin_flg_show
-    if admin_flg == 1
+    if admin_flg == User::ADMIN_USER
       I18n.t('admin.users.admin_flg.true')
     else
       I18n.t('admin.users.admin_flg.false')

--- a/myapp/app/helpers/sessions_helper.rb
+++ b/myapp/app/helpers/sessions_helper.rb
@@ -15,4 +15,8 @@ module SessionsHelper
   def logged_in?
     !current_user.nil?
   end
+
+  def admin_user?
+    !current_user.nil? && current_user.admin_flg == 1
+  end
 end

--- a/myapp/app/helpers/sessions_helper.rb
+++ b/myapp/app/helpers/sessions_helper.rb
@@ -17,6 +17,6 @@ module SessionsHelper
   end
 
   def admin_user?
-    !current_user.nil? && current_user.admin_flg == 1
+    !current_user.nil? && current_user.admin_flg == User::ADMIN_USER
   end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -2,9 +2,9 @@ class User < ApplicationRecord
   has_secure_password
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
-  ADMIN_USER_MINIMUM_COUNT =
-    ADMIN_USER = 1
+  ADMIN_USER_MINIMUM_COUNT = 1
   NORMAL_USER = 0
+  ADMIN_USER = 1
 
   has_many :tasks, dependent: :destroy
 

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -2,9 +2,27 @@ class User < ApplicationRecord
   has_secure_password
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  ADMIN_USER_MINIMUM_COUNT = 1
 
   has_many :tasks, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, { presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } }
+  validate :at_least_minimum_number_admin
+  before_destroy :validate_admin_num
+
+  private
+  
+  def at_least_minimum_number_admin
+    if admin_flg == 0 && User.where(admin_flg: 1).count == ADMIN_USER_MINIMUM_COUNT
+      errors.add(:base, :at_least_minimum_number_admin)
+    end
+  end
+
+  def validate_admin_num
+    if admin_flg == 1 && User.where(admin_flg: 1).count == ADMIN_USER_MINIMUM_COUNT
+      errors.add(:base, :at_least_minimum_number_admin)
+      throw(:abort)
+    end
+  end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -2,7 +2,9 @@ class User < ApplicationRecord
   has_secure_password
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
-  ADMIN_USER_MINIMUM_COUNT = 1
+  ADMIN_USER_MINIMUM_COUNT =
+    ADMIN_USER = 1
+  NORMAL_USER = 0
 
   has_many :tasks, dependent: :destroy
 
@@ -14,13 +16,13 @@ class User < ApplicationRecord
   private
 
   def at_least_minimum_number_admin
-    return unless admin_flg.zero? && User.where(admin_flg: 1).count == ADMIN_USER_MINIMUM_COUNT
+    return unless admin_flg == NORMAL_USER && User.where(admin_flg: ADMIN_USER).count == ADMIN_USER_MINIMUM_COUNT
 
     errors.add(:base, :at_least_minimum_number_admin)
   end
 
   def validate_admin_num
-    return unless admin_flg == 1 && User.where(admin_flg: 1).count == ADMIN_USER_MINIMUM_COUNT
+    return unless admin_flg == ADMIN_USER && User.where(admin_flg: ADMIN_USER).count == ADMIN_USER_MINIMUM_COUNT
 
     errors.add(:base, :at_least_minimum_number_admin)
     throw(:abort)

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -8,21 +8,21 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, { presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } }
-  validate :at_least_minimum_number_admin
+  validate :at_least_minimum_number_admin, on: :update
   before_destroy :validate_admin_num
 
   private
-  
+
   def at_least_minimum_number_admin
-    if admin_flg == 0 && User.where(admin_flg: 1).count == ADMIN_USER_MINIMUM_COUNT
-      errors.add(:base, :at_least_minimum_number_admin)
-    end
+    return unless admin_flg.zero? && User.where(admin_flg: 1).count == ADMIN_USER_MINIMUM_COUNT
+
+    errors.add(:base, :at_least_minimum_number_admin)
   end
 
   def validate_admin_num
-    if admin_flg == 1 && User.where(admin_flg: 1).count == ADMIN_USER_MINIMUM_COUNT
-      errors.add(:base, :at_least_minimum_number_admin)
-      throw(:abort)
-    end
+    return unless admin_flg == 1 && User.where(admin_flg: 1).count == ADMIN_USER_MINIMUM_COUNT
+
+    errors.add(:base, :at_least_minimum_number_admin)
+    throw(:abort)
   end
 end

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -16,11 +16,7 @@
         <td><%= u.name %></td>
         <td><%= u.email %></td>
         <td>
-          <% if u.admin_flg == 1 %>
-            <%= t 'admin.users.admin_flg.true' %>
-          <% else %>
-            <%= t 'admin.users.admin_flg.false' %>
-          <% end %>
+          <%= u.decorate.admin_flg_show %>
         </td>
         <td><%= u.tasks.count %></td>
         <td><%= link_to t('.user_tasks'), admin_user_tasks_path(u), class: "btn btn-outline-primary btn-sm" %></td>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th><%= t 'admin.users.name' %></th>
       <th><%= t 'admin.users.email' %></th>
+      <th><%= t 'admin.users.admin_flg.title' %></th>
       <th><%= t 'admin.users.tasks_count' %></th>
       <th></th>
     </tr>
@@ -14,6 +15,13 @@
       <tr>
         <td><%= u.name %></td>
         <td><%= u.email %></td>
+        <td>
+          <% if u.admin_flg == 1 %>
+            <%= t 'admin.users.admin_flg.true' %>
+          <% else %>
+            <%= t 'admin.users.admin_flg.false' %>
+          <% end %>
+        </td>
         <td><%= u.tasks.count %></td>
         <td><%= link_to t('.user_tasks'), admin_user_tasks_path(u), class: "btn btn-outline-primary btn-sm" %></td>
         <td>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -57,6 +57,18 @@
                   <span class="ml-2"><%= t 'sidebar.new_task' %></span>
                 </a>
               </li>
+              <% if admin_user? %>
+                <li class="nav-item">
+                  <a href="<%= admin_users_path %>" id="sidebar-new-link" class="nav-link <%= 'active' if current_page?(admin_users_path) %>">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-people-fill" viewBox="0 0 16 16">
+                      <path d="M7 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1H7zm4-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/>
+                      <path fill-rule="evenodd" d="M5.216 14A2.238 2.238 0 0 1 5 13c0-1.355.68-2.75 1.936-3.72A6.325 6.325 0 0 0 5 9c-4 0-5 3-5 4s1 1 1 1h4.216z"/>
+                      <path d="M4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/>
+                    </svg>
+                    <span class="ml-2"><%= t 'sidebar.users_link' %></span>
+                  </a>
+                </li>
+              <% end %>
             </ul>
           <% end %>
         </div>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -216,6 +216,7 @@ ja:
   sidebar:
     task_list: "タスク一覧"
     new_task: "タスク新規追加"
+    users_link: "ユーザー管理画面"
   content:
     save: "保存"
     back: "戻る"

--- a/myapp/config/locales/models/ja.yml
+++ b/myapp/config/locales/models/ja.yml
@@ -17,6 +17,7 @@ ja:
         not_started: 未着手
         in_progress: 進行中
         completed: 完了
+        
   # 全てのmodelで共通して使用するattributesを記載
   attributes:
     created_at: 作成日

--- a/myapp/config/locales/models/ja.yml
+++ b/myapp/config/locales/models/ja.yml
@@ -11,6 +11,12 @@ ja:
           not_started: 未着手
           in_progress: 進行中
           completed: 完了
+    errors:
+      models:
+        user:
+          attributes:
+            base:
+              at_least_minimum_number_admin: "管理権限を持つユーザーは規定数残してください。"
   enums:
     task:
       status:

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -33,8 +33,11 @@ ja:
     users:
       name: '名前'
       email: 'メールアドレス'
-      admin_flg: '管理権限'
       tasks_count: '登録タスク数'
+      admin_flg:
+        true: '管理者'
+        false: '一般'
+        title: '権限'
       index:
         title: 'ユーザー一覧'
         edit_user: '編集'

--- a/myapp/package.json
+++ b/myapp/package.json
@@ -12,6 +12,6 @@
     },
     "version": "0.1.0",
     "devDependencies": {
-        "webpack-dev-server": "^4.9.1"
+        "webpack-dev-server": "^4.9.2"
     }
 }

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -63,4 +63,36 @@ RSpec.describe 'Userモデルのテスト', type: :model do
       end
     end
   end
+
+  describe 'admin_flg' do
+    let!(:admin) { create(:admin_user) }
+    let!(:normal) { create(:normal_user)}
+    context '更新処理で管理ユーザーが一人も存在しなくなる場合' do
+      it 'バリデーションで弾かれること' do
+        admin.update(admin_flg: 0)
+        expect(admin).not_to be_valid
+      end
+    end
+
+    context '一般ユーザーの更新' do
+      it '正常に行えること' do
+        normal.update(admin_flg: 1)
+        expect(admin).to be_valid
+      end
+    end
+
+    context '削除処理で管理ユーザーが一人も存在しなくなる場合' do
+      it '削除が行われないこと' do
+        admin.destroy
+        expect(admin).not_to be_destroyed
+      end
+    end
+
+    context '一般ユーザーが削除される場合' do
+      it '削除が正常に行われること' do
+        normal.destroy
+        expect(normal).to be_destroyed
+      end
+    end
+  end
 end

--- a/myapp/spec/system/admin/admin_users_spec.rb
+++ b/myapp/spec/system/admin/admin_users_spec.rb
@@ -5,125 +5,181 @@ RSpec.describe 'AdminUsers', type: :system do
 
   let!(:admin_user) { create(:admin_user) }
 
-  describe '一覧ページ' do
-    before { visit admin_users_path }
-    context 'アクセス時' do
-      it '画面が正常に表示されること' do
-        expect(page).to have_content normal_user.name
-        expect(page).to have_content admin_user.name
+  describe '管理権限を持つユーザーでログイン' do
+    before do
+      visit login_path
+      fill_in 'session_email', with: admin_user.email
+      fill_in 'session_password', with: admin_user.password
+      click_button 'ログイン'
+    end
+
+    describe '一覧ページ' do
+      before { visit admin_users_path }
+      context 'アクセス時' do
+        it '画面が正常に表示されること' do
+          expect(page).to have_content normal_user.name
+          expect(page).to have_content admin_user.name
+        end
+
+        it 'ユーザーに紐づくタスクの数が表示されていること' do
+          expect(all('table tr td')[2].text).eql?(Task.where(user_id: normal_user.id).count)
+        end
       end
 
-      it 'ユーザーに紐づくタスクの数が表示されていること' do
-        expect(all('table tr td')[2].text).eql?(Task.where(user_id: normal_user.id).count)
+      context 'タスク一覧をクリックしたとき' do
+        it '正常に遷移できること' do
+          all('table tr')[1].click_on 'タスク一覧'
+          expect(current_path).to eq admin_user_tasks_path normal_user.id
+        end
+      end
+
+      context '編集をクリックしたとき' do
+        it '正常に遷移できること' do
+          all('table tr')[1].click_on '編集'
+          expect(current_path).to eq edit_admin_user_path normal_user.id
+        end
+      end
+
+      context 'ユーザー追加をクリックしたとき' do
+        it '正常に遷移できること' do
+          click_on 'ユーザー追加'
+          expect(current_path).to eq new_admin_user_path
+        end
+      end
+      
+      context '削除をクリックしたとき' do
+        it 'ユーザーが正常に削除されること' do
+          all('table tr')[1].click_on '削除'
+          expect(User.where(id: normal_user.id)).not_to exist
+        end
+
+        it 'ユーザーに紐づくタスクも削除されること' do
+          all('table tr')[1].click_on '削除'
+          expect(Task.where(user_id: normal_user.id)).not_to exist
+        end
       end
     end
 
-    context 'タスク一覧をクリックしたとき' do
-      it '正常に遷移できること' do
-        all('table tr')[1].click_on 'タスク一覧'
-        expect(current_path).to eq admin_user_tasks_path normal_user.id
+    describe '新規作成ページ' do
+      before { visit new_admin_user_path }
+      context 'ユーザー新規作成時' do
+        let!(:name) {'new user'}
+        it 'ユーザー新規追加が正常に行われること' do
+          fill_in 'user[name]', with: name
+          fill_in 'user[email]', with: 'newuser@gmail.com'
+          fill_in 'user[password]', with: 'password'
+          click_button '保存'
+          expect(User.where(name: name)).to exist
+          expect(page).to have_content 'ユーザーを新規作成しました。'
+        end
+      end
+
+      context '戻るボタンが押された時' do
+        it '正常に遷移すること' do
+          click_on '戻る'
+          expect(current_path).to eq admin_users_path
+        end
       end
     end
 
-    context '編集をクリックしたとき' do
-      it '正常に遷移できること' do
-        all('table tr')[1].click_on '編集'
-        expect(current_path).to eq edit_admin_user_path normal_user.id
+    describe '編集ページ' do
+      before { visit edit_admin_user_path normal_user}
+
+      context 'アクセスした時' do
+        it '画面が正常に表示されること' do
+          expect(page).to have_content 'ユーザー情報編集'
+        end
+      end
+
+      context '更新した時' do
+        it '更新が正常に行われること' do
+          name = 'edit name'
+          email = 'edit@gmail.com'
+          password = 'changepass'
+          fill_in 'user[name]', with: name
+          fill_in 'user[email]', with: email
+          fill_in 'user[password]', with: password
+          check 'user[admin_flg]'
+          click_button '保存'
+          expect(page).to have_content 'ユーザー情報を更新しました。'
+          current_user = User.find(normal_user.id)
+          expect(current_user.name).to eq name
+          expect(current_user.email).to eq email
+          expect(current_user.admin_flg).to eq 1
+          expect(current_user.authenticate(password)).not_to eq false
+        end
+      end
+
+      context 'パスワードを空で更新した時' do
+        it 'パスワードの更新が行われないこと' do
+          check 'user[admin_flg]'
+          click_button '保存'
+          expect(page).to have_content 'ユーザー情報を更新しました。'
+          current_user = User.find(normal_user.id)
+          expect(current_user.authenticate(normal_user.password)).not_to eq false
+        end
       end
     end
 
-    context 'ユーザー追加をクリックしたとき' do
-      it '正常に遷移できること' do
-        click_on 'ユーザー追加'
-        expect(current_path).to eq new_admin_user_path
+    describe 'ユーザータスク一覧画面' do
+      before { visit admin_user_tasks_path normal_user.id }
+      context 'アクセス時' do
+        it '画面が正常に表示されること' do
+          expect(page).to have_content task.title
+        end
       end
+
+      context '戻るボタンを押した時' do
+        it 'ユーザー一覧画面に戻ること' do
+          click_on '戻る'
+          expect(current_path).to eq admin_users_path
+        end
+      end
+    end
+  end
+  
+  describe '一般ユーザーでログイン' do
+    let!(:redirect_to) {tasks_path}
+    before do
+      visit login_path
+      fill_in 'session_email', with: normal_user.email
+      fill_in 'session_password', with: normal_user.password
+      click_button 'ログイン'
     end
     
-    context '削除をクリックしたとき' do
-      it 'ユーザーが正常に削除されること' do
-        all('table tr')[1].click_on '削除'
-        expect(User.where(id: normal_user.id)).not_to exist
-      end
-
-      it 'ユーザーに紐づくタスクも削除されること' do
-        all('table tr')[1].click_on '削除'
-        expect(Task.where(user_id: normal_user.id)).not_to exist
-      end
-    end
-  end
-
-  describe '新規作成ページ' do
-    before { visit new_admin_user_path }
-    context 'ユーザー新規作成時' do
-      let!(:name) {'new user'}
-      it 'ユーザー新規追加が正常に行われること' do
-        fill_in 'user[name]', with: name
-        fill_in 'user[email]', with: 'newuser@gmail.com'
-        fill_in 'user[password]', with: 'password'
-        click_button '保存'
-        expect(User.where(name: name)).to exist
-        expect(page).to have_content 'ユーザーを新規作成しました。'
+    describe '一覧ページ' do
+      context 'アクセス時' do
+        it 'アクセスできずリダイレクトされること' do
+          visit admin_users_path
+          expect(current_path).to eq redirect_to
+        end
       end
     end
 
-    context '戻るボタンが押された時' do
-      it '正常に遷移すること' do
-        click_on '戻る'
-        expect(current_path).to eq admin_users_path
-      end
-    end
-  end
-
-  describe '編集ページ' do
-    before { visit edit_admin_user_path normal_user}
-
-    context 'アクセスした時' do
-      it '画面が正常に表示されること' do
-        expect(page).to have_content 'ユーザー情報編集'
+    describe '新規作成ページ' do
+      context 'アクセス時' do
+        it 'アクセスできずリダイレクトされること' do
+          visit new_admin_user_path
+          expect(current_path).to eq redirect_to
+        end
       end
     end
 
-    context '更新した時' do
-      it '更新が正常に行われること' do
-        name = 'edit name'
-        email = 'edit@gmail.com'
-        password = 'changepass'
-        fill_in 'user[name]', with: name
-        fill_in 'user[email]', with: email
-        fill_in 'user[password]', with: password
-        check 'user[admin_flg]'
-        click_button '保存'
-        expect(page).to have_content 'ユーザー情報を更新しました。'
-        current_user = User.find(normal_user.id)
-        expect(current_user.name).to eq name
-        expect(current_user.email).to eq email
-        expect(current_user.admin_flg).to eq 1
-        expect(current_user.authenticate(password)).not_to eq false
+    describe '編集ページ' do
+      context 'アクセス時' do
+        it 'アクセスできずリダイレクトされること' do
+          visit edit_admin_user_path normal_user
+          expect(current_path).to eq redirect_to
+        end
       end
     end
 
-    context 'パスワードを空で更新した時' do
-      it 'パスワードの更新が行われないこと' do
-        click_button '保存'
-        expect(page).to have_content 'ユーザー情報を更新しました。'
-        current_user = User.find(normal_user.id)
-        expect(current_user.authenticate(normal_user.password)).not_to eq false
-      end
-    end
-  end
-
-  describe 'ユーザータスク一覧画面' do
-    before { visit admin_user_tasks_path normal_user.id }
-    context 'アクセス時' do
-      it '画面が正常に表示されること' do
-        expect(page).to have_content task.title
-      end
-    end
-
-    context '戻るボタンを押した時' do
-      it 'ユーザー一覧画面に戻ること' do
-        click_on '戻る'
-        expect(current_path).to eq admin_users_path
+    describe 'ユーザータスク一覧画面' do
+      context 'アクセス時' do
+        it 'アクセスできずリダイレクトされること' do
+          visit admin_user_tasks_path normal_user.id
+          expect(current_path).to eq redirect_to
+        end
       end
     end
   end

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -1133,7 +1133,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@*":
+"@types/serve-static@*", "@types/serve-static@^1.13.10":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
   integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
@@ -7695,15 +7695,16 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.9.1:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.1.tgz#184607b0287c791aeaa45e58e8fe75fcb4d7e2a8"
-  integrity sha512-CTMfu2UMdR/4OOZVHRpdy84pNopOuigVIsRbGX3LVDMWNP8EUgC5mUBMErbwBlHTEX99ejZJpVqrir6EXAEajA==
+webpack-dev-server@^4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.2.tgz#c188db28c7bff12f87deda2a5595679ebbc3c9bc"
+  integrity sha512-H95Ns95dP24ZsEzO6G9iT+PNw4Q7ltll1GfJHV4fKphuHWgKFzGHWi4alTlTnpk1SPPk41X+l2RB7rLfIhnB9Q==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"
     "@types/express" "^4.17.13"
     "@types/serve-index" "^1.9.1"
+    "@types/serve-static" "^1.13.10"
     "@types/sockjs" "^0.3.33"
     "@types/ws" "^8.5.1"
     ansi-html-community "^0.0.8"


### PR DESCRIPTION
## 課題
- ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
- 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
- ユーザ管理画面でロールを選択できるようにしましょう
- 管理ユーザが1人もいなくならないように削除の制御をしましょう

## 対応
- 管理ユーザーのログイン時のみユーザー管理画面にアクセスできるように修正
- 管理ユーザーが0人にならないように、編集、削除機能にバリデーションを追加

## テストケース
- 一般ユーザーがアクセスしても管理機能を持つ画面にアクセスすることができないこと
- 管理権限を持つユーザーがアクセスした場合は管理機能の画面に正常にアクセスができること
- ユーザー編集の際に管理権限を持つユーザーがいなくなってしまう場合はバリデーションにかかること
- ユーザー削除の際に管理権限を持つユーザーがいなくなる場合は削除ができないこと
- 一般ユーザーの権限変更、削除は正常に行えること
## 画面
ユーザー一覧画面に管理の項目を追加し、そこにユーザーの権限を表示
管理ユーザーがログインした際にのみサイドバーにユーザー一覧が表示されるように修正
![Screen Shot 2022-06-08 at 14 10 23](https://user-images.githubusercontent.com/105190694/172536388-95e2e3e7-3b94-4c5d-9891-458092b7bcf8.png)
