### PR TITLE
wataru okamoto step15: デザインを当てよう

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -70,3 +70,5 @@ gem 'bcrypt'
 gem 'kaminari'
 
 gem 'bootstrap', '~> 5.1.3'
+
+gem 'jquery-rails'

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -68,3 +68,5 @@ gem 'bcrypt'
 
 # for pagination
 gem 'kaminari'
+
+gem 'bootstrap', '~> 5.1.3'

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.5.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -294,6 +298,7 @@ DEPENDENCIES
   fablicop
   factory_bot_rails
   jbuilder (~> 2.7)
+  jquery-rails
   kaminari
   listen (~> 3.2)
   mysql2 (>= 0.4.4)

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -59,10 +59,16 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    autoprefixer-rails (10.4.7.0)
+      execjs (~> 2)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
+    bootstrap (5.1.3)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.9.3, < 3)
+      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.36.0)
@@ -84,6 +90,7 @@ GEM
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.10.0)
+    execjs (2.8.1)
     fablicop (1.4.0)
       rubocop (>= 1.14, < 1.29)
       rubocop-rails
@@ -138,6 +145,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    popper_js (2.9.3)
     public_suffix (4.0.7)
     puma (4.3.12)
       nio4r (~> 2.0)
@@ -278,6 +286,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt
   bootsnap (>= 1.4.2)
+  bootstrap (~> 5.1.3)
   byebug
   capybara (>= 2.15)
   capybara-screenshot

--- a/myapp/app/assets/stylesheets/application.scss
+++ b/myapp/app/assets/stylesheets/application.scss
@@ -13,3 +13,6 @@
  *= require_tree .
  *= require_self
  */
+
+ /*  Custom bootstrap variables must be set or imported *before* bootstrap. */
+@import "bootstrap";

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -24,7 +24,7 @@ class TasksController < ApplicationController
       flash[:success] = I18n.t('tasks.flash.create.success')
       redirect_to @task
     else
-      flash.now[:error] = I18n.t('tasks.flash.create.error')
+      flash.now[:danger] = I18n.t('tasks.flash.create.error')
       render :new
     end
   end
@@ -36,7 +36,7 @@ class TasksController < ApplicationController
       flash[:success] = I18n.t('tasks.flash.update.success')
       redirect_to @task
     else
-      flash.now[:error] = I18n.t('tasks.flash.update.error')
+      flash.now[:danger] = I18n.t('tasks.flash.update.error')
       render :edit
     end
   end
@@ -45,7 +45,7 @@ class TasksController < ApplicationController
     if Task.find(params[:id]).destroy
       flash[:success] = I18n.t('tasks.flash.destroy.success')
     else
-      flash[:error] = I18n.t('tasks.flash.destroy.error')
+      flash[:danger] = I18n.t('tasks.flash.destroy.error')
     end
     redirect_to tasks_path
   end

--- a/myapp/app/views/layouts/_header.html.erb
+++ b/myapp/app/views/layouts/_header.html.erb
@@ -1,0 +1,7 @@
+<nav class="navbar navbar-light bg-ligh">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/" >
+      <%= yield(:page_title) %>
+    </a>
+  </div>
+</nav>

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,9 +1,9 @@
 <%= form_with url: tasks_path, method: :get, local: true do |form| %>
-  <div class="row">
-    <div class="col-2">
+  <div class="row justify-content-center">
+    <div class="col-3">
       <%= form.text_field :keyword, name: 'keyword', value: params[:keyword], class: "form-control" %>
     </div>
-    <div class="col-1">
+    <div class="col-2">
       <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] }, { id: 'status' , class: "form-control" } %>
     </div>
     <div class="col">

--- a/myapp/app/views/layouts/_search.html.erb
+++ b/myapp/app/views/layouts/_search.html.erb
@@ -1,5 +1,13 @@
 <%= form_with url: tasks_path, method: :get, local: true do |form| %>
-  <%= form.text_field :keyword, name: 'keyword', value: params[:keyword] %>
-  <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] }, { id: 'status' } %>
-  <%= form.submit I18n.t('dictionary.button.search') %>
+  <div class="row">
+    <div class="col-2">
+      <%= form.text_field :keyword, name: 'keyword', value: params[:keyword], class: "form-control" %>
+    </div>
+    <div class="col-1">
+      <%= form.select :status, Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, { include_blank: '状態を選択', selected: params[:status] }, { id: 'status' , class: "form-control" } %>
+    </div>
+    <div class="col">
+      <%= form.submit I18n.t('dictionary.button.search'), class: "btn btn-secondary" %>
+    </div>
+  </div>
 <% end %>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -12,7 +12,9 @@
   <body>
     <h1><%= yield(:page_title) %></h1>
     <% flash.each do |message_type, message| %>
