### PR TITLE
wataru okamoto: step10:タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: 'DESC')
   end
 
   def show

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,10 +2,14 @@
 
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
 
-<div>
-  <% @tasks.each do |task| %>
-    <%= link_to task.name, task %>
-    <%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task) %>
-    <%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"} %><br />
-  <% end %>
-</div>
+<table>
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= link_to task.name, task %></td>
+        <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task) %></td>
+        <td><%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"} %><br /></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,11 +2,11 @@
 
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
 
-<table>
+<table class="tasks">
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
-        <td><%= link_to task.name, task %></td>
+        <td class="task-title"><%= link_to task.name, task %></td>
         <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task) %></td>
         <td><%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"} %><br /></td>
       </tr>

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -23,14 +23,25 @@ RSpec.describe 'Task', type: :system do
 
     context 'when user has tasks' do
       before do
-        create(:task)
+        create(:task, name: 'test1')
+        create(:task, name: 'test2')
+        create(:task, name: 'test3')
         visit current_path
       end
 
       it "return user's task" do # rubocop:disable RSpec/MultipleExpectations
-        expect(page).to have_link '散歩'
+        expect(page).to have_link 'test1'
+        expect(page).to have_link 'test2'
+        expect(page).to have_link 'test3'
         expect(page).to have_link '編集'
         expect(page).to have_link '削除'
+      end
+
+      it 'tasks displayed in DESC order of creation date' do
+        within '.tasks' do
+          task_titles = all('.task-title').map(&:text)
+          expect(task_titles).to eq %w[test3 test2 test1]
+        end
       end
     end
   end


### PR DESCRIPTION
# 概要
[Rails研修ステップ10](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9710-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%81%BE%E3%81%97%E3%82%87%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
- ID順で並んでいるタスク一覧を作成日時の降順で並び替えよう
- 並び替えがうまく行っていることをsystem specで書いて確認しよう


# 実装内容
- タスクコントローラー内で作成日時の降順でDBから取得するように変更
- system specに表示順を確認するテストケースを追加

## 画面
### タスク一覧画面
テスト１→テスト２→テスト３の順で作成した結果
<img width="1821" alt="Screen Shot 2022-06-27 at 11 54 28" src="https://user-images.githubusercontent.com/44032125/175851382-3f89d95c-8c2a-4a86-ac2d-28accddfb702.png">



# 動作確認方法
```
$ git clone git@github.com:Fablic/training.git
$ git checkout -b hoge origin/wataru-okamoto_step7

$ docker-compose up --build
# http://localhost:3001にアクセス
```