### PR TITLE
ステップ14: ページネーションを追加しよう

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -26,6 +26,8 @@ gem 'turbolinks', '~> 5'
 
 gem 'rails-i18n'
 
+gem 'kaminari'
+
 # FactoryBot
 gem 'factory_bot_rails', '~> 4.11'
 

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   # Task List
   def index
-    @tasks = Task.all
+    @tasks = Task.all.page(params[:page])
   end
 
   # Show Task
@@ -58,7 +58,7 @@ class TasksController < ApplicationController
   end
 
   def search
-    @tasks = Task.where_title(params[:title]).where_status(Task.statuses[params[:status]])
+    @tasks = Task.where_title(params[:title]).where_status(Task.statuses[params[:status]]).page(params[:page])
     render :index
   end
 

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -13,4 +13,7 @@ class Task < ApplicationRecord
   # scope
   scope :where_title, -> (title) { where('title LIKE ?', "%#{title}%") if title.present? }
   scope :where_status, -> (status) { where('status = ?', status) if status.present? }
+
+  # pagenation
+  paginates_per 5
 end

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -39,3 +39,4 @@
       <% end %>
     </tbody>
 </table>
+<div class='pagenation'><%= paginate(@tasks) %></div>

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -1,375 +1,100 @@
-require 'rails_helper'
-
-describe 'タスク管理機能', type: :system do
-
-  describe '一覧表示機能' do
-    subject(:visit_tasks) { visit tasks_path }
-
-    describe '表示機能' do
-      # タスクが表示される期待動作を共通化
-
-      context 'タスクが1件存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: '1', status: '1', label: '1') }
-
-        let(:tds){ all('tbody tr')[0].all('td') }
-        it 'タスク名が表示される' do
-          visit_tasks
-          expect(tds[0]).to have_content '最初のタスク'
-        end
-
-        it 'ラベルが表示される' do
-          visit_tasks
-          expect(tds[1]).to have_content '1'
-        end
-      end
-
-      context 'タスクが2件(複数)存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: '1', status: '1', label: '0 label') }
-        let!(:task_2) { FactoryBot.create(:task, title: '1 title', description: '２つ目のタスクを実施する', user_id: '1', status: '1', label: '1 label') }
-
-        let(:tds){ all('tbody tr')[1].all('td') }
-        it 'タスク名が表示される' do
-          visit_tasks
-          expect(tds[0]).to have_content '1 title'
-        end
-
-        it 'ラベルが表示される' do
-          visit_tasks
-          expect(tds[1]).to have_content '1 label'
-        end
-      end
-
-      describe '画面遷移機能' do
-        let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: '1', status: '1', label: '0 label') }
-        context '詳細ボタンをクリックした場合' do
-          it '詳細画面へ遷移できる' do
-            visit_tasks
-            click_link 'Details', match: :first
-            expect(page).to have_current_path task_path(task_a)
-          end
-        end
-
-        context '新規登録ボタンをクリックした場合' do
-          it '新規登録画面へ遷移できる' do
-            visit_tasks
-            click_link '新規登録'
-            expect(page).to have_current_path new_task_path
-          end
-        end
-
-        context '編集ボタンをクリックした場合' do
-          it '編集画面へ遷移できる' do
-            visit_tasks
-            click_link 'Update', match: :first
-            expect(page).to have_current_path edit_task_path(task_a)
-          end
-        end
-      end
+describe 'ページング機能' do
+  context 'タスク5件以内' do
+    before do
+      FactoryBot.create(:task, title: 'title_one')
+      FactoryBot.create(:task, title: 'title_two')
+      FactoryBot.create(:task, title: 'title_three')
+      FactoryBot.create(:task, title: 'title_four')
+      FactoryBot.create(:task, title: 'title_five')
     end
 
-    describe '検索機能' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'A1', status: Task.statuses[:not_started]) }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'A2', status: Task.statuses[:in_progress]) }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'B1', status: Task.statuses[:not_started]) }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'B2', status: Task.statuses[:in_progress]) }
+    it 'ページングが表示されないこと 1' do
+      visit root_path
+      expect(find('div.pagenation')).not_to have_content '1'
+    end
 
-      context '条件なし' do
-        let(:conditions) { { title: '', status: '' } }
+    it 'ページングが表示されないこと 2' do
+      visit root_path
+      expect(find('div.pagenation')).not_to have_content '2'
+    end
 
