### PR TITLE
ステップ20: タスクにラベルをつけられるようにしよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   # Task List
   def index
-    @tasks = current_user.tasks.all.page(params[:page])
+    @tasks = current_user.tasks.includes([:labels]).includes([:tasks_labels]).all.page(params[:page])
   end
 
   # Show Task
@@ -49,7 +49,7 @@ class TasksController < ApplicationController
   end
 
   def search
-    @tasks = current_user.tasks.where_title(params[:title]).where_status(Task.statuses[params[:status]]).page(params[:page])
+    @tasks = current_user.tasks.search(params[:title], params[:status], params[:label]).page(params[:page])
     render :index
   end
 
@@ -57,6 +57,6 @@ class TasksController < ApplicationController
 
   # Get Task Parameter
   def task_params
-    task = params.require(:task).permit(:title, :description, :label, :status)
+    params.require(:task).permit(:title, :description, :status, { label_ids: [] })
   end
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   # Task List
   def index
-    @tasks = current_user.tasks.includes([:labels]).includes([:tasks_labels]).all.page(params[:page])
+    @tasks = current_user.tasks.preload([:labels]).all.page(params[:page])
   end
 
   # Show Task

--- a/myapp/app/models/label.rb
+++ b/myapp/app/models/label.rb
@@ -1,0 +1,5 @@
+class Label < ApplicationRecord
+  # 結合キー
+  has_many :tasks_labels, dependent: :destroy
+  has_many :tasks, through: :tasks_labels
+end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,6 +1,8 @@
 class Task < ApplicationRecord
   # 結合キー
   belongs_to :user
+  has_many :tasks_labels, dependent: :destroy
+  has_many :labels, through: :tasks_labels
 
   # バリデーション
   validates :title, presence: true, length: { maximum: 30 }
@@ -14,8 +16,10 @@ class Task < ApplicationRecord
   }
 
   # scope
+  scope :search, -> (title, status, label_id) { eager_load(:labels).eager_load(:tasks_labels).where_title(title).where_status(Task.statuses[status]).where_label(label_id) }
   scope :where_title, -> (title) { where('title LIKE ?', "%#{title}%") if title.present? }
   scope :where_status, -> (status) { where('status = ?', status) if status.present? }
+  scope :where_label, -> (label_id){ where(labels: { id: label_id }).left_outer_joins(:labels) if label_id.present? }
 
   # pagenation
   paginates_per 5

--- a/myapp/app/models/tasks_label.rb
+++ b/myapp/app/models/tasks_label.rb
@@ -1,0 +1,5 @@
+class TasksLabel < ApplicationRecord
+  # 結合キー
+  belongs_to :task
+  belongs_to :label
+end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -15,6 +15,8 @@
   <%= f.text_field :description, id: 'textarea2' %>
   <p><%= I18n.t('task.status') %></p>
   <%= f.select :status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k] } %>
+  <p><%= I18n.t('task.label') %></p>
+  <%= f.collection_select :label_ids, Label.all, :id, :name, { include_blank: '' }, { multiple: true } %>
   <br><br>
   <%= f.submit id: 'submit' %>
 <% end %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -6,10 +6,12 @@
 <div>
 <%= form_with url: search_path, method: :get, local: true do |f| %>
   <p>検索</p>
-    <span><% I18n.t("task.title") %></span>
+    <span><%= I18n.t("task.title") %></span>
     <%= f.text_field :title %>
-    <span><% I18n.t("task.status") %></span>
+    <span><%= I18n.t("task.status") %></span>
     <%= f.select :status, Task.statuses.keys.map { |k| [I18n.t("enums.task.status.#{k}"), k]} , include_blank: true %>
+    <span><%= I18n.t('task.label') %></span>
+    <%= f.collection_select(:label,  Label.all, :id, :name, { include_blank: true }) %></p>
   <br>
   <%= f.submit '検索' %>
 <% end %>
@@ -30,7 +32,13 @@
       <% @tasks.each do |task| %>
         <tr>
           <td><span><%= task.title %></span></td>
