### PR TITLE
Katsumi-N step18,19: ユーザの管理画面を実装しよう&ユーザにロールを追加しよう

### DIFF
--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -18,7 +18,7 @@ class Admin::UsersController < ApplicationController
     @user = User.new(user_params)
     return render 'new' unless @user.save
 
-    flash[:success] = 'User created'
+    flash[:success] = I18n.t('admin.users.create.flash_created')
     redirect_to admin_users_path
   end
 
@@ -30,13 +30,16 @@ class Admin::UsersController < ApplicationController
     @user = User.find(params[:id])
     # adminが0人になる場合は保存しない
     if @user.role == 'admin' && user_params[:role] == 'normal' && count_admin_user == 1
-      flash[:danger] = 'Require at least 1 admin user'
+      flash[:danger] = I18n.t('admin.users.update.flash_req')
       return redirect_to admin_users_path
     end
     # その他で保存できないとき
-    return render 'edit' unless @user.update(user_params)
+    unless @user.update(user_params)
+      flash[:danger] = @user.errors.full_messages.join('<br>')
+      return render 'edit'
+    end
 
-    flash[:success] = 'User updated!'
+    flash[:success] = I18n.t('admin.users.update.flash_update')
     redirect_to admin_users_path
   end
 
@@ -44,16 +47,17 @@ class Admin::UsersController < ApplicationController
     user = User.find(params[:id])
     # 自分を指定しても消せないようにする
     if params[:id].to_i == session[:user_id]
-      flash[:danger] = 'Can not delete yourself'
+      flash[:danger] = I18n.t('admin.users.destroy.flash_delete_me')
       return redirect_to admin_users_path
     end
 
     user.destroy
-    flash[:success] = 'User deleted!'
+    flash[:success] = I18n.t('admin.users.destroy.flash_deleted')
     redirect_to admin_users_path
   end
 
   private
+
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation, :role)
   end
@@ -63,6 +67,6 @@ class Admin::UsersController < ApplicationController
   end
 
   def count_admin_user
-    return User.where(role: 'admin').length
+    User.where(role: 'admin').length
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -11,21 +11,46 @@ class Admin::UsersController < ApplicationController
   end
 
   def new
+    @user = User.new
   end
 
   def create
+    @user = User.new(user_params)
+
+    return render 'new' unless @user.save
+
+    flash[:success] = 'User created'
+    redirect_to admin_users_path
   end
 
   def edit
+    @user = User.find(params[:id])
   end
 
   def update
+    @user = User.find(params[:id])
+
+    return render 'edit' unless @user.update(user_params)
+
+    flash[:success] = 'User updated!'
+    redirect_to admin_users_path
   end
 
   def destroy
+    # 自分を指定しても消せないようにする
+    return redirect_to admin_users_path if params[:id].to_i == session[:user_id]
+
+    User.find(params[:id]).destroy
+
+    flash[:success] = 'User deleted!'
+    redirect_to admin_users_path
   end
 
   private
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :role)
+  end
+
   def admin_user
     redirect_to root_path unless admin?
   end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -16,7 +16,10 @@ class Admin::UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    return render 'new' unless @user.save
+    unless @user.save
+      flash[:danger] = @user.errors.full_messages.join('<br>')
+      return render 'new'
+    end
 
     flash[:success] = I18n.t('admin.users.create.flash_created')
     redirect_to admin_users_path

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < ApplicationController
   def index
-    # @users
+    @users = User.includes(:tasks).all
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class Admin::UsersController < ApplicationController
-  before_action :admin_user
+  include Admin::UsersHelper
+  before_action :check_admin_user
   PAGE_NUM = 10
 
   def index
@@ -32,7 +33,7 @@ class Admin::UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     # adminが0人になる場合は保存しない
-    if @user.role == 'admin' && user_params[:role] == 'normal' && count_admin_user == 1
+    if @user.admin? && user_params[:role] == 'normal' && User.count_admin_user == 1
       flash[:danger] = I18n.t('admin.users.update.flash_req')
       return redirect_to admin_users_path
     end
@@ -65,11 +66,7 @@ class Admin::UsersController < ApplicationController
     params.require(:user).permit(:name, :email, :password, :password_confirmation, :role)
   end
 
