### PR TITLE
wataru okamoto step13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -51,11 +51,7 @@ class TasksController < ApplicationController
   end
 
   def search
-    tasks = Task.sortby(params[:sort], params[:direction])
-    tasks = tasks.search_by_name_or_description(params[:keyword])
-    tasks = tasks.search_by_status(params[:status])
-
-    @tasks = tasks
+    @tasks = Task.search(params)
     render 'index'
   end
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -60,13 +60,15 @@ class TasksController < ApplicationController
   end
 
   def search
-    @tasks = Task.all.order(created_at: 'DESC')
-    if params[:keyword] != ''
-      @tasks = Task.where('name LIKE ? OR description LIKE ?', "%#{params[:keyword]}%", "%#{params[:keyword]}%")
+    tasks = Task.all.order(created_at: 'DESC')
+    if params[:keyword].present?
+      tasks = tasks.where('name LIKE ? OR description LIKE ?', "%#{params[:keyword]}%", "%#{params[:keyword]}%")
     end
-    if params[:status]
-      @tasks = Task.where(status: params[:status])
+    if params[:status].present?
+      tasks = tasks.where(status: params[:status])
     end
+
+    @tasks = tasks
     render 'index'
   end
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -59,6 +59,11 @@ class TasksController < ApplicationController
     redirect_to tasks_path
   end
 
+  def search
+    @tasks = Task.where('name LIKE ?', "%#{params[:keyword]}%")
+    render 'index'
+  end
+
   private
 
   def task_params

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -60,7 +60,13 @@ class TasksController < ApplicationController
   end
 
   def search
-    @tasks = Task.where('name LIKE ? OR description LIKE ?', "%#{params[:keyword]}%", "%#{params[:keyword]}%")
+    @tasks = Task.all.order(created_at: 'DESC')
+    if params[:keyword] != ''
+      @tasks = Task.where('name LIKE ? OR description LIKE ?', "%#{params[:keyword]}%", "%#{params[:keyword]}%")
+    end
+    if params[:status]
+      @tasks = Task.where(status: params[:status])
+    end
     render 'index'
   end
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -50,7 +50,7 @@ class TasksController < ApplicationController
     redirect_to tasks_path
   end
 
-  def search # rubocop:disable all
+  def search
     sort = params[:sort]
     tasks = if sort.present?
               case sort
@@ -65,12 +65,8 @@ class TasksController < ApplicationController
               Task.sort_created_desc
             end
 
-    if params[:keyword].present?
-      tasks = tasks.name_or_description(params[:keyword])
-    end
-    if params[:status].present?
-      tasks = tasks.status(params[:status])
-    end
+    tasks = tasks.name_or_description(params[:keyword])
+    tasks = tasks.status(params[:status])
 
     @tasks = tasks
     render 'index'

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -51,20 +51,6 @@ class TasksController < ApplicationController
   end
 
   def search
-    # sort = params[:sort]
-    # tasks = if sort.present?
-    #           case sort
-    #           when 'limit'
-    #             Task.sort_limit_asc
-    #           when '-limit'
-    #             Task.sort_limit_desc
-    #           else
-    #             Task.sort_created_desc
-    #           end
-    #         else
-    #           Task.sort_created_desc
-    #         end
-
     tasks = Task.sortby(params[:sort], params[:direction])
     tasks = tasks.name_or_description(params[:keyword])
     tasks = tasks.status(params[:status])

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -59,13 +59,26 @@ class TasksController < ApplicationController
     redirect_to tasks_path
   end
 
-  def search
-    tasks = Task.all.order(created_at: 'DESC')
+  def search # rubocop:disable all
+    sort = params[:sort]
+    tasks = if sort.present?
+              case sort
+              when 'limit'
+                Task.sort_limit_asc
+              when '-limit'
+                Task.sort_limit_desc
+              else
+                Task.sorted
+              end
+            else
+              Task.sorted
+            end
+
     if params[:keyword].present?
-      tasks = tasks.where('name LIKE ? OR description LIKE ?', "%#{params[:keyword]}%", "%#{params[:keyword]}%")
+      tasks = tasks.name_or_description(params[:keyword])
     end
     if params[:status].present?
-      tasks = tasks.where(status: params[:status])
+      tasks = tasks.status(params[:status])
     end
 
     @tasks = tasks

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -68,10 +68,10 @@ class TasksController < ApplicationController
               when '-limit'
                 Task.sort_limit_desc
               else
-                Task.sorted
+                Task.sort_created_desc
               end
             else
-              Task.sorted
+              Task.sort_created_desc
             end
 
     if params[:keyword].present?

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,16 +2,7 @@
 
 class TasksController < ApplicationController
   def index
-    sort = params[:sort]
-
-    @tasks = case sort
-             when 'limit'
-               Task.sort_limit_asc
-             when '-limit'
-               Task.sort_limit_desc
-             else
-               Task.all.order(created_at: 'DESC')
-             end
+    @tasks = Task.sort_created_desc
   end
 
   def show

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.search(params)
+    @tasks = Task.search(status: params[:status], keyword: params[:keyword], sort: params[:sort], direction: params[:direction])
   end
 
   def show

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.sort_created_desc
+    @tasks = Task.sortby(params[:sort], params[:direction])
   end
 
   def show
