### PR TITLE
Kumo raku step15 bootstrap & css

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -30,6 +30,7 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'kaminari'
+gem 'bootstrap4-kaminari-views'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -29,8 +29,8 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
-gem 'kaminari'
 gem 'bootstrap4-kaminari-views'
+gem 'kaminari'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -61,6 +61,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.15.0)
       msgpack (~> 1.2)
+    bootstrap4-kaminari-views (1.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.36.0)
@@ -239,6 +242,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
+  bootstrap4-kaminari-views
   byebug
   capybara (>= 2.15)
   factory_bot_rails

--- a/myapp/app/javascript/packs/application.js
+++ b/myapp/app/javascript/packs/application.js
@@ -15,3 +15,6 @@ require("channels")
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+
+import 'bootstrap'
+import '../stylesheets/application.scss'

--- a/myapp/app/javascript/stylesheets/application.scss
+++ b/myapp/app/javascript/stylesheets/application.scss
@@ -1,0 +1,1 @@
+@import '~bootstrap/scss/bootstrap';

--- a/myapp/app/javascript/stylesheets/application.scss
+++ b/myapp/app/javascript/stylesheets/application.scss
@@ -1,1 +1,2 @@
 @import '~bootstrap/scss/bootstrap';
+@import 'tasks/index';

--- a/myapp/app/javascript/stylesheets/tasks/index.sass
+++ b/myapp/app/javascript/stylesheets/tasks/index.sass
@@ -1,0 +1,15 @@
+.task-index
+  .tasks-table
+    table-layout: fixed
+  .th-id
+    width: 5%
+  .th-status
+    width: 12%
+  .th-title
+    width: 20%
+  .th-description
+    width: 25%
+  .th-created-at
+    width: 15%
+  .th-end-date
+    width: 16%

--- a/myapp/app/views/common_partials/_flash_messages.html.erb
+++ b/myapp/app/views/common_partials/_flash_messages.html.erb
@@ -1,0 +1,9 @@
+<div class="row mb-4">
+  <% flash.each do |message_type, message| %>
+    <% if message_type == 'success' %>
+      <p class="col alert alert-success"><%= message %></p>
+    <% else %>
+      <p class="col alert alert-danger"><%= message %></p>
+    <% end %>
+  <% end %>
+</div>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -10,6 +10,8 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div class="container my-4">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application' %>
+    <%= javascript_pack_tag 'application' %>
   </head>
 
   <body>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
 
   <body>
     <div class="container my-4">
+      <%= render '/common_partials/flash_messages' %>
       <%= yield %>
     </div>
   </body>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,31 +1,33 @@
-<%= form_with(model: task, local: true) do |form| %>
-  <div>
-    <%= form.label :title %><br>
-    <%= form.text_field :title %>
-    <% task.errors.full_messages_for(:title).each do |message| %>
-      <div><%= message %></div>
-    <% end %>
-  </div>
+<div class="row mb-4">
+  <%= form_with(model: task, local: true, class: 'col-4') do |form| %>
+    <div class="form-group mb-4">
+      <%= form.label :title %>
+      <%= form.text_field :title, class: 'form-control' %>
+      <% task.errors.full_messages_for(:title).each do |message| %>
+        <div class="alert alert-danger mt-2"><%= message %></div>
+      <% end %>
+    </div>
 
-  <div>
-    <%= form.label :status %>
-    <%= form.select :status, I18n.t('enums.task.status').invert %>
-  </div>
+    <div class="form-row mx-0 mb-3">
+      <%= form.label :status, class: 'col-4' %>
+      <%= form.select :status, I18n.t('enums.task.status').invert, {}, class: 'form-control col-8' %>
+    </div>
 
-  <div>
-    <%= form.label :description %><br>
-    <%= form.text_area :description %><br>
-    <% task.errors.full_messages_for(:description).each do |message| %>
-      <div><%= message %></div>
-    <% end %>
-  </div>
+    <div class="form-group mb-4">
+      <%= form.label :description %>
+      <%= form.text_area :description, class: 'form-control' %>
+      <% task.errors.full_messages_for(:description).each do |message| %>
+        <div class="alert alert-danger mt-2"><%= message %></div>
+      <% end %>
+    </div>
 
-  <div>
-    <%= form.label :end_date %>
-    <%= form.datetime_field :end_date %>
-  </div>
+    <div class="form-row mx-0 mb-4">
+      <%= form.label :end_date, class: 'col-4' %>
+      <%= form.datetime_field :end_date, class: 'form-control col-8' %>
+    </div>
 