-      <%= message %><br/>
+      <p class="alert alert-<%= message_type %>">
+        <%= message %><br/>
+      </p>
     <% end %>
     <%= yield %>
   </body>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
   </head>
 
   <body>
-    <h1><%= yield(:page_title) %></h1>
+    <%= render partial: 'layouts/header' %>
     <% flash.each do |message_type, message| %>
       <p class="alert alert-<%= message_type %>">
         <%= message %><br/>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,14 +1,30 @@
-<%= form_with model: task, local: true do |form| %>
-  <%= render 'layouts/error_message', model: task %>
-  <%= form.label :name %>
-  <%= form.text_field :name %>
-  <%= form.label :description %>
-  <%= form.text_area :description %>
-  <%= form.label :limit %>
-  <%= form.date_field :limit %>
-  <%= form.label :status %>
-  <%= form.select :status,  Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, {selected: "TODO"} %>
-  <%= form.label :priority %>
-  <%= form.select :priority,  Task.priorities_i18n.keys.map {|k| [Task.priorities_i18n[k],k]}, {selected: "Low"} %>
-  <%= form.submit %>
-<% end %>
+<div class="container">
+  <%= form_with model: task, local: true do |form| %>
+    <%= render 'layouts/error_message', model: task %>
+    <div class="form-group">
+      <%= form.label :name %>
+      <%= form.text_field :name, class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= form.label :description %>
+      <%= form.text_area :description, class: "form-control" %>
+    </div>
+    <div class="row">
+      <div class="col">
+        <%= form.label :limit %>
+        <%= form.date_field :limit, class: "form-control" %>
+      </div>
+      <div class="col">
+        <%= form.label :status %>
+        <%= form.select :status,  Task.statuses_i18n.keys.map {|k| [Task.statuses_i18n[k],k]}, {selected: "TODO"}, { class: "form-control" } %>
+      </div>
+      <div class="col">
+        <%= form.label :priority %>
+        <%= form.select :priority,  Task.priorities_i18n.keys.map {|k| [Task.priorities_i18n[k],k]}, {selected: "Low"}, { class: "form-control" } %>
+      </div>
+    </div>
+    <div class="d-grid gap-2 col-6 mx-auto mt-4">
+      <%= form.submit class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,29 +1,31 @@
 <% content_for(:page_title, I18n.t('tasks.index.title')) %>
 
-<%= link_to I18n.t('dictionary.button.create'), '/tasks/new', class: "btn btn-primary" %>
-<%= render partial: 'layouts/search' %>
+<div class="container">
+  <%= link_to I18n.t('dictionary.button.create'), '/tasks/new', class: "btn btn-primary" %>
+  <%= render partial: 'layouts/search' %>
 
-<table class="tasks table table-striped">
-  <thead  class="table-light">
-    <tr>
-      <th><%= I18n.t('activerecord.attributes.task.name') %></th>
-      <th><%= sort_order "limit", I18n.t('activerecord.attributes.task.limit') %></th>
-      <th><%= sort_order "created_at", I18n.t('activerecord.attributes.task.created_at') %></th>
-      <th></th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @tasks.each do |task| %>
+  <table class="tasks table table-striped">
+    <thead  class="table-light">
       <tr>
-        <td class="task-title"><%= link_to task.name, task %></td>
-        <td><%= I18n.l(task.limit) %></td>
-        <td><%= I18n.l(task.created_at) %></td>
-        <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task) %></td>
-        <td><%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"} %><br /></td>
+        <th><%= I18n.t('activerecord.attributes.task.name') %></th>
+        <th><%= sort_order "limit", I18n.t('activerecord.attributes.task.limit') %></th>
+        <th><%= sort_order "created_at", I18n.t('activerecord.attributes.task.created_at') %></th>
+        <th></th>
+        <th></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @tasks.each do |task| %>
+        <tr>
+          <td class="task-title"><%= link_to task.name, task %></td>
+          <td><%= I18n.l(task.limit) %></td>
+          <td><%= I18n.l(task.created_at) %></td>
+          <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task) %></td>
+          <td><%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"} %><br /></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 
-<%= paginate @tasks %>
+  <%= paginate @tasks %>
+</div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -8,6 +8,7 @@
     <thead  class="table-light">
       <tr>
         <th><%= I18n.t('activerecord.attributes.task.name') %></th>
+        <th><%= sort_order "status", I18n.t('activerecord.attributes.task.status') %></th>
         <th><%= sort_order "limit", I18n.t('activerecord.attributes.task.limit') %></th>
         <th><%= sort_order "created_at", I18n.t('activerecord.attributes.task.created_at') %></th>
         <th></th>
