### PR TITLE
STEP16: 複数人で利用できるようにしよう

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -48,6 +48,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'bullet'
 end
 
 group :test do

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -30,6 +30,8 @@ gem 'rubocop', require: false
 
 gem 'kaminari'
 
+gem 'bullet'
+
 # RSpec
 gem 'rspec-rails', '~> 3.7'
 
@@ -48,7 +50,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'bullet'
 end
 
 group :test do

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -63,6 +63,9 @@ GEM
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.36.0)
       addressable
@@ -231,6 +234,7 @@ GEM
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (2.2.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -252,6 +256,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
+  bullet
   byebug
   capybara (>= 2.15)
   factory_bot_rails (~> 4.11)

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -13,23 +13,26 @@ class TasksController < ApplicationController
 
   def show
     @task = Task.find(params[:id])
+    @user = User.find(@task.user_id)
   end
 
   def new
     @task = Task.new
+    @users_name = users_name
   end
 
   def edit
     @task = Task.find(params[:id])
+    @users_name = users_name
   end
 
   def create
     @task = Task.new(task_params)
-    @task.user_id = 1
 
     if @task.save
       redirect_to tasks_url, notice: "タスク「#{@task.title}」を登録しました。"
     else
+      @users_name = users_name
       render :new
     end
   end
@@ -53,10 +56,14 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :description, :status)
+    params.require(:task).permit(:title, :description, :status, :user_id)
   end
 
   def set_task
     @task = Task.find(params[:id])
+  end
+
+  def users_name
+    User.all.map { |k| [k.name, k.id] }
   end
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -8,19 +8,14 @@ class TasksController < ApplicationController
   end
 
   def show
-    @task = Task.find(params[:id])
-    @user = User.find(@task.user_id)
+    @task = Task.includes(:user).find(params[:id])
   end
 
   def new
     @task = Task.new
-    @users_name = users_name
   end
 
-  def edit
-    @task = Task.find(params[:id])
-    @users_name = users_name
-  end
+  def edit; end
 
   def create
     @task = Task.new(task_params)
@@ -28,7 +23,6 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to tasks_url, notice: "タスク「#{@task.title}」を登録しました。"
     else
-      @users_name = users_name
       render :new
     end
   end
@@ -57,9 +51,5 @@ class TasksController < ApplicationController
 
   def set_task
     @task = Task.find(params[:id])
-  end
-
-  def users_name
-    User.all.map { |k| [k.name, k.id] }
   end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ApplicationRecord
+  belongs_to :user
 
   validates :title, presence: true
   validates :title, length: { maximum: 30 }

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+    has_many :tasks, dependent: :destroy
 end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -30,7 +30,9 @@
   </div>
   <div>
     <%= f.label :ユーザ %>
-    <%= f.select(:user_id, @users_name) %>
+    <div>
+      <%= f.collection_select(:user_id, User.all, :id, :name) %>
+    </div>
   </div>
   <br>
   <div>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -28,6 +28,10 @@
         <%= f.select(:status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k] }) %>
       <% end %>
     </div>
+    <div>
+      <%= f.label :ユーザ %>
+     <%= f.select(:user_id, @users_name) %>
+    </div>
     <br>
     <div>
     <%= f.submit id: 'submit' %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -8,32 +8,32 @@
   </div>
 <% end %>
 <%= form_for(@task) do |f| %>
-    <div>
-      <%= f.label :タイトル %>
-    </div>
-    <div>
-      <%= f.text_field :title, id: 'textarea1' %>
-    </div>
-    <div>
-      <%= f.label :説明 %>
-    </div>
-    <div>
-      <%= f.text_area :description, id: 'textarea2' %>
-    </div>
-    <div>
-      <% if is_status %>
-        <div>
-          <%= f.label :ステータス %>
-        </div>
-        <%= f.select(:status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k] }) %>
-      <% end %>
-    </div>
-    <div>
-      <%= f.label :ユーザ %>
-     <%= f.select(:user_id, @users_name) %>
-    </div>
-    <br>
-    <div>
+  <div>
+    <%= f.label :タイトル %>
+  </div>
+  <div>
+    <%= f.text_field :title, id: 'textarea1' %>
+  </div>
+  <div>
+    <%= f.label :説明 %>
+  </div>
+  <div>
+    <%= f.text_area :description, id: 'textarea2' %>
+  </div>
+  <div>
+    <% if is_status %>
+      <div>
+        <%= f.label :ステータス %>
+      </div>
+      <%= f.select(:status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k] }) %>
+    <% end %>
+  </div>
+  <div>
+    <%= f.label :ユーザ %>
+    <%= f.select(:user_id, @users_name) %>
+  </div>
+  <br>
+  <div>
     <%= f.submit id: 'submit' %>
   </div>
 <% end %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -9,13 +9,13 @@
 <% end %>
 <%= form_for(@task) do |f| %>
   <div>