-          <td><span><%= task.label %></span></td>
+          <td>
+            <ul>
+              <% task.labels.each do |label| %>
+                <li><%= label.name %></li>
+              <% end %>
+            </ul>
+          </td>
           <td><span><%= I18n.t("enums.task.status.#{task.status}") %></span></td>
           <td><%= link_to(I18n.t('button.detail'), task_path(task), {id: "show#{task.id}", class: 'btn_a'}) %></td>
           <td><%= link_to(I18n.t('button.update'), edit_task_path(task), {id: "update#{task.id}", class: 'btn_a'}) %></td>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -4,6 +4,9 @@
 <p><%= I18n.t('task.description') %></p>
 <p><%= @task[:description] %></p>
 <p><%= I18n.t('task.label') %></p>
+<% @task.labels.each do |label| %>
+  <li><%= label.name %></li>
+<% end %>
 <p><%= @task[:label] %></p>
 <p><%= I18n.t('task.status') %></p>
 <p><%= I18n.t("enums.task.status.#{@task.status}") %></p>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,13 +1,13 @@
 <h1>Task Details</h1>
 <p><%= I18n.t('task.title') %></p>
-<p><%= @task[:title] %></p>
+<p><%= @task.title %></p>
 <p><%= I18n.t('task.description') %></p>
-<p><%= @task[:description] %></p>
+<p><%= @task.description %></p>
 <p><%= I18n.t('task.label') %></p>
 <% @task.labels.each do |label| %>
   <li><%= label.name %></li>
 <% end %>
-<p><%= @task[:label] %></p>
+<p><%= @task.label %></p>
 <p><%= I18n.t('task.status') %></p>
 <p><%= I18n.t("enums.task.status.#{@task.status}") %></p>
 <%= link_to(I18n.t('link.back'), tasks_url) %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -7,7 +7,6 @@
 <% @task.labels.each do |label| %>
   <li><%= label.name %></li>
 <% end %>
-<p><%= @task.label %></p>
 <p><%= I18n.t('task.status') %></p>
 <p><%= I18n.t("enums.task.status.#{@task.status}") %></p>
 <%= link_to(I18n.t('link.back'), tasks_url) %>

--- a/myapp/db/migrate/20220808084114_create_tasks.rb
+++ b/myapp/db/migrate/20220808084114_create_tasks.rb
@@ -3,9 +3,8 @@ class CreateTasks < ActiveRecord::Migration[6.0]
     create_table :tasks do |t|
       t.string :title, limit: 128, null: false, default: ''
       t.text :description
-      t.integer :user_id, limit: 8, null: false
+      t.references :user
       t.string :status, limit: 1, null: false, default: '0'
-      t.string :label, limit: 64
       t.datetime :deleted_at
 
       t.timestamps

--- a/myapp/db/migrate/20220913102658_create_tasks_labels.rb
+++ b/myapp/db/migrate/20220913102658_create_tasks_labels.rb
@@ -1,0 +1,10 @@
+class CreateTasksLabels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tasks_labels do |t|
+      t.references :task
+      t.references :label
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/migrate/20220913103138_create_labels.rb
+++ b/myapp/db/migrate/20220913103138_create_labels.rb
@@ -1,0 +1,9 @@
+class CreateLabels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :labels do |t|
+      t.string :name, limit: 64
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_11_151809) do
+ActiveRecord::Schema.define(version: 2022_09_13_103138) do
+
+  create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", limit: 64
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 128, default: "", null: false
@@ -23,6 +29,15 @@ ActiveRecord::Schema.define(version: 2022_09_11_151809) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
+  end
+
+  create_table "tasks_labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "task_id"
+    t.bigint "label_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["label_id"], name: "index_tasks_labels_on_label_id"
+    t.index ["task_id"], name: "index_tasks_labels_on_task_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -21,14 +21,14 @@ ActiveRecord::Schema.define(version: 2022_09_13_103138) do
   create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", limit: 128, default: "", null: false
     t.text "description"
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.string "status", limit: 1, default: "0", null: false
-    t.string "label", limit: 64
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "tasks_labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -6,7 +6,15 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# Task、User 初期データ
+User.destroy_all
+Label.destroy_all
+
+# User
 10.times do |n|
-  user = User.create!(name: "ユーザ#{n + 1}", password: "test#{n + 1}", email: "email#{n + 1}@example.com")
+  User.create!(name: "ユーザ#{n + 1}", password: "test#{n + 1}", email: "email#{n + 1}@example.com")
+end
+
+# Label
+5.times do |n|
+  Label.create!(name: "ラベル#{n + 1}")
 end