-  def admin_user
+  def check_admin_user
     redirect_to root_path unless admin?
-  end
-
-  def count_admin_user
-    User.where(role: 'admin').length
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -16,7 +16,6 @@ class Admin::UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-
     return render 'new' unless @user.save
 
     flash[:success] = 'User created'
@@ -29,7 +28,12 @@ class Admin::UsersController < ApplicationController
 
   def update
     @user = User.find(params[:id])
-
+    # adminが0人になる場合は保存しない
+    if @user.role == 'admin' && user_params[:role] == 'normal' && count_admin_user == 1
+      flash[:danger] = 'Require at least 1 admin user'
+      return redirect_to admin_users_path
+    end
+    # その他で保存できないとき
     return render 'edit' unless @user.update(user_params)
 
     flash[:success] = 'User updated!'
@@ -37,11 +41,18 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
+    user = User.find(params[:id])
     # 自分を指定しても消せないようにする
-    return redirect_to admin_users_path if params[:id].to_i == session[:user_id]
+    if params[:id].to_i == session[:user_id]
+      flash[:danger] = 'Can not delete yourself'
+      return redirect_to admin_users_path
+    # adminが0人になるときは削除しない
+    elsif user.role == 'admin' && count_admin_user == 1
+      flash[:danger] = 'Require at least 1 admin user'
+      return redirect_to admin_users_path
+    end
 
-    User.find(params[:id]).destroy
-
+    user.destroy
     flash[:success] = 'User deleted!'
     redirect_to admin_users_path
   end
@@ -53,5 +64,9 @@ class Admin::UsersController < ApplicationController
 
   def admin_user
     redirect_to root_path unless admin?
+  end
+
+  def count_admin_user
+    return User.where(role: 'admin').length
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,5 +1,32 @@
 class Admin::UsersController < ApplicationController
+  before_action :admin_user
+  PAGE_NUM = 10
+
   def index
-    @users = User.includes(:tasks).all
+    @users = User.includes(:tasks).all.page(params[:page]).per(PAGE_NUM)
+  end
+
+  def tasks
+    @tasks = User.find_by(id: params[:id]).tasks
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  private
+  def admin_user
+    redirect_to root_path unless admin?
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -46,10 +46,6 @@ class Admin::UsersController < ApplicationController
     if params[:id].to_i == session[:user_id]
       flash[:danger] = 'Can not delete yourself'
       return redirect_to admin_users_path
-    # adminが0人になるときは削除しない
-    elsif user.role == 'admin' && count_admin_user == 1
-      flash[:danger] = 'Require at least 1 admin user'
-      return redirect_to admin_users_path
     end
 
     user.destroy

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,0 +1,5 @@
+class Admin::UsersController < ApplicationController
+  def index
+    # @users
+  end
+end

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
-  include Admin::UsersHelper
+
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from ActionController::RoutingError, with: :render_404
   rescue_from Exception, with: :render_500

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
+  include Admin::UsersHelper
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from ActionController::RoutingError, with: :render_404
   rescue_from Exception, with: :render_500

--- a/myapp/app/helpers/admin/users_helper.rb
+++ b/myapp/app/helpers/admin/users_helper.rb
@@ -1,0 +1,5 @@
+module Admin::UsersHelper
+  def admin?
+    current_user.role == 'admin'
+  end
+end

--- a/myapp/app/helpers/admin/users_helper.rb
+++ b/myapp/app/helpers/admin/users_helper.rb
@@ -1,5 +1,5 @@
 module Admin::UsersHelper
   def admin?
-    current_user.role == 'admin'
+    current_user.admin?
   end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,7 +1,12 @@
 class User < ApplicationRecord
-	has_many :tasks, dependent: :destroy
-	enum role: { normal: 0, admin: 1 }
-	VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-	validates :email, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }, format: { with: User::VALID_EMAIL_REGEX }
-	has_secure_password
+  has_many :tasks, dependent: :destroy
+  enum role: { normal: 0, admin: 1 }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 },
+                    format: { with: User::VALID_EMAIL_REGEX }
+  has_secure_password
+
+  def self.count_admin_user
+    admin.count
+  end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
 	has_many :tasks, dependent: :destroy
