### PR TITLE
wataru okamoto step18: ユーザの管理画面を実装しよう

### DIFF
--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,0 +1,2 @@
+class Admin::UsersController < ApplicationController
+end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,2 +1,15 @@
-class Admin::UsersController < ApplicationController
+# frozen_string_literal: true
+
+class Admin::UsersController < ApplicationController # rubocop:disable Style/ClassAndModuleChildren
+  before_action :admin_user
+
+  def index
+    @users = User.all.order(created_at: :desc)
+  end
+
+  private
+
+  def admin_user
+    redirect_to(root_path) unless current_user.admin?
+  end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -50,11 +50,14 @@ module Admin
     end
 
     def destroy
-      if User.find(params[:id]).destroy
+      if login_user?
+        flash[:danger] = I18n.t('users.flash.destroy.login_user')
+      elsif User.find(params[:id]).destroy
         flash[:success] = I18n.t('users.flash.destroy.success')
       else
-        flash[:danger] = I18n.t('users.flash.destroy.success')
+        flash[:danger] = I18n.t('users.flash.destroy.error')
       end
+
       redirect_to admin_users_path
     end
 
@@ -66,6 +69,12 @@ module Admin
 
     def user_params
       params.require(:user).permit(:name, :email, :password)
+    end
+
+    def login_user?
+      return true if params[:id].to_i == current_user.id
+
+      false
     end
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -9,6 +9,7 @@ class Admin::UsersController < ApplicationController # rubocop:disable Style/Cla
 
   def show
     @user = User.find(params[:id])
+    @tasks = Task.search(user_id: @user.id, status: params[:status], keyword: params[:keyword], sort: params[:sort], direction: params[:direction]).page(params[:page])
   end
 
   def new

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -7,6 +7,10 @@ class Admin::UsersController < ApplicationController # rubocop:disable Style/Cla
     @users = User.all.order(created_at: :desc)
   end
 
+  def show
+    @user = User.find(params[:id])
+  end
+
   def new
     @user = User.new
   end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -10,7 +10,11 @@ module Admin
 
     def show
       @user = User.find(params[:id])
-      @tasks = Task.search(user_id: @user.id, status: params[:status], keyword: params[:keyword], sort: params[:sort], direction: params[:direction]).page(params[:page])
+      @tasks = Task.search(user_id: @user.id,
+                           status: params[:status],
+                           keyword: params[:keyword],
+                           sort: params[:sort],
+                           direction: params[:direction]).page(params[:page])
     end
 
     def new

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -19,8 +19,10 @@ class Admin::UsersController < ApplicationController # rubocop:disable Style/Cla
     @user = User.new(user_params)
 
     if @user.save
+      flash[:success] = I18n.t('users.flash.create.success')
       redirect_to admin_users_path
     else
+      flash.now[:danger] = I18n.t('users.flash.create.error')
       render :new
     end
   end
@@ -29,10 +31,21 @@ class Admin::UsersController < ApplicationController # rubocop:disable Style/Cla
     @user = User.find(params[:id])
 
     if @user.update(user_params)
+      flash[:success] = I18n.t('users.flash.update.success')
       redirect_to admin_users_path
     else
+      flash.now[:danger] = I18n.t('users.flash.update.error')
       render :new
     end
+  end
+
+  def destroy
+    if User.find(params[:id]).destroy
+      flash[:success] = I18n.t('users.flash.destroy.success')
+    else
+      flash[:danger] = I18n.t('users.flash.destroy.success')
+    end
+    redirect_to admin_users_path
   end
 
   private

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -7,9 +7,41 @@ class Admin::UsersController < ApplicationController # rubocop:disable Style/Cla
     @users = User.all.order(created_at: :desc)
   end
 
+  def new
+    @user = User.new
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      redirect_to admin_users_path
+    else
+      render :new
+    end
+  end
+
+  def update
+    @user = User.find(params[:id])
+
+    if @user.update(user_params)
+      redirect_to admin_users_path
+    else
+      render :new
+    end
+  end
+
   private
 
   def admin_user
     redirect_to(root_path) unless current_user.admin?
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password)
   end
 end

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,65 +1,67 @@
 # frozen_string_literal: true
 
-class Admin::UsersController < ApplicationController # rubocop:disable Style/ClassAndModuleChildren
-  before_action :admin_user
+module Admin
+  class UsersController < ApplicationController
+    before_action :admin_user
 