-    <%= f.label :タイトル %>
+    <%= f.label :title %>
   </div>
   <div>
     <%= f.text_field :title, id: 'textarea1' %>
   </div>
   <div>
-    <%= f.label :説明 %>
+    <%= f.label :description %>
   </div>
   <div>
     <%= f.text_area :description, id: 'textarea2' %>
@@ -23,13 +23,13 @@
   <div>
     <% if is_status %>
       <div>
-        <%= f.label :ステータス %>
+        <%= f.label :status %>
       </div>
       <%= f.select(:status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k] }) %>
     <% end %>
   </div>
   <div>
-    <%= f.label :ユーザ %>
+    <%= f.label :user %>
     <div>
       <%= f.collection_select(:user_id, User.all, :id, :name) %>
     </div>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -18,7 +18,7 @@
     </div>
     <li>ユーザ</li>
     <div>
-      <%= @user.name %>
+      <%= @task.user.name %>
     </div>
     <li>登録日時</li>
     <div>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -16,9 +16,9 @@
     <div>
       <%= @task.label %>
     </div>
-    <li>ユーザID</li>
+    <li>ユーザ</li>
     <div>
-      <%= @task.user_id %>
+      <%= @user.name %>
     </div>
     <li>登録日時</li>
     <div>

--- a/myapp/config/application.rb
+++ b/myapp/config/application.rb
@@ -18,6 +18,8 @@ module Myapp
     # DB側から受け取った時刻をローカルのタイムゾーンとして解釈するよう設定
     config.active_record.default_timezone = :local
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/myapp/config/environments/development.rb
+++ b/myapp/config/environments/development.rb
@@ -59,4 +59,13 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true # Bulletを有効化する
+    Bullet.alert = true # JavaScriptのポップアップアラートを表示する
+    Bullet.bullet_logger = true # log/bullet.logに出力
+    Bullet.console = true # ブラウザのconsole.logに出力
+    Bullet.rails_logger = true # Railsのログに結果を出力
+    Bullet.add_footer = true # ページの左下に結果を表示
+  end
 end

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -1,5 +1,3 @@
-
-
 # Files in the config/locales directory are used for internationalization
 # and are automatically loaded by Rails. If you want to use locales other
 # than English, add the necessary files in this directory.

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -1,3 +1,5 @@
+
+
 # Files in the config/locales directory are used for internationalization
 # and are automatically loaded by Rails. If you want to use locales other
 # than English, add the necessary files in this directory.
@@ -30,19 +32,86 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 ja:
-  time:
-    formats:
-      default: "%Y/%m/%d %H:%M:%S"
   activerecord:
     models:
       task: タスク
+      user: ユーザー
     attributes:
       task:
-        id: id
-        title: タスク名
-        description: 詳細
-        label: 優先度
+        title: タイトル
+        content: 内容
+        user_id: ユーザーID
         status: ステータス
-  attributes:
-    created_at: 登録日時
-    updated_at: 更新日時
+        label: ラベル
+        deleted_at: 削除日
+        crated_at: 作成日
+        updated_at: 更新日
+      user:
+        name: 名前
+        deleted_at: 削除日
+        crated_at: 作成日
+        updated_at: 更新日
+  enums:
+    task:
+      status:
+        not_started: 未着手
+        in_progress: 着手中
+        closed: 完了
+  view_title:
+    index: タスク一覧画面
+    new: タスク作成画面
+    show: タスク詳細画面
+    edit: タスク編集画面
+  task:
+    title: タイトル
+    content: 内容
+    label: ラベル
+    status: ステータス
+    user: 担当者
+    created_at: 作成日
+  button:
+    create: 作成
+    delete: 削除
+    update: 更新
+  link:
+    create: 作成
+    detail: 詳細
+    edit: 編集
+    list_back: 一覧へ
+  message:
+    delete_confirm: 削除しますか?
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -5,3 +5,13 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+10.times do |i|
+    user = User.create!(name: "ユーザ#{i}")
+    Task.create!(
+      title: "タスク#{i}",
+      description: "こちらはタスク#{i}の内容です。",
+      user_id: user.id,
+      status: '0',
+      label: "ラベル#{i}"
+    )
+  end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -14,4 +14,4 @@
       status: '0',
       label: "ラベル#{i}"
     )
