### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/.gitignore
+++ b/myapp/.gitignore
@@ -8,6 +8,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
-/lib/maintenance/maintenance.txt
 
 package.json

--- a/myapp/.gitignore
+++ b/myapp/.gitignore
@@ -8,5 +8,6 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/lib/maintenance/maintenance.txt
 
 package.json

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -2,7 +2,12 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :null_session
+  before_action :render_503_except, if: :maintenance_mode?
   include SessionsHelper
+
+  def maintenance_mode?
+    File.exist?("lib/maintenance/maintenance.txt")
+  end
 
   def routing_error
     raise ActionController::RoutingError, params[:path]
@@ -12,6 +17,10 @@ class ApplicationController < ActionController::Base
     rescue_from Exception,                        with: :_render500
     rescue_from ActiveRecord::RecordNotFound,     with: :_render404
     rescue_from ActionController::RoutingError,   with: :_render404
+  end
+
+  def render_503_except
+    render 'errors/503'
   end
 
   private

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   end
 
   def maintenance_mode?
-    File.exist?("lib/maintenance/maintenance.txt")
+    File.exist?("tmp/maintenance.txt")
   end
 
   def render_503_except

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -5,10 +5,6 @@ class ApplicationController < ActionController::Base
   before_action :render_503_except, if: :maintenance_mode?
   include SessionsHelper
 
-  def maintenance_mode?
-    File.exist?("lib/maintenance/maintenance.txt")
-  end
-
   def routing_error
     raise ActionController::RoutingError, params[:path]
   end
@@ -17,6 +13,10 @@ class ApplicationController < ActionController::Base
     rescue_from Exception,                        with: :_render500
     rescue_from ActiveRecord::RecordNotFound,     with: :_render404
     rescue_from ActionController::RoutingError,   with: :_render404
+  end
+
+  def maintenance_mode?
+    File.exist?("lib/maintenance/maintenance.txt")
   end
 
   def render_503_except

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   end
 
   def maintenance_mode?
-    File.exist?("tmp/maintenance.txt")
+    File.exist?('tmp/maintenance.txt')
   end
 
   def render_503_except

--- a/myapp/app/views/errors/503.html.erb
+++ b/myapp/app/views/errors/503.html.erb
@@ -1,0 +1,2 @@
+<h1>503</h1>
+<p>maintenance_mode<p>

--- a/myapp/lib/tasks/task_maintenance.rake
+++ b/myapp/lib/tasks/task_maintenance.rake
@@ -1,11 +1,11 @@
 namespace :task_maintenance do
   desc 'メンテナンスモード実行/解除'
   task :start do
-    unless File.exist?("tmp/maintenance.txt")
-      File.new("tmp/maintenance.txt", "w")
+    unless File.exist?('tmp/maintenance.txt')
+      File.new('tmp/maintenance.txt', "w")
       puts 'メンテナンスモード'
     else
-      File.delete("tmp/maintenance.txt")
+      File.delete('tmp/maintenance.txt')
       puts '通常モード'
     end
   end

--- a/myapp/lib/tasks/task_maintenance.rake
+++ b/myapp/lib/tasks/task_maintenance.rake
@@ -1,11 +1,11 @@
 namespace :task_maintenance do
   desc 'メンテナンスモード実行/解除'
   task :start do
-    unless File.exist?("lib/maintenance/maintenance.txt")
-      File.new("lib/maintenance/maintenance.txt", "w")
+    unless File.exist?("tmp/maintenance.txt")
+      File.new("tmp/maintenance.txt", "w")
       puts 'メンテナンスモード'
     else
-      File.delete("lib/maintenance/maintenance.txt")
+      File.delete("tmp/maintenance.txt")
       puts '通常モード'
     end
   end

--- a/myapp/lib/tasks/task_maintenance.rake
+++ b/myapp/lib/tasks/task_maintenance.rake
@@ -1,0 +1,12 @@
+namespace :task_maintenance do
+  desc 'メンテナンスモード実行/解除'
+  task :start do
+    unless File.exist?("lib/maintenance/maintenance.txt")
+      File.new("lib/maintenance/maintenance.txt", "w")
+      puts 'メンテナンスモード'
+    else
+      File.delete("lib/maintenance/maintenance.txt")
+      puts '通常モード'
+    end
+  end
+end

--- a/myapp/lib/tasks/task_maintenance.rake
+++ b/myapp/lib/tasks/task_maintenance.rake
@@ -2,7 +2,7 @@ namespace :task_maintenance do
   desc 'メンテナンスモード実行/解除'
   task :start do
     unless File.exist?('tmp/maintenance.txt')