-        it '検索結果の件数が一致すること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(all('tbody tr').size).to be(4)
-        end
+    it 'ページングが表示されないこと Next' do
+      visit root_path
+      expect(find('div.pagenation')).not_to have_content 'Next'
+    end
 
-        it 'A1が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'A1'
-        end
-
-        it 'A2が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'A2'
-        end
-
-        it 'B1が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'B1'
-        end
-
-        it 'B2が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'B2'
-        end
-      end
-
-      context 'titleのみ指定して検索' do
-        let(:conditions) { { title: 'A', status: '' } }
-
-        it '検索結果の件数が一致すること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(all('tbody tr').size).to be(2)
-        end
-
-        it 'A1が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'A1'
-        end
-
-        it 'A2が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'A2'
-        end
-
-        it 'B1が表示されないこと' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).not_to have_content 'B1'
-        end
-
-        it 'B2が表示されないこと' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).not_to have_content 'B2'
-        end
-      end
-
-      context 'statusのみ指定して検索' do
-        let(:conditions) { { title: '', status: '未着手' } }
-
-        it '検索結果の件数が一致すること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(all('tbody tr').size).to be(2)
-        end
-
-        it 'A1が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'A1'
-        end
-
-        it 'A2が表示されないこと' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).not_to have_content 'A2'
-        end
-
-        it 'B1が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'B1'
-        end
-
-        it 'titleB2が表示されないこと' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).not_to have_content 'titleB2'
-        end
-      end
-
-      context 'title、statusを指定して検索' do
-        let(:conditions) { { title: 'A', status: '未着手' } }
-
-        it '検索結果の件数が一致すること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(all('tbody tr').size).to be(1)
-        end
-
-        it 'A1が表示されること' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).to have_content 'A1'
-        end
-
-        it 'A2が表示されないこと' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).not_to have_content 'A2'
-        end
-
-        it 'B1が表示されないこと' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).not_to have_content 'B1'
-        end
-
-        it 'B2が表示されないこと' do
-          visit root_path
-          fill_in 'title', with: conditions[:title]
-          select value = conditions[:status], from: 'status'
-          click_on '検索'
-          expect(page).not_to have_content 'B2'
-        end
-      end
+    it 'ページングが表示されないこと Last' do
+      visit root_path
+      expect(find('div.pagenation')).not_to have_content 'Last'
     end
   end
 
-  describe '詳細表示機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: '1', status: '1', label: '0 label') }
-    subject(:visit_task_a) { visit task_path(task_a) }
-
-    describe '表示機能' do
-      context 'タスクが存在する場合' do
-        it 'タスク名が表示される' do
-          visit_task_a
-          expect(page).to have_content '0 title'
-        end
-
-        it '詳細が表示される' do
-          visit_task_a
-          expect(page).to have_content '最初のタスクを実施する'
-        end
-
-        it 'ラベルが表示される' do
-          visit_task_a
-          expect(page).to have_content '0 label'
-        end
-      end
+  context 'タスク11件' do
+    before do
+      FactoryBot.create(:task, title: 'title_one')
+      FactoryBot.create(:task, title: 'title_two')
+      FactoryBot.create(:task, title: 'title_three')
+      FactoryBot.create(:task, title: 'title_four')
+      FactoryBot.create(:task, title: 'title_five')
+      FactoryBot.create(:task, title: 'title_six')
+      FactoryBot.create(:task, title: 'title_seven')
+      FactoryBot.create(:task, title: 'title_eight')
+      FactoryBot.create(:task, title: 'title_nine')
+      FactoryBot.create(:task, title: 'title_ten')
+      FactoryBot.create(:task, title: 'title_eleven')
     end
 
-    describe '画面遷移機能' do
-      context '一覧へボタンをクリックした場合' do
-        it '一覧画面へ遷移できる' do
-          visit_task_a
-          click_link '一覧に戻る'
-          expect(page).to have_current_path tasks_path
-        end
-      end
-    end
-  end
-
-  describe '新規登録機能' do
-    subject(:visit_new_task){ visit new_task_path }
-
-    context 'タスクの各項目を登録した場合' do
-      let(:input_values) {
-        {
-          title: '新規作成のテスト2',
-          description: '新規作成のテストを書く2',
-          user_id: '1',
-        }
-      }
-
-      it 'タスクが正常に登録される' do
-        visit_new_task
-        # 登録処理
-        fill_in 'textarea1', with: '新規作成のテスト2'
-        fill_in 'textarea2', with: '新規作成のテストを書く2'
-        expect { click_button 'submit' }.to change(Task, :count).by(1)
-      end
+    it 'ページングが表示されること 1' do
+      visit root_path
+      expect(find('div.pagenation')).to have_content '1'
     end
 