@@ -51,20 +51,21 @@ class TasksController < ApplicationController
   end
 
   def search
-    sort = params[:sort]
-    tasks = if sort.present?
-              case sort
-              when 'limit'
-                Task.sort_limit_asc
-              when '-limit'
-                Task.sort_limit_desc
-              else
-                Task.sort_created_desc
-              end
-            else
-              Task.sort_created_desc
-            end
+    # sort = params[:sort]
+    # tasks = if sort.present?
+    #           case sort
+    #           when 'limit'
+    #             Task.sort_limit_asc
+    #           when '-limit'
+    #             Task.sort_limit_desc
+    #           else
+    #             Task.sort_created_desc
+    #           end
+    #         else
+    #           Task.sort_created_desc
+    #         end
 
+    tasks = Task.sortby(params[:sort], params[:direction])
     tasks = tasks.name_or_description(params[:keyword])
     tasks = tasks.status(params[:status])
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -52,8 +52,8 @@ class TasksController < ApplicationController
 
   def search
     tasks = Task.sortby(params[:sort], params[:direction])
-    tasks = tasks.name_or_description(params[:keyword])
-    tasks = tasks.status(params[:status])
+    tasks = tasks.search_by_name_or_description(params[:keyword])
+    tasks = tasks.search_by_status(params[:status])
 
     @tasks = tasks
     render 'index'

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -60,7 +60,7 @@ class TasksController < ApplicationController
   end
 
   def search
-    @tasks = Task.where('name LIKE ?', "%#{params[:keyword]}%")
+    @tasks = Task.where('name LIKE ? OR description LIKE ?', "%#{params[:keyword]}%", "%#{params[:keyword]}%")
     render 'index'
   end
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.sortby(params[:sort], params[:direction])
+    @tasks = Task.search(params)
   end
 
   def show
@@ -48,11 +48,6 @@ class TasksController < ApplicationController
       flash[:error] = I18n.t('tasks.flash.destroy.error')
     end
     redirect_to tasks_path
-  end
-
-  def search
-    @tasks = Task.search(params)
-    render 'index'
   end
 
   private

--- a/myapp/app/helpers/tasks_helper.rb
+++ b/myapp/app/helpers/tasks_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module TasksHelper
+  def sort_order(column, title)
+    direction = column == params[:sort] && params[:direction] == 'asc' ? 'desc' : 'asc'
+    link_to title, { sort: column, direction: direction }
+  end
+end

--- a/myapp/app/helpers/tasks_helper.rb
+++ b/myapp/app/helpers/tasks_helper.rb
@@ -3,6 +3,6 @@
 module TasksHelper
   def sort_order(column, title)
     direction = column == params[:sort] && params[:direction] == 'asc' ? 'desc' : 'asc'
-    link_to title, { sort: column, direction: direction }
+    link_to title, { sort: column, direction: direction, keyword: params[:keyword], status: params[:status] }
   end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -9,6 +9,14 @@ class Task < ApplicationRecord
   scope :sort_created_desc, -> { order(created_at: 'DESC') }
   scope :sort_limit_asc, -> { order(limit: 'ASC') }
   scope :sort_limit_desc, -> { order(limit: 'DESC') }
-  scope :name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "%#{keyword}%", "%#{keyword}%") }
-  scope :status, -> (status) { where(status: status) }
+  scope :name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "%#{keyword}%", "%#{keyword}%") if keyword.present? }
+  scope :status, -> (status) { where(status: status) if status.present? }
+
+  scope :sortby, lambda { |column, direction|
+    if column.blank? || direction.blank?
+      order(created_at: 'DESC')
+    else
+      order("#{column} #{direction}")
+    end
+  }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -11,7 +11,7 @@ class Task < ApplicationRecord
 
   scope :sortby, lambda { |column, direction|
     if column.blank? || direction.blank?
-      order(created_at: 'DESC')
+      order(created_at: :desc)
     else
       order("#{column}": direction.to_s)
     end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -8,12 +8,16 @@ class Task < ApplicationRecord
 
   scope :search_by_name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "#{keyword}%", "#{keyword}%") if keyword.present? }
   scope :search_by_status, -> (status) { where(status: status) if status.present? }
-
   scope :sortby, lambda { |column, direction|
     if column.blank? || direction.blank?
       order(created_at: :desc)
     else
       order("#{column}": direction.to_s)
     end
+  }
+  scope :search, lambda { |params|
+    search_by_status(params[:status])
+    .search_by_name_or_description(params[:keyword])
+    .sortby(params[:sort], params[:direction])
   }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -6,6 +6,9 @@ class Task < ApplicationRecord
   enum priority: { Low: 1, Normal: 2, High: 3 }
   enum status: { TODO: 1, IN_PROGRESS: 2, DONE: 3 }
 