-      File.new('tmp/maintenance.txt', "w")
+      File.new('tmp/maintenance.txt', 'w')
       puts 'メンテナンスモード'
     else
       File.delete('tmp/maintenance.txt')

--- a/myapp/spec/lib/tasks/task_maintenance_spec.rb
+++ b/myapp/spec/lib/tasks/task_maintenance_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rake_helper'
+require 'rails_helper'
+
+RSpec.describe 'task_maintenance:start' do
+  subject(:task) { Rake.application['task_maintenance:start'] }
+
+  it 'change_to_maintenance_mode' do
+    task.invoke
+    visit login_path
+    expect(page).to have_content '503'
+  end
+end

--- a/myapp/spec/lib/tasks/task_maintenance_spec.rb
+++ b/myapp/spec/lib/tasks/task_maintenance_spec.rb
@@ -3,7 +3,7 @@
 require 'rake_helper'
 
 RSpec.describe 'task_maintenance:start' do
-  context "maintenance_check" do
+  context 'maintenance_check' do
     File.delete('tmp/maintenance.txt') if File.exist?('tmp/maintenance.txt')
     subject(:task) { Rake.application['task_maintenance:start'] }
 
@@ -13,7 +13,7 @@ RSpec.describe 'task_maintenance:start' do
     end
 
     it 'change_to_normal_mode' do
-      File.new('tmp/maintenance.txt', "w") unless File.exist?('tmp/maintenance.txt')
+      File.new('tmp/maintenance.txt', 'w') unless File.exist?('tmp/maintenance.txt')
       task.invoke
       expect(File.exist?('tmp/maintenance.txt')).to eq(false)
     end

--- a/myapp/spec/lib/tasks/task_maintenance_spec.rb
+++ b/myapp/spec/lib/tasks/task_maintenance_spec.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
 require 'rake_helper'
-require 'rails_helper'
 
 RSpec.describe 'task_maintenance:start' do
-  subject(:task) { Rake.application['task_maintenance:start'] }
+  context "maintenance_check" do
+    File.delete('tmp/maintenance.txt') if File.exist?('tmp/maintenance.txt')
+    subject(:task) { Rake.application['task_maintenance:start'] }
 
-  it 'change_to_maintenance_mode' do
-    task.invoke
-    visit login_path
-    expect(page).to have_content '503'
+    it 'change_to_maintenance_mode' do
+      task.invoke
+      expect(File.exist?('tmp/maintenance.txt')).to eq(true)
+    end
+
+    it 'change_to_normal_mode' do
+      File.new('tmp/maintenance.txt', "w") unless File.exist?('tmp/maintenance.txt')
+      task.invoke
+      expect(File.exist?('tmp/maintenance.txt')).to eq(false)
+    end
   end
 end

--- a/myapp/spec/rake_helper.rb
+++ b/myapp/spec/rake_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+RSpec.configure do |config|
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
+end

--- a/myapp/spec/rake_helper.rb
+++ b/myapp/spec/rake_helper.rb
@@ -6,4 +6,8 @@ RSpec.configure do |config|
   config.before(:suite) do
     Rails.application.load_tasks
   end
+
+  config.before(:each) do
+    Rake.application.tasks.each(&:reenable)
+  end
 end

--- a/myapp/spec/system/task_schedule_spec.rb
+++ b/myapp/spec/system/task_schedule_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe 'TaskSchedule', type: :system do
 
   context 'maintenance_mode_check' do
     before do
-      File.new('tmp/maintenance.txt', "w") unless File.exist?('tmp/maintenance.txt')
+      File.new('tmp/maintenance.txt', 'w') unless File.exist?('tmp/maintenance.txt')
     end
 
     after do

--- a/myapp/spec/system/task_schedule_spec.rb
+++ b/myapp/spec/system/task_schedule_spec.rb
@@ -274,9 +274,11 @@ RSpec.describe 'TaskSchedule', type: :system do
     before do
       File.new('tmp/maintenance.txt', "w") unless File.exist?('tmp/maintenance.txt')
     end
+
     after do
       File.delete('tmp/maintenance.txt') if File.exist?('tmp/maintenance.txt')
     end
+
     it 'task_maintenance:start' do
       visit login_path
       expect(page).to have_content '503'

--- a/myapp/spec/system/task_schedule_spec.rb
+++ b/myapp/spec/system/task_schedule_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'rake_helper'
 
 RSpec.describe 'TaskSchedule', type: :system do
   let(:user) { create(:user) }
   let(:task) { create(:task, title: 'showタスク', body: 'showボディ', finish_at: 1.year.from_now, user_id: user.id) }
   let(:label) { create(:label, :labels1) }
   let!(:labelling) { create(:labelling, task_id: task.id, label_id: label.id) }
