### PR TITLE
STEP14: ページネーションを追加しよう

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -28,6 +28,8 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'rubocop', require: false
 
+gem 'kaminari'
+
 # RSpec
 gem 'rspec-rails', '~> 3.7'
 

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -89,6 +89,18 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -243,6 +255,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   factory_bot_rails (~> 4.11)
+  kaminari
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   puma (~> 4.1)

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -5,9 +5,9 @@ class TasksController < ApplicationController
 
   def index
     if params && (params[:word].present? || params[:status].present?)
-      @tasks = Task.search(params[:name], params[:status]).page(params[:page]).per(5)
+      @tasks = Task.search(params[:name], params[:status]).order('tasks.created_at desc').page(params[:page]).per(5)
     else
-      @tasks = Task.all.page(params[:page]).per(5)
+      @tasks = Task.all.order('tasks.created_at desc').page(params[:page]).per(5)
     end
   end
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.where_title(params[:title]).where_status(params[:status]).order('tasks.created_at desc').page(params[:page]).per(5)
+    @tasks = Task.where_title(params[:title]).where_status(params[:status]).order('tasks.created_at desc').page(params[:page])
   end
 
   def show; end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -5,9 +5,9 @@ class TasksController < ApplicationController
 
   def index
     if params && (params[:word].present? || params[:status].present?)
-      @tasks = Task.search(params[:word], Task.statuses[params[:status]])
+      @tasks = Task.search(params[:name], params[:status]).page(params[:page]).per(5)
     else
-      @tasks = Task.all.order('tasks.created_at desc')
+      @tasks = Task.all.page(params[:page]).per(5)
     end
   end
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -4,11 +4,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    if params && (params[:word].present? || params[:status].present?)
-      @tasks = Task.search(params[:name], params[:status]).order('tasks.created_at desc').page(params[:page]).per(5)
-    else
-      @tasks = Task.all.order('tasks.created_at desc').page(params[:page]).per(5)
-    end
+    @tasks = Task.where_title(params[:title]).where_status(params[:status]).order('tasks.created_at desc').page(params[:page]).per(5)
   end
 
   def show; end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -12,4 +12,6 @@ class Task < ApplicationRecord
 
     scope :where_title, -> (title) { where('title like ?', "%#{title}%") if title.present? }
     scope :where_status, -> (status) { where(status: status) if status.present? }
+
+    paginates_per 5
   end

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -44,6 +44,7 @@
       <% end %>
     </tbody>
   </table>
+          <%= paginate(@tasks) %>
 </div>
 <div name='footer'>
 </div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -44,7 +44,9 @@
       <% end %>
     </tbody>
   </table>
-          <%= paginate(@tasks) %>
+  <div class='pagenation-area'>
+    <%= paginate(@tasks) %>
+  </div>
 </div>
 <div name='footer'>
 </div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -40,4 +40,7 @@
     <% end %>
   </tbody>
 </table>
+  <div class='pagenation-area'>
+    <%= paginate(@tasks) %>
+  </div>
 <%= link_to '新規登録', new_task_path %>

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -17,10 +17,10 @@ ActiveRecord::Schema.define(version: 2022_09_08_003930) do
     t.text "description", null: false
     t.bigint "user_id", null: false
     t.string "status", limit: 1, default: "0", null: false
-    t.string "label", limit: 64
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "label"
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
   end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -17,10 +17,10 @@ ActiveRecord::Schema.define(version: 2022_09_08_003930) do
     t.text "description", null: false
     t.bigint "user_id", null: false
     t.string "status", limit: 1, default: "0", null: false
+    t.string "label", limit: 64
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "label"
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
   end

--- a/myapp/package.json
+++ b/myapp/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^4.10.0"
+    "webpack-dev-server": "^4.10.1"
   }
 }

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -23,6 +23,219 @@ describe 'タスク管理機能', type: :system do
         select value = conditions[:status], from: 'status'
         click_on '検索'
 
