### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/README.md
+++ b/myapp/README.md
@@ -70,8 +70,8 @@ docker-compose exec db /bin/bash
 * Please access the following URL with your browser
   * http://localhost:3001/
 
-## how to set mentenance mode
-* you can start mentenance mode by following command
+## how to set maintenance mode
+* you can start maintenance mode by following command
 
 ```
 rake maintenance:start
@@ -83,13 +83,13 @@ if you get following response, maintenance mode is starting
 Started mentenance mode
 ```
 
-* you can stop mentenance mode by following command
+* you can stop maintenance mode by following command
 
 ```
 rake maintenance:stop
 ```
 
-if you get following response, maintenance mode is starting
+if you get following response, maintenance mode is stopped
 
 ```
 Stopped maintenance mode

--- a/myapp/README.md
+++ b/myapp/README.md
@@ -69,3 +69,28 @@ docker-compose exec db /bin/bash
 
 * Please access the following URL with your browser
   * http://localhost:3001/
+
+## how to set mentenance mode
+* you can start mentenance mode by following command
+
+```
+rake maintenance:start
+```
+
+if you get following response, maintenance mode is starting
+
+```
+Started mentenance mode
+```
+
+* you can stop mentenance mode by following command
+
+```
+rake maintenance:stop
+```
+
+if you get following response, maintenance mode is starting
+
+```
+Stopped maintenance mode
+```

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
 
+  before_action :render503, if: :maintenance_mode?
+
   unless Rails.env.development?
     rescue_from Exception,                      with: :render500
     rescue_from ActiveRecord::RecordNotFound,   with: :render404
@@ -21,6 +23,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def maintenance_mode?
+    File.exist?(Constants::MAINTENANCE_FILE_PATH)
+  end
+
   def render404(err = nil)
     logger.info "Rendering 404 with excaption: #{err.message}" if err
     render 'errors/404.html', status: :not_found
@@ -29,6 +35,10 @@ class ApplicationController < ActionController::Base
   def render500(err = nil)
     logger.error "Rendering 500 with excaption: #{err.message}" if err
     render 'errors/500.html', status: :internal_server_error
+  end
+
+  def render503
+    render('errors/503.html', status: :service_unavailable, layout: false)
   end
 
   # ログイン状態のユーザーかどうか確認

--- a/myapp/app/views/errors/503.html.erb
+++ b/myapp/app/views/errors/503.html.erb
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Service Unavailable (503)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style>
+        .rails-default-error-page {
+            background-color: #EFEFEF;
+            color: #2E2F30;
+            text-align: center;
+            font-family: arial, sans-serif;
+            margin: 0;
+        }
+        
+        .error-actions {
+            margin-top: 15px;
+            margin-bottom: 15px;
+        }
+    </style>
+</head>
+
+<body class="rails-default-error-page">
+    <div>
+        <h1>Oops!</h1>
+        <h3>503 Service Unavailable</h3>
+        <div>
+            The service is not available at this time. Try again later.
+        </div>
+    </div>
+</body>
+
+</html>

--- a/myapp/config/initializers/constants.rb
+++ b/myapp/config/initializers/constants.rb
@@ -1,0 +1,3 @@
+module Constants
+  MAINTENANCE_FILE_PATH = Rails.root.join('tmp', 'maintenance.txt')
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc 'starting maintenance mode'
+  task start: :environment do
+    if File.exist?(Constants::MAINTENANCE_FILE_PATH)
+      puts 'It is already mentenance mode'
+      exit
+    end
+
+    FileUtils.touch(Constants::MAINTENANCE_FILE_PATH)
+    puts 'Started mentenance mode'
+  end
+
+  desc 'Stopping maintenance mode'
+  task stop: :environment do
+    unless File.exist?(Constants::MAINTENANCE_FILE_PATH)
+      puts 'Not in maintenance mode'
+      exit
+    end
+
+    FileUtils.rm(Constants::MAINTENANCE_FILE_PATH)
+    puts 'Stopped maintenance mode'
+  end
+end

--- a/myapp/spec/lib/tasks/maintenance_spec.rb
+++ b/myapp/spec/lib/tasks/maintenance_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'Rake maintenance', type: :system do
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
+  let(:maintenance_text) { '503 Service Unavailable' }
+  describe 'maintenance' do
+    context 'メンテナンスモードを開始した時' do
+      it '503の画面が表示されること' do
+        Rake.application['maintenance:start'].invoke
+        get login_path
+        expect(response.body).to have_content maintenance_text
+        expect(response).to have_http_status(503)
+      end
+    end
+
+    context 'メンテナンスモードを終了した時' do
+      it '503の画面が表示されないこと' do
+        Rake.application['maintenance:stop'].invoke
+        get login_path
+        expect(response.body).not_to have_content maintenance_text
+        expect(response).not_to have_http_status(503)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 課題
- メンテナンスを開始／終了するバッチを作ってみましょう
- メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう

## 対応
- メンテナンスを開始/終了するコマンドを作成
- メンテナンスモード中にアクセスした場合は503の画面にリダイレクトさせるように修正

## 作成コマンド

```
root@e48056dcd76e:/myapp# rake maintenance:start
Started mentenance mode

root@e48056dcd76e:/myapp# rake maintenance:stop
Stopped maintenance mode
```

## 画面
![Screen Shot 2022-06-16 at 15 38 50](https://user-images.githubusercontent.com/105190694/174007507-a05028be-eeb9-48d1-99d4-4997f56f2921.png)

## テスト
- バッチを実行するとメンテナンスモードが開始され、503画面にリダイレクトされることを確認
- 終了コマンドを実行するとメンテナンスモードが終了し、通常のアクセスができるようになることを確認