### PR TITLE
ステップ11: バリデーションを設定してみよう

### DIFF
--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,18 +1,6 @@
 class Task < ApplicationRecord
   # 結合キー
-  # belongs_to :user
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :description, presence: true, length: { maximum: 100 }
 
-  # ステータスEnum
-  enum status: {
-    not_started: '1',
-    in_progress: '2',
-    closed: '3'
-  }
-
-  # ステータス変換用Enum
-  STATUS_VIEW = {
-    Task.statuses[:not_started] => '未着手',
-    Task.statuses[:in_progress] => '着手中',
-    Task.statuses[:closed] => '完了'
-  }.freeze
 end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,3 +1,13 @@
+<% if @task.errors.any? %>
+  <div style="color: red" >
+    <ul>
+      <% @task.errors.full_messages.each do |msg| %>
+        <li class='error_list' ><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <%= form_for(@task) do |f| %>
   <p>Title</p>
   <%= f.text_field :title, id: 'textarea1' %>

--- a/myapp/spec/models/tasks_spec.rb
+++ b/myapp/spec/models/tasks_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+describe Task, type: :model do
+  describe '#validation' do
+    describe 'タイトル' do
+      context 'nil' do
+        subject(:task) { FactoryBot.build(:task, title: nil) }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '0文字' do
+        subject(:task) { FactoryBot.build(:task, title: '') }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '1文字' do
+        subject(:task) { FactoryBot.build(:task, title: '1') }
+
+        it { is_expected.to be_valid }
+      end
+
+      context '30文字' do
+        subject(:task) { FactoryBot.build(:task, title: '1' * 30) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context '31文字' do
+        subject(:task) { FactoryBot.build(:task, title: '1' * 31) }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+
+    describe '説明' do
+      context 'nil' do
+        subject(:task) { FactoryBot.build(:task, description: nil) }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '0文字' do
+        subject(:task) { FactoryBot.build(:task, description: '') }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context '1文字' do
+        subject(:task) { FactoryBot.build(:task, description: '1') }
+
+        it { is_expected.to be_valid }
+      end
+
+      context '100文字' do
+        subject(:task) { FactoryBot.build(:task, description: '1' * 100) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context '101文字' do
+        subject(:task) { FactoryBot.build(:task, description: '1' * 101) }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+  end
+end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -44,7 +44,7 @@ describe 'タスク管理機能', type: :system do
         context '詳細ボタンをクリックした場合' do
           it '詳細画面へ遷移できる' do
             visit_tasks
-            click_link 'Details', match: :first
+            click_link I18n.t('button.detail'), match: :first
             expect(page).to have_current_path task_path(task_a)
           end
         end
@@ -60,7 +60,7 @@ describe 'タスク管理機能', type: :system do
         context '編集ボタンをクリックした場合' do
           it '編集画面へ遷移できる' do
             visit_tasks
-            click_link 'Update', match: :first
+            click_link I18n.t('button.update'), match: :first
             expect(page).to have_current_path edit_task_path(task_a)
           end
         end


### PR DESCRIPTION
■要件
### ステップ11: バリデーションを設定してみよう

- バリデーションを設定しましょう
  - どのカラムにどのバリデーションを追加したらよいか考えてみましょう
  - 合わせてDBの制約も設定するマイグレーションを作成しましょう
  - マイグレーションファイルだけを作成するため、 `rails generate` コマンドで作成します
- 画面にバリデーションエラーのメッセージを表示するようにしましょう
- バリデーションに対してモデルのテストを書いてみましょう
- GitHub上でPRを作成してレビューしてもらいましょう

■対応内容
- Taskへバリデーション設定追加
- Taskのmodel spec作成
- Taskのsystem spec作成
- 現場不要な定義をTask Modelから削除
- system spec上のボタン名を日本語化対応

■確認手順
・事前準備
　下記コマンドでDockerを起動 
　``` docker-compose up --build ```
・バリデーションエラーメッセージ　
　下記URLで登録画面を開く
　``` http://localhost:3001/tasks/new ```
　タスク名、詳細欄に何も入力せず登録ボタンを押下する
　タスク名に31文字以上、詳細に101文字以上を入力して登録ボタンを押下する

・モデルテスト
　下記コマンドを実行
　``` docker-compose exec api bundle exec rspec -f d spec/models/task_spec.rb ```