-  <div>
-    <%= form.submit %>
-  </div>
-<% end %>
+    <div class="form-group mb-4">
+      <%= form.submit class: 'btn btn-primary' %>
+    </div>
+  <% end %>
+</div>

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -1,7 +1,17 @@
-<% flash.each do |message_type, message| %>
-  <%= message %>
-<% end %>
+<div class="task-edit">
+  <div class="row mb-4">
+    <% flash.each do |message_type, message| %>
+      <% if message_type == 'success' %>
+        <p class="col alert alert-success"><%= message %></p>
+      <% else %>
+        <p class="col alert alert-danger"><%= message %></p>
+      <% end %>
+    <% end %>
+  </div>
 
-<h1><%= I18n.t 'tasks.edit.title' %></h1>
+  <div class="row mb-4">
+    <h1 class="col"><%= I18n.t 'tasks.edit.title' %></h1>
+  </div>
 
-<%= render 'form', task: @task %>
+  <%= render 'form', task: @task %>
+</div>

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -1,15 +1,5 @@
 <div class="task-edit">
   <div class="row mb-4">
-    <% flash.each do |message_type, message| %>
-      <% if message_type == 'success' %>
-        <p class="col alert alert-success"><%= message %></p>
-      <% else %>
-        <p class="col alert alert-danger"><%= message %></p>
-      <% end %>
-    <% end %>
-  </div>
-
-  <div class="row mb-4">
     <h1 class="col"><%= I18n.t 'tasks.edit.title' %></h1>
   </div>
 

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -26,11 +26,13 @@
     <th><%= Task.human_attribute_name :description %></th>
     <th>
       <span><%= Task.human_attribute_name :created_at %></span>
-      <small><%= link_to (I18n.t 'tasks.index.sort.latest'), tasks_path(sort_column: 'created_at', sort_direction: 'desc') %></small>
+      <small><%= link_to (I18n.t 'tasks.index.sort.latest'), tasks_path(@conditions.merge(:sort_column => 'created_at', :sort_direction => 'desc')
+        .permit(:keyword, :status, :sort_column, :sort_direction)) %></small>
     </th>
     <th>
       <span><%= Task.human_attribute_name :end_date %></span>
-      <small><%= link_to (I18n.t 'tasks.index.sort.expiring'), tasks_path(sort_column: 'end_date', sort_direction: 'asc') %></small>
+      <small><%= link_to (I18n.t 'tasks.index.sort.expiring'), tasks_path(@conditions.merge(:sort_column => 'end_date', :sort_direction => 'asc')
+        .permit(:keyword, :status, :sort_column, :sort_direction)) %></small>
     </th>
     <th><%= I18n.t 'ops.edit' %></th>
   </tr>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,15 +1,5 @@
 <div class="task-index">
   <div class="row mb-4">
