### PR TITLE
Katsumi-N step21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -6,8 +6,6 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::RoutingError, with: :render_404
   rescue_from Exception, with: :render_500
 
-  private
-
   def render_404
     render template: 'errors/404', status: 404, layout: 'application', content_type: 'text/html'
   end

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,9 +1,12 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
-
+  include MaintenanceHelper
+  before_action :render_503, if: :maintenance?
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from ActionController::RoutingError, with: :render_404
   rescue_from Exception, with: :render_500
+
+  private
 
   def render_404
     render template: 'errors/404', status: 404, layout: 'application', content_type: 'text/html'
@@ -11,5 +14,10 @@ class ApplicationController < ActionController::Base
 
   def render_500
     render template: 'errors/500', status: 500, layout: 'application', content_type: 'text/html'
+  end
+
+  # メンテナンスは503
+  def render_503
+    render template: 'errors/503', status: 503, layout: 'application', content_type: 'text/html'
   end
 end

--- a/myapp/app/helpers/maintenance_helper.rb
+++ b/myapp/app/helpers/maintenance_helper.rb
@@ -1,0 +1,6 @@
+module MaintenanceHelper
+  MAINTENANCE_FILE_PATH = Rails.root.join('tmp', 'maintenance.txt')
+  def maintenance?
+    File.exist? MAINTENANCE_FILE_PATH
+  end
+end

--- a/myapp/app/helpers/maintenance_helper.rb
+++ b/myapp/app/helpers/maintenance_helper.rb
@@ -1,6 +1,5 @@
 module MaintenanceHelper
-  MAINTENANCE_FILE_PATH = Rails.root.join('tmp', 'maintenance.txt')
   def maintenance?
-    File.exist? MAINTENANCE_FILE_PATH
+    File.exist? Constants::MAINTENANCE_FILE_PATH
   end
 end

--- a/myapp/app/views/errors/503.html.erb
+++ b/myapp/app/views/errors/503.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>503</title>
+  <style>
+  .rails-error-page {
+    background-color: #F7F7F7;
+    text-align: center;
+  }
+  </style>
+</head>
+
+<body class="rails-error-page">
+  <div class="container">
+    <div>
+      <h1>ただいまメンテナンス中です</h1>
+      <p>予定時刻 6:00-8:00</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
     <div class="container">
-      <% if logged_in? %>
+      <% if logged_in? && !maintenance? %>
           <%= render 'layouts/header' %>
       <% end %>
     </div>

--- a/myapp/config/initializers/constants.rb
+++ b/myapp/config/initializers/constants.rb
@@ -1,0 +1,3 @@
+module Constants
+  MAINTENANCE_FILE_PATH = Rails.root.join('tmp', 'maintenance.txt')
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,16 +1,34 @@
 require 'fileutils'
-MAINTENANCE_FILE_PATH = Rails.root.join('tmp', 'maintenance.txt')
 
 namespace :maintenance do
   desc 'メンテナンススタート'
-  task :start do
-    # tmp/maintenance.txtを作成
-    FileUtils.touch(MAINTENANCE_FILE_PATH) unless File.exist?(MAINTENANCE_FILE_PATH)
+  task start: :environment do
+    if File.exist?(Constants::MAINTENANCE_FILE_PATH)
+      puts '既にメンテナンスモードです'
+    else
+      # tmp/maintenance.txtを作成
+      FileUtils.touch(Constants::MAINTENANCE_FILE_PATH)
+      puts 'メンテナンスモードを開始します'
+    end
   end
 
   desc 'メンテナンス終了'
-  task :end do
-    # tmp/maintenance.txtを削除
-    File.delete(MAINTENANCE_FILE_PATH) if File.exist?(MAINTENANCE_FILE_PATH)
+  task end: :environment do
+    if File.exist?(Constants::MAINTENANCE_FILE_PATH)
+      # tmp/maintenance.txtを削除
+      File.delete(Constants::MAINTENANCE_FILE_PATH)
+      puts 'メンテナンスモードを終了します'
+    else
+      puts '通常モードです'
+    end
+  end
+
+  desc 'モードを確認'
+  task status: :environment do
+    if File.exist?(Constants::MAINTENANCE_FILE_PATH)
+      puts 'メンテナンスモードです'
+    else
+      puts '通常モードです'
+    end
   end
 end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,16 @@
