### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -57,11 +57,16 @@ class TasksController < ApplicationController
     end
   end
 
+  def search
+    @tasks = Task.where_title(params[:title]).where_status(Task.statuses[params[:status]])
+    render :index
+  end
+
   private
 
   # Get Task Parameter
   def task_params
-    task = params.require(:task).permit(:title, :description, :label)
+    task = params.require(:task).permit(:title, :description, :label, :status)
   end
 
   # Get UserNames
@@ -74,12 +79,4 @@ class TasksController < ApplicationController
 #    user_names
 #  end
 
-  # Get Statuses
-#  def statuses
-#    statuses = []
-#    Task::STATUS_VIEW.each do |key, value|
-#      statuses.push([value, key])
-#    end
-#    statuses
-#  end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -3,4 +3,14 @@ class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 30 }
   validates :description, presence: true, length: { maximum: 100 }
 
+  # ステータスEnum
+  enum status: {
+    not_started: '1',
+    in_progress: '2',
+    closed: '3',
+  }
+
+  # scope
+  scope :where_title, -> (title) { where('title LIKE ?', "%#{title}%") if title.present? }
+  scope :where_status, -> (status) { where('status = ?', status) if status.present? }
 end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -13,7 +13,7 @@
   <%= f.text_field :title, id: 'textarea1' %>
   <p><%= I18n.t('task.description') %></p>
   <%= f.text_field :description, id: 'textarea2' %>
-  <p>Status</p>
+  <p><%= I18n.t('task.status') %></p>
   <%= f.select :status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k] } %>
   <br><br>
   <%= f.submit id: 'submit' %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -9,9 +9,9 @@
 <% end %>
 
 <%= form_for(@task) do |f| %>
-  <p>Title</p>
+  <p><%= I18n.t('task.title') %></p>
   <%= f.text_field :title, id: 'textarea1' %>
-  <p>Description</p>
+  <p><%= I18n.t('task.description') %></p>
   <%= f.text_field :description, id: 'textarea2' %>
   <br>
   <%= f.submit id: 'submit' %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -13,6 +13,8 @@
   <%= f.text_field :title, id: 'textarea1' %>
   <p>Description</p>
   <%= f.text_field :description, id: 'textarea2' %>
-  <br>
+  <p>Status</p>
+  <%= f.select :status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k] } %>
+  <br><br>
   <%= f.submit id: 'submit' %>
 <% end %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -9,9 +9,9 @@
 <% end %>
 
 <%= form_for(@task) do |f| %>
-  <p><%= I18n.t('task.title') %></p>
+  <p>Title</p>
   <%= f.text_field :title, id: 'textarea1' %>
-  <p><%= I18n.t('task.description') %></p>
+  <p>Description</p>
   <%= f.text_field :description, id: 'textarea2' %>
   <br>
   <%= f.submit id: 'submit' %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,13 +1,13 @@
-<p class=“alert-success”><%= notice %></p>
+<p class="alert-success"><%= notice %></p>
 <h1>Task List</h1>
-<%= link_to(I18n.t('link.create'), new_task_path, {class: 'btn_a'}) %>
+<%= link_to('新規登録', new_task_path, {class: 'btn_a'}) %>
 <br>
 <br>
 <table>
     <thead>
       <tr>
-        <th><%= I18n.t('task.title') %></th>
-        <th><%= I18n.t('task.label') %></th>
+        <th>title</th>
+        <th>label</th>
         <th></th>
         <th></th>
         <th></th>
@@ -18,9 +18,9 @@
         <tr>
           <td><span><%= task.title %></span></td>
           <td><span><%= task.label %></span></td>
-          <td><%= link_to('Details', task_path(task), {id: "show#{task.id}", class: 'btn_a'}) %></td>
-          <td><%= link_to(I18n.t('button.update'), edit_task_path(task), {id: "update#{task.id}", class: 'btn_a'}) %></td>
-          <td><%= link_to(I18n.t('button.delete'), task_path(task), method: :delete, id: "delete#{task.id}", class: 'btn_a') %></td>
+          <td><%= link_to('Details', task_path(task), {id: "show#{task.id}" ,class: 'btn_a'}) %></td>
+          <td><%= link_to('Update', edit_task_path(task), {id: "update#{task.id}" ,class: 'btn_a'}) %></td>
+          <td><%= link_to('Delete', task_path(task), method: :delete, id: "delete#{task.id}" ,class: 'btn_a') %></td>
         </tr>
       <% end %>
     </tbody>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -31,6 +31,7 @@
         <tr>
           <td><span><%= task.title %></span></td>
           <td><span><%= task.label %></span></td>