+        expect(page).to have_content 'titleA1'
+      end
+
+      it 'titleA2が表示されること' do
+        visit root_path
+        fill_in 'title', with: conditions[:title]
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).to have_content 'titleA2'
+      end
+
+      it 'titleB1が表示されること' do
+        visit root_path
+        fill_in 'title', with: conditions[:title]
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).to have_content 'titleB1'
+      end
+
+      it 'titleB2が表示されること' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).to have_content 'titleB2'
+      end
+    end
+
+    context 'titleのみ指定して検索' do
+      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started', user_id: '1') }
+      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress', user_id: '1') }
+      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started', user_id: '1') }
+      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress', user_id: '1') }
+      let(:conditions) { { title: 'A' } }
+
+      it '検索結果の件数が一致すること' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = '', from: 'status'
+        click_on '検索'
+
+        expect(all('tbody tr').size).to be(2)
+      end
+
+      it 'titleA1が表示されること' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = '', from: 'status'
+        click_on '検索'
+
+        expect(page).to have_content 'titleA1'
+      end
+
+      it 'titleA2が表示されること' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = '', from: 'status'
+        click_on '検索'
+
+        expect(page).to have_content 'titleA2'
+      end
+
+      it 'titleB1が表示されないこと' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = '', from: 'status'
+        click_on '検索'
+
+        expect(page).not_to have_content 'titleB1'
+      end
+
+      it 'titleB2が表示されないこと' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = '', from: 'status'
+        click_on '検索'
+
+        expect(page).not_to have_content 'titleB2'
+      end
+    end
+
+    context 'statusのみ指定して検索' do
+      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started', user_id: '1') }
+      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress', user_id: '1') }
+      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started', user_id: '1') }
+      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress', user_id: '1') }
+      let(:conditions) { { status: 'Not started' } }
+
+      it '検索結果の件数が一致すること' do
+        visit root_path
+
+        fill_in 'title', with: ''
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(all('tbody tr').size).to be(2)
+      end
+
+      it 'titleA1が表示されること' do
+        visit root_path
+
+        fill_in 'title', with: ''
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).to have_content 'titleA1'
+      end
+
+      it 'titleA2が表示されないこと' do
+        visit root_path
+
+        fill_in 'title', with: ''
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).not_to have_content 'titleA2'
+      end
+
+      it 'titleB1が表示されること' do
+        visit root_path
+
+        fill_in 'title', with: ''
+        select value = conditions[:status], from: 'status'
+         click_on '検索'
+
+        expect(page).to have_content 'titleB1'
+      end
+
+      it 'titleB2が表示されないこと' do
+        visit root_path
+
+        fill_in 'title', with: ''
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).not_to have_content 'titleB2'
+      end
+
+    end
+
+    context 'title、statusを指定して検索' do
+      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started', user_id: '1') }
+      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress', user_id: '1') }
+      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started', user_id: '1') }
+      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress', user_id: '1') }
+      let(:conditions) { { title: 'A', status: 'Not started' } }
+
+      it '検索結果の件数が一致すること' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(all('tbody tr').size).to be(1)
+      end
+
+      it 'titleA1が表示されること' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).to have_content 'titleA1'
+      end
+
+      it 'titleA2が表示されないこと' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).not_to have_content 'titleA2'
+      end
+
+      it 'titleB1が表示されないこと' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).not_to have_content 'titleB1'
+      end
+
+      it 'titleB2が表示されないこと' do
+        visit root_path
+
+        fill_in 'title', with: conditions[:title]
+        select value = conditions[:status], from: 'status'
+        click_on '検索'
+
+        expect(page).not_to have_content 'titleB2'
+      end
+    end
+  end
+
+  describe '一覧表示機能' do
+    subject(:visit_tasks) { visit tasks_path }
+
+    describe '表示機能'do
+
       context 'タスクが1件存在する場合' do
         let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: '1', status: '1', label: 1) }
 
@@ -74,11 +287,11 @@ describe 'タスク管理機能', type: :system do
     end
     describe 'ページングエリア' do
       context 'ページングなし' do
