### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/.gitignore
+++ b/myapp/.gitignore
@@ -31,5 +31,6 @@ doc/
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/public/tmp/maintenance.txt
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,5 +1,19 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user
+  before_action :render503, if: :maintenance_mode?
+
+  def maintenance_mode?
+    File.exist?(Constants::MAINTENANCE_FILE_PATH)
+  end
+
+  def render503
+    render(
+      file: Rails.public_path.join('503.html'),
+      content_type: 'text/html',
+      layout: false,
+      status: :service_unavailable
+    )
+  end
 
   private
 

--- a/myapp/config/initializers/constants.rb
+++ b/myapp/config/initializers/constants.rb
@@ -1,0 +1,3 @@
+module Constants
+  MAINTENANCE_FILE_PATH = Rails.public_path.join('tmp/maintenance.txt')
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,13 @@
+require Rails.root.join('config/initializers/constants.rb')
+
+namespace :maintenance do
+  desc 'メンテナンスモード開始'
+  task :start do
+    FileUtils.touch(Rails.public_path.join(Constants::MAINTENANCE_FILE_PATH)) unless File.exist?(Rails.public_path.join(Constants::MAINTENANCE_FILE_PATH))
+  end
+
+  desc 'メンテナンスモード停止'
+  task :stop do
+    FileUtils.rm(Rails.public_path.join(Constants::MAINTENANCE_FILE_PATH)) if File.exist?(Rails.public_path.join(Constants::MAINTENANCE_FILE_PATH))
+  end
+end

--- a/myapp/public/503.html
+++ b/myapp/public/503.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>We're sorry, currently under maintenance. (503)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style>
+        .rails-default-error-page {
+            background-color: #EFEFEF;
+            color: #2E2F30;
+            text-align: center;
+            font-family: arial, sans-serif;
+            margin: 0;
+        }
+    </style>
+</head>
+
+<body class="rails-default-error-page">
+    <div>
+        <h1>503 SERVICE UNAVAILABLE!</h1>
+        <p>Service Unavailable. <br>
+        This service is currently under maintenance.<br>
+        Please come back after the service resumes.</p>
+    </div>
+</body>
+</html>

--- a/myapp/spec/lib/tasks/maintenance_spec.rb
+++ b/myapp/spec/lib/tasks/maintenance_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'rake task maintenance', type: :system do
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
+  let(:maintenance_text) { 'This service is currently under maintenance.' }
+
+  describe 'maintenance' do
+    context 'メンテナンスモードを開始した場合' do
+      let(:start) { Rake.application['maintenance:start'] }
+
+      it 'メンテナンス画面(ステータス：503)が表示されること' do
+        start.invoke
+        get root_path
+        expect(response.body).to include maintenance_text
+        expect(response).to have_http_status(503)
+      end
+    end
+
+    context 'メンテナンスモードを停止した場合' do
+      let(:stop) { Rake.application['maintenance:stop'] }
+
+      it 'メンテナンス画面(ステータス：503)が表示されないこと' do
+        stop.invoke
+        get root_path
+        expect(response.body).not_to include maintenance_text
+        expect(response).to have_http_status(302)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 要件（仕様書など）
[ステップ21: メンテナンス機能を作ろう](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)

## 修正概要
■ メンテナンス機能追加

## 実装内容
■ メンテナンス機能追加
 -> https://github.com/Fablic/training/pull/1319/commits/9da55b4f8ad55e3c9f1803b77aca96eff0525fa9
- メンテナンス画面作成
＝メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせる
- メンテナンスモード切替用のバッチ作成
＝メンテナンスを開始／終了するバッチを実装(lib/tasks/maintenance.rake)

【補足】
※メンテナンス状態の管理について
メンテナンス用の機能をサポートするgem([turnout](https://github.com/biola/turnout))を参考にし、ファイルの存在有無によってメンテナンス状態を管理するよう実装しました。

※定数管理について
fril_apiのソースコードを確認したところ、confg等のgemを使用せず「config/initializers/constants.rb」に定義する形であった為、本研修においても現場に合わせる形でconstants.rbに定義いたしました。

## 動作確認（操作内容、画面キャプチャなど）
※Rsepc実施済(全てOK)
※rubocop実施済

起動手順
```
bundle exec rails db:setup ※DB未作成の場合のみ実行
bundle exec rake webpacker:compile
bundle exec rails s
```

メンテナンスバッチ実行手順
```
[メンテナンスモード開始時]
rails maintenance:start

[メンテナンスモード終了時]
rails maintenance:stop
```

#### ■ メンテナンスモード適用なし(通常時 または rails maintenance:stop実行後)
<img width="648" alt="スクリーンショット 2022-06-08 17 29 22" src="https://user-images.githubusercontent.com/103913705/172570208-54687382-8e2f-48e8-8091-692132cc4f19.png">


#### ■ メンテナンスモード適用あり(rails maintenance:start実行後)
<img width="648" alt="スクリーンショット 2022-06-08 17 29 48" src="https://user-images.githubusercontent.com/103913705/172570237-7c87e9a0-8e2e-4270-8b62-46019c704e7c.png">