--- a/myapp/package.json
+++ b/myapp/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^4.11.0"
+    "webpack-dev-server": "^4.11.1"
   }
 }

--- a/myapp/public/404.html
+++ b/myapp/public/404.html
@@ -58,10 +58,9 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>404 NOT FOUND</h1>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>ページが見つかりませんでした。</p>
   </div>
 </body>
 </html>

--- a/myapp/public/500.html
+++ b/myapp/public/500.html
@@ -58,9 +58,9 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>We're sorry, but something went wrong.</h1>
+      <h1>500 INTERNAL SERVER ERROR</h1>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>アクセスしようとしたページは表示できませんでした。</p>
   </div>
 </body>
 </html>

--- a/myapp/spec/factories/labels.rb
+++ b/myapp/spec/factories/labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :label do
+
+  end
+end

--- a/myapp/spec/factories/tasks.rb
+++ b/myapp/spec/factories/tasks.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     title { 'test title' }
     description { 'test description' }
     status { Task.statuses[:not_started] }
-    label { '1' }
 
     user
   end

--- a/myapp/spec/factories/tasks.rb
+++ b/myapp/spec/factories/tasks.rb
@@ -5,5 +5,15 @@ FactoryBot.define do
     status { Task.statuses[:not_started] }
 
     user
+
+    trait :with_label do
+      transient do
+        label_name { 'label_name' }
+      end
+
+      after(:build) do | task, evaluator |
+        task.labels << build(:label, name: evaluator.label_name)
+      end
+    end
   end
 end

--- a/myapp/spec/factories/tasks_labels.rb
+++ b/myapp/spec/factories/tasks_labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tasks_label do
+
+  end
+end

--- a/myapp/spec/models/label_spec.rb
+++ b/myapp/spec/models/label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/models/tasks_label_spec.rb
+++ b/myapp/spec/models/tasks_label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TasksLabel, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -15,9 +15,9 @@ describe 'タスク管理機能', type: :system do
 
     describe '表示機能' do
       context 'タスクが1件存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
-        let!(:label_1) { FactoryBot.create(:label, name: 'label') }
-        let!(:task_label_1) { FactoryBot.create(:tasks_label, task_id: task_1.id, label_id: label_1.id) }
+        let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
+        let!(:label_a) { FactoryBot.create(:label, name: 'label') }
+        let!(:task_label_a) { FactoryBot.create(:tasks_label, task_id: task_a.id, label_id: label_a.id) }
         let(:tds){ all('tbody tr')[0].all('td') }
 
         it 'タスク名が表示される' do
@@ -32,12 +32,12 @@ describe 'タスク管理機能', type: :system do
       end
 
       context 'タスクが2件(複数)存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