-  def index
-    @users = User.all.order(created_at: :desc)
-  end
+    def index
+      @users = User.all.order(created_at: :desc)
+    end
 
-  def show
-    @user = User.find(params[:id])
-    @tasks = Task.search(user_id: @user.id, status: params[:status], keyword: params[:keyword], sort: params[:sort], direction: params[:direction]).page(params[:page])
-  end
+    def show
+      @user = User.find(params[:id])
+      @tasks = Task.search(user_id: @user.id, status: params[:status], keyword: params[:keyword], sort: params[:sort], direction: params[:direction]).page(params[:page])
+    end
 
-  def new
-    @user = User.new
-  end
+    def new
+      @user = User.new
+    end
 
-  def edit
-    @user = User.find(params[:id])
-  end
+    def edit
+      @user = User.find(params[:id])
+    end
 
-  def create
-    @user = User.new(user_params)
+    def create
+      @user = User.new(user_params)
 
-    if @user.save
-      flash[:success] = I18n.t('users.flash.create.success')
+      if @user.save
+        flash[:success] = I18n.t('users.flash.create.success')
+        redirect_to admin_users_path
+      else
+        flash.now[:danger] = I18n.t('users.flash.create.error')
+        render :new
+      end
+    end
+
+    def update
+      @user = User.find(params[:id])
+
+      if @user.update(user_params)
+        flash[:success] = I18n.t('users.flash.update.success')
+        redirect_to admin_users_path
+      else
+        flash.now[:danger] = I18n.t('users.flash.update.error')
+        render :new
+      end
+    end
+
+    def destroy
+      if User.find(params[:id]).destroy
+        flash[:success] = I18n.t('users.flash.destroy.success')
+      else
+        flash[:danger] = I18n.t('users.flash.destroy.success')
+      end
       redirect_to admin_users_path
-    else
-      flash.now[:danger] = I18n.t('users.flash.create.error')
-      render :new
     end
-  end
 
-  def update
-    @user = User.find(params[:id])
+    private
 
-    if @user.update(user_params)
-      flash[:success] = I18n.t('users.flash.update.success')
-      redirect_to admin_users_path
-    else
-      flash.now[:danger] = I18n.t('users.flash.update.error')
-      render :new
+    def admin_user
+      redirect_to(root_path) unless current_user.admin?
     end
-  end
 
-  def destroy
-    if User.find(params[:id]).destroy
-      flash[:success] = I18n.t('users.flash.destroy.success')
-    else
-      flash[:danger] = I18n.t('users.flash.destroy.success')
+    def user_params
+      params.require(:user).permit(:name, :email, :password)
     end
-    redirect_to admin_users_path
-  end
-
-  private
-
-  def admin_user
-    redirect_to(root_path) unless current_user.admin?
-  end
-
-  def user_params
-    params.require(:user).permit(:name, :email, :password)
   end
 end

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  def show
+    @user = current_user
+  end
 end

--- a/myapp/app/helpers/admin/users_helper.rb
+++ b/myapp/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/myapp/app/views/admin/users/_form.html.erb
+++ b/myapp/app/views/admin/users/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <%= form_with model: user, url: admin_users_path, local: true do |form| %>
+  <%= form_with model: user, url: path, local: true do |form| %>
     <%= render 'layouts/error_message', model: user %>
     <div class="form-group">
       <%= form.label :name %>

--- a/myapp/app/views/admin/users/_form.html.erb
+++ b/myapp/app/views/admin/users/_form.html.erb
@@ -1,0 +1,22 @@
+<div class="container">
+  <%= form_with model: user, url: admin_users_path, local: true do |form| %>
+    <%= render 'layouts/error_message', model: user %>
+    <div class="form-group">
+      <%= form.label :name %>
+      <%= form.text_field :name, class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= form.label :email %>
+      <%= form.email_field :email, class: "form-control" %>
+    </div>
+    <div class="row">
+      <div class="col">
+        <%= form.label :password %>
+        <%= form.password_field :password, class: "form-control" %>
+      </div>
+    </div>
+    <div class="d-grid gap-2 col-6 mx-auto mt-4">
+      <%= form.submit class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/myapp/app/views/admin/users/edit.html.erb
+++ b/myapp/app/views/admin/users/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: {user: @user, path: admin_user_path} %>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:page_title, I18n.t('admin.users.index.title')) %>
+
+<div class="container">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>name</th>
+        <th>email</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td><%= user.name %></td>
+          <td><%= user.email %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -14,6 +14,7 @@
         <tr>
           <td><%= user.name %></td>
           <td><%= user.email %></td>