-  end
+end

--- a/myapp/spec/factories/tasks.rb
+++ b/myapp/spec/factories/tasks.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
     description { 'test description' }
     status   { 'not_started' }
     label { '1' }
+
+    user
   end
 end

--- a/myapp/spec/factories/user.rb
+++ b/myapp/spec/factories/user.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-    factory :user, class: User do
-      name        { 'name' }
-    end
+  factory :user, class: User do
+    name { 'name' }
   end
+end

--- a/myapp/spec/factories/user.rb
+++ b/myapp/spec/factories/user.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+    factory :user, class: User do
+      name        { 'name' }
+    end
+  end

--- a/myapp/spec/rails_helper.rb
+++ b/myapp/spec/rails_helper.rb
@@ -44,11 +44,11 @@ RSpec.configure do |config|
       )
       Capybara::Selenium::Driver.new(app, browser: :remote, url: hub_url, desired_capabilities: chrome_capabilities)
     end
-  
+
     config.before(:each, type: :system) do
       driven_by :rack_test
     end
-  
+
     config.before(:each, type: :system, js: true) do
       driven_by :remote_chrome
       Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
@@ -82,4 +82,16 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+    # bullet settings
+  if Bullet.enable?
+    config.before(:each) do
+      Bullet.start_request
+    end
+
+    config.after(:each) do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification? # Bulletによる通知をRSpecの結果に表示
+      Bullet.end_request
+    end
+  end
+
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -237,7 +237,7 @@ describe 'タスク管理機能', type: :system do
     describe '表示機能'do
 
       context 'タスクが1件存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '1', label: 1) }
+        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: 'not_started', label: 1) }
 
         let(:tds){ all('tbody tr')[0].all('td') }
         it 'タスク名が表示される' do
@@ -252,8 +252,8 @@ describe 'タスク管理機能', type: :system do
       end
 
       context 'タスクが2件(複数)存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '1', label: 1) }
-        let!(:task_2) { FactoryBot.create(:task, title: '２つ目のタスク', description: '２つ目のタスクを実施する', status: '1', label: 2) }
+        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: 'not_started', label: 1) }
+        let!(:task_2) { FactoryBot.create(:task, title: '２つ目のタスク', description: '２つ目のタスクを実施する', status: 'not_started', label: 2) }
 
         it 'タスク名が表示される' do
           visit_tasks
@@ -268,7 +268,7 @@ describe 'タスク管理機能', type: :system do
     end
 
     describe '画面遷移機能' do
-      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '1', label: 1) }
+      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: 'not_started', label: 1) }
       context '詳細ボタンをクリックした場合' do
         it '詳細画面へ遷移できる' do
           visit_tasks
@@ -287,11 +287,13 @@ describe 'タスク管理機能', type: :system do
     end
     describe 'ページングエリア' do
       context 'ページングなし' do
-        let!(:task_one) { FactoryBot.create(:task) }
-        let!(:task_two) { FactoryBot.create(:task) }
-        let!(:task_three) { FactoryBot.create(:task) }
-        let!(:task_four) { FactoryBot.create(:task) }
-        let!(:task_five) { FactoryBot.create(:task) }
+        before do
+          FactoryBot.create(:task, title: 'task1')
+          FactoryBot.create(:task, title: 'task2')
+          FactoryBot.create(:task, title: 'task3')
+          FactoryBot.create(:task, title: 'task4')
+          FactoryBot.create(:task, title: 'task5')
+        end
 
         it 'ページングが表示されないこと ページ番号1' do
           visit root_path
@@ -315,17 +317,19 @@ describe 'タスク管理機能', type: :system do
       end
 
       context 'ページングあり' do
