### PR TITLE
wataru okamoto step21: メンテナンス機能を作ろう

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Task Management App
 
+## How to turn on maintenance mode
+```
+$ docker-compose exec api /bin/bash
+$ rails runner Constants::Maintenance.on
+```
+
+## How to turn off maintenance mode
+```
+$ docker-compose exec api /bin/bash
+$ rails runner Constants::Maintenance.off
+```
+
 ## front design
 ### Login Page
 ![LoginPage](docs/LoginPage.png)

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
 
   def maintenance_mode?
     maintenance_mode = Constant.find_by(key: 'maintenance_mode')
-    return true if maintenance_mode.value
+    return true if maintenance_mode.value == 'true'
 
     false
   end

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -34,6 +34,8 @@ class ApplicationController < ActionController::Base
   def maintenance_mode?
     maintenance_mode = Constant.find_by(key: 'maintenance_mode')
     return true if maintenance_mode.value
+
+    false
   end
 
   def _render503(error = nil)

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -32,8 +32,8 @@ class ApplicationController < ActionController::Base
   end
 
   def maintenance_mode?
-    maintenance_mode = Constant.where(key: 'maintenance_mode')
-    return true if maintenance_mode
+    maintenance_mode = Constant.find_by(key: 'maintenance_mode')
+    return true if maintenance_mode.value
   end
 
   def _render503(error = nil)

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::Base
 
   def maintenance_mode?
     maintenance_mode = Constant.find_by(key: 'maintenance_mode')
+    return false if maintenance_mode.nil?
     return true if maintenance_mode.value == 'true'
 
     false

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -32,11 +32,7 @@ class ApplicationController < ActionController::Base
   end
 
   def maintenance_mode?
-    maintenance_mode = Constant.find_by(key: 'maintenance_mode')
-    return false if maintenance_mode.nil?
-    return true if maintenance_mode.value == 'true'
-
-    false
+    Constant.find_by(key: 'maintenance_mode')&.value == 'true'
   end
 
   def _render503(error = nil)

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include SessionsHelper
+  before_action :_render503, if: :maintenance_mode?
 
   # error handle
   rescue_from Exception, with: :_render500
@@ -28,5 +29,15 @@ class ApplicationController < ActionController::Base
     return if logged_in?
 
     redirect_to login_path
+  end
+
+  def maintenance_mode?
+    maintenance_mode = Constant.where(key: 'maintenance_mode')
+    return true if maintenance_mode
+  end
+
+  def _render503(error = nil)
+    logger.info "Rendering 503 with exception: #{error.message}" if error
+    render 'errors/503.html', content_type: 'text/html', status: :service_unavailable
   end
 end

--- a/myapp/app/models/constant.rb
+++ b/myapp/app/models/constant.rb
@@ -1,0 +1,2 @@
+class Constant < ApplicationRecord
+end

--- a/myapp/app/models/task_label.rb
+++ b/myapp/app/models/task_label.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TaskLabel < ApplicationRecord
   belongs_to :task
   belongs_to :label

--- a/myapp/app/views/errors/503.html.erb
+++ b/myapp/app/views/errors/503.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class="text-center">
+    <h1>ただいまメンテナンス中です</h1>
+    <p>
+      システムアップデートのためサービスを停止しています。<br>
+      ご不便をおかけしますが、メンテナンス終了までしばらくお待ちください。
+    </p>
+    <h2>お問い合わせ</h2>
+    <p>
+      メンテナンスに関するお問い合わせは<a href="mailto:maintenace@examle.com">maintenance@example.com</a>までお願いします。
+    </p>
+  </div>
+</div>

--- a/myapp/config/application.rb
+++ b/myapp/config/application.rb
@@ -18,5 +18,7 @@ module Myapp
     config.i18n.default_locale = :ja
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    config.autoload_paths += Dir["#{config.root}/lib"]
   end
 end

--- a/myapp/db/migrate/20220727004547_create_constants.rb
+++ b/myapp/db/migrate/20220727004547_create_constants.rb
@@ -1,0 +1,9 @@
+class CreateConstants < ActiveRecord::Migration[6.0]
+  def change
+    create_table :constants do |t|
+      t.boolean :maintenance_mode, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/migrate/20220727004547_create_constants.rb
+++ b/myapp/db/migrate/20220727004547_create_constants.rb
@@ -1,7 +1,8 @@
 class CreateConstants < ActiveRecord::Migration[6.0]
   def change
     create_table :constants do |t|
-      t.boolean :maintenance_mode, default: false, null: false
+      t.string :key, null: false
+      t.boolean :value, default: false, null: false
 
       t.timestamps
     end

--- a/myapp/db/migrate/20220727060410_change_data_value_to_constant.rb
+++ b/myapp/db/migrate/20220727060410_change_data_value_to_constant.rb
@@ -1,0 +1,5 @@
+class ChangeDataValueToConstant < ActiveRecord::Migration[6.0]
+  def change
+    change_column :constants, :value, :string
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_21_064221) do
+ActiveRecord::Schema.define(version: 2022_07_27_004547) do
+
+  create_table "constants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.boolean "maintenance_mode", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -13,7 +13,8 @@
 ActiveRecord::Schema.define(version: 2022_07_27_004547) do
 
   create_table "constants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.boolean "maintenance_mode", default: false, null: false
