### PR TITLE
wataru okamoto step12: 終了期限を追加しよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,8 +2,10 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = if params[:sort_limit]
-               Task.sort_limit
+    @tasks = if params[:sort_limit_asc]
+               Task.sort_limit_asc
+             elsif params[:sort_limit_desc]
+               Task.sort_limit_desc
              else
                Task.all.order(created_at: 'DESC')
              end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,11 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all.order(created_at: 'DESC')
+    @tasks = if params[:sort_limit]
+               Task.sort_limit
+             else
+               Task.all.order(created_at: 'DESC')
+             end
   end
 
   def show

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,9 +2,12 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = if params[:sort_limit_asc]
+    sort = params[:sort]
+
+    @tasks = case sort
+             when 'limit'
                Task.sort_limit_asc
-             elsif params[:sort_limit_desc]
+             when '-limit'
                Task.sort_limit_desc
              else
                Task.all.order(created_at: 'DESC')

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -6,5 +6,6 @@ class Task < ApplicationRecord
   enum priority: { Low: 1, Normal: 2, High: 3 }
   enum status: { TODO: 1, IN_PROGRESS: 2, DONE: 3 }
 
-  scope :sort_limit, -> { order(limit: 'ASC') }
+  scope :sort_limit_asc, -> { order(limit: 'ASC') }
+  scope :sort_limit_desc, -> { order(limit: 'DESC') }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -5,4 +5,6 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { minimum: 2, maximum: 32 }
   enum priority: { Low: 1, Normal: 2, High: 3 }
   enum status: { TODO: 1, IN_PROGRESS: 2, DONE: 3 }
+
+  scope :sort_limit, -> { order(limit: 'ASC') }
 end

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -3,8 +3,8 @@
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
 <p>
   <%= link_to I18n.t('dictionary.button.sort.created'), root_path %>
-  <%= link_to I18n.t('dictionary.button.sort.limit_asc'), tasks_path(sort_limit_asc: 'true') %>
-  <%= link_to I18n.t('dictionary.button.sort.limit_desc'), tasks_path(sort_limit_desc: 'true') %>
+  <%= link_to I18n.t('dictionary.button.sort.limit_asc'), tasks_path(sort: 'limit') %>
+  <%= link_to I18n.t('dictionary.button.sort.limit_desc'), tasks_path(sort: '-limit') %>
 </p>
 
 <table class="tasks">

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,9 +1,11 @@
 <% content_for(:page_title, I18n.t('tasks.index.title')) %>
 
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
-<%= link_to I18n.t('dictionary.button.sort.created'), root_path %>
-<%= link_to I18n.t('dictionary.button.sort.limit_asc'), tasks_path(sort_limit_asc: 'true') %>
-<%= link_to I18n.t('dictionary.button.sort.limit_desc'), tasks_path(sort_limit_desc: 'true') %>
+<p>
+  <%= link_to I18n.t('dictionary.button.sort.created'), root_path %>
+  <%= link_to I18n.t('dictionary.button.sort.limit_asc'), tasks_path(sort_limit_asc: 'true') %>
+  <%= link_to I18n.t('dictionary.button.sort.limit_desc'), tasks_path(sort_limit_desc: 'true') %>
+</p>
 
 <table class="tasks">
   <tbody>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_title, I18n.t('tasks.index.title')) %>
 
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
+<%= link_to 'created', root_path %>
+<%= link_to 'limit', tasks_path(sort_limit: 'true') %>
 
 <table class="tasks">
   <tbody>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,8 +1,9 @@
 <% content_for(:page_title, I18n.t('tasks.index.title')) %>
 
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
-<%= link_to 'created', root_path %>
-<%= link_to 'limit', tasks_path(sort_limit: 'true') %>
+<%= link_to I18n.t('dictionary.button.sort.created'), root_path %>
+<%= link_to I18n.t('dictionary.button.sort.limit_asc'), tasks_path(sort_limit_asc: 'true') %>
+<%= link_to I18n.t('dictionary.button.sort.limit_desc'), tasks_path(sort_limit_desc: 'true') %>
 
 <table class="tasks">
   <tbody>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -11,6 +11,10 @@ ja:
       destory: "削除"
       home: "一覧へ"
       edit: "編集"
+      sort:
+        created: "作成日時順"
+        limit_asc: "終了期限近い順"
+        limit_desc: "終了期限遠い順"
   helpers:
     submit:
       create: "新規作成"

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe Task, type: :model do
   end
 
   describe '#name' do
-    context 'when valid input' do
+    context 'when entering valid input' do
       it 'addition is success' do
         task = build(:task, name: 'テストタスク')
         expect(task).to be_valid
       end
     end
 
-    context 'when entering title column' do
+    context 'when entering invalide input' do
       it 'failure if nil' do
         task = build(:task, name: nil)
         expect(task.valid?).to be false

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -7,11 +7,10 @@ RSpec.describe Task, type: :model do
     create(:user)
   end
 