-        let!(:task_one) { FactoryBot.create(:task, title: 'titleOne') }
-        let!(:task_two) { FactoryBot.create(:task, title: 'titleTwo') }
-        let!(:task_three) { FactoryBot.create(:task, title: 'titleThree') }
-        let!(:task_four) { FactoryBot.create(:task, title: 'titleFour') }
-        let!(:task_five) { FactoryBot.create(:task, title: 'titleFive') }
-        let!(:task_six) { FactoryBot.create(:task, title: 'titleSix') }
-        let!(:task_seven) { FactoryBot.create(:task, title: 'titleSeven') }
-        let!(:task_eight) { FactoryBot.create(:task, title: 'titleEight') }
-        let!(:task_nine) { FactoryBot.create(:task, title: 'titleNine') }
-        let!(:task_ten) { FactoryBot.create(:task, title: 'titleTen') }
-        let!(:task_eleven) { FactoryBot.create(:task, title: 'titleEleven') }
+        before do
+          FactoryBot.create(:task, title: 'titleOne')
+          FactoryBot.create(:task, title: 'titleTwo')
+          FactoryBot.create(:task, title: 'titleThree')
+          FactoryBot.create(:task, title: 'titleFour')
+          FactoryBot.create(:task, title: 'titleFive')
+          FactoryBot.create(:task, title: 'titleSix')
+          FactoryBot.create(:task, title: 'titleSeven')
+          FactoryBot.create(:task, title: 'titleEight')
+          FactoryBot.create(:task, title: 'titleNine')
+          FactoryBot.create(:task, title: 'titleTen')
+          FactoryBot.create(:task, title: 'titleEleven')
+        end
 
         it 'ページングが表示されること ページ番号1' do
           visit root_path
@@ -376,7 +380,7 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe '詳細表示機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '0') }
+    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: 'not_started') }
     subject(:visit_task_a) { visit task_path(task_a) }
 
     describe '表示機能' do
@@ -393,7 +397,7 @@ describe 'タスク管理機能', type: :system do
 
         it 'ステータスが表示される' do
           visit_task_a
-          expect(page).to have_content '0'
+          expect(page).to have_content '未着手'
         end
 
         it 'ユーザIDが表示される' do
@@ -454,10 +458,11 @@ describe 'タスク管理機能', type: :system do
 
   describe '新規登録機能' do
     subject(:visit_new_task){ visit new_task_path }
-
+    subject(:visit_task_a) { visit task_path(task_a) }
+    let!(:user_1) { FactoryBot.create(:user, name: 'ユーザ1') }
+    let!(:user_2) { FactoryBot.create(:user, name: 'ユーザ2') }
     describe '登録機能' do
       context 'タスクの内容を入力した場合' do
-        let!(:user) { FactoryBot.create(:user, name: 'ユーザ1') }
         let(:input_values) {
           {
             title: '新規作成のテスト2',
@@ -470,7 +475,7 @@ describe 'タスク管理機能', type: :system do
           visit_new_task
           fill_in 'textarea1', with: input_values[:title]
           fill_in 'textarea2', with: input_values[:description]
-          select value = user.name
+          select value = user_1.name
           # DBに登録されている
           expect { click_button 'submit' }.to change(Task, :count).by(1)
         end
@@ -480,6 +485,7 @@ describe 'タスク管理機能', type: :system do
           visit_new_task
           fill_in 'textarea1', with: input_values[:title]
           fill_in 'textarea2', with: input_values[:description]
+          select value = user_1.name
           click_button 'submit'
           # 画面で入力された内容でDBに登録されている
           expect(Task.find_by(input_values)).to be_present
@@ -490,6 +496,7 @@ describe 'タスク管理機能', type: :system do
           visit_new_task
           fill_in 'textarea1', with: input_values[:title]
           fill_in 'textarea2', with: input_values[:description]
+          select value = user_1.name
           # Flashメッセージが表示される
           click_button 'submit'
           expect(page).to have_selector '.alert-success', text: "タスク「#{input_values[:title]}」を登録しました。"
@@ -500,10 +507,21 @@ describe 'タスク管理機能', type: :system do
           visit_new_task
           fill_in 'textarea1', with: input_values[:title]
           fill_in 'textarea2', with: input_values[:description]
-
-          visit_new_task
+          select value = user_1.name
           click_button 'submit'
           expect(page).to have_current_path tasks_path
+        end
+
+        it '担当者が一致している' do
+          # タスク内容入力
+          visit_new_task
+          fill_in 'textarea1', with: input_values[:title]
+          fill_in 'textarea2', with: input_values[:description]
+          select value = user_1.name
+          click_button 'submit'
+          # 画面で入力された内容でDBに登録されている
+          click_link '詳細', match: :first
+          expect(page).to have_content 'ユーザ1'
         end
       end
     end
@@ -520,8 +538,10 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe '編集機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '1', label: 1) }
-    subject(:visit_task_a_edit){visit edit_task_path(task_a)}
+    let!(:user_1) { FactoryBot.create(:user, name: 'ユーザ1') }
+    let!(:user_2) { FactoryBot.create(:user, name: 'ユーザ2') }
+    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: 'not_started', label: 1) }
+    subject(:visit_task_a_edit){ visit edit_task_path(task_a) }
 
     describe '表示機能' do
       context '画面を表示した場合' do