+  scope :sorted, -> { order(created_at: 'DESC') }
   scope :sort_limit_asc, -> { order(limit: 'ASC') }
   scope :sort_limit_desc, -> { order(limit: 'DESC') }
+  scope :name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "%#{keyword}%", "%#{keyword}%") }
+  scope :status, -> (status) { where(status: status) }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -6,7 +6,7 @@ class Task < ApplicationRecord
   enum priority: { Low: 1, Normal: 2, High: 3 }
   enum status: { TODO: 1, IN_PROGRESS: 2, DONE: 3 }
 
-  scope :sorted, -> { order(created_at: 'DESC') }
+  scope :sort_created_desc, -> { order(created_at: 'DESC') }
   scope :sort_limit_asc, -> { order(limit: 'ASC') }
   scope :sort_limit_desc, -> { order(limit: 'DESC') }
   scope :name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "%#{keyword}%", "%#{keyword}%") }

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -15,9 +15,9 @@ class Task < ApplicationRecord
       order("#{column}": direction.to_s)
     end
   }
-  scope :search, lambda { |params|
-    search_by_status(params[:status])
-    .search_by_name_or_description(params[:keyword])
-    .sortby(params[:sort], params[:direction])
+  scope :search, lambda { |status:, keyword:, sort:, direction:|
+    search_by_status(status)
+    .search_by_name_or_description(keyword)
+    .sortby(sort, direction)
   }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -16,7 +16,7 @@ class Task < ApplicationRecord
     if column.blank? || direction.blank?
       order(created_at: 'DESC')
     else
-      order("#{column} #{direction}")
+      order("#{column}": direction.to_s)
     end
   }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -6,8 +6,8 @@ class Task < ApplicationRecord
   enum priority: { Low: 1, Normal: 2, High: 3 }
   enum status: { TODO: 1, IN_PROGRESS: 2, DONE: 3 }
 
-  scope :name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "#{keyword}%", "#{keyword}%") if keyword.present? }
-  scope :status, -> (status) { where(status: status) if status.present? }
+  scope :search_by_name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "#{keyword}%", "#{keyword}%") if keyword.present? }
+  scope :search_by_status, -> (status) { where(status: status) if status.present? }
 
   scope :sortby, lambda { |column, direction|
     if column.blank? || direction.blank?

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -6,9 +6,6 @@ class Task < ApplicationRecord
   enum priority: { Low: 1, Normal: 2, High: 3 }
   enum status: { TODO: 1, IN_PROGRESS: 2, DONE: 3 }
 
-  scope :sort_created_desc, -> { order(created_at: 'DESC') }
-  scope :sort_limit_asc, -> { order(limit: 'ASC') }
-  scope :sort_limit_desc, -> { order(limit: 'DESC') }
   scope :name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "%#{keyword}%", "%#{keyword}%") if keyword.present? }
   scope :status, -> (status) { where(status: status) if status.present? }
 

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -6,7 +6,7 @@ class Task < ApplicationRecord
   enum priority: { Low: 1, Normal: 2, High: 3 }
   enum status: { TODO: 1, IN_PROGRESS: 2, DONE: 3 }
 
-  scope :name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "%#{keyword}%", "%#{keyword}%") if keyword.present? }
+  scope :name_or_description, -> (keyword) { where('name LIKE ? OR description LIKE ?', "#{keyword}%", "#{keyword}%") if keyword.present? }
   scope :status, -> (status) { where(status: status) if status.present? }
 
   scope :sortby, lambda { |column, direction|

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,5 +1,6 @@
 <%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
   <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
+  <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] } %>
   <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] } %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,4 +1,4 @@
 <%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
-  <%= form.text_field :keyword %>
+  <%= form.text_field :keyword, name: 'keyword' %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,0 +1,4 @@
+<%= form_with method: :get, local: true do |form| %>
+  <%= form.text_field :keyword %>
+  <%= form.submit %>
+<% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,4 +1,5 @@
 <%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
   <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
+  <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] } %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,6 +1,6 @@
 <%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
   <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
-  <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] } %>
-  <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] } %>
+  <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] }, { id: 'status' } %>
+  <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] }, { id: 'status' } %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,6 +1,5 @@
 <%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
   <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
   <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] }, { id: 'status' } %>
-  <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] }, { id: 'sort' } %>
   <%= form.submit I18n.t('dictionary.button.search') %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,6 +1,6 @@
 <%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
   <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
   <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] }, { id: 'status' } %>
-  <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] }, { id: 'status' } %>
+  <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] }, { id: 'sort' } %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,4 +1,4 @@
 <%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
-  <%= form.text_field :keyword, name: 'keyword' %>
+  <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
+<%= form_with url: tasks_path, method: :get, local: true do |form| %>
   <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
   <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] }, { id: 'status' } %>
   <%= form.submit I18n.t('dictionary.button.search') %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,4 +1,4 @@