+          <td><span><%= I18n.t("enums.task.status.#{task.status}") %></span></td>
           <td><%= link_to(I18n.t('button.detail'), task_path(task), {id: "show#{task.id}" ,class: 'btn_a'}) %></td>
           <td><%= link_to(I18n.t('button.update'), edit_task_path(task), {id: "update#{task.id}" ,class: 'btn_a'}) %></td>
           <td><%= link_to(I18n.t('button.delete'), task_path(task), method: :delete, id: "delete#{task.id}" ,class: 'btn_a') %></td>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,13 +1,13 @@
-<p class="alert-success"><%= notice %></p>
+<p class=“alert-success”><%= notice %></p>
 <h1>Task List</h1>
-<%= link_to('新規登録', new_task_path, {class: 'btn_a'}) %>
+<%= link_to(I18n.t('link.create'), new_task_path, {class: 'btn_a'}) %>
 <br>
 <br>
 <table>
     <thead>
       <tr>
-        <th>title</th>
-        <th>label</th>
+        <th><%= I18n.t('task.title') %></th>
+        <th><%= I18n.t('task.label') %></th>
         <th></th>
         <th></th>
         <th></th>
@@ -18,9 +18,9 @@
         <tr>
           <td><span><%= task.title %></span></td>
           <td><span><%= task.label %></span></td>
-          <td><%= link_to('Details', task_path(task), {id: "show#{task.id}" ,class: 'btn_a'}) %></td>
-          <td><%= link_to('Update', edit_task_path(task), {id: "update#{task.id}" ,class: 'btn_a'}) %></td>
-          <td><%= link_to('Delete', task_path(task), method: :delete, id: "delete#{task.id}" ,class: 'btn_a') %></td>
+          <td><%= link_to('Details', task_path(task), {id: "show#{task.id}", class: 'btn_a'}) %></td>
+          <td><%= link_to(I18n.t('button.update'), edit_task_path(task), {id: "update#{task.id}", class: 'btn_a'}) %></td>
+          <td><%= link_to(I18n.t('button.delete'), task_path(task), method: :delete, id: "delete#{task.id}", class: 'btn_a') %></td>
         </tr>
       <% end %>
     </tbody>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -3,11 +3,24 @@
 <%= link_to('新規登録', new_task_path, {class: 'btn_a'}) %>
 <br>
 <br>
+<div>
+<%= form_with url: search_path, method: :get, local: true do |f| %>
+  <p>検索</p>
+    <p>タスク名</p>
+    <%= f.text_field :title %>
+    <p>ステータス</p>
+    <%= f.select :status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k]} , include_blank: true %>
+  <br>
+  <%= f.submit '検索' %>
+<% end %>
+</div>
+<br>
 <table>
     <thead>
       <tr>
         <th>title</th>
         <th>label</th>
+        <th>status</th>
         <th></th>
         <th></th>
         <th></th>
@@ -18,6 +31,7 @@
         <tr>
           <td><span><%= task.title %></span></td>
           <td><span><%= task.label %></span></td>
+          <td><span><%= I18n.t("enums.task.status.#{task.status}") %></span></td>
           <td><%= link_to('Details', task_path(task), {id: "show#{task.id}" ,class: 'btn_a'}) %></td>
           <td><%= link_to('Update', edit_task_path(task), {id: "update#{task.id}" ,class: 'btn_a'}) %></td>
           <td><%= link_to('Delete', task_path(task), method: :delete, id: "delete#{task.id}" ,class: 'btn_a') %></td>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -5,6 +5,6 @@
 <p><%= @task[:description] %></p>
 <p><%= I18n.t('task.label') %></p>
 <p><%= @task[:label] %></p>
-<p>Status</p>
+<p><%= I18n.t('task.status') %></p>
 <p><%= I18n.t("enums.task.status.#{@task.status}") %></p>
 <%= link_to('一覧に戻る', tasks_url) %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,8 +1,8 @@
 <h1>Task Details</h1>
-<p><%= I18n.t('task.title') %></p>
+<p>Title</p>
 <p><%= @task[:title] %></p>
-<p><%= I18n.t('task.description') %></p>
+<p>Description</p>
 <p><%= @task[:description] %></p>
