### PR TITLE
Katsumi-N step10-12 タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/myapp/.gitignore
+++ b/myapp/.gitignore
@@ -15,11 +15,12 @@ rerun.txt
 pickle-email-*.html
 
 # Ignore all logfiles and tempfiles.
-/log/*
-/tmp/*
+log/*
+tmp/*
 !/log/.keep
 !/tmp/.keep
-
+docs/*
+bin/*
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/master.key
@@ -70,9 +71,6 @@ yarn-debug.log*
 /storage/*
 !/storage/.keep
 /public/uploads
-
-
-
 /public/packs
 /public/packs-test
 /node_modules

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
-
   def index
-    @tasks = Task.all
+    @tasks = Task.order("#{sort_column} #{sort_direction}")
+    @direction = sort_direction
   end
 
   def show
@@ -48,6 +48,17 @@ class TasksController < ApplicationController
   def task_params
     # status, priorityはのちのstepで追加する
     params.require(:task).permit(:title, :description, :expire_at)
+  end
+
+  # TODO: noteに合わせる？
+  # ?sort=hogeでソートするカラムを受け取る. 存在しないカラムの時はtitleでソート
+  def sort_column
+    Task.column_names.include?(params[:sort]) ? params[:sort] : 'title'
+  end
+
+  # ?order=asc[desc] で昇順/降順を指定する. 該当しないときはasc
+  def sort_direction
+    %[asc desc].include?(params[:order]) ? params[:order] : 'asc'
   end
 
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -50,15 +50,20 @@ class TasksController < ApplicationController
     params.require(:task).permit(:title, :description, :expire_at)
   end
 
-  # TODO: noteに合わせる？
   # ?sort=hogeでソートするカラムを受け取る. 存在しないカラムの時はtitleでソート
   def sort_column
-    Task.column_names.include?(params[:sort]) ? params[:sort] : 'title'
+    # params[:sort]がnilのときはtitleでソート
+    col = params[:sort].nil? ? 'title' : params[:sort]
+    #Taskのカラム以外が指定されたときはtitleをソート
+    Task.column_names.include?(col) ? col : 'title'
   end
 
   # ?order=asc[desc] で昇順/降順を指定する. 該当しないときはasc
   def sort_direction
-    %[asc desc].include?(params[:order]) ? params[:order] : 'asc'
+    # params[:order]がnilのときは昇順でソートする
+    ord = params[:order].nil? ? 'asc' : params[:order]
+    # asc/desc以外が指定された時は昇順でソートする
+    %[asc desc].include?(ord) ? ord : 'asc'
   end
 
 end

--- a/myapp/app/helpers/tasks_helper.rb
+++ b/myapp/app/helpers/tasks_helper.rb
@@ -3,4 +3,8 @@ module TasksHelper
     direction = direction == 'asc' ? 'desc' : 'asc'
     link_to title, { sort: column, order: direction }
   end
+
+  def parse_date(date)
+    return date.strftime("%Y/%m/%d %H:%M")
+  end
 end

--- a/myapp/app/helpers/tasks_helper.rb
+++ b/myapp/app/helpers/tasks_helper.rb
@@ -1,2 +1,6 @@
 module TasksHelper
+  def sort_order(column, title, direction)
+    direction = direction == 'asc' ? 'desc' : 'asc'
+    link_to title, { sort: column, order: direction }
+  end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
 
-validates :title, presence: true
+validates :title, presence: true, length: { maximum: 255 }
 
 end

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -5,7 +5,7 @@
       <tr>
         <th scope="col"><%= t('tasks.form.title') %></th>
         <th scope="col"><%= t('tasks.form.description') %></th>
-        <th scope="col"><%= t('tasks.form.expire') %></th>
+        <th scope="col"><%= sort_order('expire_at', t('tasks.form.expire'), @direction) %></th>
         <th scope="col"><%= sort_order("created_at", t('tasks.form.created_at'), @direction) %></th>
         <th></th>
         <th></th>
@@ -16,8 +16,12 @@
         <tr>
           <td><%= link_to task.title, task %></td>
           <td><%= task.description %></td>
-          <td><%= task.expire_at %></td>
-          <td><%= task.created_at %></td>
+          <% if task.expire_at.present? %>
+            <td><%= parse_date(task.expire_at) %></td>
+          <% else %>
+            <td><%= t('tasks.index.no_expire') %></td>
+          <% end %>
+          <td><%= parse_date(task.created_at) %></td>
           <td><%= link_to t('.edit'), edit_task_path(task), { id: "edit-#{task.id}" } %></td>
           <td><%= link_to t('.delete'), task_path(task), { method: :delete, data: { comfirm: "Sure?" }, id: "delete-#{task.id}" } %></td>
         </tr>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,13 +1,11 @@
 <div class="card card-skin">
   <h1><%= t '.all' %></h1>
-
   <table>
     <thead>
       <tr>
         <th scope="col"><%= t('tasks.form.title') %></th>
-        <th scope="col"><%= t('tasks.form.description') %></th>
         <th scope="col"><%= t('tasks.form.expire') %></th>
-        <th scope="col"><%= t('tasks.form.created_at') %></th>
+        <th scope="col"><%= sort_order("created_at", "作成日時", @direction) %></th>
         <th></th>
         <th></th>
       </tr>
@@ -16,20 +14,14 @@
       <% @tasks.each do | task | %>
         <tr>
           <td><%= link_to task.title, task %></td>
-          <td><%= task.description %></td>
-          <td><%= task.expire_at.strftime("%Y/%m/%d %H:%M") %></td>
-          <td><%= task.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+          <td><%= task.expire_at %></td>
+          <td><%= task.created_at %></td>
           <td><%= link_to t('.edit'), edit_task_path(task), { id: "edit-#{task.id}" } %></td>
           <td><%= link_to t('.delete'), task_path(task), { method: :delete, data: { comfirm: "Sure?" }, id: "delete-#{task.id}" } %></td>
         </tr>
       <% end %>
-      
     </tbody>
   </table>
-  <ul>
-
-  </ul>
-
   <%= link_to t('.create'), new_task_path, class: 'btn btn-default' %>
   
 </div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,17 +1,33 @@
 <div class="card card-skin">
   <h1><%= t '.all' %></h1>
+
+  <table>
+    <thead>
+      <tr>
+        <th scope="col"><%= t('tasks.form.title') %></th>
+        <th scope="col"><%= t('tasks.form.description') %></th>
+        <th scope="col"><%= t('tasks.form.expire') %></th>
+        <th scope="col"><%= t('tasks.form.created_at') %></th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @tasks.each do | task | %>
+        <tr>
+          <td><%= link_to task.title, task %></td>
+          <td><%= task.description %></td>
+          <td><%= task.expire_at.strftime("%Y/%m/%d %H:%M") %></td>
+          <td><%= task.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+          <td><%= link_to t('.edit'), edit_task_path(task), { id: "edit-#{task.id}" } %></td>
+          <td><%= link_to t('.delete'), task_path(task), { method: :delete, data: { comfirm: "Sure?" }, id: "delete-#{task.id}" } %></td>
+        </tr>
+      <% end %>
+      
+    </tbody>
+  </table>
   <ul>
-    <% @tasks.each do | task | %>
-      <div><%= link_to task.title, task %></div>
-      <div><%= task.description %></div>
-      <%= task.expire_at %>
-      <p>
 
-      <%= link_to t('.edit'), edit_task_path(task), { id: "edit-#{task.id}" } %>
-      <%= link_to t('.delete'), task_path(task), { method: :delete, data: { comfirm: "Sure?" }, id: "delete-#{task.id}" } %></br>
-
-      </p>
-    <% end %>
   </ul>
 
   <%= link_to t('.create'), new_task_path, class: 'btn btn-default' %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -4,8 +4,9 @@
     <thead>
       <tr>
         <th scope="col"><%= t('tasks.form.title') %></th>
+        <th scope="col"><%= t('tasks.form.description') %></th>
         <th scope="col"><%= t('tasks.form.expire') %></th>
-        <th scope="col"><%= sort_order("created_at", "作成日時", @direction) %></th>
+        <th scope="col"><%= sort_order("created_at", t('tasks.form.created_at'), @direction) %></th>
         <th></th>
         <th></th>
       </tr>
@@ -14,6 +15,7 @@
       <% @tasks.each do | task | %>
         <tr>
           <td><%= link_to task.title, task %></td>
+          <td><%= task.description %></td>
           <td><%= task.expire_at %></td>
           <td><%= task.created_at %></td>
           <td><%= link_to t('.edit'), edit_task_path(task), { id: "edit-#{task.id}" } %></td>

--- a/myapp/config/locales/views/tasks/ja.yml
+++ b/myapp/config/locales/views/tasks/ja.yml
@@ -13,6 +13,7 @@ ja:
       edit: '編集'
       delete: '削除'
       create: '新規作成'
+      no_expire: '期限なし'
     edit:
       edit: 'タスクの編集'
     show:

--- a/myapp/config/locales/views/tasks/ja.yml
+++ b/myapp/config/locales/views/tasks/ja.yml
@@ -5,6 +5,7 @@ ja:
       description: '詳細'
       expire: '有効期限'
       save: '保存'
+      created_at: '作成日時'
     new:
       new: 'タスクの新規作成'
     index:

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  example '作成できるか' do
+    task = FactoryBot.build(:task)
+    expect(task).to be_valid
+  end
+
+  example 'タイトルが存在しないと無効' do
+    task_notitle = FactoryBot.build(:task, :no_title)
+    task_notitle.valid?
+    expect(task_notitle.errors[:title]).to include I18n.t('errors.messages.blank')
+  end
+
+  example 'タイトルが256文字以上だと無効' do
+    task_longtitle = FactoryBot.build(:task, :long_title)
+    task_longtitle.valid?
+    expect(task_longtitle.errors[:title]).to include I18n.t('errors.messages.too_long', :count => 255)
+  end
+end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
+include TasksHelper
 
 RSpec.describe 'Tasks', type: :system do
+
   describe 'タスクの一覧を表示', type: :system do
     context '1件登録されているとき' do
       example 'タスクの各要素とEdit, Deleteボタンが表示' do
         task = FactoryBot.create(:task)
         visit root_path
         expect(page).to have_content task.title
-        expect(page).to have_content task.expire_at
+        expect(page).to have_content parse_date task.expire_at
         expect(page).to have_content task.description
-        expect(page).to have_content task.created_at
+        expect(page).to have_content parse_date task.created_at
         expect(page).to have_content I18n.t('tasks.index.create')
         expect(page).to have_content I18n.t('tasks.index.edit')
         expect(page).to have_content I18n.t('tasks.index.delete')
@@ -31,7 +33,7 @@ RSpec.describe 'Tasks', type: :system do
           expect(page).to have_content 'Task created!'
           expect(page).to have_content 'test title'
           expect(page).to have_content 'test description'
-          expect(page).to have_content '2022-06-10 12:00:00'
+          expect(page).to have_content '2022/06/10 12:00'
         end.to change(Task, :count).by(1)
       end
     end
@@ -54,10 +56,8 @@ RSpec.describe 'Tasks', type: :system do
     context '1件正しいデータで更新したとき' do
       example '1件目のタスクのみが更新して表示され、flashメッセージが表示' do
         tasks = FactoryBot.create_list(:task, 2)
-
         visit root_path
         find_by_id("edit-#{tasks[0].id}").click
-
         fill_in I18n.t('tasks.form.title'), with: 'edited title'
         fill_in I18n.t('tasks.form.description'), with: 'edited desc'
         fill_in I18n.t('tasks.form.expire'), with: '2022-06-10 00:00:00'
@@ -65,10 +65,11 @@ RSpec.describe 'Tasks', type: :system do
 
         expect(page).to have_content 'Task updated!'
         expect(page).to have_content 'edited title'
-        expect(page).to have_content '2022-06-10 00:00:00'
-
+        expect(page).to have_content 'edited desc'
+        expect(page).to have_content '2022/06/10 00:00'
         expect(page).to have_content tasks[1].title
-        expect(page).to have_content tasks[1].expire_at
+        expect(page).to have_content tasks[1].description
+        expect(page).to have_content parse_date tasks[1].expire_at
       end
     end
 
@@ -142,6 +143,39 @@ RSpec.describe 'Tasks', type: :system do
 
         expect(page.body.index(task_created_1week_ago.title)).to be < page.body.index(task_created_yesterday.title)
         expect(page.body.index(task_created_yesterday.title)).to be < page.body.index(task_created_today.title)
+      end
+    end
+  end
+
+  describe '有効期限でソート' do
+    let!(:task_expire_tomorrow) {
+      FactoryBot.create(:task, :expire_tomorrow)
+    }
+    let!(:task_expire_next_month) {
+      FactoryBot.create(:task, :expire_next_month)
+    }
+    let!(:task_expire_today) {
+      FactoryBot.create(:task)
+    }
+
+    context '1度有効期限を押したとき' do
+        # 降順→昇順に切り替わる
+      example '降順にソート' do
+        visit root_path
+        click_link I18n.t('tasks.form.expire')
+
+        expect(page.body.index(task_expire_next_month.title)).to be < page.body.index(task_expire_tomorrow.title)
+        expect(page.body.index(task_expire_tomorrow.title)).to be < page.body.index(task_expire_today.title)
+      end
+    end
+    context '2度有効期限を押したとき' do
+      example '昇順にソート' do
+        visit root_path
+        click_link I18n.t('tasks.form.expire')
+        click_link I18n.t('tasks.form.expire')
+
+        expect(page.body.index(task_expire_today.title)).to be < page.body.index(task_expire_tomorrow.title)
+        expect(page.body.index(task_expire_tomorrow.title)).to be < page.body.index(task_expire_next_month.title)
       end
     end
   end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe 'Tasks', type: :system do
         task = FactoryBot.create(:task)
         visit root_path
         expect(page).to have_content task.title
-        expect(page).to have_content task.description
         expect(page).to have_content task.expire_at
+        expect(page).to have_content task.description
+        expect(page).to have_content task.created_at
         expect(page).to have_content I18n.t('tasks.index.create')
         expect(page).to have_content I18n.t('tasks.index.edit')
         expect(page).to have_content I18n.t('tasks.index.delete')
@@ -64,11 +65,9 @@ RSpec.describe 'Tasks', type: :system do
 
         expect(page).to have_content 'Task updated!'
         expect(page).to have_content 'edited title'
-        expect(page).to have_content 'edited desc'
         expect(page).to have_content '2022-06-10 00:00:00'
 
         expect(page).to have_content tasks[1].title
-        expect(page).to have_content tasks[1].description
         expect(page).to have_content tasks[1].expire_at
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -113,4 +113,36 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
   end
+
+  describe '作成日時でソート' do
+    let!(:task_created_yesterday) {
+      FactoryBot.create(:task, :created_yesterday)
+    }
+    let!(:task_created_1week_ago) {
+      FactoryBot.create(:task, :created_1week_ago)
+    }
+    let!(:task_created_today) {
+      FactoryBot.create(:task)
+    }
+    context '1度作成日時を押したとき' do
+      example '降順にソート' do
+        visit root_path
+        click_link I18n.t('tasks.form.created_at')
+
+        expect(page.body.index(task_created_today.title)).to be < page.body.index(task_created_yesterday.title)
+        expect(page.body.index(task_created_yesterday.title)).to be < page.body.index(task_created_1week_ago.title)
+      end
+    end
+    context '2度作成日時を押したとき' do
+      example '昇順にソート' do
+        visit root_path
+        # 降順→昇順に切り替わる
+        click_link I18n.t('tasks.form.created_at')
+        click_link I18n.t('tasks.form.created_at')
+
+        expect(page.body.index(task_created_1week_ago.title)).to be < page.body.index(task_created_yesterday.title)
+        expect(page.body.index(task_created_yesterday.title)).to be < page.body.index(task_created_today.title)
+      end
+    end
+  end
 end

--- a/myapp/test/factories/tasks.rb
+++ b/myapp/test/factories/tasks.rb
@@ -4,6 +4,14 @@ FactoryBot.define do
     description { "テストデータをFactory Botで管理する" }
     expire_at { "2022-06-13 12:00:00" }
 
+    trait :no_title do
+      title { nil }
+    end
+
+    trait :long_title do
+      title { 'a' * 256 }
+    end
+
     trait :created_yesterday do
       created_at { Time.current.yesterday }
     end
@@ -11,5 +19,6 @@ FactoryBot.define do
     trait :created_1week_ago do
       created_at { Time.current.ago(7.days) }
     end
+
   end
 end

--- a/myapp/test/factories/tasks.rb
+++ b/myapp/test/factories/tasks.rb
@@ -3,5 +3,13 @@ FactoryBot.define do
     sequence(:title) { |n| "Rails研修#{n}" }
     description { "テストデータをFactory Botで管理する" }
     expire_at { "2022-06-13 12:00:00" }
+
+    trait :created_yesterday do
+      created_at { Time.current.yesterday }
+    end
+
+    trait :created_1week_ago do
+      created_at { Time.current.ago(7.days) }
+    end
   end
 end

--- a/myapp/test/factories/tasks.rb
+++ b/myapp/test/factories/tasks.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :task do
     sequence(:title) { |n| "Rails研修#{n}" }
     description { "テストデータをFactory Botで管理する" }
-    expire_at { "2022-06-13 12:00:00" }
+    expire_at { Time.current }
 
     trait :no_title do
       title { nil }
@@ -18,6 +18,14 @@ FactoryBot.define do
 
     trait :created_1week_ago do
       created_at { Time.current.ago(7.days) }
+    end
+
+    trait :expire_tomorrow do
+      expire_at { Time.current.tomorrow }
+    end
+
+    trait :expire_next_month do
+      expire_at { Time.current + 1.month }
     end
 
   end


### PR DESCRIPTION
Rails研修の[step10-12](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)になります。

## 課題
### step10:タスク一覧を作成日時の順番で並び替えましょう 

### step11: バリデーションを設定してみよう
 既にtitleにはnot null 制約と空文字に対するバリデーションを設定してたので、今回はmodel specを追加しました

### step12: 終了期限を追加しよう
既に終了期限のカラムを追加していたのでソート機能とそのsystem specを追加しました

## 実装したこと
## step10:タスク一覧を作成日時の順番で並び替えましょう 
- [x] 作成日時のソート機能の実装
- [x] 作成日時のソート機能のテスト(system spec)

### 画面

<img width="613" alt="スクリーンショット 2022-06-17 14 03 03" src="https://user-images.githubusercontent.com/61781055/174228614-cd702a72-1bc2-439b-a7c3-da8067c7b85d.png">

### テスト結果

![スクリーンショット 2022-06-17 14 00 20](https://user-images.githubusercontent.com/61781055/174228520-de216fb0-44d1-45cf-a09b-9ed3b8906c7a.png)

## step11: バリデーションを設定してみよう
- [x]  バリデーションに対するmodel specの実装

### テスト結果

![スクリーンショット 2022-06-17 14 01 34](https://user-images.githubusercontent.com/61781055/174228447-8519817a-fdec-4cda-ae6c-a46a1bcb0730.png)

## step12: 終了期限を追加しよう
- [x] viewにソート機能を追加
- [x] 終了期限のソート機能のテスト(system spec)

### 画面

<img width="621" alt="スクリーンショット 2022-06-17 14 03 50" src="https://user-images.githubusercontent.com/61781055/174228689-d995d396-d446-4418-8b0c-ab0de6727b68.png">

### テスト結果

![スクリーンショット 2022-06-17 14 00 20](https://user-images.githubusercontent.com/61781055/174228380-768b016e-93e5-476c-9b37-caa9c24f95e9.png)