-<%= form_with method: :get, local: true do |form| %>
+<%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
   <%= form.text_field :keyword %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -2,5 +2,5 @@
   <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
   <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] }, { id: 'status' } %>
   <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] }, { id: 'sort' } %>
-  <%= form.submit %>
+  <%= form.submit I18n.t('dictionary.button.search') %>
 <% end %>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,6 +1,6 @@
 <%= form_with url: search_tasks_path, method: :get, local: true do |form| %>
   <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
-  <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] } %>
   <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] } %>
+  <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] } %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -3,13 +3,6 @@
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
 <%= render partial: 'layouts/search' %>
 
-<div>
-  <%= form_with url: tasks_path, method: :get, local: true do |form| %>
-    <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] } %>
-    <%= form.submit %>
-  <% end %>
-</div>
-
 <table class="tasks">
   <tbody>
     <% @tasks.each do |task| %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -6,8 +6,8 @@
 <table class="tasks">
   <thead>
     <tr>
-      <th><%= sort_order "name", "タイトル"%></th>
-      <th><%= sort_order "limit", "期限" %></th>
+      <th><%= sort_order "name", I18n.t('activerecord.attributes.task.name') %></th>
+      <th><%= sort_order "limit", I18n.t('activerecord.attributes.task.limit') %></th>
     </tr>
   </thead>
   <tbody>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,10 +2,12 @@
 
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
 <%= render partial: 'layouts/search' %>
+
 <div>
-  <%= link_to I18n.t('dictionary.button.sort.created'), root_path %>
-  <%= link_to I18n.t('dictionary.button.sort.limit_asc'), tasks_path(sort: 'limit') %>
-  <%= link_to I18n.t('dictionary.button.sort.limit_desc'), tasks_path(sort: '-limit') %>
+  <%= form_with url: tasks_path, method: :get, local: true do |form| %>
+    <%= form.select :sort, [[I18n.t('dictionary.button.sort.created'), 'created_at'], [I18n.t('dictionary.button.sort.limit_asc'), 'limit'],[I18n.t('dictionary.button.sort.limit_desc'), '-limit']], { include_blank: '並び替え', selected: params[:sort] } %>
+    <%= form.submit %>
+  <% end %>
 </div>
 
 <div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -6,15 +6,17 @@
 <table class="tasks">
   <thead>
     <tr>
-      <th><%= sort_order "name", I18n.t('activerecord.attributes.task.name') %></th>
+      <th><%= I18n.t('activerecord.attributes.task.name') %></th>
       <th><%= sort_order "limit", I18n.t('activerecord.attributes.task.limit') %></th>
+      <th><%= sort_order "created_at", I18n.t('activerecord.attributes.task.created_at') %></th>
     </tr>
   </thead>
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
         <td class="task-title"><%= link_to task.name, task %></td>
-        <td><%= task.limit %></td>
+        <td><%= I18n.l(task.limit) %></td>
+        <td><%= I18n.l(task.created_at) %></td>
         <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task) %></td>
         <td><%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"} %><br /></td>
       </tr>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -10,13 +10,6 @@
   <% end %>
 </div>
 
-<div>
-  <%= link_to I18n.t('enums.task.status.TODO'), search_tasks_path(status: 'TODO') %>
-  <%= link_to I18n.t('enums.task.status.IN_PROGRESS'), search_tasks_path(status: 'IN_PROGRESS') %>
-  <%= link_to I18n.t('enums.task.status.DONE'), search_tasks_path(status: 'DONE') %>
-</div>
-
-
 <table class="tasks">
   <tbody>
     <% @tasks.each do |task| %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,11 +2,18 @@
 
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
 <%= render partial: 'layouts/search' %>
-<p>
+<div>
   <%= link_to I18n.t('dictionary.button.sort.created'), root_path %>
   <%= link_to I18n.t('dictionary.button.sort.limit_asc'), tasks_path(sort: 'limit') %>
   <%= link_to I18n.t('dictionary.button.sort.limit_desc'), tasks_path(sort: '-limit') %>
-</p>
+</div>
+
+<div>
+  <%= link_to I18n.t('enums.task.status.TODO'), search_tasks_path(status: 'TODO') %>
+  <%= link_to I18n.t('enums.task.status.IN_PROGRESS'), search_tasks_path(status: 'IN_PROGRESS') %>
+  <%= link_to I18n.t('enums.task.status.DONE'), search_tasks_path(status: 'DONE') %>
+</div>
+
 
 <table class="tasks">
   <tbody>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:page_title, I18n.t('tasks.index.title')) %>
 
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
+<%= render partial: 'layouts/search' %>
 <p>
   <%= link_to I18n.t('dictionary.button.sort.created'), root_path %>
   <%= link_to I18n.t('dictionary.button.sort.limit_asc'), tasks_path(sort_limit_asc: 'true') %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -4,10 +4,17 @@
 <%= render partial: 'layouts/search' %>
 
 <table class="tasks">