-<p><%= I18n.t('task.label') %></p>
+<p>Label</p>
 <p><%= @task[:label] %></p>
 <%= link_to('一覧に戻る', tasks_url) %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,8 +1,8 @@
 <h1>Task Details</h1>
-<p>Title</p>
+<p><%= I18n.t('task.title') %></p>
 <p><%= @task[:title] %></p>
-<p>Description</p>
+<p><%= I18n.t('task.description') %></p>
 <p><%= @task[:description] %></p>
-<p>Label</p>
+<p><%= I18n.t('task.label') %></p>
 <p><%= @task[:label] %></p>
 <%= link_to('一覧に戻る', tasks_url) %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -5,4 +5,6 @@
 <p><%= @task[:description] %></p>
 <p>Label</p>
 <p><%= @task[:label] %></p>
+<p>Status</p>
+<p><%= I18n.t("enums.task.status.#{@task.status}") %></p>
 <%= link_to('一覧に戻る', tasks_url) %>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -59,7 +59,6 @@ ja:
     description: '内容'
     label: 'ラベル'
     status: 'ステータス'
-    created_at: '作成日'
   button:
     detail: 詳細
     delete: 削除

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -43,6 +43,12 @@ ja:
         deleted_at: 削除日
         crated_at: 作成日
         updated_at: 更新日
+  enums:
+    task:
+      status:
+        not_started: 未着手
+        in_progress: 着手中
+        closed: 完了
   view_title:
     index: 'タスク一覧画面'
     new: 'タスク作成画面'

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -1,6 +1,6 @@
 # Files in the config/locales directory are used for internationalization
 # and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.　
+# than English, add the necessary files in this directory.
 #
 # To use the locales, use `I18n.t`:
 #
@@ -36,24 +36,34 @@ ja:
     attributes:
       task:
         title: タイトル
-        description: 内容
+        content: 内容
         user_id: ユーザーID
         status: ステータス
         label: ラベル
         deleted_at: 削除日
         crated_at: 作成日
         updated_at: 更新日
+  view_title:
+    index: 'タスク一覧画面'
+    new: 'タスク作成画面'
+    show: 'タスク詳細画面'
+    edit: 'タスク編集画面'
   task:
-    title: タイトル
-    description: 内容
-    label: ラベル
-  link:
-    create: 新規登録
+    title: 'タイトル'
+    content: '内容'
+    label: 'ラベル'
+    created_at: '作成日'
   button:
-    delete: 削除
-    update: 更新
+    create: '作成'
+    delete: '削除'
+    update: '更新'
+  link:
+    create: '作成'
+    detail: '詳細'
+    edit: '編集'
+    list_back: '一覧へ'
   message:
-    delete_confirm: 削除しますか?
+    delete_confirm: '削除しますか?'
   time:
     formats:
-      default: “%Y/%m/%d %H:%M:%S”
+      default: "%Y/%m/%d %H:%M:%S"

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -1,6 +1,6 @@
 # Files in the config/locales directory are used for internationalization
 # and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
+# than English, add the necessary files in this directory.　
 #
 # To use the locales, use `I18n.t`:
 #
@@ -36,34 +36,24 @@ ja:
     attributes:
       task:
         title: タイトル
-        content: 内容
+        description: 内容
         user_id: ユーザーID
         status: ステータス
         label: ラベル
         deleted_at: 削除日
         crated_at: 作成日
         updated_at: 更新日
-  view_title:
-    index: 'タスク一覧画面'
-    new: 'タスク作成画面'
-    show: 'タスク詳細画面'
-    edit: 'タスク編集画面'
   task:
-    title: 'タイトル'
-    content: '内容'
-    label: 'ラベル'
-    created_at: '作成日'
-  button:
-    create: '作成'
-    delete: '削除'
-    update: '更新'
+    title: タイトル
+    description: 内容
+    label: ラベル
   link:
-    create: '作成'
-    detail: '詳細'
-    edit: '編集'
-    list_back: '一覧へ'
+    create: 新規登録
+  button:
+    delete: 削除
+    update: 更新
   message:
-    delete_confirm: '削除しますか?'
+    delete_confirm: 削除しますか?
   time:
     formats:
-      default: "%Y/%m/%d %H:%M:%S"
+      default: “%Y/%m/%d %H:%M:%S”

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -58,6 +58,7 @@ ja:
     title: 'タイトル'
     description: '内容'
     label: 'ラベル'
+    status: 'ステータス'
     created_at: '作成日'
   button:
     detail: 詳細
