### PR TITLE
wataru okamoto step11: バリデーションを設定してみよう

### DIFF
--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -7,5 +7,5 @@ class User < ApplicationRecord
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
   validates :name, presence: true, length: { maximum: 30, allow_blank: true }, uniqueness: true
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }
-  validates :password_digest, presence: true, length: { minimum: 8 }, allow_nil: true
+  validates :password, presence: true, length: { minimum: 8 }, allow_nil: true
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ApplicationRecord
   has_secure_password
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
-  validates :name, presence: true, length: { maximum: 30, allow_blank: true }, uniqueness: true # TODO: Rails/UniqueValidationWithoutIndex step11で直す
-  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } # TODO: Rails/UniqueValidationWithoutIndex step11で直す
-  validates :password_digest, presence: true, length: { minimum: 8 }, allow_nil: true
+  validates :name, presence: true, length: { maximum: 30, allow_blank: true }, uniqueness: true
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
   validates :name, presence: true, length: { maximum: 30, allow_blank: true }, uniqueness: true
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }
+  validates :password_digest, presence: true, length: { minimum: 8 }, allow_nil: true
 end

--- a/myapp/app/views/layouts/_error_message.html.erb
+++ b/myapp/app/views/layouts/_error_message.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div>
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: task, local: true do |form| %>
+  <%= render 'layouts/error_message', model: task %>
   <%= form.label :name %>
   <%= form.text_field :name %>
   <%= form.label :description %>

--- a/myapp/db/migrate/20220628030721_change_detail_of_users.rb
+++ b/myapp/db/migrate/20220628030721_change_detail_of_users.rb
@@ -1,0 +1,5 @@
+class ChangeDetailOfUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_index :users, [:name, :email], unique: true
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_22_042936) do
+ActiveRecord::Schema.define(version: 2022_06_28_030721) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2022_06_22_042936) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name", "email"], name: "index_users_on_name_and_email", unique: true
   end
 
   add_foreign_key "tasks", "users"

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe Task, type: :model do
 
   describe '#name' do
     context 'when entering valid input' do
-      let(:task) { create(:task) }
-
       it 'addition is success' do
+        task = build(:task, name: 'テストタスク')
         expect(task).to be_valid
       end
     end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Task, type: model do
+
+end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -2,6 +2,25 @@
 
 require 'rails_helper'
 
-RSpec.describe Task, type: model do
+RSpec.describe Task, type: :model do
+  before do
+    create(:user)
+  end
 
+  describe 'validation test' do
+    context 'when valid input' do
+      let(:task) { create(:task) }
+
+      it 'addition is success' do
+        expect(task).to be_valid
+      end
+    end
+
+    context 'when entering title column' do
+      it 'failure if nil' do
+        task = build(:task, name: nil)
+        expect(task.valid?).to be false
+      end
+    end
+  end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Task, type: :model do
         task = build(:task, name: nil)
         expect(task.valid?).to be false
       end
+
+      it 'failure if less than 2 characters' do
+        task = build(:task, name: 't')
+        expect(task.valid?).to be false
+      end
+
+      it 'failure if more than 32 characters' do
+        task = build(:task, name: 'test-input-case-it-is-more-than-32-characters')
+        expect(task.valid?).to be false
+      end
     end
   end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Task, type: :model do
     create(:user)
   end
 
-  describe 'validation test' do
-    context 'when valid input' do
+  describe '#name' do
+    context 'when entering valid input' do
       let(:task) { create(:task) }
 
       it 'addition is success' do
@@ -16,7 +16,7 @@ RSpec.describe Task, type: :model do
       end
     end
 