-
+	enum role: { normal: 0, admin: 1 }
 	VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 	validates :email, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }, format: { with: User::VALID_EMAIL_REGEX }
 	has_secure_password

--- a/myapp/app/views/admin/users/_form.html.erb
+++ b/myapp/app/views/admin/users/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with(model: [:admin, @user], local: true) do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name, class: "form-control" %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email, class: "form-control" %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password, class: "form-control"%>
+
+  <%= f.label :password_confirmation, "Confirmation" %>
+  <%= f.password_field :password_confirmation, class: "form-control" %>
+
+  <%= f.label :role %>
+  <%= f.select :role, User.roles.keys.map { |k| [k, k] }, class: "form-control" %>
+
+  <%= f.submit "Submit", class: "btn btn-primary" %>
+<% end %>

--- a/myapp/app/views/admin/users/edit.html.erb
+++ b/myapp/app/views/admin/users/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="container pt-5">
+  <%= t('.edit') %>
+  <%= render 'admin/users/form' %>
+</div>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Admin page</h1>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,1 +1,31 @@
-<h1>Admin page</h1>
+<div class="container">
+  <table class="table">
+    <thead>
+      <tr>
+        <th scope="col">id</th>
+        <th scope="col">email</th>
+        <th scope="col">name</th>
+        <th scope="col">tasks</th>
+        <th scope="col">tasks_num</th>
+        <th scope="col">role</th>
+        <th scope="col">role_change</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td><%= user.id %></td>
+          <td><%= user.email %></td>
+          <td><%= user.name %></td>
+          <td>TODO: ユーザーのタスク一覧へのリンク</td>
+          <td><%= user.tasks.length %></td>
+          <td><%= user.role %></td>
+          <%= form_with(url: admin_user_path(user) ) do |f| %>
+            <td><%= f.select :role, User.roles.keys.map { |k| [k, k] }, class: 'form-control' %></td>
+            <td><%= f.submit "change", class: "button" %></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="pt-5">
   <table class="table">
     <thead>
       <tr>
@@ -6,9 +6,9 @@
         <th scope="col">email</th>
         <th scope="col">name</th>
         <th scope="col">tasks</th>
-        <th scope="col">tasks_num</th>
+        <th scope="col">total tasks</th>
         <th scope="col">role</th>
-        <th scope="col">role_change</th>
+        <th scope="col"></th>
       </tr>
     </thead>
     <tbody>
@@ -17,15 +17,21 @@
           <td><%= user.id %></td>
           <td><%= user.email %></td>
           <td><%= user.name %></td>
-          <td>TODO: ユーザーのタスク一覧へのリンク</td>
+          <td><%= link_to "#{user.name}'s tasks", admin_users_tasks_path(user) %></td>
           <td><%= user.tasks.length %></td>
           <td><%= user.role %></td>
-          <%= form_with(url: admin_user_path(user) ) do |f| %>
-            <td><%= f.select :role, User.roles.keys.map { |k| [k, k] }, class: 'form-control' %></td>
-            <td><%= f.submit "change", class: "button" %></td>
-          <% end %>
+          <td>
+            <%= link_to admin_user_path(user), { method: :delete, data: { comfirm: "Sure?" }, id: "delete-#{user.id}", remote: true} do %>
+              <i class="fa-solid fa-trash"></i>
+            <% end %>
+            <%= link_to edit_admin_user_path(user), id: "edit-#{user.id}" do %>
+              <i class="fa-solid fa-pen-to-square"></i>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>
   </table>
+  <%= paginate @users %>
+  <%= link_to "New User", new_admin_user_path, class: 'btn btn-secondary' %>
 </div>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<div class="pt-5">
+<div class="mt-5">
   <table class="table">
     <thead>
       <tr>
@@ -8,6 +8,7 @@
         <th scope="col">tasks</th>
         <th scope="col">total tasks</th>
         <th scope="col">role</th>
+        <th scope="col">change role</th>
         <th scope="col"></th>
       </tr>
     </thead>
@@ -21,7 +22,15 @@
           <td><%= user.tasks.length %></td>
           <td><%= user.role %></td>
           <td>