@@ -68,3 +69,5 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
+  link:
+    create: 作成

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'tasks#index'
   resources :tasks
+
+  get 'search', to: 'tasks#search'
 end

--- a/myapp/db/migrate/20220905102327_add_index_to_tasks_title.rb
+++ b/myapp/db/migrate/20220905102327_add_index_to_tasks_title.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasksTitle < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :title
+  end
+end

--- a/myapp/db/migrate/20220905102338_add_index_to_tasks_status.rb
+++ b/myapp/db/migrate/20220905102338_add_index_to_tasks_status.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasksStatus < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_08_084136) do
+ActiveRecord::Schema.define(version: 2022_09_05_102338) do
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 128, default: "", null: false
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2022_08_08_084136) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status"], name: "index_tasks_on_status"
+    t.index ["title"], name: "index_tasks_on_title"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/myapp/package.json
+++ b/myapp/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^4.10.1"
+    "webpack-dev-server": "^4.11.0"
   }
 }

--- a/myapp/spec/factories/tasks.rb
+++ b/myapp/spec/factories/tasks.rb
@@ -1,8 +1,9 @@
 FactoryBot.define do
-    factory :task do
-      title { 'test title' }
-      description { 'test description' }
-      status { 0 }
-      label { '1' }
-    end
+  factory :task do
+    title { 'test title' }
+    description { 'test description' }
+    status { Task.statuses[:not_started] }
+    label { '1' }
+    user_id  { 1 }
   end
+end

--- a/myapp/spec/models/tasks_spec.rb
+++ b/myapp/spec/models/tasks_spec.rb
@@ -66,4 +66,98 @@ describe Task, type: :model do
       end
     end
   end
+
+  describe '#scope' do
+    describe 'where_title' do
+      context '完全一致' do
+        let!(:task) { FactoryBot.create(:task, title: 'あいうえお') }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_title('あいうえお').count).to eq 1
+        end
+      end
+
+      context '前方一致' do
+        let!(:task) { FactoryBot.create(:task, title: 'あいうえお') }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_title('あい').count).to eq 1
+        end
+      end
+
+      context '後方一致' do
+        let!(:task) { FactoryBot.create(:task, title: 'あいうえお') }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_title('えお').count).to eq 1
+        end
+      end
+
+      context '中央一致' do
+        let!(:task) { FactoryBot.create(:task, title: 'あいうえお') }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_title('いうえ').count).to eq 1
+        end
+      end
+
+      context '不一致' do
+        let!(:task) { FactoryBot.create(:task, title: 'あいうえお') }
+
+        it '検索結果が存在しないこと' do
+          expect(Task.where_title('TEST')).to be_empty
+        end
+      end
+
+      context '空文字' do
+        let!(:task) { FactoryBot.create(:task, title: 'あいうえお') }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_title('').count).to eq 1
+        end
+      end
+
+      context 'nil' do
+        let!(:task) { FactoryBot.create(:task, title: 'あいうえお') }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_title(nil).count).to eq 1
+        end
+      end
+    end
+
+    describe 'where_status' do
+      context '一致' do
+        let!(:task) { FactoryBot.create(:task, status: Task.statuses[:in_progress]) }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_status(Task.statuses[:in_progress]).count).to eq 1
+        end
+      end
+
+      context '不一致' do
+        let!(:task) { FactoryBot.create(:task, status: Task.statuses[:in_progress]) }
+
+        it '検索結果が存在しないこと' do
+          expect(Task.where_status(Task.statuses[:not_started])).to be_empty
+        end
+      end
+
+      context '空文字' do
+        let!(:task) { FactoryBot.create(:task, status: Task.statuses[:in_progress]) }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_status('').count).to eq 1
+        end
+      end
+
+      context 'nil' do
+        let!(:task) { FactoryBot.create(:task, status: Task.statuses[:in_progress]) }
+
+        it '検索結果が存在すること' do
+          expect(Task.where_status(nil).count).to eq 1
+        end
+      end
+    end
+  end
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -66,6 +66,189 @@ describe 'タスク管理機能', type: :system do
         end
       end
     end