+  <thead>
+    <tr>
+      <th><%= sort_order "name", "タイトル"%></th>
+      <th><%= sort_order "limit", "期限" %></th>
+    </tr>
+  </thead>
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
         <td class="task-title"><%= link_to task.name, task %></td>
+        <td><%= task.limit %></td>
         <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task) %></td>
         <td><%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"} %><br /></td>
       </tr>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -20,3 +20,6 @@ ja:
     submit:
       create: "新規作成"
       update: "更新"
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -19,3 +19,4 @@ ja:
     submit:
       create: "新規作成"
       update: "更新"
+      submit: "検索"

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -11,6 +11,7 @@ ja:
       destory: "削除"
       home: "一覧へ"
       edit: "編集"
+      search: "検索"
       sort:
         created: "作成日時順"
         limit_asc: "終了期限近い順"
@@ -19,4 +20,3 @@ ja:
     submit:
       create: "新規作成"
       update: "更新"
-      submit: "検索"

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -3,7 +3,9 @@
 Rails.application.routes.draw do
   root 'tasks#index'
 
-  resources :tasks
+  resources :tasks do
+    get :search, on: :collection
+  end
 
   # for error page
   get '*not_found' => 'application#routing_error'

--- a/myapp/db/migrate/20220701062236_add_index_tasks_name.rb
+++ b/myapp/db/migrate/20220701062236_add_index_tasks_name.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksName < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :name
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_28_030721) do
+ActiveRecord::Schema.define(version: 2022_07_01_062236) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2022_06_28_030721) do
     t.integer "status"
     t.date "limit"
     t.bigint "user_id"