-            <%= link_to admin_user_path(user), { method: :delete, data: { comfirm: "Sure?" }, id: "delete-#{user.id}", remote: true} do %>
+            <%= form_with(model: [:admin, user]) do |f| %>
+              <%= f.select :role, User.roles.keys.map { |k| [k, k] }, class: "form-control" %>
+              <%= f.button type: "submit", class: "btn btn-light" do %>
+                <i class="fa-solid fa-arrows-rotate"></i>
+              <% end %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to admin_user_path(user), { method: :delete, data: { comfirm: "Sure?" }, id: "delete-#{user.id}", remote: true } do %>
               <i class="fa-solid fa-trash"></i>
             <% end %>
             <%= link_to edit_admin_user_path(user), id: "edit-#{user.id}" do %>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -14,7 +14,7 @@
     </thead>
     <tbody>
       <% @users.each do |user| %>
-        <tr>
+        <tr id=<%= "user_#{user.id}" %>>
           <td><%= user.id %></td>
           <td><%= user.email %></td>
           <td><%= user.name %></td>
@@ -23,8 +23,8 @@
           <td><%= user.role %></td>
           <td>
             <%= form_with(model: [:admin, user]) do |f| %>
-              <%= f.select :role, User.roles.keys.map { |k| [k, k] }, class: "form-control" %>
-              <%= f.button type: "submit", class: "btn btn-light" do %>
+              <%= f.select :role, User.roles.keys.map { |k| [k, k] }, {}, { id: "user_role_#{user.id}", class: "form-select form-select-sm" } %>
+              <%= f.button type: "submit", id: "role_#{user.id}", class: "btn btn-light" do %>
                 <i class="fa-solid fa-arrows-rotate"></i>
               <% end %>
             <% end %>

--- a/myapp/app/views/admin/users/new.html.erb
+++ b/myapp/app/views/admin/users/new.html.erb
@@ -1,0 +1,4 @@
+<div class="container pt-5">
+  <%= t('.new') %>
+  <%= render 'admin/users/form' %>
+</div>

--- a/myapp/app/views/admin/users/tasks.html.erb
+++ b/myapp/app/views/admin/users/tasks.html.erb
@@ -1,0 +1,24 @@
+<div class="mt-5">
+  <table class="table">
+    <thead>
+      <tr>
+        <th scope="col">title</th>
+        <th scope="col">description</th>
+        <th scope="col">status</th>
+        <th scope="col">expire</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @tasks.each do |task| %>
+        <tr>
+          <td><%= task.title %></td>
+          <td><%= task.description %></td>
+          <td><%= task.status %></td>
+          <td><%= task.expire_at %></td>
+        </tr>
+      <% end %>
+
+    </tbody>
+  </table>
+</div>

--- a/myapp/app/views/layouts/_header.html.erb
+++ b/myapp/app/views/layouts/_header.html.erb
@@ -4,6 +4,9 @@
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item"><%= link_to "Home",   root_path, class: "nav-link active text-white" %></li>
         <li class="nav-item"><%= link_to 'Logout', logout_path, class: "nav-link text-white" %></li>
+        <% if admin? %>
+          <li class="nav-item"><%= link_to "Admin",   admin_users_path, class: "nav-link active text-white" %></li>
+        <% end %>
       </ul>
       <div class="d-flex">
         <%= form_with url: search_path, method: :get, local: true, class:"d-flex" do |f| %>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <div class="container p-5">
       <!-- flashメッセージ -->
       <% flash.each do |message_type, message| %>
-        <div class="alert alert-<%= message_type %> m-3"><%= message %></div>
+        <div class="alert alert-<%= message_type %> m-3"><%= sanitize message, tags: %w(br) %></div>
       <% end %>
       <%= yield %>
     </div>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -10,15 +10,16 @@
   </head>
 
   <body>
-    <% if logged_in? %>
-      <%= render 'layouts/header' %>
-    <% end %>
-
-    <!-- flashメッセージ -->
-    <% flash.each do |message_type, message| %>
-      <div class="alert alert-<%= message_type %>"><%= message %></div>
-    <% end %>
-    <div class="container pt-5">
+    <div class="container">
+      <% if logged_in? %>
+          <%= render 'layouts/header' %>
+      <% end %>
+    </div>
+    <div class="container p-5">
+      <!-- flashメッセージ -->
+      <% flash.each do |message_type, message| %>
+        <div class="alert alert-<%= message_type %> m-3"><%= message %></div>
+      <% end %>
       <%= yield %>
     </div>
   </body>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body class="pt-5">