+
+    describe '検索機能' do
+      let!(:task_A1) { FactoryBot.create(:task, title: 'A1', status: Task.statuses[:not_started]) }
+      let!(:task_A2) { FactoryBot.create(:task, title: 'A2', status: Task.statuses[:in_progress]) }
+      let!(:task_B1) { FactoryBot.create(:task, title: 'B1', status: Task.statuses[:not_started]) }
+      let!(:task_B2) { FactoryBot.create(:task, title: 'B2', status: Task.statuses[:in_progress]) }
+
+      context '条件なし' do
+        let(:conditions) { { title: '', status: '' } }
+
+        it '検索結果の件数が一致すること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(all('tbody tr').size).to be(4)
+        end
+
+        it 'A1が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'A1'
+        end
+
+        it 'A2が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'A2'
+        end
+
+        it 'B1が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'B1'
+        end
+
+        it 'B2が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'B2'
+        end
+      end
+
+      context 'titleのみ指定して検索' do
+        let(:conditions) { { title: 'A', status: '' } }
+
+        it '検索結果の件数が一致すること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(all('tbody tr').size).to be(2)
+        end
+
+        it 'A1が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'A1'
+        end
+
+        it 'A2が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'A2'
+        end
+
+        it 'B1が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).not_to have_content 'B1'
+        end
+
+        it 'B2が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).not_to have_content 'B2'
+        end
+      end
+
+      context 'statusのみ指定して検索' do
+        let(:conditions) { { title: '', status: '未着手' } }
+
+        it '検索結果の件数が一致すること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(all('tbody tr').size).to be(2)
+        end
+
+        it 'A1が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'A1'
+        end
+
+        it 'A2が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).not_to have_content 'A2'
+        end
+
+        it 'B1が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'B1'
+        end
+
+        it 'titleB2が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).not_to have_content 'titleB2'
+        end
+      end
+
+      context 'title、statusを指定して検索' do
+        let(:conditions) { { title: 'A', status: '未着手' } }
+
+        it '検索結果の件数が一致すること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(all('tbody tr').size).to be(1)
+        end
+
+        it 'A1が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).to have_content 'A1'
+        end
+
+        it 'A2が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).not_to have_content 'A2'
+        end
+
+        it 'B1が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).not_to have_content 'B1'
+        end
+
+        it 'B2が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          click_on '検索'
+          expect(page).not_to have_content 'B2'
+        end
+      end
+    end
   end
 
   describe '詳細表示機能' do

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -52,7 +52,7 @@ describe 'タスク管理機能', type: :system do
         context '新規登録ボタンをクリックした場合' do
           it '新規登録画面へ遷移できる' do
             visit_tasks
-            click_link '新規登録'
+            click_link I18n.t('link.create')
             expect(page).to have_current_path new_task_path
           end
         end

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -7730,10 +7730,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.10.1.tgz#124ac9ac261e75303d74d95ab6712b4aec3e12ed"
-  integrity sha512-FIzMq3jbBarz3ld9l7rbM7m6Rj1lOsgq/DyLGMX/fPEB1UBUPtf5iL/4eNfhx8YYJTRlzfv107UfWSWcBK5Odw==
+webpack-dev-server@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.11.0.tgz#290ee594765cd8260adfe83b2d18115ea04484e7"
+  integrity sha512-L5S4Q2zT57SK7tazgzjMiSMBdsw+rGYIX27MgPgx7LDhWO0lViPrHKoLS7jo5In06PWYAhlYu3PbyoC6yAThbw==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"


### PR DESCRIPTION
■要件
### ステップ13: ステータスを追加して、検索できるようにしよう

- ステータス（未着手・着手中・完了）を追加してみよう
  - 【オプション要件】初学者ではない場合はstateを管理するGemを導入しても構いません
- 一覧画面でタイトルとステータスで検索ができるようにしよう
  - 【オプション要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構いません
- 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
  - 以降のステップでも必要に応じて確認する癖をつけましょう
- 検索インデックスを貼りましょう
- 検索に対してmodel specを追加してみよう（system specも拡充しておきましょう）

■対応内容
- Taskにステータス追加
- 検索機能追加
- Modelのspec追加

■確認手順
・事前準備
 　下記コマンドでDockerを起動 
　docker-compose up --build 
・検索機能
　 下記URLでタスク一覧画面を開く
 　[http://localhost:3001/ ](http://localhost:3001/%E2%80%A8)
　検索エリアのタスク名に入力し、ステータスを選択して検索ボタンを押下する
　
・モデルテスト
 　下記コマンドを実行
 　docker-compose exec api bundle exec rspec -f d spec/models/task_spec.rb 
・システムテスト
　下記コマンドを実行
　docker-compose exec api bundle exec rspec -f d spec/system/tasks_spec.rb