### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/README.md
+++ b/myapp/README.md
@@ -33,6 +33,19 @@ Things you may want to cover:
 |  updated_at  |  DATETIME  |    |  yes  |  -  |
 <br>
 
+* Script
+
+メンテナンス開始
+
+``` shell
+docker-compose exec api rake 'system_maintenance:change_system_maintenance_status[1001, 1]'
+```
+
+メンテナンス終了
+
+``` shell
+docker-compose exec api rake 'system_maintenance:change_system_maintenance_status[1001, 0]'
+```
 
 * Ruby version
 

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :current_user
   before_action :re_sign_in
-  before_action :is_system_started
+  before_action :is_maintenance
 
   def sign_in(user)
     session[:user_id] = user.id
@@ -21,8 +21,8 @@ class ApplicationController < ActionController::Base
     redirect_to(login_path) if current_user.nil?
   end
 
-  def is_system_started
-    if SystemMaintenance.is_stopped(SystemMaintenance::KEY_TASK_MANAGEMENT)
+  def is_maintenance
+    if SystemMaintenance.is_maintenance?(SystemMaintenance::KEY_TASK_MANAGEMENT)
       render(
         file: Rails.public_path.join("503.html"),
         content_type: "text/html",

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :current_user
   before_action :re_sign_in
+  before_action :is_system_started
 
   def sign_in(user)
     session[:user_id] = user.id
@@ -18,5 +19,16 @@ class ApplicationController < ActionController::Base
 
   def re_sign_in
     redirect_to(login_path) if current_user.nil?
+  end
+
+  def is_system_started
+    if SystemMaintenance.is_stopped(SystemMaintenance::KEY_TASK_MANAGEMENT)
+      render(
+        file: Rails.public_path.join("503.html"),
+        content_type: "text/html",
+        layout: false,
+        status: :service_unavailable,
+      )
+    end
   end
 end

--- a/myapp/app/models/system_maintenance.rb
+++ b/myapp/app/models/system_maintenance.rb
@@ -1,16 +1,7 @@
 class SystemMaintenance < ApplicationRecord
-  enum status: {
-    started: '1',
-    stopped: '9',
-  }
-
   KEY_TASK_MANAGEMENT = '1001'
 
-  def self.is_started(key)
-    SystemMaintenance.statuses[SystemMaintenance.find_by(key: key).status] == SystemMaintenance.statuses[:started] ? true : false
-  end
-
-  def self.is_stopped(key)
-    SystemMaintenance.statuses[SystemMaintenance.find_by(key: key).status] == SystemMaintenance.statuses[:stopped] ? true : false
+  def self.is_maintenance?(key)
+    SystemMaintenance.find_by(key: key).maintenance_flg
   end
 end

--- a/myapp/app/models/system_maintenance.rb
+++ b/myapp/app/models/system_maintenance.rb
@@ -1,0 +1,16 @@
+class SystemMaintenance < ApplicationRecord
+  enum status: {
+    started: '1',
+    stopped: '9',
+  }
+
+  KEY_TASK_MANAGEMENT = '1001'
+
+  def self.is_started(key)
+    SystemMaintenance.statuses[SystemMaintenance.find_by(key: key).status] == SystemMaintenance.statuses[:started] ? true : false
+  end
+
+  def self.is_stopped(key)
+    SystemMaintenance.statuses[SystemMaintenance.find_by(key: key).status] == SystemMaintenance.statuses[:stopped] ? true : false
+  end
+end

--- a/myapp/config/application.rb
+++ b/myapp/config/application.rb
@@ -18,6 +18,7 @@ module Myapp
         # DB側から受け取った時刻をローカルのタイムゾーンとして解釈するよう設定
         config.active_record.default_timezone = :local
 
+        config.autoload_paths += Dir["#{config.root}/lib"]
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/myapp/db/migrate/20220914090913_create_system_maintenances.rb
+++ b/myapp/db/migrate/20220914090913_create_system_maintenances.rb
@@ -2,7 +2,7 @@ class CreateSystemMaintenances < ActiveRecord::Migration[6.0]
   def change
     create_table :system_maintenances do |t|
       t.string :key
-      t.string :status, limit: 1, null: false, default: '1'
+      t.boolean :maintenance_flg, default: false
 
       t.timestamps
     end

--- a/myapp/db/migrate/20220914090913_create_system_maintenances.rb
+++ b/myapp/db/migrate/20220914090913_create_system_maintenances.rb
@@ -1,0 +1,10 @@
+class CreateSystemMaintenances < ActiveRecord::Migration[6.0]
+  def change
+    create_table :system_maintenances do |t|
+      t.string :key
+      t.string :status, limit: 1, null: false, default: '1'
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_13_103138) do
+ActiveRecord::Schema.define(version: 2022_09_14_090913) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", limit: 64
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "system_maintenances", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "key"
+    t.string "status", limit: 1, default: "1", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2022_09_14_090913) do
 
   create_table "system_maintenances", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "key"