+          <td><%= link_to I18n.t('dictionary.button.edit'), edit_admin_user_path(user), class: "btn btn-info" %></td>
         </tr>
       <% end %>
     </tbody>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:page_title, I18n.t('admin.users.index.title')) %>
 
 <div class="container">
+  <%= link_to I18n.t('dictionary.button.create'), new_admin_user_path, class: "btn btn-primary mb-2" %>
   <table class="table">
     <thead>
       <tr>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -15,6 +15,7 @@
           <td><%= user.name %></td>
           <td><%= user.email %></td>
           <td><%= link_to I18n.t('dictionary.button.edit'), edit_admin_user_path(user), class: "btn btn-info" %></td>
+          <td><%= link_to I18n.t('dictionary.button.destory'), admin_user_path(user), method: :delete, data: {confirm: "Do you want to delete #{user.name}?"}, class: "btn btn-danger" %><br /></td>
         </tr>
       <% end %>
     </tbody>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -15,7 +15,7 @@
         <tr>
           <td><%= link_to user.name, admin_user_path(user) %></td>
           <td><%= user.email %></td>
-          <td>1</td>
+          <td><%= Task.search_by_user_id(user.id).count %></td>
           <td><%= link_to I18n.t('dictionary.button.edit'), edit_admin_user_path(user), class: "btn btn-info" %></td>
           <td><%= link_to I18n.t('dictionary.button.destory'), admin_user_path(user), method: :delete, data: {confirm: "Do you want to delete #{user.name}?"}, class: "btn btn-danger" %><br /></td>
         </tr>

--- a/myapp/app/views/admin/users/index.html.erb
+++ b/myapp/app/views/admin/users/index.html.erb
@@ -7,13 +7,15 @@
       <tr>
         <th>name</th>
         <th>email</th>
+        <th>tasks</th>
       </tr>
     </thead>
     <tbody>
       <% @users.each do |user| %>
         <tr>
-          <td><%= user.name %></td>
+          <td><%= link_to user.name, admin_user_path(user) %></td>
           <td><%= user.email %></td>
+          <td>1</td>
           <td><%= link_to I18n.t('dictionary.button.edit'), edit_admin_user_path(user), class: "btn btn-info" %></td>
           <td><%= link_to I18n.t('dictionary.button.destory'), admin_user_path(user), method: :delete, data: {confirm: "Do you want to delete #{user.name}?"}, class: "btn btn-danger" %><br /></td>
         </tr>

--- a/myapp/app/views/admin/users/new.html.erb
+++ b/myapp/app/views/admin/users/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: {user: @user, path: admin_users_path} %>

--- a/myapp/app/views/admin/users/show.html.erb
+++ b/myapp/app/views/admin/users/show.html.erb
@@ -1,0 +1,20 @@
+<div class="container">
+<table class="table">
+  <table class="table">
+    <tbody>
+      <tr>
+        <th>name:</th>
+        <td><%= @user.name %></td>
+      </tr>
+      <tr>
+        <th>email:</th>
+        <td><%= @user.email %></td>
+      </tr>
+      <tr>
+        <th>password:</th>
+        <td>********</td>
+      </tr>
+    </tbody>
+  </table>
+</table>
+</div>

--- a/myapp/app/views/admin/users/show.html.erb
+++ b/myapp/app/views/admin/users/show.html.erb
@@ -1,20 +1,45 @@
+<% content_for(:page_title, I18n.t('admin.users.show.title')) %>
+
 <div class="container">
-<table class="table">
   <table class="table">
+    <table class="table">
+      <tbody>
+        <tr>
+          <th>name:</th>
+          <td><%= @user.name %></td>
+        </tr>
+        <tr>
+          <th>email:</th>
+          <td><%= @user.email %></td>
+        </tr>
+        <tr>
+          <th>password:</th>
+          <td>********</td>
+        </tr>
+      </tbody>
+    </table>
+  </table>
+
+  <table class="table">
+    <thead>
+      <tr>
+        <th><%= I18n.t('activerecord.attributes.task.name') %></th>
+        <th><%= sort_order "status", I18n.t('activerecord.attributes.task.status') %></th>
+        <th><%= sort_order "limit", I18n.t('activerecord.attributes.task.limit') %></th>
+        <th><%= sort_order "created_at", I18n.t('activerecord.attributes.task.created_at') %></th>
+      </tr>
+    </thead>
     <tbody>