+  <body>
     <% if logged_in? %>
       <%= render 'layouts/header' %>
     <% end %>
@@ -18,7 +18,7 @@
     <% flash.each do |message_type, message| %>
       <div class="alert alert-<%= message_type %>"><%= message %></div>
     <% end %>
-    <div class="container">
+    <div class="container pt-5">
       <%= yield %>
     </div>
   </body>

--- a/myapp/config/locales/controllers/admin/users/ja.yml
+++ b/myapp/config/locales/controllers/admin/users/ja.yml
@@ -1,0 +1,12 @@
+ja:
+  admin:
+    users:
+      create:
+        flash_created: 'ユーザーが作成されました'
+      update:
+        flash_update: 'ユーザーが更新されました'
+        flash_req: 'Adminユーザーは1人以上必要です'
+        flash_invalid_password: 'パスワードが一致しません'
+      destroy:
+        flash_delete_me: '自分は削除できません'
+        flash_deleted: 'ユーザーが削除されました'

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   # admin/**
   namespace :admin do
     resources :users
+    get '/users/:id/tasks', to: 'users#tasks', as: 'users_tasks'
   end
   # 404/500エラーページ
   get '*path' => 'application#render_404'

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   get '/logout', to: 'sessions#destroy'
+  # admin/**
+  namespace :admin do
+    resources :users
+  end
   # 404/500エラーページ
   get '*path' => 'application#render_404'
   post '*path' => 'application#render_404'

--- a/myapp/db/migrate/20220628024548_add_role_to_user.rb
+++ b/myapp/db/migrate/20220628024548_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_23_023700) do
+ActiveRecord::Schema.define(version: 2022_06_28_024548) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2022_06_23_023700) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_digest"
+    t.integer "role", default: 0
   end
 
   add_foreign_key "tasks", "users"

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -1,6 +1,22 @@
 TASK_NUM = 20
 USER_NUM = 5
 
+# Adminユーザー
+admin_user = User.create!(
+  name: 'admin_user',
+  email: 'admin@example.com',
+  password: 'password',
+  role: 1,
+)
+
+TASK_NUM.times do |j|
+  admin_user.tasks.create(
+    title: "Admin-Task#{j}",
+    description: 'Taskの説明',
+    status: rand(0..2),
+  )
+end
+
 USER_NUM.times do |i|
   name = Faker::Name.name
   user = User.create(

--- a/myapp/spec/rails_helper.rb
+++ b/myapp/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -66,8 +66,8 @@ RSpec.configure do |config|
     hub_url = 'https://chrome:4444/wd/hub'
     chrome_capabilities = ::Selenium::WebDriver::Remote::Capabilities.chrome(
       'goog:chromeOptions' => {
-        'args' => %w[no-sandbox headless disable-gpu window-size=1680,1050],
-      },
+        'args' => %w[no-sandbox headless disable-gpu window-size=1680,1050]
+      }
     )
     Capybara::Selenium::Driver.new(app, browser: :remote, url: hub_url, desired_capabilities: chrome_capabilities)
   end
@@ -84,4 +84,5 @@ RSpec.configure do |config|
   end
 
   config.include LoginSupport
+  config.include AdminUserSupport
 end

--- a/myapp/spec/support/admin_user_support.rb
+++ b/myapp/spec/support/admin_user_support.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AdminUserSupport
+  def check_user_list(user, page)
+    expect(page).to have_content user.id
+    expect(page).to have_content user.name
+    expect(page).to have_link "#{user.name}'s tasks", href: admin_users_tasks_path(user.id)
+    expect(page).to have_content user.tasks.length
+    expect(page).to have_content user.role
+  end
+end