-    t.string "status", limit: 1, default: "1", null: false
+    t.boolean "maintenance_flg", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -21,4 +21,4 @@ end
 end
 
 # SystemMaintenance
-SystemMaintenance.create!(key: SystemMaintenance::KEY_TASK_MANAGEMENT, status: SystemMaintenance.statuses[:started])
+SystemMaintenance.create!(key: SystemMaintenance::KEY_TASK_MANAGEMENT, maintenance_flg: false)

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -8,6 +8,7 @@
 
 User.destroy_all
 Label.destroy_all
+SystemMaintenance.destroy_all
 
 # User
 10.times do |n|
@@ -18,3 +19,6 @@ end
 5.times do |n|
   Label.create!(name: "ラベル#{n + 1}")
 end
+
+# SystemMaintenance
+SystemMaintenance.create!(key: SystemMaintenance::KEY_TASK_MANAGEMENT, status: SystemMaintenance.statuses[:started])

--- a/myapp/lib/tasks/system_maintenance.rake
+++ b/myapp/lib/tasks/system_maintenance.rake
@@ -1,0 +1,15 @@
+namespace :system_maintenance do
+  desc '機能開始/停止'
+  task :change_system_maintenance_status, ['id', 'status'] => :environment do |task, args|
+    puts 'start-----------------'
+    if args.id.nil? || args.status.nil?
+      puts 'must be set args'
+      puts 'end-------------------'
+      next
+    end
+    systemMaintenance = SystemMaintenance.find_by(key: args.id.to_i)
+    systemMaintenance.update(status: args.status)
+    puts "key: #{systemMaintenance.key}, status: #{systemMaintenance.status}"
+    puts 'end-------------------'
+  end
+end

--- a/myapp/lib/tasks/system_maintenance.rake
+++ b/myapp/lib/tasks/system_maintenance.rake
@@ -1,15 +1,15 @@
 namespace :system_maintenance do
   desc '機能開始/停止'
-  task :change_system_maintenance_status, ['id', 'status'] => :environment do |task, args|
-    puts 'start-----------------'
-    if args.id.nil? || args.status.nil?
+  task :change_system_maintenance_status, ['id', 'maintenance_flg'] => :environment do |task, args|
+    puts 'start---------------------------'
+    if args.id.nil? || args.maintenance_flg.nil?
       puts 'must be set args'
-      puts 'end-------------------'
+      puts 'end-----------------------------'
       next
     end
     systemMaintenance = SystemMaintenance.find_by(key: args.id.to_i)
-    systemMaintenance.update(status: args.status)
-    puts "key: #{systemMaintenance.key}, status: #{systemMaintenance.status}"
-    puts 'end-------------------'
+    systemMaintenance.update(maintenance_flg: args.maintenance_flg == '1' ? true : false)
+    puts "key: #{systemMaintenance.key}, maintenance_flg: #{systemMaintenance.maintenance_flg}"
+    puts 'end-----------------------------'
   end
 end