+    t.index ["name"], name: "index_tasks_on_name"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -11,7 +11,7 @@ User.create!(
   description = "test-description-#{n+1}"
   priority = rand(1..3)
   status = rand(1..3)
-  limit = "2022-#{rand(1...12)}-#{rand(1...28)}".to_date
+  limit = "2022-#{rand(1..12)}-#{rand(1..28)}".to_date
   user_id = 1
   Task.create!(
     name: name,

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -6,19 +6,21 @@ User.create!(
   password: 'password'
 )
 
-30.times do |n|
-  name = "test-#{n+1}"
-  description = "test-description-#{n+1}"
-  priority = rand(1..3)
-  status = rand(1..3)
-  limit = "2022-#{rand(1..12)}-#{rand(1..28)}".to_date
-  user_id = 1
-  Task.create!(
-    name: name,
-    description: description,
-    priority: priority,
-    status: status,
-    limit: limit,
-    user_id: user_id
-  )
+if Rails.env.development?
+  30.times do |n|
+    name = "test-#{n+1}"
+    description = "test-description-#{n+1}"
+    priority = rand(1..3)
+    status = rand(1..3)
+    limit = "2022-#{rand(1..12)}-#{rand(1..28)}".to_date
+    user_id = 1
+    Task.create!(
+      name: name,
+      description: description,
+      priority: priority,
+      status: status,
+      limit: limit,
+      user_id: user_id
+    )
+  end
 end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -1,10 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
 
 User.create!(
   id: 1,
@@ -12,3 +5,20 @@ User.create!(
   email: 'test@gmail.com',
   password: 'password'
 )
+
+30.times do |n|
+  name = "test-#{n+1}"
+  description = "test-description-#{n+1}"
+  priority = rand(1..3)
+  status = rand(1..3)
+  limit = "2022-#{rand(1...12)}-#{rand(1...28)}".to_date
+  user_id = 1
+  Task.create!(
+    name: name,
+    description: description,
+    priority: priority,
+    status: status,
+    limit: limit,
+    user_id: user_id
+  )
+end

--- a/myapp/package.json
+++ b/myapp/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^4.9.2"
+    "webpack-dev-server": "^4.9.3"
   }
 }

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Task, type: :model do
   end
 
   describe '#scope' do
-    let(:task1) { create(:task, name: 'テスト1', status: 'TODO', limit: Time.new(2021, 1, 10).in_time_zone, created_at: Time.new(2021, 12, 1).in_time_zone) }
-    let(:task2) { create(:task, name: 'テスト2', status: 'IN_PROGRESS', limit: Time.new(2021, 1, 2).in_time_zone, created_at: Time.new(2021, 12, 2).in_time_zone) }
-    let(:task3) { create(:task, name: 'テスト3', status: 'DONE', limit: Time.new(2021, 1, 3).in_time_zone, created_at: Time.new(2021, 12, 3).in_time_zone) }
+    let(:task1) { create(:task, name: 'テスト11', status: 'TODO', limit: Time.new(2021, 1, 10).in_time_zone, created_at: Time.new(2021, 12, 1).in_time_zone) }
+    let(:task2) { create(:task, name: 'テスト21', status: 'IN_PROGRESS', limit: Time.new(2021, 1, 2).in_time_zone, created_at: Time.new(2021, 12, 2).in_time_zone) }
+    let(:task3) { create(:task, name: 'テスト31', status: 'DONE', limit: Time.new(2021, 1, 3).in_time_zone, created_at: Time.new(2021, 12, 3).in_time_zone) }
 
     describe ':sortby' do
       context 'when specify the limit column and asc direction' do # rubocop:disable RSpec/NestedGroups
@@ -66,7 +66,11 @@ RSpec.describe Task, type: :model do
 
     describe ':name_or_description' do
       it 'searched by name or description' do
-        expect(Task.search_by_name_or_description('テスト1')).to eq [task1]
+        expect(Task.search_by_name_or_description('テスト11')).to eq [task1]
+      end
+
+      it 'searched by name in forward matching' do
+        expect(Task.search_by_name_or_description('テスト2')).to eq [task2]
       end
     end
 

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -38,33 +38,41 @@ RSpec.describe Task, type: :model do
     let(:task2) { create(:task, name: 'テスト2', status: 'IN_PROGRESS', limit: Time.new(2021, 1, 2).in_time_zone, created_at: Time.new(2021, 12, 2).in_time_zone) }
     let(:task3) { create(:task, name: 'テスト3', status: 'DONE', limit: Time.new(2021, 1, 3).in_time_zone, created_at: Time.new(2021, 12, 3).in_time_zone) }
 
-    describe ':sort_created_desc' do
-      it 'sorted by creation date' do
-        expect(Task.sort_created_desc).to eq [task3, task2, task1]
+    describe ':sortby' do
+      context 'when specify the limit column and asc direction' do # rubocop:disable RSpec/NestedGroups
+        it 'sorted by limit asc' do
+          expect(Task.sortby('limit', 'asc')).to eq [task2, task3, task1]
+        end
       end
-    end
 
-    describe ':sort_limit_desc' do
-      it 'sorted in desc order by limit' do
-        expect(Task.sort_limit_desc).to eq [task1, task3, task2]
+      context 'when specify the limit column and desc direction' do # rubocop:disable RSpec/NestedGroups
+        it 'sorted by limit desc' do
+          expect(Task.sortby('limit', 'desc')).to eq [task1, task3, task2]
+        end
       end
-    end
 
-    describe ':sort_limit_asc' do
-      it 'sorted in asc order by limit' do
-        expect(Task.sort_limit_asc).to eq [task2, task3, task1]
+      context 'when specify the created_at column and asc direction' do # rubocop:disable RSpec/NestedGroups
+        it 'sorted by creation date asc' do
+          expect(Task.sortby('created_at', 'asc')).to eq [task1, task2, task3]
+        end
+      end
+
+      context 'when specify the created_at column and desc direction' do # rubocop:disable RSpec/NestedGroups
+        it 'sorted by creation date desc' do
+          expect(Task.sortby('created_at', 'desc')).to eq [task3, task2, task1]
+        end
       end
     end
 
     describe ':name_or_description' do
       it 'searched by name or description' do
-        expect(Task.name_or_description('テスト1')).to eq [task1]
+        expect(Task.search_by_name_or_description('テスト1')).to eq [task1]
       end
     end
 
     describe ':status' do
       it 'searched by status' do
-        expect(Task.status('DONE')).to eq [task3]
+        expect(Task.search_by_status('DONE')).to eq [task3]
       end
     end
   end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -32,4 +32,40 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe '#scope' do
+    let(:task1) { create(:task, name: 'テスト1', status: 'TODO', limit: Time.new(2021, 1, 10).in_time_zone, created_at: Time.new(2021, 12, 1).in_time_zone) }
+    let(:task2) { create(:task, name: 'テスト2', status: 'IN_PROGRESS', limit: Time.new(2021, 1, 2).in_time_zone, created_at: Time.new(2021, 12, 2).in_time_zone) }
+    let(:task3) { create(:task, name: 'テスト3', status: 'DONE', limit: Time.new(2021, 1, 3).in_time_zone, created_at: Time.new(2021, 12, 3).in_time_zone) }
+
+    describe ':sort_created_desc' do
+      it 'sorted by creation date' do
+        expect(Task.sort_created_desc).to eq [task3, task2, task1]
+      end
+    end
+
+    describe ':sort_limit_desc' do
+      it 'sorted in desc order by limit ' do # rubocop:disable RSpec/ExcessiveDocstringSpacing
+        expect(Task.sort_limit_desc).to eq [task1, task3, task2]
+      end
+    end
+
+    describe ':sort_limit_asc' do
+      it 'sorted in asc order by limit ' do # rubocop:disable RSpec/ExcessiveDocstringSpacing
+        expect(Task.sort_limit_asc).to eq [task2, task3, task1]
+      end
+    end
+
+    describe ':name_or_description' do
+      it 'searched by name or description' do
+        expect(Task.name_or_description('テスト1')).to eq [task1]
+      end
+    end
+
+    describe ':status' do
+      it 'searched by status' do
+        expect(Task.status('DONE')).to eq [task3]
+      end
+    end
+  end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -45,13 +45,13 @@ RSpec.describe Task, type: :model do
     end
 
     describe ':sort_limit_desc' do
-      it 'sorted in desc order by limit ' do # rubocop:disable RSpec/ExcessiveDocstringSpacing
+      it 'sorted in desc order by limit' do
         expect(Task.sort_limit_desc).to eq [task1, task3, task2]
       end
     end
 
     describe ':sort_limit_asc' do
-      it 'sorted in asc order by limit ' do # rubocop:disable RSpec/ExcessiveDocstringSpacing
+      it 'sorted in asc order by limit' do
         expect(Task.sort_limit_asc).to eq [task2, task3, task1]
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -77,6 +77,30 @@ RSpec.describe 'Task', type: :system do
         end
       end
     end
+
+    context 'when use search function' do
+      before do
+        create(:task, name: '洗濯', description: 'コインランドリーに行く', priority: 'Low', status: 'TODO', limit: Time.new(2022, 1, 10).in_time_zone, created_at: Time.new(2021, 12, 1).in_time_zone)
+        create(:task, name: '掃除', description: '洗面所掃除する', priority: 'Normal', status: 'IN_PROGRESS', limit: Time.new(2022, 1, 2).in_time_zone, created_at: Time.new(2021, 12, 2).in_time_zone)
+        create(:task, name: '買い物', description: '柔軟剤買う', priority: 'High', status: 'DONE',  limit: Time.new(2022, 1, 30).in_time_zone, created_at: Time.new(2021, 12, 3).in_time_zone)
+        visit current_path
+      end
+
+      it 'can search using the search form' do # rubocop:disable RSpec/MultipleExpectations
+        fill_in 'keyword', with: '洗濯'
+        click_on '検索'
+        expect(page).to have_content '洗濯'
+        expect(page).not_to have_content '掃除'
+        expect(page).not_to have_content '買い物'
+      end
+
+      it 'can search using status button' do # rubocop:disable RSpec/MultipleExpectations
+        click_on '着手中'
+        expect(page).not_to have_content '洗濯'
+        expect(page).to have_content '掃除'
+        expect(page).not_to have_content '買い物'
+      end
+    end
   end
 
   describe '#show' do

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe 'Task', type: :system do
       end
 
       it 'sorted by creation date' do
-        click_on '作成日時順'
+        select '作成日時順', from: 'sort'
+        click_on '検索'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
           expect(task_titles).to eq %w[test3 test2 test1]
@@ -62,7 +63,8 @@ RSpec.describe 'Task', type: :system do
       end
 
       it 'sorted in asc order by limit date' do
-        click_on '終了期限近い順'
+        select '終了期限近い順', from: 'sort'
+        click_on '検索'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
           expect(task_titles).to eq %w[test2 test1 test3]
@@ -70,7 +72,8 @@ RSpec.describe 'Task', type: :system do
       end
 
       it 'sorted in desc order by limit date' do
-        click_on '終了期限遠い順'
+        select '終了期限遠い順', from: 'sort'
+        click_on '検索'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
           expect(task_titles).to eq %w[test3 test1 test2]
@@ -95,7 +98,8 @@ RSpec.describe 'Task', type: :system do
       end
 
       it 'can search using status button' do # rubocop:disable RSpec/MultipleExpectations
-        click_on '着手中'
+        select '着手中', from: 'status'
+        click_on '検索'
         expect(page).not_to have_content '洗濯'
         expect(page).to have_content '掃除'
         expect(page).not_to have_content '買い物'

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -83,25 +83,38 @@ RSpec.describe 'Task', type: :system do
 
     context 'when use search function' do
       before do
-        create(:task, name: '洗濯', description: 'コインランドリーに行く', priority: 'Low', status: 'TODO', limit: Time.new(2022, 1, 10).in_time_zone, created_at: Time.new(2021, 12, 1).in_time_zone)
+        create(:task, name: '洗濯1', description: 'コインランドリーに行く', priority: 'Low', status: 'TODO', limit: Time.new(2022, 1, 10).in_time_zone, created_at: Time.new(2021, 12, 1).in_time_zone)
+        create(:task, name: '洗濯2', description: 'クリーニング屋に行く', priority: 'High', status: 'DONE', limit: Time.new(2022, 1, 10).in_time_zone, created_at: Time.new(2021, 12, 1).in_time_zone)
         create(:task, name: '掃除', description: '洗面所掃除する', priority: 'Normal', status: 'IN_PROGRESS', limit: Time.new(2022, 1, 2).in_time_zone, created_at: Time.new(2021, 12, 2).in_time_zone)
         create(:task, name: '買い物', description: '柔軟剤買う', priority: 'High', status: 'DONE',  limit: Time.new(2022, 1, 30).in_time_zone, created_at: Time.new(2021, 12, 3).in_time_zone)
         visit current_path
       end
 
-      it 'can search using the search form' do # rubocop:disable RSpec/MultipleExpectations
+      it 'can search using the keyword' do # rubocop:disable RSpec/MultipleExpectations
         fill_in 'keyword', with: '洗濯'
         click_on '検索'
-        expect(page).to have_content '洗濯'
+        expect(page).to have_content '洗濯1'
+        expect(page).to have_content '洗濯2'
         expect(page).not_to have_content '掃除'
         expect(page).not_to have_content '買い物'
       end
 
-      it 'can search using status button' do # rubocop:disable RSpec/MultipleExpectations
+      it 'can search using status' do # rubocop:disable RSpec/MultipleExpectations
         select '着手中', from: 'status'
         click_on '検索'
-        expect(page).not_to have_content '洗濯'
+        expect(page).not_to have_content '洗濯1'
+        expect(page).not_to have_content '洗濯2'
         expect(page).to have_content '掃除'
+        expect(page).not_to have_content '買い物'
+      end
+
+      it 'can search using keyword and status' do # rubocop:disable RSpec/MultipleExpectations
+        fill_in 'keyword', with: '洗濯'
+        select '未着手', from: 'status'
+        click_on '検索'
+        expect(page).to have_content '洗濯1'
+        expect(page).not_to have_content '洗濯2'
+        expect(page).not_to have_content '掃除'
         expect(page).not_to have_content '買い物'
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -54,17 +54,15 @@ RSpec.describe 'Task', type: :system do
       end
 
       it 'sorted by creation date' do
-        select '作成日時順', from: 'sort'
-        click_on '検索'
+        click_on '作成日時'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
-          expect(task_titles).to eq %w[test3 test2 test1]
+          expect(task_titles).to eq %w[test1 test2 test3]
         end
       end
 
       it 'sorted in asc order by limit date' do
-        select '終了期限近い順', from: 'sort'
-        click_on '検索'
+        click_on '期限'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
           expect(task_titles).to eq %w[test2 test1 test3]
@@ -72,8 +70,8 @@ RSpec.describe 'Task', type: :system do
       end
 
       it 'sorted in desc order by limit date' do
-        select '終了期限遠い順', from: 'sort'
-        click_on '検索'
+        click_on '期限'
+        click_on '期限'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
           expect(task_titles).to eq %w[test3 test1 test2]

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -2293,10 +2293,10 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-connect-history-api-fallback@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
-  integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
+connect-history-api-fallback@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
+  integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
 
 console-browserify@^1.1.0:
   version "1.2.0"
@@ -7717,10 +7717,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.2.tgz#c188db28c7bff12f87deda2a5595679ebbc3c9bc"
-  integrity sha512-H95Ns95dP24ZsEzO6G9iT+PNw4Q7ltll1GfJHV4fKphuHWgKFzGHWi4alTlTnpk1SPPk41X+l2RB7rLfIhnB9Q==
+webpack-dev-server@^4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.3.tgz#2360a5d6d532acb5410a668417ad549ee3b8a3c9"
+  integrity sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"
@@ -7734,7 +7734,7 @@ webpack-dev-server@^4.9.2:
     chokidar "^3.5.3"
     colorette "^2.0.10"
     compression "^1.7.4"
-    connect-history-api-fallback "^1.6.0"
+    connect-history-api-fallback "^2.0.0"
     default-gateway "^6.0.3"
     express "^4.17.3"
     graceful-fs "^4.2.6"


### PR DESCRIPTION
# 概要
[Rails研修ステップ13](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)
- ステータス（未着手、着手中、完了）を追加してみよう
- 一覧画面でタイトルとステータスで検索できるようにしよう
- 検索インデックスを貼りましょう 
- 検索に対してspecを拡充しましょう


# 実装内容
- タスクモデルに予め追加していた`status`属性で検索できるようにタスクコントローラーとビュー(`index.html.erb`,` _search.html.erb`)を編集 
- I18nで日本語対応
- tasksテーブルの`name`カラムに検索インデックスを追加 
- system specで検索できているかを確認するテストコードを追加   

## 画面
### タスク一覧画面
<img width="1821" alt="Screen Shot 2022-07-04 at 11 32 07" src="https://user-images.githubusercontent.com/44032125/177071417-79506ea2-ef12-4973-a30e-d122541fc931.png">

### `test-1`と検索した時
<img width="1821" alt="Screen Shot 2022-07-04 at 11 43 24" src="https://user-images.githubusercontent.com/44032125/177072449-b9bac540-c791-4928-8efe-310d5c068d01.png">

### `未着手`をクリックした時
<img width="1821" alt="Screen Shot 2022-07-04 at 11 44 33" src="https://user-images.githubusercontent.com/44032125/177072539-41c73e70-aaf6-4d32-9478-4b84e8af0a3c.png">

SQLで実行した様子
<img width="1165" alt="Screen Shot 2022-07-04 at 11 45 16" src="https://user-images.githubusercontent.com/44032125/177072604-1cf56f89-0fbc-4c53-b56c-84aa3c30a040.png">


# 動作確認方法
```
$ git clone git@github.com:Fablic/training.git
$ git checkout -b hoge origin/wataru-okamoto_step13

$ docker-compose up --build
# http://localhost:3001にアクセス

# sample dataの作成
$ docker-compose exec api /bin/bash
$ rails db:seed
```