-    describe '画面遷移機能' do
-      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: '1', status: '1', label: '1') }
+    it 'ページングが表示されること 2' do
+      visit root_path
+      expect(find('div.pagenation')).to have_content '2'
+    end
 
-      context '新規登録ボタンをクリックした場合' do
-        it '一覧画面へ遷移できる' do
-          visit_new_task
-          click_button 'submit'
-          expect(page).to have_current_path tasks_path
-        end
-      end
+    it 'ページングが表示されること Next' do
+      visit root_path
+      expect(find('div.pagenation')).to have_content 'Next'
+    end
 
-      context '一覧へボタンをクリックした場合' do
-        it '一覧画面へ遷移できる' do
-          visit_new_task
-          click_link '一覧に戻る'
-          expect(page).to have_current_path tasks_path
-        end
-      end
+    it 'ページングが表示されること Last' do
+      visit root_path
+      expect(find('div.pagenation')).to have_content 'Last'
+    end
+
+    it '「2」を押下すると6件目のタスクが表示されること' do
+      visit root_path
+      click_on '2'
+      expect(page).to have_content 'title_six'
+    end
+
+    it '「Next」を押下すると6件目のタスクが表示されること' do
+      visit root_path
+      click_on 'Next'
+      expect(page).to have_content 'title_six'
+    end
+
+    it '「Last」を押下すると11件目のタスクが表示されること' do
+      visit root_path
+      click_on 'Last'
+      expect(page).to have_content 'title_eleven'
+    end
+
+    it '「First」を押下すると1件目のタスクが表示されること' do
+      visit root_path
+      click_on 'Last'
+      click_on 'First'
+      expect(page).to have_content 'title_one'
+    end
+
+    it '「Last」を押下後に「Previous」を押下すると6件目のタスクが表示されること' do
+      visit root_path
+      click_on 'Last'
+      click_on 'Previous'
+      expect(page).to have_content 'title_six'
     end
   end
-
-  describe '編集機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: '1', status: '1', label: '1') }
-    subject(:visit_task_a_edit){visit edit_task_path(task_a)}
-
-    describe '表示機能' do
-      context '画面を表示した場合' do
-        it '編集前のタスク名が表示される' do
-          visit_task_a_edit
-          expect(page).to have_field 'textarea1', with: '最初のタスク'
-        end
-        it '編集前の詳細が表示される' do
-          visit_task_a_edit
-          expect(page).to have_field 'textarea2', with: '最初のタスクを実施する'
-        end
-      end
-      context 'タスクの各項目を更新した場合' do
-        let(:input_values) {
-          {
-            title: '最初のタスク',
-            description: '最初のタスクを実施する',
-            user_id: '1',
-          }
-        }
-
-        it 'タスクが正常に更新される' do
-          visit_task_a_edit
-          # 更新処理
-          fill_in 'textarea1', with: '最初のタスク'
-          fill_in 'textarea2', with: '最初のタスクを実施する'
-          # 画面で入力された内容でDBのデータが更新されている
-          expect(Task.find_by(input_values)).to be_present
-        end
-      end
-
-      describe '画面遷移機能' do
-        context '一覧へボタンをクリックした場合' do
-          it '一覧画面へ遷移できる' do
-            visit_task_a_edit
-            click_link '一覧に戻る'
-            expect(page).to have_current_path tasks_path
-          end
-        end
-      end
-    end
-  end
+end
 end


### PR DESCRIPTION
■要件
### ステップ14: ページネーションを追加しよう

- KaminariというGemを使って一覧画面にページネーションを追加してみましょう

■対応内容
- ページング追加

■確認方法
・事前準備
　下記コマンドでDockerを起動
　docker-compose up --build
・ページング確認
　下記URLでタスク一覧画面を開き、ページングが表示されていることを確認 
　http://localhost:3001/
　
　検索フィールドのタスク名に「タスク」を入力し、検索ボタンを押下
　検索をした場合もページングが表示されることを確認
・システムテスト
　下記コマンドを実行
　docker-compose exec api bundle exec rspec -f d spec/system/tasks_spec.rb