-        let!(:task_one) { FactoryBot.create(:task) }
-        let!(:task_two) { FactoryBot.create(:task) }
-        let!(:task_three) { FactoryBot.create(:task) }
-        let!(:task_four) { FactoryBot.create(:task) }
-        let!(:task_five) { FactoryBot.create(:task) }
+        let!(:task_one) { FactoryBot.create(:task, user_id: '1') }
+        let!(:task_two) { FactoryBot.create(:task, user_id: '1') }
+        let!(:task_three) { FactoryBot.create(:task, user_id: '1') }
+        let!(:task_four) { FactoryBot.create(:task, user_id: '1') }
+        let!(:task_five) { FactoryBot.create(:task, user_id: '1') }
 
         it 'ページングが表示されないこと ページ番号1' do
           visit root_path
@@ -102,17 +315,17 @@ describe 'タスク管理機能', type: :system do
       end
 
       context 'ページングあり' do
-        let!(:task_one) { FactoryBot.create(:task, title: 'titleOne') }
-        let!(:task_two) { FactoryBot.create(:task, title: 'titleTwo') }
-        let!(:task_three) { FactoryBot.create(:task, title: 'titleThree') }
-        let!(:task_four) { FactoryBot.create(:task, title: 'titleFour') }
-        let!(:task_five) { FactoryBot.create(:task, title: 'titleFive') }
-        let!(:task_six) { FactoryBot.create(:task, title: 'titleSix') }
-        let!(:task_seven) { FactoryBot.create(:task, title: 'titleSeven') }
-        let!(:task_eight) { FactoryBot.create(:task, title: 'titleEight') }
-        let!(:task_nine) { FactoryBot.create(:task, title: 'titleNine') }
-        let!(:task_ten) { FactoryBot.create(:task, title: 'titleTen') }
-        let!(:task_eleven) { FactoryBot.create(:task, title: 'titleEleven') }
+        let!(:task_one) { FactoryBot.create(:task, title: 'titleOne', user_id: '1') }
+        let!(:task_two) { FactoryBot.create(:task, title: 'titleTwo', user_id: '1') }
+        let!(:task_three) { FactoryBot.create(:task, title: 'titleThree', user_id: '1') }
+        let!(:task_four) { FactoryBot.create(:task, title: 'titleFour', user_id: '1') }
+        let!(:task_five) { FactoryBot.create(:task, title: 'titleFive', user_id: '1') }
+        let!(:task_six) { FactoryBot.create(:task, title: 'titleSix', user_id: '1') }
+        let!(:task_seven) { FactoryBot.create(:task, title: 'titleSeven', user_id: '1') }
+        let!(:task_eight) { FactoryBot.create(:task, title: 'titleEight', user_id: '1') }
+        let!(:task_nine) { FactoryBot.create(:task, title: 'titleNine', user_id: '1') }
+        let!(:task_ten) { FactoryBot.create(:task, title: 'titleTen', user_id: '1') }
+        let!(:task_eleven) { FactoryBot.create(:task, title: 'titleEleven', user_id: '1') }
 
         it 'ページングが表示されること ページ番号1' do
           visit root_path

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -1,235 +1,6 @@
 require 'rails_helper'
 
 describe 'タスク管理機能', type: :system do