-        let!(:label_1) { FactoryBot.create(:label, name: '0 label') }
-        let!(:task_label_1) { FactoryBot.create(:tasks_label, task_id: task_1.id, label_id: label_1.id) }
-        let!(:task_2) { FactoryBot.create(:task, title: '1 title', description: '２つ目のタスクを実施する', user_id: user.id, status: '1') }
-        let!(:label_2) { FactoryBot.create(:label, name: '1 label') }
-        let!(:task_label_2) { FactoryBot.create(:tasks_label, task_id: task_2.id, label_id: label_2.id) }
+        let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
+        let!(:label_a) { FactoryBot.create(:label, name: '0 label') }
+        let!(:task_label_a) { FactoryBot.create(:tasks_label, task_id: task_a.id, label_id: label_a.id) }
+        let!(:task_b) { FactoryBot.create(:task, title: '1 title', description: '２つ目のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
+        let!(:label_b) { FactoryBot.create(:label, name: '1 label') }
+        let!(:task_label_b) { FactoryBot.create(:tasks_label, task_id: task_b.id, label_id: label_b.id) }
         let(:tds){ all('tbody tr')[1].all('td') }
 
         it 'タスク名が表示される' do
@@ -52,7 +52,7 @@ describe 'タスク管理機能', type: :system do
       end
 
       describe '画面遷移機能' do
-        let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
+        let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
         context '詳細ボタンをクリックした場合' do
           it '詳細画面へ遷移できる' do
             visit_tasks
@@ -480,7 +480,7 @@ describe 'タスク管理機能', type: :system do
     end
   end
   describe '詳細表示機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
+    let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
     let!(:label_a) { FactoryBot.create(:label, name: '0 label') }
     let!(:task_label_a) { FactoryBot.create(:tasks_label, task_id: task_a.id, label_id: label_a.id) }
     subject(:visit_task_a) { visit task_path(task_a) }
@@ -537,7 +537,7 @@ describe 'タスク管理機能', type: :system do
     end
 
     describe '画面遷移機能' do
-      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
+      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
 
       context '新規登録ボタンをクリックした場合' do
         it '一覧画面へ遷移できる' do
@@ -558,7 +558,8 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe '編集機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
+    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
+    let!(:label_a) { FactoryBot.create(:label, name: 'update label') }
     subject(:visit_task_a_edit){visit edit_task_path(task_a)}
 
     describe '表示機能' do
@@ -567,27 +568,41 @@ describe 'タスク管理機能', type: :system do
           visit_task_a_edit
           expect(page).to have_field 'textarea1', with: '最初のタスク'
         end
+
         it '編集前の詳細が表示される' do
           visit_task_a_edit
           expect(page).to have_field 'textarea2', with: '最初のタスクを実施する'
         end
       end
+
       context 'タスクの各項目を更新した場合' do
         let(:input_values) {
           {
             title: '最初のタスク',
             description: '最初のタスクを実施する',
             user_id: user.id,
+            label: label_a.name,
           }
         }
 
         it 'タスクが正常に更新される' do
           visit_task_a_edit
           # 更新処理
-          fill_in 'textarea1', with: '最初のタスク'
-          fill_in 'textarea2', with: '最初のタスクを実施する'
+          fill_in 'textarea1', with: input_values[:title]
+          fill_in 'textarea2', with: input_values[:description]
+          select value = input_values[:label], from: 'task[label_ids][]'
           # 画面で入力された内容でDBのデータが更新されている
-          expect(Task.find_by(input_values)).to be_present
+          expect(Task.find_by(title: input_values[:title], description: input_values[:description])).to be_present
+        end
+
+        it 'タスクとラベルが正常に紐づく' do
+          visit_task_a_edit
+          # 更新処理
+          fill_in 'textarea1', with: input_values[:title]
+          fill_in 'textarea2', with: input_values[:description]
+          select value = input_values[:label], from: 'task[label_ids][]'
+          # 画面で入力された内容でDBのデータが更新されている
+          expect(Label.find_by(name: input_values[:label])).to be_present
         end
       end
 

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -15,9 +15,7 @@ describe 'タスク管理機能', type: :system do
 
     describe '表示機能' do
       context 'タスクが1件存在する場合' do
-        let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
-        let!(:label_a) { FactoryBot.create(:label, name: 'label') }
-        let!(:task_label_a) { FactoryBot.create(:tasks_label, task_id: task_a.id, label_id: label_a.id) }
+        let!(:task_a) { FactoryBot.create(:task, :with_label, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started], label_name: 'label') }
         let(:tds){ all('tbody tr')[0].all('td') }
 
         it 'タスク名が表示される' do
@@ -32,12 +30,8 @@ describe 'タスク管理機能', type: :system do
       end
 
       context 'タスクが2件(複数)存在する場合' do
-        let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
-        let!(:label_a) { FactoryBot.create(:label, name: '0 label') }
-        let!(:task_label_a) { FactoryBot.create(:tasks_label, task_id: task_a.id, label_id: label_a.id) }
-        let!(:task_b) { FactoryBot.create(:task, title: '1 title', description: '２つ目のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
-        let!(:label_b) { FactoryBot.create(:label, name: '1 label') }
-        let!(:task_label_b) { FactoryBot.create(:tasks_label, task_id: task_b.id, label_id: label_b.id) }
+        let!(:task_a) { FactoryBot.create(:task, :with_label, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started], label_name: '0 label') }
+        let!(:task_b) { FactoryBot.create(:task, :with_label, title: '1 title', description: '２つ目のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started], label_name: '1 label') }
         let(:tds){ all('tbody tr')[1].all('td') }
 
         it 'タスク名が表示される' do
@@ -82,11 +76,9 @@ describe 'タスク管理機能', type: :system do
     describe '検索機能' do
       let!(:task_A1) { FactoryBot.create(:task, title: 'A1', status: Task.statuses[:not_started], user_id: user.id) }
       let!(:task_A2) { FactoryBot.create(:task, title: 'A2', status: Task.statuses[:in_progress], user_id: user.id) }
-      let!(:task_A3) { FactoryBot.create(:task, title: 'A3', status: Task.statuses[:not_started], user_id: user.id) }
+      let!(:task_A3) { FactoryBot.create(:task, :with_label, title: 'A3', status: Task.statuses[:not_started], user_id: user.id, label_name: 'label') }
       let!(:task_B1) { FactoryBot.create(:task, title: 'B1', status: Task.statuses[:not_started], user_id: user.id) }
       let!(:task_B2) { FactoryBot.create(:task, title: 'B2', status: Task.statuses[:in_progress], user_id: user.id) }
-      let!(:label_A3) { FactoryBot.create(:label, name: 'label') }
-      let!(:task_label_A3) { FactoryBot.create(:tasks_label, task_id: task_A3.id, label_id: label_A3.id) }
 
       context '条件なし' do
         let(:conditions) { { title: '', status: '', label: '' } }
@@ -480,9 +472,7 @@ describe 'タスク管理機能', type: :system do
     end
   end
   describe '詳細表示機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
-    let!(:label_a) { FactoryBot.create(:label, name: '0 label') }
-    let!(:task_label_a) { FactoryBot.create(:tasks_label, task_id: task_a.id, label_id: label_a.id) }
+    let!(:task_a) { FactoryBot.create(:task, :with_label, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started], label_name: '0 label') }
     subject(:visit_task_a) { visit task_path(task_a) }
 
     describe '表示機能' do
@@ -558,7 +548,7 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe '編集機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started]) }
+    let!(:task_a) { FactoryBot.create(:task, :with_label, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: Task.statuses[:not_started], label_name: 'label') }
     let!(:label_a) { FactoryBot.create(:label, name: 'update label') }
     subject(:visit_task_a_edit){visit edit_task_path(task_a)}
 

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -14,12 +14,12 @@ describe 'タスク管理機能', type: :system do
     subject(:visit_tasks) { visit tasks_path }
 
     describe '表示機能' do
-      # タスクが表示される期待動作を共通化
-
       context 'タスクが1件存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1', label: '1') }
-
+        let!(:task_1) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
+        let!(:label_1) { FactoryBot.create(:label, name: 'label') }
+        let!(:task_label_1) { FactoryBot.create(:tasks_label, task_id: task_1.id, label_id: label_1.id) }
         let(:tds){ all('tbody tr')[0].all('td') }
+
         it 'タスク名が表示される' do
           visit_tasks
           expect(tds[0]).to have_content '最初のタスク'
@@ -27,15 +27,19 @@ describe 'タスク管理機能', type: :system do
 
         it 'ラベルが表示される' do
           visit_tasks
-          expect(tds[1]).to have_content '1'
+          expect(tds[1]).to have_content 'label'
         end
       end
 
       context 'タスクが2件(複数)存在する場合' do
-        let!(:task_1) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1', label: '0 label') }
-        let!(:task_2) { FactoryBot.create(:task, title: '1 title', description: '２つ目のタスクを実施する', user_id: user.id, status: '1', label: '1 label') }
-
+        let!(:task_1) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
+        let!(:label_1) { FactoryBot.create(:label, name: '0 label') }
+        let!(:task_label_1) { FactoryBot.create(:tasks_label, task_id: task_1.id, label_id: label_1.id) }
+        let!(:task_2) { FactoryBot.create(:task, title: '1 title', description: '２つ目のタスクを実施する', user_id: user.id, status: '1') }
+        let!(:label_2) { FactoryBot.create(:label, name: '1 label') }
+        let!(:task_label_2) { FactoryBot.create(:tasks_label, task_id: task_2.id, label_id: label_2.id) }
         let(:tds){ all('tbody tr')[1].all('td') }
+
         it 'タスク名が表示される' do
           visit_tasks
           expect(tds[0]).to have_content '1 title'
@@ -48,7 +52,7 @@ describe 'タスク管理機能', type: :system do
       end
 
       describe '画面遷移機能' do
-        let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1', label: '0 label') }
+        let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
         context '詳細ボタンをクリックした場合' do
           it '詳細画面へ遷移できる' do
             visit_tasks
@@ -78,24 +82,29 @@ describe 'タスク管理機能', type: :system do
     describe '検索機能' do
       let!(:task_A1) { FactoryBot.create(:task, title: 'A1', status: Task.statuses[:not_started], user_id: user.id) }
       let!(:task_A2) { FactoryBot.create(:task, title: 'A2', status: Task.statuses[:in_progress], user_id: user.id) }
+      let!(:task_A3) { FactoryBot.create(:task, title: 'A3', status: Task.statuses[:not_started], user_id: user.id) }
       let!(:task_B1) { FactoryBot.create(:task, title: 'B1', status: Task.statuses[:not_started], user_id: user.id) }
       let!(:task_B2) { FactoryBot.create(:task, title: 'B2', status: Task.statuses[:in_progress], user_id: user.id) }
+      let!(:label_A3) { FactoryBot.create(:label, name: 'label') }
+      let!(:task_label_A3) { FactoryBot.create(:tasks_label, task_id: task_A3.id, label_id: label_A3.id) }
 
       context '条件なし' do
-        let(:conditions) { { title: '', status: '' } }
+        let(:conditions) { { title: '', status: '', label: '' } }
 
         it '検索結果の件数が一致すること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
-          expect(all('tbody tr').size).to be(4)
+          expect(all('tbody tr').size).to be(5)
         end
 
         it 'A1が表示されること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'A1'
         end
@@ -104,14 +113,25 @@ describe 'タスク管理機能', type: :system do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'A2'
+        end
+
+        it 'A3が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).to have_content 'A3'
         end
 
         it 'B1が表示されること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'B1'
         end
@@ -120,26 +140,29 @@ describe 'タスク管理機能', type: :system do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'B2'
         end
       end
 
       context 'titleのみ指定して検索' do
-        let(:conditions) { { title: 'A', status: '' } }
+        let(:conditions) { { title: 'A', status: '', label: '' } }
 
         it '検索結果の件数が一致すること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
-          expect(all('tbody tr').size).to be(2)
+          expect(all('tbody tr').size).to be(3)
         end
 
         it 'A1が表示されること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'A1'
         end
@@ -148,14 +171,25 @@ describe 'タスク管理機能', type: :system do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'A2'
+        end
+
+        it 'A3が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).to have_content 'A3'
         end
 
         it 'B1が表示されないこと' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).not_to have_content 'B1'
         end