--- a/myapp/spec/system/admin/admin_users_spec.rb
+++ b/myapp/spec/system/admin/admin_users_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin::Users', type: :system do
+  include TasksHelper
+  let!(:normal_user) do
+    FactoryBot.create(:user)
+  end
+  let!(:admin_user) do
+    FactoryBot.create(:user, email: 'admin@example.com', role: 'admin')
+  end
+
+  describe 'ユーザー管理画面への遷移前', type: :system do
+    context 'Adminユーザーのとき' do
+      example 'ヘッダーにリンクが表示' do
+        login(admin_user)
+        expect(page).to have_link 'Admin', href: '/admin/users'
+      end
+    end
+    context '一般ユーザーのとき' do
+      example 'ヘッダーにリンクが表示されない' do
+        login(normal_user)
+        expect(page).to have_no_link 'Admin', href: '/admin/users'
+      end
+      example '直接管理ページにアクセスしてもメインページにリダイレクトされる' do
+        login(normal_user)
+        visit admin_users_path
+        expect(page).to have_content I18n.t('tasks.index.all')
+      end
+    end
+  end
+  describe 'ユーザー管理画面に遷移後', type: :system do
+    before do
+      login(admin_user)
+      click_link 'Admin'
+    end
+
+    context 'ユーザー一覧画面' do
+      example 'ユーザーの一覧が表示されるか' do
+        check_user_list(normal_user, page)
+        check_user_list(admin_user, page)
+        expect(User.count).to eq 2
+      end
+    end
+
+    context 'ユーザー作成したとき' do
+      example '一覧画面にユーザーが一人追加される' do
+        expect do
+          click_link 'New User', href: '/admin/users/new'
+          fill_in 'Name', with: 'newuser'
+          fill_in 'Email', with: 'newuser@example.com'
+          fill_in 'Password', with: 'password'
+          fill_in 'Confirmation', with: 'password'
+          click_button 'Submit'
+          new_user = User.find_by(email: 'newuser@example.com')
+          check_user_list(new_user, page)
+        end.to change(User, :count).by(1)
+      end
+    end
+
+    context 'ユーザーのロールを変更したとき' do
+      context '通常ユーザーからAdminユーザーに変更したとき' do
+        example 'roleがadminになりflashメッセージが表示' do
+          select 'admin', from: "user_role_#{normal_user.id}"
+          click_button "role_#{normal_user.id}"
+          expect(find_by_id("user_#{normal_user.id}")).to have_content 'admin'
+          expect(page).to have_content I18n.t('admin.users.update.flash_update')
+        end
+      end
+      context 'Adminユーザーから通常ユーザーに変更し、更新後にadminが1人以上になるとき' do
+        example 'roleがnormalになりflashメッセージが表示' do
+          select 'normal', from: "user_role_#{normal_user.id}"
+          click_button "role_#{normal_user.id}"
+          expect(find_by_id("user_#{normal_user.id}")).to have_content 'normal'
+          expect(page).to have_content I18n.t('admin.users.update.flash_update')
+        end
+      end
+      context 'Adminユーザーから通常ユーザーに変更し、更新後にadminが0人になるとき' do
+        example 'flashメッセージが表示され更新されない' do
+          select 'normal', from: "user_role_#{admin_user.id}"
+          click_button "role_#{admin_user.id}"
+          expect(find_by_id("user_#{admin_user.id}")).to have_content 'admin'
+          expect(page).to have_content I18n.t('admin.users.update.flash_req')
+        end
+      end
+    end
+
+    context 'ユーザーの更新' do
+      context '正しいデータで更新したとき' do
+        example 'ユーザー管理画面へリダイレクトされflashメッセージが表示' do
+          click_link "edit-#{normal_user.id}"
+          fill_in 'Name', with: 'Name-update'
+          click_button 'Submit'
+          expect(find_by_id("user_#{normal_user.id}")).to have_content 'Name-update'
+          expect(page).to have_content I18n.t('admin.users.update.flash_update')
+        end
+      end
+      context 'PasswordとConfirmationが異なるとき' do
+        example 'パスワードは更新されずflashメッセージが表示' do
+          click_link "edit-#{normal_user.id}"
+          fill_in 'Password', with: 'hoge'
+          fill_in 'Confirmation', with: 'fuga'
+          click_button 'Submit'
+          expect(page).to have_content I18n.t('errors.messages.confirmation', attribute: 'Password')
+        end
+      end
+    end
+
+    context 'ユーザーの削除' do
+      context '自分を削除するとき' do
+        example '削除されずflashメッセージが表示' do
+          click_link "delete-#{admin_user.id}"
+          expect(page).to have_content I18n.t('admin.users.destroy.flash_delete_me')
+          expect(page).to have_content admin_user.id
+        end
+      end
+      context '他のユーザーを削除するとき' do
+        example '削除されflashメッセージが表示' do
+          click_link "delete-#{normal_user.id}"
+          expect(page).to have_content I18n.t('admin.users.destroy.flash_deleted')
+          expect(page).not_to have_content normal_user.id
+        end
+      end
+    end
+  end
+end