-  describe '検索エリア' do
-    context '条件なし検索' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started') }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress') }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started') }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress') }
-      let(:conditions) { { word: '' } }
-
-      it '検索結果の件数が一致すること' do
-        visit root_path
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-        expect(all('tbody tr').size).to be(4)
-      end
-
-      it 'titleA1が表示されること' do
-        visit root_path
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(page).to have_content 'titleA1'
-      end
-
-      it 'titleA2が表示されること' do
-        visit root_path
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(page).to have_content 'titleA2'
-      end
-
-      it 'titleB1が表示されること' do
-        visit root_path
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(page).to have_content 'titleB1'
-      end
-
-      it 'titleB2が表示されること' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(page).to have_content 'titleB2'
-      end
-    end
-
-    context 'wordのみ指定して検索' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started') }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress') }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started') }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress') }
-      let(:conditions) { { word: 'A' } }
-
-      it '検索結果の件数が一致すること' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(all('tbody tr').size).to be(2)
-      end
-
-      it 'titleA1が表示されること' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(page).to have_content 'titleA1'
-      end
-
-      it 'titleA2が表示されること' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(page).to have_content 'titleA2'
-      end
-
-      it 'titleB1が表示されないこと' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(page).not_to have_content 'titleB1'
-      end
-
-      it 'titleB2が表示されないこと' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = '', from: 'status'
-        click_on '検索'
-
-        expect(page).not_to have_content 'titleB2'
-      end
-    end
-
-    context 'statusのみ指定して検索' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started') }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress') }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started') }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress') }
-      let(:conditions) { { status: 'Not started' } }
-
-      it '検索結果の件数が一致すること' do
-        visit root_path
-
-        fill_in 'word', with: ''
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(all('tbody tr').size).to be(2)
-      end
-
-      it 'titleA1が表示されること' do
-        visit root_path
-
-        fill_in 'word', with: ''
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(page).to have_content 'titleA1'
-      end
-
-      it 'titleA2が表示されないこと' do
-        visit root_path
-
-        fill_in 'word', with: ''
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(page).not_to have_content 'titleA2'
-      end
-
-      it 'titleB1が表示されること' do
-        visit root_path
-
-        fill_in 'word', with: ''
-        select value = conditions[:status], from: 'status'
-         click_on '検索'
-
-        expect(page).to have_content 'titleB1'
-      end
-
-      it 'titleB2が表示されないこと' do
-        visit root_path
-
-        fill_in 'word', with: ''
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(page).not_to have_content 'titleB2'
-      end
-
-    end
-
-    context 'word、statusを指定して検索' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started') }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress') }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started') }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress') }
-      let(:conditions) { { word: 'A', status: 'Not started' } }
-
-      it '検索結果の件数が一致すること' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(all('tbody tr').size).to be(1)
-      end
-
-      it 'titleA1が表示されること' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(page).to have_content 'titleA1'
-      end
-
-      it 'titleA2が表示されないこと' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(page).not_to have_content 'titleA2'
-      end
-
-      it 'titleB1が表示されないこと' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(page).not_to have_content 'titleB1'
-      end
-
-      it 'titleB2が表示されないこと' do
-        visit root_path
-
-        fill_in 'word', with: conditions[:word]
-        select value = conditions[:status], from: 'status'
-        click_on '検索'
-
-        expect(page).not_to have_content 'titleB2'
-      end
-    end
-  end
 
   describe '一覧表示機能' do
     subject(:visit_tasks) { visit tasks_path }
@@ -282,6 +53,94 @@ describe 'タスク管理機能', type: :system do
           visit_tasks
           click_link '新規登録'
           expect(page).to have_current_path new_task_path