+require 'fileutils'
+MAINTENANCE_FILE_PATH = Rails.root.join('tmp', 'maintenance.txt')
+
+namespace :maintenance do
+  desc 'メンテナンススタート'
+  task :start do
+    # tmp/maintenance.txtを作成
+    FileUtils.touch(MAINTENANCE_FILE_PATH) unless File.exist?(MAINTENANCE_FILE_PATH)
+  end
+
+  desc 'メンテナンス終了'
+  task :end do
+    # tmp/maintenance.txtを削除
+    File.delete(MAINTENANCE_FILE_PATH) if File.exist?(MAINTENANCE_FILE_PATH)
+  end
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -19,7 +19,7 @@ namespace :maintenance do
       File.delete(Constants::MAINTENANCE_FILE_PATH)
       puts 'メンテナンスモードを終了します'
     else
-      puts '通常モードです'
+      puts 'メンテナンスモードは終了しています。通常モードです'
     end
   end
 

--- a/myapp/spec/rake_helper.rb
+++ b/myapp/spec/rake_helper.rb
@@ -1,0 +1,10 @@
+require 'rake'
+RSpec.configure do |config|
+  config.before(:suite) do
+    Rails.application.load_tasks # Load all the tasks just as Rails does (`load 'Rakefile'` is another simple way)
+  end
+
+  config.before(:each) do
+    Rake.application.tasks.each(&:reenable) # Remove persistency between examples
+  end
+end

--- a/myapp/spec/system/tasks/maintenances_spec.rb
+++ b/myapp/spec/system/tasks/maintenances_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require 'rake_helper'
+
+RSpec.describe 'Maintenances', type: :system do
+  subject(:maintenance_start) do
+    Rake.application['maintenance:start']
+  end
+  subject(:maintenance_end) do
+    Rake.application['maintenance:end']
+  end
+  subject(:maintenance_status) do
+    Rake.application['maintenance:status']
+  end
+
+  after do
+    maintenance_end.invoke
+  end
+
+  context 'メンテナンスモードのとき' do
+    before do
+      maintenance_start.invoke
+    end
+
+    example 'メンテナンスページが表示' do
+      visit root_path
+      expect(page).to have_http_status 503
+      expect(page).to have_content 'ただいまメンテナンス中です'
+    end
+
+    example 'メンテナンスを終了できるか' do
+      maintenance_end.invoke
+      visit root_path
+      expect(page).to have_http_status 200
+    end
+
+    example 'モードの確認ができるか' do
+      expect { maintenance_status.invoke }.to output("メンテナンスモードです\n").to_stdout
+    end
+  end
+
+  context '通常モードのとき' do
+    example 'メンテナンスモードに移行できるか' do
+      maintenance_start.invoke
+      visit root_path
+      expect(page).to have_http_status 503
+    end
+
+    example 'モードの確認ができるか' do
+      expect { maintenance_status.invoke }.to output("通常モードです\n").to_stdout
+    end
+  end
+end

--- a/myapp/spec/system/tasks/maintenances_spec.rb
+++ b/myapp/spec/system/tasks/maintenances_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe 'Maintenances', type: :system do
     example 'メンテナンスページが表示' do
       visit root_path
       expect(page).to have_http_status 503
-      expect(page).to have_content 'ただいまメンテナンス中です'
     end
 
     example 'メンテナンスを終了できるか' do
@@ -47,6 +46,10 @@ RSpec.describe 'Maintenances', type: :system do
 
     example 'モードの確認ができるか' do
       expect { maintenance_status.invoke }.to output("通常モードです\n").to_stdout
+    end
+
+    example '通常モードでメンテナンスを終了しても何も起こらない' do
+      expect { maintenance_end.invoke }.to output("メンテナンスモードは終了しています。通常モードです\n").to_stdout
     end
   end
 end


### PR DESCRIPTION
Rails研修の[step21](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)になります

## 課題
- [x] メンテナンスを開始／終了するバッチを作ってみましょう
- [x] メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
## 実装したこと
`$ docker-compose exec api rails maintenance:start`
でメンテナンスモードに切り替え
`$ docker-compose exec api rails maintenance:end`
で通常モードに切り替え
`$ docker-compose exec api rails maintenance:status`
で通常モード/メンテナンスモードを確認するバッチを作成しました

メンテナンスモードに切り替え

https://user-images.githubusercontent.com/61781055/177490432-caf98beb-c1d2-4591-bffc-e13ff77608d8.mov

通常モードに切り替え

https://user-images.githubusercontent.com/61781055/177490519-bdf011c3-51f4-4b42-8d78-7dc2226004e9.mov