-    <% flash.each do |message_type, message| %>
-      <% if message_type == 'success' %>
-        <p class="col alert alert-success"><%= message %></p>
-      <% else %>
-        <p class="col alert alert-danger"><%= message %></p>
-      <% end %>
-    <% end %>
-  </div>
-
-  <div class="row mb-4">
     <h1 class="col"><%= I18n.t 'tasks.index.title' %></h1>
   </div>
 

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,54 +1,80 @@
-<% flash.each do |message_type, message| %>
-  <%= message %>
-<% end %>
-
-<h1><%= I18n.t 'tasks.index.title' %></h1>
-
-<div class="search-form">
-  <%= form_with url: tasks_path, method: :get, local: true do |form| %>
-    <%= form.text_field :keyword, value: @conditions[:keyword] %>
-    <%= form.submit "検索" %><br>
-
-    <%= form.radio_button :status, nil, checked: true %>
-    <%= form.label :status, I18n.t('undefined') %>
-    <% Task.statuses.each do |k, v| %>
-      <%= form.radio_button :status, v, checked: @conditions[:status] == v.to_s %>
-      <%= form.label :status, I18n.t('enums.task.status')[k.to_sym], {value: v} %>
+<div class="task-index">
+  <div class="row mb-4">
+    <% flash.each do |message_type, message| %>
+      <% if message_type == 'success' %>
+        <p class="col alert alert-success"><%= message %></p>
+      <% else %>
+        <p class="col alert alert-danger"><%= message %></p>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
+
+  <div class="row mb-4">
+    <h1 class="col"><%= I18n.t 'tasks.index.title' %></h1>
+  </div>
+
+  <div class="row mb-4">
+    <%= form_with url: tasks_path, method: :get, class: 'col', local: true do |form| %>
+      <div class="form-row mb-2">
+        <%= form.text_field :keyword, value: @conditions[:keyword], class: 'form-control col-4 mr-2' %>
+        <%= form.submit '検索', class: 'btn btn-primary col-2' %>
+      </div>
+      <div class="form-row ml-3">
+        <div class="form-check col-1">
+          <%= form.radio_button :status, nil, checked: true, class: 'form-check-input' %>
+          <%= form.label :status, I18n.t('undefined'), class: 'form-check-label' %>
+        </div>
+        <% Task.statuses.each do |k, v| %>
+          <div class="form-check col-1">
+            <%= form.radio_button :status, v, checked: @conditions[:status] == v.to_s, class: 'form-check-input' %>
+            <%= form.label :status, I18n.t('enums.task.status')[k.to_sym], {value: v, class: 'form-check-label'} %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="row">
+    <table class="col table tasks-table">
+      <thead>
+        <tr>
+          <th class="th-id"><%= Task.human_attribute_name :id %></th>
+          <th class="th-status"><%= Task.human_attribute_name :status %></th>
+          <th class="th-title"><%= Task.human_attribute_name :title %></th>
+          <th class="th-description"><%= Task.human_attribute_name :description %></th>
+          <th class="th-created-at">
+            <span><%= Task.human_attribute_name :created_at %></span>
+            <small><%= link_to (I18n.t 'tasks.index.sort.latest'), tasks_path(@conditions.merge(:sort_column => 'created_at', :sort_direction => 'desc')
+              .permit(:keyword, :status, :sort_column, :sort_direction)) %></small>
+          </th>
+          <th class="th-end-date">
+            <span><%= Task.human_attribute_name :end_date %></span>
+            <small><%= link_to (I18n.t 'tasks.index.sort.expiring'), tasks_path(@conditions.merge(:sort_column => 'end', :sort_direction => 'asc')
+              .permit(:keyword, :status, :sort_column, :sort_direction)) %></small>
+          </th>
+          <th class="th-edit"><%= I18n.t 'ops.edit' %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @tasks.each do |task| %>
+          <tr>
+            <td><%= task.id %></td>
+            <td><%= I18n.t('enums.task.status')[task.status.to_sym] %></td>
+            <td class="text-truncate"><%= link_to task.title, task %></td>
+            <td class="text-truncate"><%= task.description %></td>
+            <td><%= I18n.l(task.created_at.to_date, format: :long) %></td>
+            <td><%= task.end_date ? I18n.l(task.end_date, format: :long) : '-' %></td>
+            <td><%= link_to (I18n.t 'ops.edit'), edit_task_path(task) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="row">
+    <div class="col-10">
+      <%= paginate @tasks, theme: 'twitter-bootstrap-4' %>
+    </div>
+    <%= link_to (I18n.t 'tasks.common.new_task'), new_task_path, class: 'col-2 btn btn-primary mb-4' %>
+  </div>
 </div>
-
-<table>
-  <tr>
-    <th><%= Task.human_attribute_name :id %></th>
-    <th><%= Task.human_attribute_name :status %></th>
-    <th><%= Task.human_attribute_name :title %></th>
-    <th><%= Task.human_attribute_name :description %></th>
-    <th>
-      <span><%= Task.human_attribute_name :created_at %></span>
-      <small><%= link_to (I18n.t 'tasks.index.sort.latest'), tasks_path(@conditions.merge(:sort_column => 'created_at', :sort_direction => 'desc')
-        .permit(:keyword, :status, :sort_column, :sort_direction)) %></small>
-    </th>
-    <th>
-      <span><%= Task.human_attribute_name :end_date %></span>
-      <small><%= link_to (I18n.t 'tasks.index.sort.expiring'), tasks_path(@conditions.merge(:sort_column => 'end_date', :sort_direction => 'asc')
-        .permit(:keyword, :status, :sort_column, :sort_direction)) %></small>
-    </th>
-    <th><%= I18n.t 'ops.edit' %></th>
-  </tr>
-  <% @tasks.each do |task| %>
-    <tr>
-      <td><%= task.id %></td>
-      <td><%= I18n.t('enums.task.status')[task.status.to_sym] %></td>
-      <td><%= link_to task.title, task %></td>
-      <td><%= task.description %></td>
-      <td><%= I18n.l(task.created_at.to_date, format: :long) %></td>
-      <td><%= task.end_date ? I18n.l(task.end_date, format: :long) : '-' %></td>
-      <td><%= link_to (I18n.t 'ops.edit'), edit_task_path(task) %></td>
-    </tr>
-  <% end %>
-</table>
-
-<%= link_to (I18n.t 'tasks.common.new_task'), new_task_path %>
-
-<%= paginate @tasks %>

