### PR TITLE
Kumo raku step14 pagenation

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -29,6 +29,7 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'kaminari'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -92,6 +92,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -232,6 +244,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   puma (~> 4.1)

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@
 class TasksController < ApplicationController
   def index
     @conditions = params || {}
-    @tasks = Task.search(@conditions).page(params[:page])
+    @tasks = Task.search(@conditions)
   end
 
   def show

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@
 class TasksController < ApplicationController
   def index
     @conditions = params || {}
-    @tasks = Task.search(@conditions)
+    @tasks = Task.search(@conditions).page(params[:page])
   end
 
   def show

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -20,6 +20,7 @@ class Task < ApplicationRecord
     # ソート
     tasks = tasks.sort_tasks(conditions['sort_column'], conditions['sort_direction'])
 
-    tasks.present? ? tasks : {}
+    # ページネーション
+    tasks = tasks.page(conditions[:page])
   end
 end

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -48,3 +48,5 @@
 </table>
 
 <%= link_to (I18n.t 'tasks.common.new_task'), new_task_path %>
+
+<%= paginate @tasks %>

--- a/myapp/config/initializers/kaminari_config.rb
+++ b/myapp/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  config.window = 2
+  config.outer_window = 1
+  config.left = 1
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/myapp/config/initializers/kaminari_config.rb
+++ b/myapp/config/initializers/kaminari_config.rb
@@ -5,7 +5,7 @@ Kaminari.configure do |config|
   # config.max_per_page = nil
   config.window = 2
   config.outer_window = 1
-  config.left = 1
+  # config.left = 0
   # config.right = 0
   # config.page_method_name = :page
   # config.param_name = :page

--- a/myapp/config/locales/common.ja.yml
+++ b/myapp/config/locales/common.ja.yml
@@ -31,3 +31,10 @@ ja:
     top_page: 'トップページ'
   messages:
     confirm_delete: '本当に削除しますか？'
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe 'Test cases for Task :', type: :system do
         expect(page).to have_content 'test2'
         expect(page).to have_content '2023年11月01日(水) 10時30分00秒'
         expect(page).to have_content '完了'
-        expect(Task.count).to eq 2
       end
 
       context 'when sort,' do
@@ -55,7 +54,6 @@ RSpec.describe 'Test cases for Task :', type: :system do
           expect(page).to have_content 'タスク一覧'
           # 正規表現で並び順をチェック
           expect(page.text).to match(/Spec.*Spec2/)
-          expect(Task.count).to eq 2
         end
       end
 
@@ -94,6 +92,37 @@ RSpec.describe 'Test cases for Task :', type: :system do
 
           expect(page).to have_content 'Spec2'
           expect(page).not_to have_content '2022年12月07日(水) 10時30分00秒'
+        end
+      end
+
+      context 'test pagenation' do
+        before do
+          FactoryBot.create(:task, title: 'Spec3', status: 0)
+          FactoryBot.create(:task, title: 'Spec4', status: 0)
+          FactoryBot.create(:task, title: 'Spec5', status: 0)
+          FactoryBot.create(:task, title: 'Spec6', status: 0)
+          FactoryBot.create(:task, title: 'Spec7', status: 0)
+          FactoryBot.create(:task, title: 'Spec8', status: 0)
+          FactoryBot.create(:task, title: 'Spec9', status: 0)
+          FactoryBot.create(:task, title: 'Spec10', status: 0)
+          FactoryBot.create(:task, title: 'Spec11', status: 0)
+          FactoryBot.create(:task, title: 'Spec12', status: 0)
+          FactoryBot.create(:task, title: 'Spec13', status: 0)
+          FactoryBot.create(:task, title: 'Spec14', status: 0)
+          FactoryBot.create(:task, title: 'Spec15', status: 0)
+          FactoryBot.create(:task, title: 'Spec16', status: 1)
+          FactoryBot.create(:task, title: 'Spec17', status: 1)
+          FactoryBot.create(:task, title: 'Spec18', status: 1)
+          FactoryBot.create(:task, title: 'Spec19', status: 1)
+          FactoryBot.create(:task, title: 'Spec20', status: 2)
+          FactoryBot.create(:task, title: 'Spec21', status: 2)
+          FactoryBot.create(:task, title: 'Spec22', status: 2)
+          # 一覧画面を開く
+          visit tasks_path
+        end
+
+        it 'pagenation works' do
+          expect(page).to have_content '1 2 3 次 › 最後 »'
         end
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -97,32 +97,23 @@ RSpec.describe 'Test cases for Task :', type: :system do
 
       context 'test pagenation' do
         before do
-          FactoryBot.create(:task, title: 'Spec3', status: 0)
-          FactoryBot.create(:task, title: 'Spec4', status: 0)
-          FactoryBot.create(:task, title: 'Spec5', status: 0)
-          FactoryBot.create(:task, title: 'Spec6', status: 0)
-          FactoryBot.create(:task, title: 'Spec7', status: 0)
-          FactoryBot.create(:task, title: 'Spec8', status: 0)
-          FactoryBot.create(:task, title: 'Spec9', status: 0)
-          FactoryBot.create(:task, title: 'Spec10', status: 0)
-          FactoryBot.create(:task, title: 'Spec11', status: 0)
-          FactoryBot.create(:task, title: 'Spec12', status: 0)
-          FactoryBot.create(:task, title: 'Spec13', status: 0)
-          FactoryBot.create(:task, title: 'Spec14', status: 0)
-          FactoryBot.create(:task, title: 'Spec15', status: 0)
-          FactoryBot.create(:task, title: 'Spec16', status: 1)
-          FactoryBot.create(:task, title: 'Spec17', status: 1)
-          FactoryBot.create(:task, title: 'Spec18', status: 1)
-          FactoryBot.create(:task, title: 'Spec19', status: 1)
-          FactoryBot.create(:task, title: 'Spec20', status: 2)
-          FactoryBot.create(:task, title: 'Spec21', status: 2)
-          FactoryBot.create(:task, title: 'Spec22', status: 2)
+          # status=0 のレコードを15個作成する
+          FactoryBot.create_list(:task, 15, status: 0) { |task, index| task.title = "Spec#{index}" }
+          # status=1 のレコードを10個作成する
+          FactoryBot.create_list(:task, 5, status: 1) { |task, index| task.title = "Spec#{index}" }
           # 一覧画面を開く
           visit tasks_path
         end
 
         it 'pagenation works' do
           expect(page).to have_content '1 2 3 次 › 最後 »'
+        end
+
+        it 'pagenation works after search' do
+          choose '未着手'
+          click_button '検索'
+
+          expect(page).to have_content '1 2 次 › 最後 »'
         end
       end
     end


### PR DESCRIPTION
## 概要

[ステップ14: ページネーションを追加しよう](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9714-%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)
> KaminariというGemを使って一覧画面にページネーションを追加してみましょう

## 対応内容

- kaminari Gem の導入
- タスク一覧ページにページャを追加
- 関連するテスト追加

## 動作確認

- 一覧ページにて、10件以下の場合はページャが表示されない
- 一覧ページにて、10件以上の場合はページャが表示される
- 検索しても正しくページネーションされる
- ページャの各パーツが正しく動作する

<img width="802" alt="Screen Shot 2022-12-14 at 11 56 09" src="https://user-images.githubusercontent.com/117716650/207494288-c425a66e-16d7-4753-b716-b42806290c40.png">