@@ -164,26 +198,29 @@ describe 'タスク管理機能', type: :system do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).not_to have_content 'B2'
         end
       end
 
       context 'statusのみ指定して検索' do
-        let(:conditions) { { title: '', status: '未着手' } }
+        let(:conditions) { { title: '', status: '未着手', label: '' } }
 
         it '検索結果の件数が一致すること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
-          expect(all('tbody tr').size).to be(2)
+          expect(all('tbody tr').size).to be(3)
         end
 
         it 'A1が表示されること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'A1'
         end
@@ -192,14 +229,25 @@ describe 'タスク管理機能', type: :system do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).not_to have_content 'A2'
+        end
+
+        it 'A3が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).to have_content 'A3'
         end
 
         it 'B1が表示されること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'B1'
         end
@@ -208,26 +256,29 @@ describe 'タスク管理機能', type: :system do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).not_to have_content 'titleB2'
         end
       end
 
       context 'title、statusを指定して検索' do
-        let(:conditions) { { title: 'A', status: '未着手' } }
+        let(:conditions) { { title: 'A', status: '未着手', label: '' } }
 
         it '検索結果の件数が一致すること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
-          expect(all('tbody tr').size).to be(1)
+          expect(all('tbody tr').size).to be(2)
         end
 
         it 'A1が表示されること' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).to have_content 'A1'
         end