@@ -18,6 +19,7 @@
       <% @tasks.each do |task| %>
         <tr>
           <td class="task-title"><%= link_to task.name, task %></td>
+          <td><%= task.status_i18n %></td>
           <td><%= I18n.l(task.limit) %></td>
           <td><%= I18n.l(task.created_at) %></td>
           <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task), class: "btn btn-info" %></td>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_title, I18n.t('tasks.index.title')) %>
 
 <div class="container">
-  <%= link_to I18n.t('dictionary.button.create'), '/tasks/new', class: "btn btn-primary" %>
+  <%= link_to I18n.t('dictionary.button.create'), '/tasks/new', class: "btn btn-primary mb-2" %>
   <%= render partial: 'layouts/search' %>
 
-  <table class="tasks table table-striped">
+  <table class="tasks table table-striped mt-2">
     <thead  class="table-light">
       <tr>
         <th><%= I18n.t('activerecord.attributes.task.name') %></th>
@@ -20,8 +20,8 @@
           <td class="task-title"><%= link_to task.name, task %></td>
           <td><%= I18n.l(task.limit) %></td>
           <td><%= I18n.l(task.created_at) %></td>
-          <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task) %></td>
-          <td><%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"} %><br /></td>
+          <td><%= link_to I18n.t('dictionary.button.edit'), edit_task_path(task), class: "btn btn-info" %></td>
+          <td><%= link_to I18n.t('dictionary.button.destory'), task, method: :delete, data: {confirm: "Do you want to delete #{task.name}?"}, class: "btn btn-danger" %><br /></td>
         </tr>
       <% end %>
     </tbody>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -3,12 +3,14 @@
 <%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
 <%= render partial: 'layouts/search' %>
 
-<table class="tasks">
-  <thead>
+<table class="tasks table table-striped">
+  <thead  class="table-light">
     <tr>
       <th><%= I18n.t('activerecord.attributes.task.name') %></th>
       <th><%= sort_order "limit", I18n.t('activerecord.attributes.task.limit') %></th>
       <th><%= sort_order "created_at", I18n.t('activerecord.attributes.task.created_at') %></th>
+      <th></th>
+      <th></th>
     </tr>
   </thead>
   <tbody>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title, I18n.t('tasks.index.title')) %>
 
-<%= link_to I18n.t('dictionary.button.create'), '/tasks/new' %>
+<%= link_to I18n.t('dictionary.button.create'), '/tasks/new', class: "btn btn-primary" %>
 <%= render partial: 'layouts/search' %>
 
 <table class="tasks table table-striped">

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,27 +1,36 @@
 <% content_for(:page_title, I18n.t('tasks.show.title')) %>
 
 <div class="container">
-  <%= link_to I18n.t('dictionary.button.edit'), edit_task_path(@task), class: "btn btn-light" %>
+  <%= link_to I18n.t('dictionary.button.edit'), edit_task_path(@task), class: "btn btn-info" %>
 
-  <%= link_to I18n.t('dictionary.button.destory'), @task, method: :delete, data: {confirm: "Do you want to delete #{@task.name}?"}, class: "btn btn-light" %>
+  <%= link_to I18n.t('dictionary.button.destory'), @task, method: :delete, data: {confirm: "Do you want to delete #{@task.name}?"}, class: "btn btn-danger" %>
 
-  <h2>
-    <%= @task.name %>
-  </h2>
+  <div class="bg-light">
+    <h2>
+      <%= @task.name %>
+    </h2>
 
-  <div>
-    <p>
-      <%= @task.description %>
-    </p>
-    <span>
-      <label>Status</label>
-      <%= @task.status_i18n %>
-      <label>Priority</label>
-      <%= @task.priority_i18n %>
-      <label>Limit</label>
-      <%= @task.limit %>
-    </span>
+    <div>
+      <p>
+        <%= @task.description %>
+      </p>
+      <table class="table table-borderless">
+        <thead>
+          <tr>
+            <th><%= I18n.t('activerecord.attributes.task.limit') %></th>
+            <th><%= I18n.t('activerecord.attributes.task.status') %></th>
+            <th><%= I18n.t('activerecord.attributes.task.priority') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= I18n.l(@task.limit) %></td>
+            <td><%= @task.status_i18n %></td>
+            <td><%= @task.priority_i18n %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
-
   <%= link_to I18n.t('dictionary.button.home'), root_path %>
 </div>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_title, I18n.t('tasks.show.title')) %>
 
 <div class="container">
-  <%= link_to I18n.t('dictionary.button.edit'), edit_task_path(@task) %>
+  <%= link_to I18n.t('dictionary.button.edit'), edit_task_path(@task), class: "btn btn-light" %>
 
