### PR TITLE
wataru okamoto step16: 複数人で利用できるようにしよう

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -32,6 +32,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'bullet'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_bot_rails'
 end

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       popper_js (>= 2.9.3, < 3)
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
+    bullet (7.0.2)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.36.0)
       addressable
@@ -264,6 +267,7 @@ GEM
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (2.1.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -287,6 +291,7 @@ DEPENDENCIES
   bcrypt
   bootsnap (>= 1.4.2)
   bootstrap (~> 5.1.3)
+  bullet
   byebug
   capybara (>= 2.15)
   capybara-screenshot

--- a/myapp/config/environments/development.rb
+++ b/myapp/config/environments/development.rb
@@ -59,4 +59,13 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true # Bulletを有効化する
+    Bullet.alert = true # JavaScriptのポップアップアラートを表示する
+    Bullet.bullet_logger = true # log/bullet.logに出力
+    Bullet.console = true # ブラウザのconsole.logに出力
+    Bullet.rails_logger = true # Railsのログに結果を出力
+    Bullet.add_footer = true # ページの左下に結果を表示
+  end
 end

--- a/myapp/config/environments/test.rb
+++ b/myapp/config/environments/test.rb
@@ -46,4 +46,10 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    Bullet.enable = true # Bulletを有効化する
+    Bullet.bullet_logger = true # log/bullet.logに出力
+    Bullet.raise = true # N+1クエリ発生時にエラーを起こし、テストをfailさせる
+  end
 end

--- a/myapp/spec/rails_helper.rb
+++ b/myapp/spec/rails_helper.rb
@@ -88,4 +88,15 @@ RSpec.configure do |config|
     Capybara.server_port = 3000
     Capybara.app_host = "https://#{Capybara.server_host}:#{Capybara.server_port}"
   end
+
+  if Bullet.enable?
+    config.before(:each) do
+      Bullet.start_request
+    end
+
+    config.after(:each) do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification? # Bulletによる通知をRSpecの結果に表示
+      Bullet.end_request
+    end
+  end
 end


### PR DESCRIPTION
# 概要
[Rails研修ステップ16](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9716-%E8%A4%87%E6%95%B0%E4%BA%BA%E3%81%A7%E5%88%A9%E7%94%A8%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E5%B0%8E%E5%85%A5)
- ユーザモデルを作成しましょう
- 最初のユーザをseedで作成してみよう
- ユーザとタスクが紐づくようにしよう
  - 関連に関してインデックスを貼りましょう
  -  N＋1問題を回避するための仕組みを取り入れましょう    


# 実装内容
## 今ステップまでに実装していた内容
- ユーザモデル[`models/user.rb`](https://github.com/Fablic/training/blob/wataru-okamoto_step16/myapp/app/models/user.rb)の作成
- [`db/seed.rb`](https://github.com/Fablic/training/blob/wataru-okamoto_step16/myapp/db/seeds.rb)に最初のユーザを作成するための記述追加
- タスクテーブルのuser_idにインデックスを追加[`db/schema.rb`](https://github.com/Fablic/training/blob/wataru-okamoto_step16/myapp/db/schema.rb)

## 今回実装した内容
-  bulletのインストール
- bulletの設定を追加


# 動作確認方法
```
$ git clone git@github.com:Fablic/training.git
$ git checkout -b hoge origin/wataru-okamoto_step16

$ docker-compose up --build
# http://localhost:3001にアクセス

# sample dataの作成
$ docker-compose exec api /bin/bash
$ rails db:seed
```