-      <tr>
-        <th>name:</th>
-        <td><%= @user.name %></td>
-      </tr>
-      <tr>
-        <th>email:</th>
-        <td><%= @user.email %></td>
-      </tr>
-      <tr>
-        <th>password:</th>
-        <td>********</td>
-      </tr>
+      <% @tasks.each do |task| %>
+        <tr>
+          <td class="task-title"><%= link_to task.name, task %></td>
+          <td><%= task.status_i18n %></td>
+          <td><%= I18n.l(task.limit) if task.limit.present? %></td>
+          <td><%= I18n.l(task.created_at) %></td>
+        </tr>
+      <% end %>
     </tbody>
   </table>
-</table>
+
+  <%= paginate @tasks %>
 </div>

--- a/myapp/app/views/admin/users/show.html.erb
+++ b/myapp/app/views/admin/users/show.html.erb
@@ -12,10 +12,6 @@
           <th>email:</th>
           <td><%= @user.email %></td>
         </tr>
-        <tr>
-          <th>password:</th>
-          <td>********</td>
-        </tr>
       </tbody>
     </table>
   </table>

--- a/myapp/app/views/layouts/_header.html.erb
+++ b/myapp/app/views/layouts/_header.html.erb
@@ -6,8 +6,9 @@
     <% if logged_in? %>
       <div class="btn-group dropdown">
         <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
-            aria-expanded="false"><%= @current_user.name %></button>
+            aria-expanded="false"><%= current_user.name %></button>
         <div class="dropdown-menu dropdown-menu-end" aria-labelledby="menu">
+            <%= link_to "user info", user_path(current_user), class: "btn" %>
             <%= link_to "logout", logout_path, method: :delete, class: "btn" %>
         </div>
       </div>

--- a/myapp/app/views/layouts/_header.html.erb
+++ b/myapp/app/views/layouts/_header.html.erb
@@ -4,13 +4,14 @@
       <%= yield(:page_title) %>
     </a>
     <% if logged_in? %>
-      <div class="btn-group dropdown">
-        <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
-            aria-expanded="false"><%= current_user.name %></button>
-        <div class="dropdown-menu dropdown-menu-end" aria-labelledby="menu">
-            <%= link_to "user info", user_path(current_user), class: "btn" %>
-            <%= link_to "logout", logout_path, method: :delete, class: "btn" %>
-        </div>
+      <div class="btn-group">
+        <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
+          <%= current_user.name %>
+        </button>
+        <ul class="dropdown-menu">
+            <li><%= link_to "user info", user_path(current_user), class: "btn dropdown-item" %></li>
+            <li><%= link_to "logout", logout_path, method: :delete, class: "btn dropdown-item" %></li>
+        </ul>
       </div>
     <% end %>
   </div>

--- a/myapp/app/views/layouts/_header.html.erb
+++ b/myapp/app/views/layouts/_header.html.erb
@@ -8,7 +8,7 @@
         <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
           <%= current_user.name %>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu" style="right: 5px;">
             <li><%= link_to "user info", user_path(current_user), class: "btn dropdown-item" %></li>
             <li><%= link_to "logout", logout_path, method: :delete, class: "btn dropdown-item" %></li>
         </ul>

--- a/myapp/app/views/users/show.html.erb
+++ b/myapp/app/views/users/show.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:page_title, I18n.t('users.show.title')) %>
+
+<div class="container">
+  <table class="table">
+    <tbody>
+      <tr>
+        <th>name:</th>
+        <td><%= @user.name %></td>
+      </tr>
+      <tr>
+        <th>email:</th>
+        <td><%= @user.email %></td>
+      </tr>
+      <tr>
+        <th>password:</th>
+        <td>********</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -18,6 +18,9 @@ ja:
       destroy:
         success: "Delete Task!!"
         error: "Failed"
+  users:
+    show:
+      title: "ユーザー情報"
   views:
     pagination:
       first: "最初"

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -21,6 +21,16 @@ ja:
   users:
     show:
       title: "ユーザー情報"
+    flash:
+      create:
+        success: "Create New User!!"
+        error: "Failed"
+      update:
+        success: "Edit User Info!!"
+        error: "Failed"
+      destroy:
+        success: "Delete User!!"
+        error: "Failed"
   admin:
     users:
       index:

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -24,7 +24,7 @@ ja:
   admin:
     users:
       index:
-        title: "ユーザー一覧"
+        title: "管理画面 : ユーザー一覧"
   views:
     pagination:
       first: "最初"

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -35,6 +35,8 @@ ja:
     users:
       index:
         title: "管理画面 : ユーザー一覧"
+      show:
+        title: "管理画面 : ユーザー情報"
   views:
     pagination:
       first: "最初"

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -31,6 +31,7 @@ ja:
       destroy:
         success: "Delete User!!"
         error: "Failed"
+        login_user: "Logged-in users cannot be deleted"
   admin:
     users:
       index:

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -21,6 +21,10 @@ ja:
   users:
     show:
       title: "ユーザー情報"
+  admin:
+    users:
+      index:
+        title: "ユーザー一覧"
   views:
     pagination:
       first: "最初"

--- a/myapp/config/locales/views/ja.yml
+++ b/myapp/config/locales/views/ja.yml
@@ -23,15 +23,15 @@ ja:
       title: "ユーザー情報"
     flash:
       create:
-        success: "Create New User!!"
-        error: "Failed"
+        success: "新しいユーザーを作成しました!!"
+        error: "ユーザーの作成に失敗しました"
       update:
-        success: "Edit User Info!!"
-        error: "Failed"
+        success: "ユーザー情報を更新しました!!"
+        error: "ユーザー情報の更新に失敗しました"
       destroy:
-        success: "Delete User!!"
-        error: "Failed"
-        login_user: "Logged-in users cannot be deleted"
+        success: "ユーザーを削除しました!!"
+        error: "ユーザーの削除に失敗しました"
+        login_user: "現在ログイン中のユーザーは削除できません"
   admin:
     users:
       index:

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     get :search, on: :collection
   end
 
-  resources :users
+  resources :users, only: :show
 
   namespace :admin do
     resources :users

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -10,6 +10,12 @@ Rails.application.routes.draw do
     get :search, on: :collection
   end
 
+  resources :users
+
+  namespace :admin do
+    resources :users
+  end
+
   # for error page
   get '*not_found' => 'application#routing_error'
   post '*not_found' => 'application#routing_error'

--- a/myapp/db/migrate/20220714015644_add_admin_to_user.rb
+++ b/myapp/db/migrate/20220714015644_add_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean
+  end
+end

--- a/myapp/db/migrate/20220714065827_modify_index_on_users.rb
+++ b/myapp/db/migrate/20220714065827_modify_index_on_users.rb
@@ -1,0 +1,7 @@
+class ModifyIndexOnUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :users, name: "index_users_on_name_and_email"
+    add_index :users, :name, unique: true
+    add_index :users, :email, unique: true
+  end
+end

--- a/myapp/db/migrate/20220721064221_change_column_not_null_to_user.rb
+++ b/myapp/db/migrate/20220721064221_change_column_not_null_to_user.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNotNullToUser < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :users, :admin, false
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_14_015644) do
+ActiveRecord::Schema.define(version: 2022_07_14_065827) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -32,7 +32,8 @@ ActiveRecord::Schema.define(version: 2022_07_14_015644) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "admin"
-    t.index ["name", "email"], name: "index_users_on_name_and_email", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["name"], name: "index_users_on_name", unique: true
   end
 
   add_foreign_key "tasks", "users"

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_01_062236) do
+ActiveRecord::Schema.define(version: 2022_07_14_015644) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2022_07_01_062236) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin"
     t.index ["name", "email"], name: "index_users_on_name_and_email", unique: true
   end
 

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_14_065827) do
+ActiveRecord::Schema.define(version: 2022_07_21_064221) do
+
+  create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "task_labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "label_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["label_id"], name: "index_task_labels_on_label_id"
+    t.index ["task_id"], name: "index_task_labels_on_task_id"
+  end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -31,10 +46,12 @@ ActiveRecord::Schema.define(version: 2022_07_14_065827) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "admin"
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
   end
 
+  add_foreign_key "task_labels", "labels"
+  add_foreign_key "task_labels", "tasks"
   add_foreign_key "tasks", "users"
 end

--- a/myapp/spec/system/admin_users_spec.rb
+++ b/myapp/spec/system/admin_users_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AdminUsers', type: :system do
+  let(:user) { create(:user, name: 'test', admin: true) }
+
+  describe '#index' do
+    before do
+      login(user: user)
+    end
+  end
+end