@@ -547,9 +567,23 @@ describe 'タスク管理機能', type: :system do
           # 更新処理
           fill_in 'textarea1', with: title
           fill_in 'textarea2', with: description
+          # ユーザ2に変更する
+          select value = user_2.name
           click_button 'submit'
           # 画面で入力された内容でDBのデータが更新されている
           expect(Task.find_by(title: title, description: description)).to be_present
+        end
+
+        it '更新したタスクのユーザが更新されている' do
+          visit_task_a_edit
+          # 更新処理
+          fill_in 'textarea1', with: title
+          fill_in 'textarea2', with: description
+          # ユーザ2に変更する
+          select value = user_2.name
+          click_button 'submit'
+          click_link '詳細', match: :first
+          expect(page).to have_content 'ユーザ2'
         end
 
         it 'Flashメッセージが表示される' do
@@ -588,7 +622,7 @@ describe 'タスク管理機能', type: :system do
     subject(:visit_new_task){ visit new_task_path }
     describe 'タイトル' do
       context '30文字で入力されている場合' do
-        let!(:task) { FactoryBot.create(:task, title: 'あ' * 30, description: '最初のタスクを実施する', status: '1', label: 1) }
+        let!(:task) { FactoryBot.create(:task, title: 'あ' * 30, description: '最初のタスクを実施する', status: 'not_started', label: 1) }
         it '登録できる' do
           visit_new_task
           fill_in 'textarea1', with: task.title
@@ -599,7 +633,7 @@ describe 'タスク管理機能', type: :system do
       end
 
       context '空の場合' do
-        let!(:task) { FactoryBot.build(:task, title: '', description: '最初のタスクを実施する', status: '1', label: 1) }
+        let!(:task) { FactoryBot.build(:task, title: '', description: '最初のタスクを実施する', status: 'not_started', label: 1) }
         it 'エラーメッセージが表示される' do
           visit_new_task
           fill_in 'textarea1', with: task.title
@@ -611,7 +645,7 @@ describe 'タスク管理機能', type: :system do
       end
 
       context '31文字以上の場合' do
-        let!(:task) { FactoryBot.build(:task, title: 'あ' * 31, description: '最初のタスクを実施する', status: '1', label: 1) }
+        let!(:task) { FactoryBot.build(:task, title: 'あ' * 31, description: '最初のタスクを実施する', status: 'not_started', label: 1) }
         it 'エラーメッセージが表示される' do
           visit_new_task
           fill_in 'textarea1', with: task.title
@@ -625,7 +659,7 @@ describe 'タスク管理機能', type: :system do
 
     describe '説明' do
       context '100文字で入力されている場合' do
-        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: 'あ' * 100, status: '1', label: 1) }
+        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: 'あ' * 100, status: 'not_started', label: 1) }
         it '登録できる' do
           visit_new_task
           fill_in 'textarea1', with: task.title
@@ -636,7 +670,7 @@ describe 'タスク管理機能', type: :system do
       end
 
       context '空の場合' do
-        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: '', status: '1', label: 1) }
+        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: '', status: 'not_started', label: 1) }
         it 'エラーメッセージが表示される' do
           visit_new_task
           fill_in 'textarea1', with: task.title
@@ -648,7 +682,7 @@ describe 'タスク管理機能', type: :system do
       end
 
       context '101文字以上の場合' do
-        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: 'あ' * 101, user_id: '1') }
+        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: 'あ' * 101, status: 'not_started', label: 1) }
         it 'エラーメッセージが表示される' do
           visit_new_task
           fill_in 'textarea1', with: task.title

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe 'タスク管理機能', type: :system do
   describe '検索エリア' do
     context '条件なし検索' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started', user_id: '1') }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress', user_id: '1') }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started', user_id: '1') }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress', user_id: '1') }
+      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started') }
+      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress') }
+      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started') }
+      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress') }
       let(:conditions) { { title: '', status: '' } }
 
       it '検索結果の件数が一致すること' do
@@ -56,10 +56,10 @@ describe 'タスク管理機能', type: :system do
     end
 
     context 'titleのみ指定して検索' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started', user_id: '1') }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress', user_id: '1') }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started', user_id: '1') }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress', user_id: '1') }
+      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started') }
+      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress') }
+      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started') }
+      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress') }
       let(:conditions) { { title: 'A' } }
 
       it '検索結果の件数が一致すること' do