--- a/myapp/app/views/tasks/new.html.erb
+++ b/myapp/app/views/tasks/new.html.erb
@@ -1,7 +1,18 @@
-<% flash.each do |message_type, message| %>
-  <%= message %>
-<% end %>
+<div class="task-new">
+  <div class="row mb-4">
+    <% flash.each do |message_type, message| %>
+      <% if message_type == 'success' %>
+        <p class="col alert alert-success"><%= message %></p>
+      <% else %>
+        <p class="col alert alert-danger"><%= message %></p>
+      <% end %>
+    <% end %>
+  </div>
 
-<h1><%= I18n.t 'tasks.new.title' %></h1>
+  <div class="row mb-4">
+    <h1 class="col"><%= I18n.t 'tasks.new.title' %></h1>
+  </div>
 
-<%= render 'form', task: @task %>
+
+  <%= render 'form', task: @task %>
+</div>

--- a/myapp/app/views/tasks/new.html.erb
+++ b/myapp/app/views/tasks/new.html.erb
@@ -1,15 +1,5 @@
 <div class="task-new">
   <div class="row mb-4">
-    <% flash.each do |message_type, message| %>
-      <% if message_type == 'success' %>
-        <p class="col alert alert-success"><%= message %></p>
-      <% else %>
-        <p class="col alert alert-danger"><%= message %></p>
-      <% end %>
-    <% end %>
-  </div>
-
-  <div class="row mb-4">
     <h1 class="col"><%= I18n.t 'tasks.new.title' %></h1>
   </div>
 

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,15 +1,5 @@
 <div class="task-show">
   <div class="row mb-4">
-    <% flash.each do |message_type, message| %>
-      <% if message_type == 'success' %>
-        <p class="col alert alert-success"><%= message %></p>
-      <% else %>
-        <p class="col alert alert-danger"><%= message %></p>
-      <% end %>
-    <% end %>
-  </div>
-
-  <div class="row mb-4">
     <h1 class="col"><%= I18n.t 'tasks.show.title' %></h1>
   </div>
 

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,17 +1,50 @@
-<% flash.each do |message_type, message| %>
-  <%= message %>
-<% end %>
+<div class="task-show">
+  <div class="row mb-4">
+    <% flash.each do |message_type, message| %>
+      <% if message_type == 'success' %>
+        <p class="col alert alert-success"><%= message %></p>
+      <% else %>
+        <p class="col alert alert-danger"><%= message %></p>
+      <% end %>
+    <% end %>
+  </div>
 
-<h1><%= I18n.t 'tasks.show.title' %></h1>
+  <div class="row mb-4">
+    <h1 class="col"><%= I18n.t 'tasks.show.title' %></h1>
+  </div>
 
-<h2><%= @task.title %></h2>
-<p><%= "#{Task.human_attribute_name :status}: #{I18n.t('enums.task.status')[@task.status.to_sym]}" %></p>
-<p><%= "#{Task.human_attribute_name :description}: #{@task.description}" %></p>
-<p><%= "#{Task.human_attribute_name :end_date}: #{@task.end_date ? I18n.l(@task.end_date, format: :long) : '-'}" %></p>
+  <div class="row mb-4">
+    <h2 class="col"><%= @task.title %></h2>
+  </div>
 