-    context 'when entering title column' do
+    context 'when entering invalid input' do
       it 'failure if nil' do
         task = build(:task, name: nil)
         expect(task.valid?).to be false

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  before do
+    create(:user, name: 'hoge', email: 'hoge@gmail.com', password: 'password')
+  end
+
+  describe '#name' do
+    context 'when entering valid input' do
+      it 'addition is success' do
+        user = build(:user, name: 'test-user')
+        expect(user).to be_valid
+      end
+    end
+
+    context 'when entering invalid input' do
+      it 'failure if nil' do
+        user = build(:user, name: nil)
+        expect(user.valid?).to be false
+      end
+
+      it 'failure if more than 30 characters' do
+        user = build(:user, name: 'test-input-case-it-is-more-than-30-characters')
+        expect(user.valid?).to be false
+      end
+
+      it 'failure if uon-unique' do
+        user = build(:user, name: 'hoge')
+        expect(user.valid?).to be false
+      end
+    end
+  end
+
+  describe '#email' do
+    context 'when entering valid input' do
+      it 'addition is success' do
+        user = build(:user, email: 'test@gmail.com')
+        expect(user).to be_valid
+      end
+    end
+
+    context 'when entering invalid input' do
+      it 'failure if nil' do
+        user = build(:user, email: nil)
+        expect(user.valid?).to be false
+      end
+
+      it 'failure if non-email format' do
+        user = build(:user, email: 'test.com')
+        expect(user.valid?).to be false
+      end
+
+      it 'failure if non-unique' do
+        user = build(:user, email: 'hoge@gmail.com')
+        expect(user.valid?).to be false
+      end
+    end
+  end
+
+  describe '#password' do
+    context 'when entering valid input' do
+      it 'addition is success' do
+        user = build(:user, password: 'p@ssword')
+        expect(user).to be_valid
+      end
+    end
+
+    context 'when entering invalid input' do
+      it 'failure if nil' do
+        user = build(:user, password: nil)
+        expect(user.valid?).to be false
+      end
+
+      it 'failure if less than 8 characters' do
+        user = build(:user, password: 'pass')
+        expect(user.valid?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
[Rails研修ステップ11](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)
- バリデーションを設定しましょう
- 画面にバリデーションエラーのメッセージを表示するようにしよう
- バリデーションに対してモデルのテストを書いてみましょう


# 実装内容
- Taskモデルのnameカラムにnull制約とlength(2文字以上32文字以下)制約を追加
- タスク新規作成時と編集時にバリデーションチェックを行い、違反していた場合は画面上にエラーメッセージを表示するように改良
- Taskモデルのバリデーションが動作しているかをRspecでテスト

## 画面
### タスク一覧画面
<img width="1821" alt="Screen Shot 2022-06-28 at 11 41 39" src="https://user-images.githubusercontent.com/44032125/176080333-02033643-20a6-4b50-8ce5-fcff858a05ee.png">

### タスク新規作成画面
- 通常時
<img width="1821" alt="Screen Shot 2022-06-28 at 11 42 16" src="https://user-images.githubusercontent.com/44032125/176080400-54548ff2-0f58-449b-9aac-a67365a296e4.png">

- タスク名なしで作成しようとした場合
<img width="1821" alt="Screen Shot 2022-06-28 at 11 43 49" src="https://user-images.githubusercontent.com/44032125/176080578-92eac68b-80f3-4971-af8c-cc1ceb89dd88.png">


- 2文字以下のタスク名を作成しようとした場合
<img width="1821" alt="Screen Shot 2022-06-28 at 11 43 59" src="https://user-images.githubusercontent.com/44032125/176080592-8373ce3e-ae33-4bf5-9249-95435bfa40b4.png">


- 32文字以上のタスクを作成しようとした場合
<img width="1821" alt="Screen Shot 2022-06-28 at 11 44 24" src="https://user-images.githubusercontent.com/44032125/176080641-92a4eacc-43be-4388-9e8a-1315d3c15353.png">

# 動作確認方法
```
$ git clone git@github.com:Fablic/training.git
$ git checkout -b hoge origin/wataru-okamoto_step11

$ docker-compose up --build
# http://localhost:3001にアクセス
```