### PR TITLE
ステップ20: タスクにラベルをつけられるようにしよう

### DIFF
--- a/myapp/app/controllers/task_schedule_controller.rb
+++ b/myapp/app/controllers/task_schedule_controller.rb
@@ -68,6 +68,6 @@ class TaskScheduleController < ApplicationController
   end
 
   def task_search_params
-    params.fetch(:search, {}).permit(:title, :status)
+    params.fetch(:search, {}).permit(:title, :status,  label_ids: [] )
   end
 end

--- a/myapp/app/controllers/task_schedule_controller.rb
+++ b/myapp/app/controllers/task_schedule_controller.rb
@@ -64,7 +64,7 @@ class TaskScheduleController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:title, :body, :finish_at, :status, :user_id)
+    params.require(:task).permit(:title, :body, :finish_at, :status, :user_id, { label_ids: [] })
   end
 
   def task_search_params

--- a/myapp/app/controllers/task_schedule_controller.rb
+++ b/myapp/app/controllers/task_schedule_controller.rb
@@ -5,15 +5,15 @@ class TaskScheduleController < ApplicationController
   def index
     @search_params = task_search_params
     @tasks = if params[:desc]
-               Task.search(@search_params).desc.page(params[:page]).eager_load(:user).where(user_id: session[:user_id])
+               Task.search(@search_params).desc.page(params[:page]).eager_load(:user).preload(:labels).where(user_id: session[:user_id])
              elsif params[:asc]
-               Task.search(@search_params).asc.page(params[:page]).eager_load(:user).where(user_id: session[:user_id])
+               Task.search(@search_params).asc.page(params[:page]).eager_load(:user).preload(:labels).where(user_id: session[:user_id])
              elsif params[:finish_desc]
-               Task.search(@search_params).finish_desc.page(params[:page]).eager_load(:user).where(user_id: session[:user_id])
+               Task.search(@search_params).finish_desc.page(params[:page]).eager_load(:user).preload(:labels).where(user_id: session[:user_id])
              elsif params[:finish_asc]
-               Task.search(@search_params).finish_asc.page(params[:page]).eager_load(:user).where(user_id: session[:user_id])
+               Task.search(@search_params).finish_asc.page(params[:page]).eager_load(:user).preload(:labels).where(user_id: session[:user_id])
              else
-               Task.search(@search_params).finish_asc.page(params[:page]).eager_load(:user).where(user_id: session[:user_id])
+               Task.search(@search_params).finish_asc.page(params[:page]).eager_load(:user).preload(:labels).where(user_id: session[:user_id])
              end
   end
 

--- a/myapp/app/controllers/task_schedule_controller.rb
+++ b/myapp/app/controllers/task_schedule_controller.rb
@@ -68,6 +68,6 @@ class TaskScheduleController < ApplicationController
   end
 
   def task_search_params
-    params.fetch(:search, {}).permit(:title, :status, { label_ids: [] } )
+    params.fetch(:search, {}).permit(:title, :status, { label_ids: [] })
   end
 end

--- a/myapp/app/controllers/task_schedule_controller.rb
+++ b/myapp/app/controllers/task_schedule_controller.rb
@@ -68,6 +68,6 @@ class TaskScheduleController < ApplicationController
   end
 
   def task_search_params
-    params.fetch(:search, {}).permit(:title, :status,  label_ids: [] )
+    params.fetch(:search, {}).permit(:title, :status, { label_ids: [] } )
   end
 end

--- a/myapp/app/models/label.rb
+++ b/myapp/app/models/label.rb
@@ -1,0 +1,2 @@
+class Label < ApplicationRecord
+end

--- a/myapp/app/models/label.rb
+++ b/myapp/app/models/label.rb
@@ -1,2 +1,4 @@
 class Label < ApplicationRecord
+  has_many :labellings, dependent: :destroy
+  has_many :tasks, through: :labellings
 end