@@ -114,11 +114,11 @@ describe 'タスク管理機能', type: :system do
     end
 
     context 'statusのみ指定して検索' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started', user_id: '1') }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress', user_id: '1') }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started', user_id: '1') }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress', user_id: '1') }
-      let(:conditions) { { status: 'Not started' } }
+      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started') }
+      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress') }
+      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started') }
+      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress') }
+      let(:conditions) { { status: '未着手' } }
 
       it '検索結果の件数が一致すること' do
         visit root_path
@@ -173,11 +173,11 @@ describe 'タスク管理機能', type: :system do
     end
 
     context 'title、statusを指定して検索' do
-      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started', user_id: '1') }
-      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress', user_id: '1') }
-      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started', user_id: '1') }
-      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress', user_id: '1') }
-      let(:conditions) { { title: 'A', status: 'Not started' } }
+      let!(:task_A1) { FactoryBot.create(:task, title: 'titleA1', status: 'not_started') }
+      let!(:task_A2) { FactoryBot.create(:task, title: 'titleA2', status: 'in_progress') }
+      let!(:task_B1) { FactoryBot.create(:task, title: 'titleB1', status: 'not_started') }
+      let!(:task_B2) { FactoryBot.create(:task, title: 'titleB2', status: 'in_progress') }
+      let(:conditions) { { title: 'A', status: '未着手' } }
 
       it '検索結果の件数が一致すること' do
         visit root_path
@@ -237,7 +237,7 @@ describe 'タスク管理機能', type: :system do
     describe '表示機能'do
 
       context 'タスクが1件存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: '1', status: '1', label: 1) }
+        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '1', label: 1) }
 
         let(:tds){ all('tbody tr')[0].all('td') }
         it 'タスク名が表示される' do
@@ -252,8 +252,8 @@ describe 'タスク管理機能', type: :system do
       end
 
       context 'タスクが2件(複数)存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: '1', status: '1', label: 1) }
-        let!(:task_2) { FactoryBot.create(:task, title: '２つ目のタスク', description: '２つ目のタスクを実施する', user_id: '1', status: '1', label: 2) }
+        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '1', label: 1) }
+        let!(:task_2) { FactoryBot.create(:task, title: '２つ目のタスク', description: '２つ目のタスクを実施する', status: '1', label: 2) }
 
         it 'タスク名が表示される' do
           visit_tasks
@@ -268,7 +268,7 @@ describe 'タスク管理機能', type: :system do
     end
 
     describe '画面遷移機能' do
-      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: '1', status: '1', label: 1) }
+      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '1', label: 1) }
       context '詳細ボタンをクリックした場合' do
         it '詳細画面へ遷移できる' do
           visit_tasks
@@ -287,11 +287,11 @@ describe 'タスク管理機能', type: :system do
     end
     describe 'ページングエリア' do
       context 'ページングなし' do
-        let!(:task_one) { FactoryBot.create(:task, user_id: '1') }
-        let!(:task_two) { FactoryBot.create(:task, user_id: '1') }
-        let!(:task_three) { FactoryBot.create(:task, user_id: '1') }
-        let!(:task_four) { FactoryBot.create(:task, user_id: '1') }
-        let!(:task_five) { FactoryBot.create(:task, user_id: '1') }
+        let!(:task_one) { FactoryBot.create(:task) }
+        let!(:task_two) { FactoryBot.create(:task) }
+        let!(:task_three) { FactoryBot.create(:task) }
+        let!(:task_four) { FactoryBot.create(:task) }
+        let!(:task_five) { FactoryBot.create(:task) }
 
         it 'ページングが表示されないこと ページ番号1' do
           visit root_path
@@ -315,17 +315,17 @@ describe 'タスク管理機能', type: :system do
       end
 
       context 'ページングあり' do