--- a/myapp/public/503.html
+++ b/myapp/public/503.html
@@ -1,0 +1,2 @@
+<h1>503 Service Unavailable</h1>
+<p>ただいまメンテナンス中です。</p>

--- a/myapp/spec/factories/system_maintenances.rb
+++ b/myapp/spec/factories/system_maintenances.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :system_maintenance do
+
+  end
+end

--- a/myapp/spec/models/system_maintenance_spec.rb
+++ b/myapp/spec/models/system_maintenance_spec.rb
@@ -1,40 +1,22 @@
 require 'rails_helper'
 
 describe SystemMaintenance, type: :model do
-  describe '#is_started' do
+  describe '#is_maintenance' do
     before do
-      FactoryBot.create(:system_maintenance, key: '1', status: SystemMaintenance.statuses[:started])
-      FactoryBot.create(:system_maintenance, key: '2', status: SystemMaintenance.statuses[:stopped])
+      FactoryBot.create(:system_maintenance, key: '1', maintenance_flg: true)
+      FactoryBot.create(:system_maintenance, key: '2', maintenance_flg: false)
     end
 
-    context '開始状態の場合' do
-      subject(:is_started) { SystemMaintenance.is_started('1') }
+    context 'メンテナンス状態の場合' do
+      subject(:is_maintenance) { SystemMaintenance.is_maintenance?('1') }
 
       it { is_expected.to be(true) }
     end
 
-    context '停止状態の場合' do
-      subject(:is_started) { SystemMaintenance.is_started('2') }
+    context 'メンテナンス状態でない場合' do
+      subject(:is_maintenance) { SystemMaintenance.is_maintenance?('2') }
 
       it { is_expected.to be(false) }
-    end
-  end
-  describe '#is_stopped' do
-    before do
-      FactoryBot.create(:system_maintenance, key: '1', status: SystemMaintenance.statuses[:started])
-      FactoryBot.create(:system_maintenance, key: '2', status: SystemMaintenance.statuses[:stopped])
-    end
-
-    context '開始状態の場合' do
-      subject(:is_stopped) { SystemMaintenance.is_stopped('1') }
-
-      it { is_expected.to be(false) }
-    end
-
-    context '停止状態の場合' do
-      subject(:is_stopped) { SystemMaintenance.is_stopped('2') }
-
-      it { is_expected.to be(true) }
     end
   end
 end

--- a/myapp/spec/models/system_maintenance_spec.rb
+++ b/myapp/spec/models/system_maintenance_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe SystemMaintenance, type: :model do
+  describe '#is_started' do
+    before do
+      FactoryBot.create(:system_maintenance, key: '1', status: SystemMaintenance.statuses[:started])
+      FactoryBot.create(:system_maintenance, key: '2', status: SystemMaintenance.statuses[:stopped])
+    end
+
+    context '開始状態の場合' do
+      subject(:is_started) { SystemMaintenance.is_started('1') }
+
+      it { is_expected.to be(true) }
+    end
+
+    context '停止状態の場合' do
+      subject(:is_started) { SystemMaintenance.is_started('2') }
+
+      it { is_expected.to be(false) }
+    end
+  end
+  describe '#is_stopped' do
+    before do
+      FactoryBot.create(:system_maintenance, key: '1', status: SystemMaintenance.statuses[:started])
+      FactoryBot.create(:system_maintenance, key: '2', status: SystemMaintenance.statuses[:stopped])
+    end
+
+    context '開始状態の場合' do
+      subject(:is_stopped) { SystemMaintenance.is_stopped('1') }
+
+      it { is_expected.to be(false) }
+    end
+
+    context '停止状態の場合' do
+      subject(:is_stopped) { SystemMaintenance.is_stopped('2') }
+
+      it { is_expected.to be(true) }
+    end
+  end
+end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe 'タスク管理機能', type: :system do
   before do