--- a/myapp/spec/system/admin/admin_users_spec.rb
+++ b/myapp/spec/system/admin/admin_users_spec.rb
@@ -45,17 +45,39 @@ RSpec.describe 'Admin::Users', type: :system do
     end
 
     context 'ユーザー作成したとき' do
-      example '一覧画面にユーザーが一人追加される' do
-        expect do
+      context '正しいデータを入力したとき' do
+        example '一覧画面にユーザーが一人追加される' do
+          expect do
+            click_link 'New User', href: '/admin/users/new'
+            fill_in 'Name', with: 'newuser'
+            fill_in 'Email', with: 'newuser@example.com'
+            fill_in 'Password', with: 'password'
+            fill_in 'Confirmation', with: 'password'
+            click_button 'Submit'
+            new_user = User.find_by(email: 'newuser@example.com')
+            check_user_list(new_user, page)
+          end.to change(User, :count).by(1)
+        end
+      end
+      context '存在するemailを入力したとき' do
+        example '作成されずflashメッセージが表示' do
           click_link 'New User', href: '/admin/users/new'
-          fill_in 'Name', with: 'newuser'
-          fill_in 'Email', with: 'newuser@example.com'
+          fill_in 'Email', with: normal_user.email
           fill_in 'Password', with: 'password'
           fill_in 'Confirmation', with: 'password'
           click_button 'Submit'
-          new_user = User.find_by(email: 'newuser@example.com')
-          check_user_list(new_user, page)
-        end.to change(User, :count).by(1)
+          expect(page).to have_content I18n.t('errors.messages.taken', attribute: 'Email')
+        end
+      end
+      context 'PasswordとConfirmationが異なるとき' do
+        example '作成されずflashメッセージが表示' do
+          click_link 'New User', href: '/admin/users/new'
+          fill_in 'Email', with: 'newuser2@example.com'
+          fill_in 'Password', with: 'password'
+          fill_in 'Confirmation', with: 'hogehoge'
+          click_button 'Submit'
+          expect(page).to have_content I18n.t('errors.messages.confirmation', attribute: 'Password')
+        end
       end
     end
 
@@ -94,6 +116,14 @@ RSpec.describe 'Admin::Users', type: :system do
           click_button 'Submit'
           expect(find_by_id("user_#{normal_user.id}")).to have_content 'Name-update'
           expect(page).to have_content I18n.t('admin.users.update.flash_update')
+        end
+      end
+      context '存在するemailを入力したとき' do
+        example 'emailは更新されずflashメッセージが表示' do
+          click_link "edit-#{normal_user.id}"
+          fill_in 'Email', with: admin_user.email
+          click_button 'Submit'
+          expect(page).to have_content I18n.t('errors.messages.taken', attribute: 'Email')
         end
       end
       context 'PasswordとConfirmationが異なるとき' do

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
-include TasksHelper
 
 RSpec.describe 'Tasks', type: :system do
-  let!(:user) {
+  include TasksHelper
+  let!(:user) do
     FactoryBot.create(:user)
-  }
+  end
 
   before do
     login(user)
@@ -20,8 +22,8 @@ RSpec.describe 'Tasks', type: :system do
         expect(page).to have_content task.description
         expect(page).to have_content parse_date task.created_at
         expect(page).to have_content I18n.t('tasks.index.create')
-        expect(page).to have_link '', href:edit_task_path(task)
-        expect(page).to have_link '', href:task_path(task)
+        expect(page).to have_link '', href: edit_task_path(task)
+        expect(page).to have_link '', href: task_path(task)
       end
     end
   end