-        let!(:task_one) { FactoryBot.create(:task, title: 'titleOne', user_id: '1') }
-        let!(:task_two) { FactoryBot.create(:task, title: 'titleTwo', user_id: '1') }
-        let!(:task_three) { FactoryBot.create(:task, title: 'titleThree', user_id: '1') }
-        let!(:task_four) { FactoryBot.create(:task, title: 'titleFour', user_id: '1') }
-        let!(:task_five) { FactoryBot.create(:task, title: 'titleFive', user_id: '1') }
-        let!(:task_six) { FactoryBot.create(:task, title: 'titleSix', user_id: '1') }
-        let!(:task_seven) { FactoryBot.create(:task, title: 'titleSeven', user_id: '1') }
-        let!(:task_eight) { FactoryBot.create(:task, title: 'titleEight', user_id: '1') }
-        let!(:task_nine) { FactoryBot.create(:task, title: 'titleNine', user_id: '1') }
-        let!(:task_ten) { FactoryBot.create(:task, title: 'titleTen', user_id: '1') }
-        let!(:task_eleven) { FactoryBot.create(:task, title: 'titleEleven', user_id: '1') }
+        let!(:task_one) { FactoryBot.create(:task, title: 'titleOne') }
+        let!(:task_two) { FactoryBot.create(:task, title: 'titleTwo') }
+        let!(:task_three) { FactoryBot.create(:task, title: 'titleThree') }
+        let!(:task_four) { FactoryBot.create(:task, title: 'titleFour') }
+        let!(:task_five) { FactoryBot.create(:task, title: 'titleFive') }
+        let!(:task_six) { FactoryBot.create(:task, title: 'titleSix') }
+        let!(:task_seven) { FactoryBot.create(:task, title: 'titleSeven') }
+        let!(:task_eight) { FactoryBot.create(:task, title: 'titleEight') }
+        let!(:task_nine) { FactoryBot.create(:task, title: 'titleNine') }
+        let!(:task_ten) { FactoryBot.create(:task, title: 'titleTen') }
+        let!(:task_eleven) { FactoryBot.create(:task, title: 'titleEleven') }
 
         it 'ページングが表示されること ページ番号1' do
           visit root_path
@@ -376,7 +376,7 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe '詳細表示機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '0', user_id: '1') }
+    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '0') }
     subject(:visit_task_a) { visit task_path(task_a) }
 
     describe '表示機能' do
@@ -393,7 +393,7 @@ describe 'タスク管理機能', type: :system do
 
         it 'ステータスが表示される' do
           visit_task_a
-          expect(page).to have_content 'Not started'
+          expect(page).to have_content '0'
         end
 
         it 'ユーザIDが表示される' do
@@ -457,11 +457,11 @@ describe 'タスク管理機能', type: :system do
 
     describe '登録機能' do
       context 'タスクの内容を入力した場合' do
+        let!(:user) { FactoryBot.create(:user, name: 'ユーザ1') }
         let(:input_values) {
           {
             title: '新規作成のテスト2',
-            description: '新規作成のテストを書く2',
-            user_id: '1',
+            description: '新規作成のテストを書く2'
           }
         }
 
@@ -470,6 +470,7 @@ describe 'タスク管理機能', type: :system do
           visit_new_task
           fill_in 'textarea1', with: input_values[:title]
           fill_in 'textarea2', with: input_values[:description]
+          select value = user.name
           # DBに登録されている
           expect { click_button 'submit' }.to change(Task, :count).by(1)
         end
@@ -519,7 +520,7 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe '編集機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: '1', status: '1', label: 1) }
+    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', status: '1', label: 1) }
     subject(:visit_task_a_edit){visit edit_task_path(task_a)}
 
     describe '表示機能' do
@@ -583,60 +584,66 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe 'バリデーション' do
+    let!(:user) { FactoryBot.create(:user, name: 'ユーザ1') }
     subject(:visit_new_task){ visit new_task_path }
     describe 'タイトル' do
       context '30文字で入力されている場合' do
-        let!(:task) { FactoryBot.create(:task, title: 'あ' * 30, description: '最初のタスクを実施する', user_id: '1', status: '1', label: 1) }
+        let!(:task) { FactoryBot.create(:task, title: 'あ' * 30, description: '最初のタスクを実施する', status: '1', label: 1) }
         it '登録できる' do
           visit_new_task
           fill_in 'textarea1', with: task.title
           fill_in 'textarea2', with: task.description
+          select value = user.name
           expect { click_button 'submit' }.to change(Task, :count).by(1)
         end
       end
 
       context '空の場合' do
-        let!(:task) { FactoryBot.build(:task, title: '', description: '最初のタスクを実施する', user_id: '1', status: '1', label: 1) }
+        let!(:task) { FactoryBot.build(:task, title: '', description: '最初のタスクを実施する', status: '1', label: 1) }
         it 'エラーメッセージが表示される' do
           visit_new_task
           fill_in 'textarea1', with: task.title
           fill_in 'textarea2', with: task.description
+          select value = user.name
           click_button 'submit'
-          expect(page).to have_content "Title can't be blank"
+          expect(page).to have_content "タイトルを入力してください"
         end
       end
 
       context '31文字以上の場合' do