--- a/myapp/spec/system/admin_users_spec.rb
+++ b/myapp/spec/system/admin_users_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'AdminUsers', type: :system do
       visit admin_users_path
     end
 
-    it 'can display admin/users page' do # rubocop:disable RSpec/MultipleExpectations
+    it 'can display admin/users page', :aggregate_failures do
       expect(page).to have_content 'test1'
       expect(page).to have_content 'test1@gmail.com'
       expect(page).to have_content '2'
@@ -32,7 +32,7 @@ RSpec.describe 'AdminUsers', type: :system do
       visit admin_users_path
     end
 
-    it 'can display user info' do # rubocop:disable RSpec/MultipleExpectations
+    it 'can display user info', :aggregate_failures do
       puts current_path
       within '.table' do
         click_on 'test1'
@@ -66,7 +66,7 @@ RSpec.describe 'AdminUsers', type: :system do
       expect(page).to have_current_path edit_admin_user_path(user.id)
     end
 
-    it 'can display user info' do # rubocop:disable RSpec/MultipleExpectations
+    it 'can display user info', :aggregate_failures do
       expect(page).to have_field 'Name', with: 'test1'
       expect(page).to have_field 'Email', with: 'test1@gmail.com'
     end
@@ -85,7 +85,7 @@ RSpec.describe 'AdminUsers', type: :system do
         fill_in 'Password', with: 'password'
       end
 
-      it 'can create new user' do # rubocop:disable RSpec/MultipleExpectations
+      it 'can create new user', :aggregate_failures do
         click_on '作成'
         expect(page).to have_content 'test1'
         expect(page).to have_content 'test2'

--- a/myapp/spec/system/admin_users_spec.rb
+++ b/myapp/spec/system/admin_users_spec.rb
@@ -3,11 +3,134 @@
 require 'rails_helper'
 
 RSpec.describe 'AdminUsers', type: :system do
-  let(:user) { create(:user, name: 'test', admin: true) }
+  let(:user) { create(:user, name: 'test1', email: 'test1@gmail.com', admin: true) }
+
+  before do
+    login(user: user)
+  end
 
   describe '#index' do
     before do
-      login(user: user)
+      create(:task, name: 'テスト1', description: 'コインランドリーに行く', priority: 'Low', status: 'TODO', user_id: user.id)
+      create(:task, name: 'テスト2', description: 'クリーニング屋に行く', priority: 'High', status: 'DONE', user_id: user.id)
+      visit admin_users_path
+    end
+
+    it 'can display admin/users page' do # rubocop:disable RSpec/MultipleExpectations
+      expect(page).to have_content 'test1'
+      expect(page).to have_content 'test1@gmail.com'
+      expect(page).to have_content '2'
+      expect(page).to have_content '編集'
+      expect(page).to have_content '削除'
+    end
+  end
+
+  describe '#show' do
+    before do
+      create(:task, name: 'テスト1', description: 'コインランドリーに行く', priority: 'Low', status: 'TODO', user_id: user.id)
+      create(:task, name: 'テスト2', description: 'クリーニング屋に行く', priority: 'High', status: 'DONE', user_id: user.id)
+      visit admin_users_path
+    end
+
+    it 'can display user info' do # rubocop:disable RSpec/MultipleExpectations
+      puts current_path
+      within '.table' do
+        click_on 'test1'
+      end
+      expect(page).to have_current_path admin_user_path(user.id)
+      expect(page).to have_content 'test1'
+      expect(page).to have_content 'test1@gmail.com'
+      expect(page).to have_content 'テスト1'
+      expect(page).to have_content 'テスト2'
+    end
+  end
+
+  describe '#new' do
+    before do
+      visit admin_users_path
+      click_on '新規作成'
+    end
+
+    it 'can go to new page' do
+      expect(page).to have_current_path new_admin_user_path
+    end
+  end
+
+  describe '#edit' do
+    before do
+      visit admin_users_path
+      click_on '編集'
+    end
+
+    it 'can go to edit page' do
+      expect(page).to have_current_path edit_admin_user_path(user.id)
+    end
+
+    it 'can display user info' do # rubocop:disable RSpec/MultipleExpectations
+      expect(page).to have_field 'Name', with: 'test1'
+      expect(page).to have_field 'Email', with: 'test1@gmail.com'
+    end
+  end
+
+  describe '#create' do
+    before do
+      visit admin_users_path
+      click_on '新規作成'
+    end
+
+    context 'when input user info' do
+      before do
+        fill_in 'Name', with: 'test2'
+        fill_in 'Email', with: 'test2@gmail.com'
+        fill_in 'Password', with: 'password'
+      end
+
+      it 'can create new user' do # rubocop:disable RSpec/MultipleExpectations
+        click_on '作成'
+        expect(page).to have_content 'test1'
+        expect(page).to have_content 'test2'
+      end
+    end
+  end
+
+  describe '#update' do
+    before do
+      visit admin_users_path
+      click_on '編集'
+    end
+
+    context 'when edit user info' do
+      before do
+        fill_in 'Name', with: 'おかもと'
+      end
+
+      it 'can change user info' do
+        click_on '更新'
+        expect(page).to have_content 'おかもと'
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:destroy_user) { create(:user, id: 2, name: 'test2', email: 'test2@gmail.com') }
+
+    before do
+      create(:task, name: 'destroy task', description: 'destroy task description', priority: 'Low', status: 'TODO', user_id: destroy_user.id)
+      visit admin_users_path
+    end
+
+    context 'when push destroy button' do
+      before do
+        click_on '削除', match: :first
+      end
+
+      it 'can destroy user' do
+        expect(page).not_to have_content 'test2'
+      end
+
+      it 'can destroy task too' do
+        change(Task, :count).by(-1)
+      end
     end
   end
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Task', type: :system do
         visit current_path
       end
 