@@ -236,14 +287,25 @@ describe 'タスク管理機能', type: :system do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).not_to have_content 'A2'
+        end
+
+        it 'A3が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).to have_content 'A3'
         end
 
         it 'B1が表示されないこと' do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).not_to have_content 'B1'
         end
@@ -252,6 +314,65 @@ describe 'タスク管理機能', type: :system do
           visit root_path
           fill_in 'title', with: conditions[:title]
           select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).not_to have_content 'B2'
+        end
+      end
+
+      context 'labelのみ指定して検索' do
+        let(:conditions) { { title: '', status: '', label: 'label' } }
+
+        it '検索結果の件数が一致すること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(all('tbody tr').size).to be(1)
+        end
+
+        it 'A1が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).not_to have_content 'A1'
+        end
+
+        it 'A2が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).not_to have_content 'A2'
+        end
+
+        it 'A3が表示されること' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).to have_content 'A3'
+        end
+
+        it 'B1が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
+          click_on '検索'
+          expect(page).not_to have_content 'B1'
+        end
+
+        it 'B2が表示されないこと' do
+          visit root_path
+          fill_in 'title', with: conditions[:title]
+          select value = conditions[:status], from: 'status'
+          select value = conditions[:label], from: 'label'
           click_on '検索'
           expect(page).not_to have_content 'B2'
         end