-  <%= link_to I18n.t('dictionary.button.destory'), @task, method: :delete, data: {confirm: "Do you want to delete #{@task.name}?"} %>
+  <%= link_to I18n.t('dictionary.button.destory'), @task, method: :delete, data: {confirm: "Do you want to delete #{@task.name}?"}, class: "btn btn-light" %>
 
   <h2>
     <%= @task.name %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,25 +1,27 @@
 <% content_for(:page_title, I18n.t('tasks.show.title')) %>
 
-<%= link_to I18n.t('dictionary.button.edit'), edit_task_path(@task) %>
+<div class="container">
+  <%= link_to I18n.t('dictionary.button.edit'), edit_task_path(@task) %>
 
-<%= link_to I18n.t('dictionary.button.destory'), @task, method: :delete, data: {confirm: "Do you want to delete #{@task.name}?"} %>
+  <%= link_to I18n.t('dictionary.button.destory'), @task, method: :delete, data: {confirm: "Do you want to delete #{@task.name}?"} %>
 
-<h2>
-  <%= @task.name %>
-</h2>
+  <h2>
+    <%= @task.name %>
+  </h2>
 
-<div>
-  <p>
-    <%= @task.description %>
-  </p>
-  <span>
-    <label>Status</label>
-    <%= @task.status_i18n %>
-    <label>Priority</label>
-    <%= @task.priority_i18n %>
-    <label>Limit</label>
-    <%= @task.limit %>
-  </span>
+  <div>
+    <p>
+      <%= @task.description %>
+    </p>
+    <span>
+      <label>Status</label>
+      <%= @task.status_i18n %>
+      <label>Priority</label>
+      <%= @task.priority_i18n %>
+      <label>Limit</label>
+      <%= @task.limit %>
+    </span>
+  </div>
+
+  <%= link_to I18n.t('dictionary.button.home'), root_path %>
 </div>
-
-<%= link_to I18n.t('dictionary.button.home'), root_path %>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -18,7 +18,7 @@ ja:
         limit_desc: "終了期限遠い順"
   helpers:
     submit:
-      create: "新規作成"
+      create: "作成"
       update: "更新"
   time:
     formats:

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'Task', type: :system do
       expect(page).to have_content 'テストのタスク'
       expect(page).to have_content '未着手'
       expect(page).to have_content '低い'
-      expect(page).to have_content '2022-6-20'.to_date
+      expect(page).to have_content I18n.l('2022-6-20'.to_date)
     end
 
     context 'when user click Edit' do
@@ -251,10 +251,10 @@ RSpec.describe 'Task', type: :system do
 
       context 'when user click "Create Task" button' do
         it 'go to Task detail page' do # rubocop:disable RSpec/MultipleExpectations
-          click_on '新規作成'
+          click_on '作成'
           expect(page).to have_content '散歩'
           expect(page).to have_content '多摩川を歩く'
-          expect(page).to have_content '2022-06-20'
+          expect(page).to have_content I18n.l('2022-06-20'.to_date)
           expect(page).to have_content '未着手'
           expect(page).to have_content '低い'
         end
@@ -291,7 +291,7 @@ RSpec.describe 'Task', type: :system do
           click_on '更新'
           expect(page).to have_content '運動'
           expect(page).to have_content '多摩川を走る'
-          expect(page).to have_content '2022-06-20'
+          expect(page).to have_content I18n.l('2022-06-20'.to_date)
           expect(page).to have_content '着手中'
           expect(page).to have_content '普通'
           expect(page).to have_content 'Edit Task!!'


### PR DESCRIPTION
# 概要
[Rails研修ステップ15](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
- Bootstrapを導入して、デザインを当てる


# 実装内容
- Bootstrapを導入
- 各ページにデザインを適用


## 画面
### タスク一覧画面
<img width="1549" alt="Screen Shot 2022-07-11 at 11 50 38" src="https://user-images.githubusercontent.com/44032125/178179799-aee242fa-b6ba-4b2b-8d41-240c16ab25d3.png">

### タスク編集/追加画面
<img width="1593" alt="Screen Shot 2022-07-11 at 11 51 10" src="https://user-images.githubusercontent.com/44032125/178179849-f4b312fe-9716-4365-9a02-16dffe29e15e.png">

### タスク詳細画面
<img width="1593" alt="Screen Shot 2022-07-11 at 11 50 53" src="https://user-images.githubusercontent.com/44032125/178179827-67816334-ce8a-4513-a016-38ddeaed3853.png">


# 動作確認方法
```
$ git clone git@github.com:Fablic/training.git
$ git checkout -b hoge origin/wataru-okamoto_step15

$ docker-compose up --build
# http://localhost:3001にアクセス

# sample dataの作成
$ docker-compose exec api /bin/bash
$ rails db:seed
```