-      it "return user's task" do # rubocop:disable RSpec/MultipleExpectations
+      it "return user's task", :aggregate_failures do
         expect(page).to have_link 'test1'
         expect(page).to have_link 'test2'
         expect(page).to have_link 'test3'
@@ -86,7 +86,7 @@ RSpec.describe 'Task', type: :system do
         visit current_path
       end
 
-      it 'can search using the keyword' do # rubocop:disable RSpec/MultipleExpectations
+      it 'can search using the keyword', :aggregate_failures do
         fill_in 'keyword', with: '洗濯'
         click_on '検索'
         expect(page).to have_content '洗濯1'
@@ -95,7 +95,7 @@ RSpec.describe 'Task', type: :system do
         expect(page).not_to have_content '買い物'
       end
 
-      it 'can search using status' do # rubocop:disable RSpec/MultipleExpectations
+      it 'can search using status', :aggregate_failures do
         select '着手中', from: 'status'
         click_on '検索'
         expect(page).not_to have_content '洗濯1'
@@ -104,7 +104,7 @@ RSpec.describe 'Task', type: :system do
         expect(page).not_to have_content '買い物'
       end
 
-      it 'can search using keyword and status' do # rubocop:disable RSpec/MultipleExpectations
+      it 'can search using keyword and status', :aggregate_failures do
         fill_in 'keyword', with: '洗濯'
         select '未着手', from: 'status'
         click_on '検索'
@@ -162,7 +162,7 @@ RSpec.describe 'Task', type: :system do
       visit task_path(task)
     end
 
-    it 'return task info' do # rubocop:disable RSpec/MultipleExpectations
+    it 'return task info', :aggregate_failures do
       expect(page).to have_content 'テストタスク'
       expect(page).to have_content 'テストのタスク'
       expect(page).to have_content '未着手'
@@ -204,7 +204,7 @@ RSpec.describe 'Task', type: :system do
     end
 
     context 'when user go to this page' do
-      it 'display blank task form' do # rubocop:disable RSpec/MultipleExpectations
+      it 'display blank task form', :aggregate_failures do
         expect(page).to have_field 'タスク名'
         expect(page).to have_field '詳細'
         expect(page).to have_field '期限'
@@ -223,7 +223,7 @@ RSpec.describe 'Task', type: :system do
     end
 
     context 'when user go to this page' do
-      it 'display task form' do # rubocop:disable RSpec/MultipleExpectations
+      it 'display task form', :aggregate_failures do
         expect(page).to have_field 'タスク名', with: task.name
         expect(page).to have_field '詳細', with: task.description
         expect(page).to have_field '期限', with: task.limit
@@ -240,7 +240,7 @@ RSpec.describe 'Task', type: :system do
     end
 
     context 'when user go to Add task page' do
-      it 'display brank form' do # rubocop:disable RSpec/MultipleExpectations
+      it 'display brank form', :aggregate_failures do
         expect(page).to have_field 'タスク名'
         expect(page).to have_field '詳細'
         expect(page).to have_field '期限'