+    SystemMaintenance.create(key: SystemMaintenance::KEY_TASK_MANAGEMENT, status: SystemMaintenance.statuses[:started])
+
     # login
     visit login_path
     fill_in 'session[email]', with: user.email
@@ -478,7 +480,32 @@ describe 'タスク管理機能', type: :system do
         end
       end
     end
+
+    describe 'メンテナンス機能' do
+      context 'システムが開始状態の場合'do
+        before do
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:started])
+        end
+
+        it 'タスク一覧画面への遷移で503エラーが表示されないこと' do
+          visit root_path
+          expect(page).not_to have_content '503 Service Unavailable'
+        end
+      end
+
+      context 'システムが停止状態の場合'do
+        before do
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:stopped])
+        end
+
+        it 'タスク一覧画面への遷移で503エラーが表示されること' do
+          visit root_path
+          expect(page).to have_content '503 Service Unavailable'
+        end
+      end
+    end
   end
+
   describe '詳細表示機能' do
     let!(:task_a) { FactoryBot.create(:task, title: '0 title', description: '最初のタスクを実施する', user_id: user.id, status: '1') }
     let!(:label_a) { FactoryBot.create(:label, name: '0 label') }
@@ -510,6 +537,30 @@ describe 'タスク管理機能', type: :system do
           visit_task_a
           click_link I18n.t('link.back')
           expect(page).to have_current_path tasks_path
+        end
+      end
+    end
+
+    describe 'メンテナンス機能' do
+      context 'システムが開始状態の場合'do
+        before do
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:started])
+        end
+
+        it 'タスク一覧画面への遷移で503エラーが表示されないこと' do
+          visit_task_a
+          expect(page).not_to have_content '503 Service Unavailable'
+        end
+      end
+
+      context 'システムが停止状態の場合'do
+        before do
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:stopped])
+        end
+
+        it 'タスク一覧画面への遷移で503エラーが表示されること' do
+          visit_task_a
+          expect(page).to have_content '503 Service Unavailable'
         end
       end
     end
@@ -552,6 +603,30 @@ describe 'タスク管理機能', type: :system do
           visit_new_task
           click_link I18n.t('link.back')
           expect(page).to have_current_path tasks_path
+        end
+      end
+    end
+
+    describe 'メンテナンス機能' do
+      context 'システムが開始状態の場合'do
+        before do
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:started])
+        end
+
+        it 'タスク一覧画面への遷移で503エラーが表示されないこと' do
+          visit_new_task
+          expect(page).not_to have_content '503 Service Unavailable'
+        end
+      end
+
+      context 'システムが停止状態の場合'do
+        before do
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:stopped])
+        end
+
+        it 'タスク一覧画面への遷移で503エラーが表示されること' do
+          visit_new_task
+          expect(page).to have_content '503 Service Unavailable'
         end
       end
     end
@@ -598,6 +673,30 @@ describe 'タスク管理機能', type: :system do
             click_link I18n.t('link.back')
             expect(page).to have_current_path tasks_path
           end
+        end
+      end
+    end
+
+    describe 'メンテナンス機能' do
+      context 'システムが開始状態の場合'do
+        before do
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:started])
+        end
+
+        it 'タスク一覧画面への遷移で503エラーが表示されないこと' do
+          visit_task_a_edit
+          expect(page).not_to have_content '503 Service Unavailable'
+        end
+      end
+
+      context 'システムが停止状態の場合'do
+        before do
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:stopped])
+        end
+
+        it 'タスク一覧画面への遷移で503エラーが表示されること' do
+          visit_task_a_edit
+          expect(page).to have_content '503 Service Unavailable'
         end
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'タスク管理機能', type: :system do
   before do
-    SystemMaintenance.create(key: SystemMaintenance::KEY_TASK_MANAGEMENT, status: SystemMaintenance.statuses[:started])
+    SystemMaintenance.create(key: SystemMaintenance::KEY_TASK_MANAGEMENT, maintenance_flg: false)
 
     # login
     visit login_path