+        end
+      end
+    end
+    describe 'ページングエリア' do
+      context 'ページングなし' do
+        let!(:task_one) { FactoryBot.create(:task) }
+        let!(:task_two) { FactoryBot.create(:task) }
+        let!(:task_three) { FactoryBot.create(:task) }
+        let!(:task_four) { FactoryBot.create(:task) }
+        let!(:task_five) { FactoryBot.create(:task) }
+
+        it 'ページングが表示されないこと ページ番号1' do
+          visit root_path
+          expect(find('div.pagenation-area')).not_to have_content '1'
+        end
+
+        it 'ページングが表示されないこと ページ番号2' do
+          visit root_path
+          expect(find('div.pagenation-area')).not_to have_content '2'
+        end
+
+        it 'ページングが表示されないこと 次ページボタン' do
+          visit root_path
+          expect(find('div.pagenation-area')).not_to have_content 'Next'
+        end
+
+        it 'ページングが表示されないこと 最終ページボタン' do
+          visit root_path
+          expect(find('div.pagenation-area')).not_to have_content 'Last'
+        end
+      end
+
+      context 'ページングあり' do
+        let!(:task_one) { FactoryBot.create(:task, title: 'titleOne') }
+        let!(:task_two) { FactoryBot.create(:task, title: 'titleTwo') }
+        let!(:task_three) { FactoryBot.create(:task, title: 'titleThree') }
+        let!(:task_four) { FactoryBot.create(:task, title: 'titleFour') }
+        let!(:task_five) { FactoryBot.create(:task, title: 'titleFive') }
+        let!(:task_six) { FactoryBot.create(:task, title: 'titleSix') }
+        let!(:task_seven) { FactoryBot.create(:task, title: 'titleSeven') }
+        let!(:task_eight) { FactoryBot.create(:task, title: 'titleEight') }
+        let!(:task_nine) { FactoryBot.create(:task, title: 'titleNine') }
+        let!(:task_ten) { FactoryBot.create(:task, title: 'titleTen') }
+        let!(:task_eleven) { FactoryBot.create(:task, title: 'titleEleven') }
+
+        it 'ページングが表示されること ページ番号1' do
+          visit root_path
+          expect(find('div.pagenation-area')).to have_content '1'
+        end
+
+        it 'ページングが表示されること ページ番号2' do
+          visit root_path
+          expect(find('div.pagenation-area')).to have_content '2'
+        end
+
+        it 'ページングが表示されること 次ページボタン' do
+          visit root_path
+          expect(find('div.pagenation-area')).to have_content 'Next'
+        end
+
+        it 'ページングが表示されること 最終ページボタン' do
+          visit root_path
+          expect(find('div.pagenation-area')).to have_content 'Last'
+        end
+
+        it 'ページ番号2を押下すると次ページの要素が表示されること' do
+          visit root_path
+          click_on '2'
+          expect(page).to have_content 'titleSix'
+        end
+
+        it '次ページボタンを押下すると次ページの要素が表示されること' do
+          visit root_path
+          click_on 'Next'
+          expect(page).to have_content 'titleSix'
+        end
+
+        it '最終ページボタンを押下すると最終ページの要素が表示されること' do
+          visit root_path
+          click_on 'Last'
+          expect(page).to have_content 'titleOne'
+        end
+
+        it '最初のページボタンを押下すると最初のページの要素が表示されること' do
+          visit root_path
+          click_on 'Last'
+          click_on 'First'
+          expect(page).to have_content 'titleEleven'
         end
       end
     end

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -7725,7 +7725,7 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.10.0:
+webpack-dev-server@^4.10.1:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.11.0.tgz#290ee594765cd8260adfe83b2d18115ea04484e7"
   integrity sha512-L5S4Q2zT57SK7tazgzjMiSMBdsw+rGYIX27MgPgx7LDhWO0lViPrHKoLS7jo5In06PWYAhlYu3PbyoC6yAThbw==

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -7730,10 +7730,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.10.0.tgz#de270d0009eba050546912be90116e7fd740a9ca"
-  integrity sha512-7dezwAs+k6yXVFZ+MaL8VnE+APobiO3zvpp3rBHe/HmWQ+avwh0Q3d0xxacOiBybZZ3syTZw9HXzpa3YNbAZDQ==
+webpack-dev-server@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.10.1.tgz#124ac9ac261e75303d74d95ab6712b4aec3e12ed"
+  integrity sha512-FIzMq3jbBarz3ld9l7rbM7m6Rj1lOsgq/DyLGMX/fPEB1UBUPtf5iL/4eNfhx8YYJTRlzfv107UfWSWcBK5Odw==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"


### PR DESCRIPTION
■要件

### ステップ14: ページネーションを追加しよう

- KaminariというGemを使って一覧画面にページネーションを追加してみましょう

■対応内容
- ページネーション作成

■確認手順
1. 以下ページへアクセス

``` http://localhost:3001 ```

<img width="547" alt="スクリーンショット 2022-09-08 11 37 40" src="https://user-images.githubusercontent.com/110374166/189021216-7767c302-13ac-444e-a87f-2bd4969cfabe.png">

2. ページングの``` 2 ```を押下
次のタスク5件が表示されること

<img width="429" alt="スクリーンショット 2022-09-08 11 38 42" src="https://user-images.githubusercontent.com/110374166/189021335-7d03f557-df96-4490-885e-6cd5ec348f32.png">

3. ページングの``` 1 ```を押下
前のタスク5件が表示されること

<img width="424" alt="スクリーンショット 2022-09-08 11 39 12" src="https://user-images.githubusercontent.com/110374166/189021414-9a1d5d33-16c6-49d0-8d51-0650c544f566.png">