@@ -258,7 +258,7 @@ RSpec.describe 'Task', type: :system do
         select '低い', from: '優先度'
       end
 
-      it 'display input task info' do # rubocop:disable RSpec/MultipleExpectations
+      it 'display input task info', :aggregate_failures do
         expect(page).to have_field 'タスク名', with: '散歩'
         expect(page).to have_field '詳細', with: '多摩川を歩く'
         expect(page).to have_field '期限', with: '2022-06-20'
@@ -267,7 +267,7 @@ RSpec.describe 'Task', type: :system do
       end
 
       context 'when user click "Create Task" button' do
-        it 'go to Task detail page' do # rubocop:disable RSpec/MultipleExpectations
+        it 'go to Task detail page', :aggregate_failures do
           click_on '作成'
           expect(page).to have_content '散歩'
           expect(page).to have_content '多摩川を歩く'
@@ -296,7 +296,7 @@ RSpec.describe 'Task', type: :system do
         select '普通', from: '優先度'
       end
 
-      it 'display new task info' do # rubocop:disable RSpec/MultipleExpectations
+      it 'display new task info', :aggregate_failures do
         expect(page).to have_field 'タスク名', with: '運動'
         expect(page).to have_field '詳細', with: '多摩川を走る'
         expect(page).to have_field '期限', with: '2022-06-20'
@@ -305,7 +305,7 @@ RSpec.describe 'Task', type: :system do
       end
 
       context 'when user click "Update Task" button' do
-        it 'go to Task detail page' do # rubocop:disable RSpec/MultipleExpectations
+        it 'go to Task detail page', :aggregate_failures do
           click_on '更新'
           expect(page).to have_content '運動'
           expect(page).to have_content '多摩川を走る'

--- a/myapp/spec/system/users_spec.rb
+++ b/myapp/spec/system/users_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/myapp/spec/system/users_spec.rb
+++ b/myapp/spec/system/users_spec.rb
@@ -3,9 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :system do
+  let(:user) { create(:user, name: 'test1', email: 'test1@gmail.com', admin: true) }
+
   before do
-    driven_by(:rack_test)
+    login(user: user)
   end
 
-  pending "add some scenarios (or delete) #{__FILE__}"
+  describe '#show' do
+    it 'display user info', :aggregate_failures do
+      visit user_path(user.id)
+      expect(page).to have_content 'test1'
+      expect(page).to have_content 'test1@gmail.com'
+    end
+  end
 end


### PR DESCRIPTION
# 概要
[Rails研修ステップ18](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E7%AE%A1%E7%90%86%E7%94%BB%E9%9D%A2%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
- 画面上に管理メニューを追加しましょう
- 管理画面には必ず`/admin`というURLを先頭につけるようにしましょう
- ユーザ一覧・作成・更新・削除を実装しましょう
- ユーザを削除したら、そのユーザが持っているタスクを削除するようにしましょう
- ユーザの一覧画面で、ユーザが持っているタスク数を表示するようにしましょう
- ユーザが作成したタスクの一覧が見られるようにしてみましょう


# 実装内容
- `routes.rb`に`/admin`というルーティングを追加
- `admin/users_controller.rb`を作成し管理ユーザに関する機能を実装
- `admin/users_controller.rb`のsystem specの記述


## 画面
### ユーザ一覧画面
<img width="1585" alt="Screen Shot 2022-07-20 at 13 33 50" src="https://user-images.githubusercontent.com/44032125/179897634-13f58206-3f66-4449-9c88-1971754b0d31.png">

### ユーザー詳細画面
<img width="1585" alt="Screen Shot 2022-07-20 at 13 34 32" src="https://user-images.githubusercontent.com/44032125/179897716-df14e6d6-7241-49d3-9cc8-19bf9eb2ed7a.png">

### ユーザー作成/編集画面
<img width="1585" alt="Screen Shot 2022-07-20 at 13 35 07" src="https://user-images.githubusercontent.com/44032125/179897782-c9442ccc-931b-46d2-a1c6-56b0b345206a.png">



# 動作確認方法
```
$ git clone git@github.com:Fablic/training.git
$ git checkout -b hoge origin/wataru-okamoto_step18

$ docker-compose up --build
# http://localhost:3001/admin/usersにアクセス

# sample dataの作成
$ docker-compose exec api /bin/bash
$ rails db:seed
```