@@ -474,9 +474,9 @@ describe 'タスク管理機能', type: :system do
     end
 
     describe 'メンテナンス機能' do
-      context 'システムが開始状態の場合'do
+      context 'メンテナンスが未開始状態の場合'do
         before do
-          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:started])
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(maintenance_flg: false)
         end
 
         it 'タスク一覧画面への遷移で503エラーが表示されないこと' do
@@ -485,9 +485,9 @@ describe 'タスク管理機能', type: :system do
         end
       end
 
-      context 'システムが停止状態の場合'do
+      context 'メンテナンスが開始状態の場合'do
         before do
-          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:stopped])
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(maintenance_flg: true)
         end
 
         it 'タスク一覧画面への遷移で503エラーが表示されること' do
@@ -532,9 +532,9 @@ describe 'タスク管理機能', type: :system do
     end
 
     describe 'メンテナンス機能' do
-      context 'システムが開始状態の場合'do
+      context 'メンテナンス未開始の場合'do
         before do
-          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:started])
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(maintenance_flg: false)
         end
 
         it 'タスク一覧画面への遷移で503エラーが表示されないこと' do
@@ -543,9 +543,9 @@ describe 'タスク管理機能', type: :system do
         end
       end
 
-      context 'システムが停止状態の場合'do
+      context 'メンテナンスが開始状態の場合'do
         before do
-          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:stopped])
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(maintenance_flg: true)
         end
 
         it 'タスク一覧画面への遷移で503エラーが表示されること' do
@@ -598,9 +598,9 @@ describe 'タスク管理機能', type: :system do
     end
 
     describe 'メンテナンス機能' do
-      context 'システムが開始状態の場合'do
+      context 'メンテナンス未開始の場合'do
         before do
-          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:started])
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(maintenance_flg: false)
         end
 
         it 'タスク一覧画面への遷移で503エラーが表示されないこと' do
@@ -609,9 +609,9 @@ describe 'タスク管理機能', type: :system do
         end
       end
 
-      context 'システムが停止状態の場合'do
+      context 'メンテナンス開始の場合'do
         before do
-          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:stopped])
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(maintenance_flg: true)
         end
 
         it 'タスク一覧画面への遷移で503エラーが表示されること' do
@@ -683,9 +683,9 @@ describe 'タスク管理機能', type: :system do
     end
 
     describe 'メンテナンス機能' do
-      context 'システムが開始状態の場合'do
+      context 'メンテナンス未開始の場合'do
         before do
-          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:started])
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(maintenance_flg: false)
         end
 
         it 'タスク一覧画面への遷移で503エラーが表示されないこと' do
@@ -696,7 +696,7 @@ describe 'タスク管理機能', type: :system do
 
       context 'システムが停止状態の場合'do
         before do
-          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(status: SystemMaintenance.statuses[:stopped])
+          SystemMaintenance.find_by(SystemMaintenance::KEY_TASK_MANAGEMENT).update(maintenance_flg: true)
         end
 
         it 'タスク一覧画面への遷移で503エラーが表示されること' do


### PR DESCRIPTION
■要件
### ステップ21: メンテナンス機能を作ろう

- メンテナンスを開始／終了するバッチを作ってみましょう
- メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
- 追加のGemを使わず、自分で実装してみましょう

■対応内容
- メンテナンス開始/終了バッチ作成
- メンテナンスページへリダイレクトする処理作成

■確認手順
①メンテナンス開始バッチ実行
docker-compose exec api rake 'system_maintenance:change_system_maintenance_status[1001, 9]'

下記ページにアクセスすると503エラーページが表示されること
http://localhost:3001/

②メンテナンス終了バッチ実行
docker-compose exec api rake 'system_maintenance:change_system_maintenance_status[1001, 1]'

下記ページにアクセスすると503エラーページが表示されないこと
http://localhost:3001/