-        let!(:task) { FactoryBot.build(:task, title: 'あ' * 31, description: '最初のタスクを実施する', user_id: '1', status: '1', label: 1) }
+        let!(:task) { FactoryBot.build(:task, title: 'あ' * 31, description: '最初のタスクを実施する', status: '1', label: 1) }
         it 'エラーメッセージが表示される' do
           visit_new_task
           fill_in 'textarea1', with: task.title
           fill_in 'textarea2', with: task.description
+          select value = user.name
           click_button 'submit'
-          expect(page).to have_content "Title is too long (maximum is 30 characters)"
+          expect(page).to have_content "タイトルは30文字以内で入力してください"
         end
       end
     end
 
     describe '説明' do
       context '100文字で入力されている場合' do
-        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: 'あ' * 100, user_id: '1', status: '1', label: 1) }
+        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: 'あ' * 100, status: '1', label: 1) }
         it '登録できる' do
           visit_new_task
           fill_in 'textarea1', with: task.title
           fill_in 'textarea2', with: task.description
+          select value = user.name
           expect { click_button 'submit' }.to change(Task, :count).by(1)
         end
       end
 
       context '空の場合' do
-        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: '', user_id: '1', status: '1', label: 1) }
+        let!(:task) { FactoryBot.build(:task, title: '最初のタスク', description: '', status: '1', label: 1) }
         it 'エラーメッセージが表示される' do
           visit_new_task
           fill_in 'textarea1', with: task.title
           fill_in 'textarea2', with: task.description
+          select value = user.name
           click_button 'submit'
-          expect(page).to have_content "Description can't be blank"
+          expect(page).to have_content "説明を入力してください"
         end
       end
 
@@ -646,8 +653,9 @@ describe 'タスク管理機能', type: :system do
           visit_new_task
           fill_in 'textarea1', with: task.title
           fill_in 'textarea2', with: task.description
+          select value = user.name
           click_button 'submit'
-          expect(page).to have_content "Description is too long (maximum is 100 characters)"
+          expect(page).to have_content "説明は100文字以内で入力してください"
         end
       end
     end


### PR DESCRIPTION
■要件

### ステップ16: 複数人で利用できるようにしよう（ユーザの導入）

- ユーザモデルを作成してみましょう
- 最初のユーザをseedで作成してみましょう
- ユーザとタスクが紐づくようにしましょう
  - 関連に対してインデックスを貼りましょう
  - N+1問題を回避するための仕組みを取り入れましょう
    - N+1クエリを自動検出するbulletを導入してみましょう（[参考記事](https://fablic.qiita.com/craftcat/items/b181b67ddae0c7d0702a)）

■対応内容
- Users追加
- Task登録時に担当者選択項目追加
- bullet導入
修正漏れ↓
- systemのtask_specのエラーメッセージが英語になっていた部分を日本語に修正
- application.rbにja.ymlを参照する文言を再度追加

■確認手順
1. 以下ページへアクセス

``` http://localhost:3001 ```

2. タスク作成

- タスク作成画面にて担当者が選択できること

<img width="382" alt="スクリーンショット 2022-09-08 16 50 11" src="https://user-images.githubusercontent.com/110374166/189066391-b5e12399-307e-4031-ba0b-0c8928f41756.png">

<img width="426" alt="スクリーンショット 2022-09-08 16 50 26" src="https://user-images.githubusercontent.com/110374166/189066510-0e52b9af-155f-43ed-b5fe-45e15544e8e5.png">

3. タスク名を押下し、タスク詳細画面へ遷移

- タスク詳細画面に担当者が表示されていること

<img width="360" alt="スクリーンショット 2022-09-08 16 50 38" src="https://user-images.githubusercontent.com/110374166/189066539-2d52413e-193c-4d51-acd4-22724f3c1eba.png">

4. 詳細画面の編集ボタンを押下し、編集画面を表示

- タスク編集画面にて担当者の選択ができること
- 担当者の編集ができること

別ユーザを選択
<img width="394" alt="スクリーンショット 2022-09-08 16 50 56" src="https://user-images.githubusercontent.com/110374166/189066788-1b1cc0bd-f620-45c3-8ed5-e21405023e83.png">

担当者が変わったことを確認
<img width="356" alt="スクリーンショット 2022-09-08 16 51 07" src="https://user-images.githubusercontent.com/110374166/189066861-9179dfd5-6d45-4428-baf9-81682f25d019.png">


5. spec実行

``` docker-compose exec api bundle exec rspec -f d spec/system/tasks_spec.rb ```