@@ -359,7 +480,9 @@ describe 'タスク管理機能', type: :system do
     end
   end
   describe '詳細表示機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1', label: '0 label') }
+    let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
+    let!(:label_a) { FactoryBot.create(:label, name: '0 label') }
+    let!(:task_label_a) { FactoryBot.create(:tasks_label, task_id: task_a.id, label_id: label_a.id) }
     subject(:visit_task_a) { visit task_path(task_a) }
 
     describe '表示機能' do
@@ -414,7 +537,7 @@ describe 'タスク管理機能', type: :system do
     end
 
     describe '画面遷移機能' do
-      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1', label: '1') }
+      let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
 
       context '新規登録ボタンをクリックした場合' do
         it '一覧画面へ遷移できる' do
@@ -435,7 +558,7 @@ describe 'タスク管理機能', type: :system do
   end
 
   describe '編集機能' do
-    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1', label: '1') }
+    let!(:task_a) { FactoryBot.create(:task, title: '最初のタスク', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
     subject(:visit_task_a_edit){visit edit_task_path(task_a)}
 
     describe '表示機能' do

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -6662,10 +6662,10 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==
 
-selfsigned@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.0.1.tgz#8b2df7fa56bf014d19b6007655fff209c0ef0a56"
-  integrity sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==
+selfsigned@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.1.1.tgz#18a7613d714c0cd3385c48af0075abf3f266af61"
+  integrity sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==
   dependencies:
     node-forge "^1"
 
@@ -7730,10 +7730,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.11.0.tgz#290ee594765cd8260adfe83b2d18115ea04484e7"
-  integrity sha512-L5S4Q2zT57SK7tazgzjMiSMBdsw+rGYIX27MgPgx7LDhWO0lViPrHKoLS7jo5In06PWYAhlYu3PbyoC6yAThbw==
+webpack-dev-server@^4.11.1:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz#ae07f0d71ca0438cf88446f09029b92ce81380b5"
+  integrity sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"
@@ -7758,7 +7758,7 @@ webpack-dev-server@^4.11.0:
     p-retry "^4.5.0"
     rimraf "^3.0.2"
     schema-utils "^4.0.0"
-    selfsigned "^2.0.1"
+    selfsigned "^2.1.1"
     serve-index "^1.9.1"
     sockjs "^0.3.24"
     spdy "^4.0.2"


### PR DESCRIPTION
■要件
### ステップ20: タスクにラベルをつけられるようにしよう

- タスクに複数のラベルをつけられるようにしてみましょう
- つけたラベルで検索できるようにしてみましょう

■対応内容
- 複数ラベル設定可能
- 複数ラベルで検索可能

■確認手順
・事前準備
　下記コマンドでDockerを起動
　docker-compose up --build
　
　下記URLにアクセス
 　 http://localhost:3001/
 　下記入力
　メールアドレス：[email1@example.com](mailto:email1@example.com)
　パスワード：test1

・タスク作成画面にて複数ラベルを設定し、タスク作成
　タスク一覧画面にて設定したラベルを指定し、検索した結果、作成したタスクが表示されることを確認
　タスク一覧画面にて設定していないラベルを指定し、検索した結果、作成したタスクが表示されないことを確認