+    t.string "key", null: false
+    t.boolean "value", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_27_004547) do
+ActiveRecord::Schema.define(version: 2022_07_27_060410) do
 
   create_table "constants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "key", null: false
-    t.boolean "value", default: false, null: false
+    t.string "value", default: "0", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -16,7 +16,7 @@ User.create!(
 
 Constant.create!(
   key: 'maintenance_mode',
-  value: false
+  value: 'false'
 )
 
 if Rails.env.development?

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -14,6 +14,11 @@ User.create!(
   password: 'password'
 )
 
+Constant.create!(
+  key: 'maintenance_mode',
+  value: false
+)
+
 if Rails.env.development?
   30.times do |n|
     name = "test-#{n+1}"

--- a/myapp/docker-compose.yml
+++ b/myapp/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       bundle exec rails webpacker:install &&
       bundle exec rails db:create &&
       bundle exec rails db:migrate &&
+      bundle exec rails db:seed &&
       rm -f tmp/pids/server.pid &&
       bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:

--- a/myapp/lib/constants/maintenance.rb
+++ b/myapp/lib/constants/maintenance.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Constants
+  class Maintenance
+    def self.on
+      maintenance_mode = Constant.find_by(key: 'maintenance_mode')
+      maintenance_mode.update(value: true)
+    end
+
+    def self.off
+      maintenance_mode = Constant.find_by(key: 'maintenance_mode')
+      maintenance_mode.update(value: false)
+    end
+  end
+end

--- a/myapp/lib/constants/maintenance.rb
+++ b/myapp/lib/constants/maintenance.rb
@@ -4,12 +4,12 @@ module Constants
   class Maintenance
     def self.on
       maintenance_mode = Constant.find_by(key: 'maintenance_mode')
-      maintenance_mode.update(value: true)
+      maintenance_mode.update(value: 'true')
     end
 
     def self.off
       maintenance_mode = Constant.find_by(key: 'maintenance_mode')
-      maintenance_mode.update(value: false)
+      maintenance_mode.update(value: 'false')
     end
   end
 end

--- a/myapp/spec/factories/constant.rb
+++ b/myapp/spec/factories/constant.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :constant do
+    key { 'maintenance_mode' }
+    value { 'true' }
+  end
+end

--- a/myapp/spec/factories/constant.rb
+++ b/myapp/spec/factories/constant.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :constant do
-    key { 'maintenance_mode' }
-    value { 'true' }
-  end
+  factory :constant
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -289,6 +289,17 @@ RSpec.describe 'Task', type: :system do
         end
       end
     end
+
+    context 'when maintenance_mode is true' do
+      before do
+        create(:constant, key: 'maintenance_mode', value: 'true')
+      end
+
+      it 'display maintenance page' do
+        visit current_path
+        expect(page).to have_content 'ただいまメンテナンス中です'
+      end
+    end
   end
 
   describe '#update' do

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -300,6 +300,17 @@ RSpec.describe 'Task', type: :system do
         expect(page).to have_content 'ただいまメンテナンス中です'
       end
     end
+
+    context 'when maintenace_mode is false' do
+      before do
+        create(:constant, key: 'maintenance_mode', value: 'false')
+      end
+
+      it 'doesnt display maintenance page' do
+        visit current_path
+        expect(page).not_to have_content 'ただいまメンテナンス中です'
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
# 概要
[Rails研修ステップ21](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86:~:text=%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721%3A%20%E3%83%A1%E3%83%B3%E3%83%86%E3%83%8A%E3%83%B3%E3%82%B9%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%9C%E3%82%8D%E3%81%86)
- メンテナンスを開始/終了するバッチを作ってみましょう
- メンテナンス中にアクセスしたユーザーはメンテナンスページにリダイレクトさせましょう
- 追加のGemを使わず、自分で実装してみましょう


# 実装内容
- メンテナンス状態を管理する`constants`テーブルの作成、Constantモデルの作成
- `application_controller.rb`に`constants`テーブルにある`maintenance_mode`の値を確認しメンテナンスページにリダイレクトさせる処理の追加
- メンテナンスページ（`503.html.erb`）の作成
- rails runnerで`maintenance_mode`のオン/オフを切り替えられるように処理を追加

## メンテナンス開始（メンテナンスモードオン）
```
$ docker-compose exec api /bin/bash
$ rails runner Constants::Maintenance.on
```

## メンテナンス終了（メンテナンスモードオフ）
```
$ docker-compose exec api /bin/bash
$ rails runner Constants::Maintenance.off
```

## 画面
### メンテナンス画面
<img width="1627" alt="Screen Shot 2022-07-27 at 11 45 42" src="https://user-images.githubusercontent.com/44032125/181149634-67b4bd51-a3df-4aa3-b2cf-84bb0a527b86.png">




# 動作確認方法
```
$ git clone git@github.com:Fablic/training.git
$ git checkout -b hoge origin/wataru-okamoto_step21

$ docker-compose up --build
# http://localhost:3001にアクセス

# sample dataの作成
$ docker-compose exec api /bin/bash
$ rails db:seed

# メンテナンス開始（メンテナンスモードオン）
$ docker-compose exec api /bin/bash
$ rails runner Constants::Maintenance.on

# メンテナンス終了（メンテナンスモードオフ）
$ docker-compose exec api /bin/bash
$ rails runner Constants::Maintenance.off
```