@@ -123,15 +125,15 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '作成日時でソート' do
-    let!(:task_created_yesterday) {
+    let!(:task_created_yesterday) do
       FactoryBot.create(:task, :created_yesterday, user_id: user.id)
-    }
-    let!(:task_created_1week_ago) {
+    end
+    let!(:task_created_1week_ago) do
       FactoryBot.create(:task, :created_1week_ago, user_id: user.id)
-    }
-    let!(:task_created_today) {
+    end
+    let!(:task_created_today) do
       FactoryBot.create(:task, user_id: user.id)
-    }
+    end
     context '1度作成日時を押したとき' do
       example '降順にソート' do
         visit root_path
@@ -155,18 +157,18 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '有効期限でソート' do
-    let!(:task_expire_tomorrow) {
+    let!(:task_expire_tomorrow) do
       FactoryBot.create(:task, :expire_tomorrow, user_id: user.id)
-    }
-    let!(:task_expire_next_month) {
+    end
+    let!(:task_expire_next_month) do
       FactoryBot.create(:task, :expire_next_month, user_id: user.id)
-    }
-    let!(:task_expire_today) {
+    end
+    let!(:task_expire_today) do
       FactoryBot.create(:task, user_id: user.id)
-    }
+    end
 
     context '1度有効期限を押したとき' do
-        # 降順→昇順に切り替わる
+      # 降順→昇順に切り替わる
       example '降順にソート' do
         visit root_path
         click_link I18n.t('tasks.form.expire')
@@ -188,15 +190,15 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '検索' do
-    let!(:task_hoge) {
+    let!(:task_hoge) do
       FactoryBot.create(:task, title: 'hogehoge', created_at: Time.current, user_id: user.id)
-    }
-    let!(:task_fuga) {
+    end
+    let!(:task_fuga) do
       FactoryBot.create(:task, title: 'fugafuga', created_at: Time.current.tomorrow, user_id: user.id)
-    }
-    let!(:task_complete) {
+    end
+    let!(:task_complete) do
       FactoryBot.create(:task, :status_completed, created_at: Time.current.yesterday, user_id: user.id)
-    }
+    end
 
     context 'タイトルで検索' do
       example 'タイトルが部分一致したタスクが表示' do


### PR DESCRIPTION
Rails研修の[step18,19](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)になります

## 課題
- [x] 管理メニューの追加
- [x] ユーザーのCRUD機能の実装 
- [x] ユーザーを削除したらタスクも同時に削除
-> Step16で実装完了
- [x] ユーザーのタスク一覧ページの実装
- [x] ユーザーにロールを追加
- [x] Adminユーザーのみ管理メニューにアクセスできるようにする
- [x] 管理メニューでロールの変更
- [x] Adminユーザーが１人もいなくならないように制御

## 実装したこと
### 管理メニュー
ユーザーの情報とタスク一覧ページへのリンク、タスク数の合計、ロール変更が表示
![スクリーンショット 2022-07-01 14 49 49](https://user-images.githubusercontent.com/61781055/176832044-960820d1-f85e-4dff-95e5-2a97ffcdfca8.png)

### ユーザーのタスク一覧
https://user-images.githubusercontent.com/61781055/176838942-26fbc9e4-8838-4f8d-874b-fa4035867cfd.mov

### ユーザー作成
デモ
https://user-images.githubusercontent.com/61781055/176834698-6c32518b-d03b-4779-9918-5162a40422be.mov

### ユーザー更新
ロールの変更
https://user-images.githubusercontent.com/61781055/176838796-beda08a6-16b9-42b6-9e67-7d705af606e6.mov

更新ボタンから更新
https://user-images.githubusercontent.com/61781055/176838714-29c0408d-adff-4c4a-a49b-803a76a318bf.mov

### ユーザー削除
https://user-images.githubusercontent.com/61781055/176838833-078fd302-951a-4203-920f-5e37733851a1.mov

自分を削除しようとした場合
https://user-images.githubusercontent.com/61781055/176838878-fdcf660e-d35c-40bb-8d1b-cfe4d02accd7.mov

### テスト結果
![スクリーンショット 2022-07-01 15 37 52](https://user-images.githubusercontent.com/61781055/176838988-a1624ece-7bcb-48f5-89fb-e2f42322c1f0.png)