+  File.delete('tmp/maintenance.txt') if File.exist?('tmp/maintenance.txt')
 
   context 'login systems check' do
     before do
@@ -265,6 +267,27 @@ RSpec.describe 'TaskSchedule', type: :system do
       click_link '次'
       expect(page).to have_content 'タスク6'
       expect(page).to have_no_content 'タスク5'
+    end
+  end
+
+  context 'maintenance_mode_check' do
+    before do
+      File.new('tmp/maintenance.txt', "w") unless File.exist?('tmp/maintenance.txt')
+    end
+    after do
+      File.delete('tmp/maintenance.txt') if File.exist?('tmp/maintenance.txt')
+    end
+    it 'task_maintenance:start' do
+      visit login_path
+      expect(page).to have_content '503'
+      visit task_schedule_index_path
+      expect(page).to have_content '503'
+      visit new_task_schedule_path
+      expect(page).to have_content '503'
+      visit task_schedule_path(task)
+      expect(page).to have_content '503'
+      visit edit_task_schedule_path(task)
+      expect(page).to have_content '503'
     end
   end
 end

--- a/myapp/spec/system/users_spec.rb
+++ b/myapp/spec/system/users_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'rake_helper'
 
 RSpec.describe 'Users', type: :system do
   let!(:user) { create(:user, admin: true) }
   let!(:user2) { create(:user, name: 'MyName2', personal_id: 'MyUserID2') }
+  File.delete('tmp/maintenance.txt') if File.exist?('tmp/maintenance.txt')
 
   context 'login systems check' do
     before do
@@ -225,6 +227,27 @@ RSpec.describe 'Users', type: :system do
       expect(page).to have_content '唯一の管理者ユーザです'
       expect(page).to have_content 'MyName'
       expect(page).to have_content 'MyUserID'
+    end
+  end
+
+  context 'maintenance_mode_check' do
+    before do
+      File.new('tmp/maintenance.txt', "w") unless File.exist?('tmp/maintenance.txt')
+    end
+    after do
+      File.delete('tmp/maintenance.txt') if File.exist?('tmp/maintenance.txt')
+    end
+    it 'task_maintenance:start' do
+      visit admin_login_path
+      expect(page).to have_content '503'
+      visit users_path
+      expect(page).to have_content '503'
+      visit new_user_path
+      expect(page).to have_content '503'
+      visit user_path(user)
+      expect(page).to have_content '503'
+      visit edit_user_path(user)
+      expect(page).to have_content '503'
     end
   end
 end

--- a/myapp/spec/system/users_spec.rb
+++ b/myapp/spec/system/users_spec.rb
@@ -234,9 +234,11 @@ RSpec.describe 'Users', type: :system do
     before do
       File.new('tmp/maintenance.txt', "w") unless File.exist?('tmp/maintenance.txt')
     end
+
     after do
       File.delete('tmp/maintenance.txt') if File.exist?('tmp/maintenance.txt')
     end
+
     it 'task_maintenance:start' do
       visit admin_login_path
       expect(page).to have_content '503'

--- a/myapp/spec/system/users_spec.rb
+++ b/myapp/spec/system/users_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe 'Users', type: :system do
 
   context 'maintenance_mode_check' do
     before do
-      File.new('tmp/maintenance.txt', "w") unless File.exist?('tmp/maintenance.txt')
+      File.new('tmp/maintenance.txt', 'w') unless File.exist?('tmp/maintenance.txt')
     end
 
     after do


### PR DESCRIPTION
* 要件（仕様書など）
    * メンテナンスを開始／終了するバッチを作ってみましょう
    * メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
    * 追加のGemを使わず、自分で実装してみましょう
* 修正概要
    * rakeを用いたバッチファイルを作成する
    * ファイルの有無でメンテナンスモードを判断する機能を追加する
    * メンテナンス中はメンテナンスページが表示されるようにする
    * バッチを実施するたびにモードのON/OFFが切り替えられるようにする

* 実装内容
    * バッチファイルを作成
    * バッチファイル内で、メンテナンスモードを判定する為にファイルを作成、削除する処理を追加。そのファイルを置くためのフォルダを作成
    * メンテナンス中に表示されるメンテナンスページを作成
    * メンテナンス中はメンテナンスページにリダイレクトされるように、コントローラーに追記
    * 判定用ファイルはgitに認識されないようにgitignoreに追記

* 動作確認（操作内容、画面キャプチャなど）
    * バッチを動作させることで、メンテナンスモード判定用のファイルを作成、削除できることの確認
    * 判定用ファイルが存在する場合、アプリではメンテナンス用画面に遷移されることの確認