--- a/myapp/app/models/label.rb
+++ b/myapp/app/models/label.rb
@@ -1,4 +1,5 @@
 class Label < ApplicationRecord
   has_many :labellings, dependent: :destroy
   has_many :tasks, through: :labellings
+  validates :name, presence: true
 end

--- a/myapp/app/models/labelling.rb
+++ b/myapp/app/models/labelling.rb
@@ -1,0 +1,4 @@
+class Labelling < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  has_many :labellings, dependent: :destroy
+  has_many :labels, through: :labellings
   validates :title, presence: true
   validates :body,  presence: true
   validates :finish_at, presence: true

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -24,7 +24,7 @@ class Task < ApplicationRecord
 
   scope :title_like, ->(title) { where('title LIKE ?', "%#{title}%") if title.present? }
   scope :status_is, ->(status) { where(status: status) if status.present? }
-  scope :label_ids_is, ->(label) { joins(:labellings).where(labellings:{ label_id: label } ) if label != [""] }
+  scope :label_ids_is, ->(label) { joins(:labellings).where(labellings: { label_id: label }) if label != [''] }
 
   enum status: {
     untouched: 0,

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -19,11 +19,11 @@ class Task < ApplicationRecord
 
     title_like(search_params[:title])
       .status_is(search_params[:status])
-#      .label_ids_is(search_params[:label_ids])
+      .label_ids_is(search_params[:label_ids])
   end
   scope :title_like, ->(title) { where('title LIKE ?', "%#{title}%") if title.present? }
   scope :status_is, ->(status) { where(status: status) if status.present? }
-#  scope :label_ids_is, ->(label) { joins(:labels).where(labels: label ) if label.present? }
+  scope :label_ids_is, ->(label) { joins(:labels).where(labels: label ) if label.present? }
 
   enum status: {
     untouched: 0,

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -21,9 +21,10 @@ class Task < ApplicationRecord
       .status_is(search_params[:status])
       .label_ids_is(search_params[:label_ids])
   end
+
   scope :title_like, ->(title) { where('title LIKE ?', "%#{title}%") if title.present? }
   scope :status_is, ->(status) { where(status: status) if status.present? }
-  scope :label_ids_is, ->(label) { joins(:labellings).where(labellings:{ label_id: label } ) if label.present? }
+  scope :label_ids_is, ->(label) { joins(:labellings).where(labellings:{ label_id: label } ) if label != [""] }
 
   enum status: {
     untouched: 0,

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -19,9 +19,11 @@ class Task < ApplicationRecord
 
     title_like(search_params[:title])
       .status_is(search_params[:status])
+#      .label_ids_is(search_params[:label_ids])
   end
   scope :title_like, ->(title) { where('title LIKE ?', "%#{title}%") if title.present? }
   scope :status_is, ->(status) { where(status: status) if status.present? }
+#  scope :label_ids_is, ->(label) { joins(:labels).where(labels: label ) if label.present? }
 
   enum status: {
     untouched: 0,

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -23,7 +23,7 @@ class Task < ApplicationRecord
   end
   scope :title_like, ->(title) { where('title LIKE ?', "%#{title}%") if title.present? }
   scope :status_is, ->(status) { where(status: status) if status.present? }
-  scope :label_ids_is, ->(label) { joins(:labels).where(labels: label ) if label.present? }
+  scope :label_ids_is, ->(label) { joins(:labellings).where(labellings:{ label_id: label } ) if label.present? }
 
   enum status: {
     untouched: 0,

--- a/myapp/app/views/task_schedule/_taskform.html.erb
+++ b/myapp/app/views/task_schedule/_taskform.html.erb
@@ -24,6 +24,10 @@
     <%= f.label t('.editor') %></br>
     <%= f.collection_select :user_id, User.all, :id, :name, prompt: true %></br>
   <div>
+  <div>
+    <%= f.label t('.label') %></br>
+    <%= f.collection_check_boxes(:label_ids, Label.all, :id, :name) %>
+  </div>
   <%= f.submit button %>
 <% end %>
 <%= link_to t('.index'), task_schedule_index_path %>

--- a/myapp/app/views/task_schedule/index.html.erb
+++ b/myapp/app/views/task_schedule/index.html.erb
@@ -22,8 +22,7 @@
       <th><%= t'.finish' %>
       <%= link_to t('.up'), task_schedule_index_path(finish_desc: 'true') %>
       <%= link_to t('.down'), task_schedule_index_path(finish_asc: 'true') %></th>
-      <th><%= t '.status' %></th>
-      <th><%= t '.editor' %></th>
+      <th><%= t '.status' %></th><th><%= t '.editor' %></th><th><%= t '.label' %></th>
   </tr>
   <% @tasks.each do |task| %>
   <tr>
@@ -33,6 +32,10 @@
     <td><%= l(task.finish_at, format: :'.default') %></td>
     <td><%= task.status_i18n %></td>
     <td><%= task.user.name %></td>
+    <td><% task.labels.each do |label| %>
+          <%= label.name %>
+        <% end %>
+    </td>
     <td><%= link_to t('.edit'), edit_task_schedule_path(task) %></td>
     <td><%= link_to t('.show'), task_schedule_path(task), method: :get %></td>
     <td><%= link_to t('.delete'), task_schedule_path(task), method: :delete,

--- a/myapp/app/views/task_schedule/index.html.erb
+++ b/myapp/app/views/task_schedule/index.html.erb
@@ -9,6 +9,7 @@
       <%= f.label t('.name') %> <%= f.text_field :title, value: @search_params[:title] %>
       <%= f.label t('.status') %> <%= f.select :status, Task.statuses_i18n.invert, {include_blank: true, prompt: false, selected: @search_params[:status]},
     class:"form-control form-control-sm col-6" %>
+      <%= f.label t('.label') %><%= f.collection_check_boxes(:label_ids, Label.all, :id, :name) %>
       <%= f.submit t('.search') %>
     <% end %>
   </div>

--- a/myapp/app/views/task_schedule/index.html.erb
+++ b/myapp/app/views/task_schedule/index.html.erb
@@ -9,7 +9,7 @@
       <%= f.label t('.name') %> <%= f.text_field :title, value: @search_params[:title] %>
       <%= f.label t('.status') %> <%= f.select :status, Task.statuses_i18n.invert, {include_blank: true, prompt: false, selected: @search_params[:status]},
     class:"form-control form-control-sm col-6" %>
-      <%= f.label t('.label') %><%= f.collection_check_boxes(:label_ids, Label.all, :id, :name) %>
+      <%= f.label t('.label') %> <%= f.collection_check_boxes(:label_ids, Label.all, :id, :name, checked: @search_params[:label_ids]) %>
       <%= f.submit t('.search') %>
     <% end %>
   </div>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -35,6 +35,7 @@ ja:
       finish: '終了期限'
       status: 'ステータス'
       editor: '作成者'
+      label: 'ラベル'
       up: '▲'
       down: '▼'
       delete_confirm: '削除します。よろしいですか'
@@ -45,6 +46,7 @@ ja:
       body: 'タスク本文'
       finish: '終了期限'
       editor: '作成者'
+      label: 'ラベル'
       index: '一覧に戻る'
     new:
       title: 'タスク登録画面'

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -64,14 +64,14 @@ ja:
       edit: '編集する'
 
     update:
-      success: "タスクの編集が完了しました"
-      danger: "編集に失敗しました"
+      success: 'タスクの編集が完了しました'
+      danger: '編集に失敗しました'
     create:
-      success: "タスクの登録が完了しました"
-      danger: "登録に失敗しました"
+      success: 'タスクの登録が完了しました'
+      danger: '登録に失敗しました'
     destroy:
-      success: "タスクを削除しました"
-      danger: "削除に失敗しました"
+      success: 'タスクを削除しました'
+      danger: '削除に失敗しました'
 
   users:
     index:
@@ -116,14 +116,14 @@ ja:
       edit: '編集する'
 
     update:
-      success: "ユーザの編集が完了しました"
-      danger: "編集に失敗しました"
+      success: 'ユーザの編集が完了しました'
+      danger: '編集に失敗しました'
     create:
-      success: "ユーザの登録が完了しました"
-      danger: "登録に失敗しました"
+      success: 'ユーザの登録が完了しました'
+      danger: '登録に失敗しました'
     destroy:
-      success: "ユーザを削除しました"
-      danger: "唯一の管理者ユーザです"
+      success: 'ユーザを削除しました'
+      danger: '唯一の管理者ユーザです'
 
   enums:
     task:

--- a/myapp/db/migrate/20220915062559_create_labels.rb
+++ b/myapp/db/migrate/20220915062559_create_labels.rb
@@ -1,0 +1,9 @@
+class CreateLabels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :labels do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/migrate/20220915062559_create_labels.rb
+++ b/myapp/db/migrate/20220915062559_create_labels.rb
@@ -1,7 +1,7 @@
 class CreateLabels < ActiveRecord::Migration[6.0]
   def change
     create_table :labels do |t|
-      t.string :name
+      t.string :name, null: false
 
       t.timestamps
     end

--- a/myapp/db/migrate/20220915062559_create_labels.rb
+++ b/myapp/db/migrate/20220915062559_create_labels.rb
@@ -5,5 +5,12 @@ class CreateLabels < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+
+    create_table :labellings do |t|
+      t.references :task, null: false, foreign_key: true
+      t.references :label, null: false, foreign_key: true
+
+      t.timestamps
+    end
   end
 end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_14_004554) do
+ActiveRecord::Schema.define(version: 2022_09_15_062559) do
+
+  create_table "labellings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "label_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["label_id"], name: "index_labellings_on_label_id"
+    t.index ["task_id"], name: "index_labellings_on_task_id"
+  end
+
+  create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
@@ -34,4 +49,6 @@ ActiveRecord::Schema.define(version: 2022_09_14_004554) do
     t.index ["personal_id"], name: "index_users_on_personal_id", unique: true
   end
 
+  add_foreign_key "labellings", "labels"
+  add_foreign_key "labellings", "tasks"
 end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2022_09_15_062559) do
   end
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/myapp/spec/factories/labellings.rb
+++ b/myapp/spec/factories/labellings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+    factory :labelling do
+      task_id { 1 }
+      label_id { 1 }
+    end
+  end
+  

--- a/myapp/spec/factories/labellings.rb
+++ b/myapp/spec/factories/labellings.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-    factory :labelling do
-      task_id { 1 }
-      label_id { 1 }
-    end
+  factory :labelling do
+    task_id { 1 }
+    label_id { 1 }
   end
+end

--- a/myapp/spec/factories/labellings.rb
+++ b/myapp/spec/factories/labellings.rb
@@ -6,4 +6,3 @@ FactoryBot.define do
       label_id { 1 }
     end
   end
-  

--- a/myapp/spec/factories/labels.rb
+++ b/myapp/spec/factories/labels.rb
@@ -2,7 +2,11 @@
 
 FactoryBot.define do
     factory :label do
-      name { 'MyLabelName' }
+      trait :label_1 do
+        name { 'MyLabelName1' }
+      end
+      trait :label_2 do
+        name { 'MyLabelName2' }
+      end
     end
   end
-  

--- a/myapp/spec/factories/labels.rb
+++ b/myapp/spec/factories/labels.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-    factory :label do
-      trait :label_1 do
-        name { 'MyLabelName1' }
-      end
-      trait :label_2 do
-        name { 'MyLabelName2' }
-      end
+  factory :label do
+    trait :labels1 do
+      name { 'MyLabelName1' }
+    end
+    trait :labels2 do
+      name { 'MyLabelName2' }
     end
   end
+end

--- a/myapp/spec/factories/labels.rb
+++ b/myapp/spec/factories/labels.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+    factory :label do
+      name { 'MyLabelName' }
+    end
+  end
+  

--- a/myapp/spec/models/label_spec.rb
+++ b/myapp/spec/models/label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/models/label_spec.rb
+++ b/myapp/spec/models/label_spec.rb
@@ -1,5 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Label, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    @label = create(:label, :labels1)
+  end
+
+  it 'check task validates' do
+    expect(@label).to be_valid
+
+    @label = build(:task, title: '')
+    expect(@label.valid?).to eq false
+  end
 end

--- a/myapp/spec/models/label_spec.rb
+++ b/myapp/spec/models/label_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Label, type: :model do
     @label = create(:label, :labels1)
   end
 
-  it 'check task validates' do
+  it 'check label validates' do
     expect(@label).to be_valid
 
-    @label = build(:task, title: '')
+    @label = build(:label, name: '')
     expect(@label.valid?).to eq false
   end
 end

--- a/myapp/spec/models/labelling_spec.rb
+++ b/myapp/spec/models/labelling_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Labelling, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/models/labelling_spec.rb
+++ b/myapp/spec/models/labelling_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Labelling, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    create(:task, id: 1)
+    create(:label, :labels1, id: 1)
+    @labelling = create(:labelling)
+  end
+
+  it 'check labelling validates' do
+    expect(@labelling).to be_valid
+
+    @labelling = build(:labelling, task_id: '')
+    expect(@labelling.valid?).to eq false
+
+    @labelling = build(:labelling, label_id: '')
+    expect(@labelling.valid?).to eq false
+  end
 end

--- a/myapp/spec/system/task_schedule_spec.rb
+++ b/myapp/spec/system/task_schedule_spec.rb
@@ -3,9 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe 'TaskSchedule', type: :system do
+  let(:user) { create(:user) }
+  let(:task) { create(:task, title: 'showタスク', body: 'showボディ', finish_at: 1.year.from_now, user_id: user.id) }
+  let(:label) { create(:label, :label_1) }
+  let!(:labelling) { create(:labelling, task_id: task.id, label_id: label.id) }
+
   context 'login systems check' do
     before do
-      create(:user)
       visit login_path
     end
 
@@ -18,7 +22,7 @@ RSpec.describe 'TaskSchedule', type: :system do
       expect(page).to have_content '正しいログインIDとパスワードを入力してください'
     end
 
-    it 'success login &logout' do
+    it 'success login & logout' do
       fill_in 'personal_id', with: 'MyUserID'
       fill_in 'password', with: 'pass'
       click_button 'ログイン'
@@ -34,11 +38,8 @@ RSpec.describe 'TaskSchedule', type: :system do
     visit login_path
   end
 
-  let(:user) { create(:user) }
-
   context 'order systems check' do
     before do
-      create(:task, title: 'showタスク', body: 'showボディ', finish_at: 1.year.from_now, user_id: user.id)
       create(:task, title: 'secondタスク', body: 'secondボディ', created_at: 1.day.from_now, finish_at: 1.day.from_now, user_id: user.id)
       create(:task, title: 'thirdタスク', body: 'thirdボディ', created_at: 1.day.ago, finish_at: 1.week.from_now, user_id: user.id)
       fill_in 'personal_id', with: 'MyUserID'
@@ -68,6 +69,7 @@ RSpec.describe 'TaskSchedule', type: :system do
 
   context 'create systems check' do
     before do
+      create(:label, :label_2)
       create(:user, personal_id: 'create', name: 'user 太郎')
       fill_in 'personal_id', with: 'create'
       fill_in 'password', with: 'pass'
@@ -82,6 +84,8 @@ RSpec.describe 'TaskSchedule', type: :system do
       fill_in 'task[body]', with: 'newボディ'
       fill_in 'task[finish_at]', with: '9999-01-01'
       select 'user 太郎', from: 'task[user_id]'
+      check 'task_label_ids_1'
+      check 'task_label_ids_2'
       click_button '登録する'
 
       expect(page).to have_content 'タスクの登録が完了しました'
@@ -90,6 +94,8 @@ RSpec.describe 'TaskSchedule', type: :system do
       expect(page).to have_content '9999/01/01'
       expect(page).to have_content '未着手'
       expect(page).to have_content 'user 太郎'
+      expect(page).to have_content 'MyLabelName1'
+      expect(page).to have_content 'MyLabelName2'
     end
 
     it 'failure new task create' do
@@ -112,7 +118,6 @@ RSpec.describe 'TaskSchedule', type: :system do
   end
 
   context 'show systems check' do
-    let!(:task) { create(:task, title: 'showタスク', body: 'showボディ', user_id: user.id) }
     before do
       fill_in 'personal_id', with: 'MyUserID'
       fill_in 'password', with: 'pass'
@@ -131,7 +136,6 @@ RSpec.describe 'TaskSchedule', type: :system do
   end
 
   context 'edit systems check' do
-    let!(:task) { create(:task, title: 'showタスク', body: 'showボディ', user_id: user.id) }
     before do
       create(:user, name: 'user 二郎', personal_id: 'editID')
       fill_in 'personal_id', with: 'MyUserID'
@@ -141,7 +145,6 @@ RSpec.describe 'TaskSchedule', type: :system do
 
     it 'complete edit task' do
       click_link('編集', href: edit_task_schedule_path(task))
-      expect(page).to have_content 'タスク編集画面'
 
       expect(page).to have_content 'タスク編集画面'
       fill_in 'task[title]', with: 'editタスク'
@@ -195,7 +198,6 @@ RSpec.describe 'TaskSchedule', type: :system do
   end
 
   context 'delete systems check' do
-    let!(:task) { create(:task, user_id: user.id) }
     before do
       fill_in 'personal_id', with: 'MyUserID'
       fill_in 'password', with: 'pass'
@@ -214,32 +216,39 @@ RSpec.describe 'TaskSchedule', type: :system do
   end
 
   context 'search systems check' do
+    let(:label2) { create(:label, :label_2) }
+    let(:task2) { create(:task, title: 'thirdタスク', status: 2, user_id: user.id) }
     before do
-      create(:task, title: 'secondタスク', user_id: user.id)
-      create(:task, title: 'thirdタスク', status: 2, user_id: user.id)
+      create(:labelling, task_id: task2.id, label_id: label2.id)
       fill_in 'personal_id', with: 'MyUserID'
       fill_in 'password', with: 'pass'
       click_button 'ログイン'
     end
 
     it 'complete title search' do
-      fill_in 'search[title]', with: 'con'
+      fill_in 'search[title]', with: 'how'
       click_button '検索'
-      expect(page).to have_content 'secondタスク'
+      expect(page).to have_content 'showタスク'
       expect(page).to have_no_content 'thirdタスク'
     end
 
     it 'complete status search' do
       select '完了', from: 'search[status]'
       click_button '検索'
+      expect(page).to have_no_content 'showタスク'
       expect(page).to have_content 'thirdタスク'
-      expect(page).to have_no_content 'secondタスク'
+    end
+
+    it 'complete labels search' do
+      check 'search_label_ids_1'
+      click_button '検索'
+      expect(page).to have_content 'showタスク'
+      expect(page).to have_no_content 'thirdタスク'
     end
   end
 
   context 'paginate systems check' do
     before do
-      create(:task, user_id: user.id)
       create(:task, finish_at: 1.day.from_now, user_id: user.id)
       create(:task, finish_at: 1.week.from_now, user_id: user.id)
       create(:task, finish_at: 2.years.from_now, user_id: user.id)

--- a/myapp/spec/system/task_schedule_spec.rb
+++ b/myapp/spec/system/task_schedule_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'TaskSchedule', type: :system do
   let(:user) { create(:user) }
   let(:task) { create(:task, title: 'showタスク', body: 'showボディ', finish_at: 1.year.from_now, user_id: user.id) }
-  let(:label) { create(:label, :label_1) }
+  let(:label) { create(:label, :labels1) }
   let!(:labelling) { create(:labelling, task_id: task.id, label_id: label.id) }
 
   context 'login systems check' do
@@ -69,7 +69,7 @@ RSpec.describe 'TaskSchedule', type: :system do
 
   context 'create systems check' do
     before do
-      create(:label, :label_2)
+      create(:label, :labels2)
       create(:user, personal_id: 'create', name: 'user 太郎')
       fill_in 'personal_id', with: 'create'
       fill_in 'password', with: 'pass'
@@ -216,7 +216,7 @@ RSpec.describe 'TaskSchedule', type: :system do
   end
 
   context 'search systems check' do
-    let(:label2) { create(:label, :label_2) }
+    let(:label2) { create(:label, :labels2) }
     let(:task2) { create(:task, title: 'thirdタスク', status: 2, user_id: user.id) }
     before do
       create(:labelling, task_id: task2.id, label_id: label2.id)

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -6662,10 +6662,10 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==
 
-selfsigned@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.0.1.tgz#8b2df7fa56bf014d19b6007655fff209c0ef0a56"
-  integrity sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==
+selfsigned@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.1.1.tgz#18a7613d714c0cd3385c48af0075abf3f266af61"
+  integrity sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==
   dependencies:
     node-forge "^1"
 
@@ -7730,10 +7730,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.11.0.tgz#290ee594765cd8260adfe83b2d18115ea04484e7"
-  integrity sha512-L5S4Q2zT57SK7tazgzjMiSMBdsw+rGYIX27MgPgx7LDhWO0lViPrHKoLS7jo5In06PWYAhlYu3PbyoC6yAThbw==
+webpack-dev-server@^4.11.1:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz#ae07f0d71ca0438cf88446f09029b92ce81380b5"
+  integrity sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"
@@ -7758,7 +7758,7 @@ webpack-dev-server@^4.11.0:
     p-retry "^4.5.0"
     rimraf "^3.0.2"
     schema-utils "^4.0.0"
-    selfsigned "^2.0.1"
+    selfsigned "^2.1.1"
     serve-index "^1.9.1"
     sockjs "^0.3.24"
     spdy "^4.0.2"


### PR DESCRIPTION
* 要件（仕様書など）
    * タスクに複数のラベルをつけられるようにしてみましょう
    * つけたラベルで検索できるようにしてみましょう
* 修正概要
    * ラベル名を管理したテーブルを作成する
    * タスクに対応したラベルを管理する中間テーブルを作成する
    * それぞれ作成したテーブルをタスクテーブルと関連付けを行う
    * タスクに複数のラベルを登録、編集時に関連付けできるようにする
    * ラベルを条件として検索できるようにする

* 実装内容
    * ラベルテーブルと中間テーブルを作成
    * モデルを修正し、多対多の構造でテーブルを関連付けする
    * タスク一覧画面で、タスクに関連ついたラベルが表示されるようにviewを修正
    * タスク登録、編集時にラベルテーブルに登録されたラベルの関連付けを登録、解除できるように処理を修正
    * 検索機能にラベルを指定して検索できる機能を追加

* 動作確認（操作内容、画面キャプチャなど）
    * タスクの登録、編集時に選択したラベルがタスクに関連付けされていることがタスク一覧画面でわかることの確認
    * ラベルを指定して検索した時、選択したラベルをもつタスクがソートされることの確認
    * Rspec実行時にエラーが発生しないことの確認

タスク一覧画面
![スクリーンショット 2022-09-16 15 04 30](https://user-images.githubusercontent.com/111721004/190567981-6d40be4b-3eb7-4ac3-8f31-9bce1fee2b33.png)

指定したラベルで検索できることの確認
![スクリーンショット 2022-09-16 15 04 50](https://user-images.githubusercontent.com/111721004/190567988-72c6ceb7-43c4-4713-9068-3883b0be355c.png)