-<%= link_to (I18n.t 'ops.edit'), edit_task_path(@task) %>
-<%= link_to (I18n.t 'ops.delete'), task_path(@task),
-  method: :delete,
-  data: { confirm: (I18n.t 'messages.confirm_delete') }
-%>
-<%= link_to (I18n.t 'tasks.index.title'), tasks_path %>
+  <div class="row">
+    <table class="table col">
+      <tbody>
+        <tr>
+          <th class="border-top border-secondary"><%= "#{Task.human_attribute_name :status}:" %></th>
+          <td class="border-top border-secondary"><%= I18n.t('enums.task.status')[@task.status.to_sym] %></td>
+          <th class="border-top border-secondary"><%= "#{Task.human_attribute_name :end_date}:" %></th>
+          <td class="border-top border-secondary"><%= @task.end_date ? I18n.l(@task.end_date, format: :long) : '-' %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="row">
+    <p class="col font-weight-bold border-top border-secondary pt-2"><%= "#{Task.human_attribute_name :description}:" %></p>
+  </div>
+  <div class="row">
+    <p class="col-6 border border-secondary rounded text-break"><%= @task.description %></p>
+  </div>
+
+  <div class="row mt-4">
+    <%= link_to (I18n.t 'ops.edit'), edit_task_path(@task), class: 'col-1 mr-4' %>
+    <%= link_to (I18n.t 'ops.delete'), task_path(@task),
+      method: :delete,
+      data: { confirm: (I18n.t 'messages.confirm_delete') },
+      class: 'col-1 mr-4'
+    %>
+    <%= link_to (I18n.t 'tasks.index.title'), tasks_path, class: 'col-2' %>
+  </div>
+
+</div>

--- a/myapp/config/webpack/environment.js
+++ b/myapp/config/webpack/environment.js
@@ -1,13 +1,3 @@
 const { environment } = require('@rails/webpacker')
 
-const webpack = require('webpack')
-environment.plugins.prepend(
-  'Provide',
-  new webpack.ProvidePlugin({
-    $: 'jquery',
-    jQuery: 'jquery',
-    Popper: 'popper.js'
-  })
-)
-
 module.exports = environment

--- a/myapp/config/webpack/environment.js
+++ b/myapp/config/webpack/environment.js
@@ -1,3 +1,13 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend(
+  'Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery',
+    jQuery: 'jquery',
+    Popper: 'popper.js'
+  })
+)
+
 module.exports = environment

--- a/myapp/package.json
+++ b/myapp/package.json
@@ -6,6 +6,9 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
+    "bootstrap": "4.5.0",
+    "jquery": "3.5.1",
+    "popper.js": "1.16.0",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/myapp/yarn.lock
+++ b/myapp/yarn.lock
@@ -1602,6 +1602,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
+bootstrap@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.0.tgz#97d9dbcb5a8972f8722c9962483543b907d9b9ec"
+  integrity sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3918,6 +3923,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4868,6 +4878,11 @@ pnp-webpack-plugin@^1.7.0:
   integrity sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==
   dependencies:
     ts-pnp "^1.1.6"
+
+popper.js@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"
+  integrity sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==
 
 portfinder@^1.0.26:
   version "1.0.32"


### PR DESCRIPTION
## 概要

[ステップ15: デザインを当てよう](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
> Bootstrapを導入して、これまで作成したアプリにデザインを当てましょう
【オプション要件】自分でCSSを書いてデザインする

## 対応内容

- webpackerでBootstrap Jquery popper追加
- gemでkaminari用のBootstrap4 gemを追加
- Bootstrapで各ページをデザイン適用

## 動作確認

- 一覧画面がエラーなく表示できます、検索、ソート、ページネーションが正しく動く
- 詳細画面がエラーなく表示できます、編集、削除、一覧に遷移はできる
- 編集画面がエラーなく表示できます、編集ができます、バリデーションエラーメッセージが表示できる
- 新規登録画面がエラーなく表示できます、新規登録ができます、バリデーションエラーメッセージが表示できる
- ページャの各パーツが正しく動作する

画面イメージ：

<img width="1329" alt="Screen Shot 2022-12-16 at 10 41 58" src="https://user-images.githubusercontent.com/117716650/208002670-1d86814e-ce2f-43dc-a8fe-6dfbfdee2cd8.png">
<img width="1328" alt="Screen Shot 2022-12-16 at 10 42 05" src="https://user-images.githubusercontent.com/117716650/208002680-a993781a-dedd-4c61-8aab-68cd6ad905a5.png">
<img width="527" alt="Screen Shot 2022-12-16 at 10 42 19" src="https://user-images.githubusercontent.com/117716650/208002684-c4763ca2-8bb4-4575-8f0d-fa927bfcc369.png">
<img width="527" alt="Screen Shot 2022-12-16 at 10 42 27" src="https://user-images.githubusercontent.com/117716650/208002659-2ae8007a-4d9f-47fa-9efe-18b8a125b6a0.png">
<img width="1261" alt="Screen Shot 2022-12-16 at 10 42 41" src="https://user-images.githubusercontent.com/117716650/208002678-ca6a492c-9a00-4a96-be69-e6e496379762.png">