-  describe 'validation test' do
+  describe '#name' do
     context 'when valid input' do
-      let(:task) { create(:task) }
-
       it 'addition is success' do
+        task = build(:task, name: 'テストタスク')
         expect(task).to be_valid
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -44,6 +44,39 @@ RSpec.describe 'Task', type: :system do
         end
       end
     end
+
+    context 'when push sort button' do
+      before do
+        create(:task, name: 'test1', limit: '2022-1-1'.to_date, created_at: '2021-12-1'.to_date)
+        create(:task, name: 'test2', limit: '2022-1-2'.to_date, created_at: '2021-12-2'.to_date)
+        create(:task, name: 'test3', limit: '2022-1-3'.to_date, created_at: '2021-12-3'.to_date)
+        visit current_path
+      end
+
+      it 'sorted by creation date' do
+        click_on '作成日時順'
+        within '.tasks' do
+          task_titles = all('.task-title').map(&:text)
+          expect(task_titles).to eq %w[test3 test2 test1]
+        end
+      end
+
+      it 'sorted in asc order by limit date' do
+        click_on '終了期限近い順'
+        within '.tasks' do
+          task_titles = all('.task-title').map(&:text)
+          expect(task_titles).to eq %w[test1 test2 test3]
+        end
+      end
+
+      it 'sorted in desc order by limit date' do
+        click_on '終了期限遠い順'
+        within '.tasks' do
+          task_titles = all('.task-title').map(&:text)
+          expect(task_titles).to eq %w[test3 test2 test1]
+        end
+      end
+    end
   end
 
   describe '#show' do

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe 'Task', type: :system do
 
     context 'when push sort button' do
       before do
-        create(:task, name: 'test1', limit: '2022-1-1'.to_date, created_at: '2021-12-1'.to_date)
-        create(:task, name: 'test2', limit: '2022-1-2'.to_date, created_at: '2021-12-2'.to_date)
-        create(:task, name: 'test3', limit: '2022-1-3'.to_date, created_at: '2021-12-3'.to_date)
+        create(:task, name: 'test1', limit: Time.new(2022, 1, 10).in_time_zone, created_at: Time.new(2021, 12, 1).in_time_zone)
+        create(:task, name: 'test2', limit: Time.new(2022, 1, 2).in_time_zone, created_at: Time.new(2021, 12, 2).in_time_zone)
+        create(:task, name: 'test3', limit: Time.new(2022, 1, 30).in_time_zone, created_at: Time.new(2021, 12, 3).in_time_zone)
         visit current_path
       end
 
@@ -65,7 +65,7 @@ RSpec.describe 'Task', type: :system do
         click_on '終了期限近い順'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
-          expect(task_titles).to eq %w[test1 test2 test3]
+          expect(task_titles).to eq %w[test2 test1 test3]
         end
       end
 
@@ -73,7 +73,7 @@ RSpec.describe 'Task', type: :system do
         click_on '終了期限遠い順'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
-          expect(task_titles).to eq %w[test3 test2 test1]
+          expect(task_titles).to eq %w[test3 test1 test2]
         end
       end
     end


### PR DESCRIPTION
# 概要
[Rails研修ステップ12](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E7%B5%82%E4%BA%86%E6%9C%9F%E9%99%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
- タスクに対して、終了期限を登録できるようにしよう
- 一覧画面で、終了期限でソートできるようにしよう
- specを拡充しましょう   


# 実装内容
- タスクモデルに予め追加していた`limit`属性でソートできるようにタスクモデル、タスクコントローラーを編集 
- 一覧画面（`index.html.erb`）でソートを切り替えられるようにボタンを追加
- I18nで日本語対応
- system specでソートできているかを確認するテストコードを追加   

## 画面
### タスク一覧画面
明日までにやるタスク→明後日までにやるタスク→来週までにやるタスクの順に追加
<img width="1777" alt="Screen Shot 2022-06-29 at 11 44 39" src="https://user-images.githubusercontent.com/44032125/176339972-6afdd450-aace-4086-b56e-433f601cfe79.png">

### 終了期限近い順ボタン押下時
<img width="1821" alt="Screen Shot 2022-06-29 at 11 46 02" src="https://user-images.githubusercontent.com/44032125/176340152-fb686708-8f92-4803-bda5-73b442063004.png">

### 終了時間遠い順ボタン押下時
<img width="1821" alt="Screen Shot 2022-06-29 at 11 46 32" src="https://user-images.githubusercontent.com/44032125/176340222-776c9934-babb-4a1e-883e-48c85ec72831.png">


# 動作確認方法
```
$ git clone git@github.com:Fablic/training.git
$ git checkout -b hoge origin/wataru-okamoto_step12

$ docker-compose up --build
# http://localhost:3001にアクセス

# sample dataの作成
$ docker-compose exec api /bin/bash
$ rails db:seed
```