### PR TITLE
AnneJu step 19: Add a role to the user

### DIFF
--- a/myapp/app/controllers/admin/base_controller.rb
+++ b/myapp/app/controllers/admin/base_controller.rb
@@ -1,0 +1,12 @@
+module Admin
+  class BaseController < ::ApplicationController
+    before_action :authorize_user
+    before_action :validate_admin
+
+    private
+
+    def validate_admin
+      redirect_to root_path unless Current.user.is_admin
+    end
+  end
+end

--- a/myapp/app/controllers/admin/tasks_controller.rb
+++ b/myapp/app/controllers/admin/tasks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Admin
-  class TasksController < ApplicationController
+  class TasksController < BaseController
     before_action :set_user
 
     def index

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -44,7 +44,7 @@ module Admin
     private
 
     def user_params
-      @user_params ||= params.require(:user).permit(:name, :email)
+      @user_params ||= params.require(:user).permit(:name, :email, :is_admin)
     end
 
     def set_user

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -36,9 +36,11 @@ module Admin
     end
 
     def destroy
-      @user.destroy
-
-      redirect_to admin_users_path, notice: I18n.t('activerecord.actions.admin.user.destroy.success_message')
+      if @user.destroy
+        redirect_to admin_users_path, notice: I18n.t('activerecord.actions.admin.user.destroy.success_message')
+      else
+        redirect_to admin_users_path, notice: I18n.t('activerecord.actions.admin.user.destroy.failed_message')
+      end
     end
 
     private

--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Admin
-  class UsersController < ApplicationController
+  class UsersController < BaseController
     INITIAL_PASSWORD = '0000'
 
     before_action :set_user, only: %i[edit update destroy]

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -21,5 +21,22 @@ class User < ApplicationRecord
 
   has_many :tasks, dependent: :delete_all
 
+  before_destroy :stop_destroy
+
   has_secure_password
+
+  scope :admin, -> { where(is_admin: true) }
+
+  def the_last_admin?
+    return false unless is_admin
+    return false if User.admin.unscope(:order).limit(2).count == 2
+    User.admin.first.id == id
+  end
+
+  def stop_destroy
+    return unless the_last_admin?
+
+    errors.add(:base, 'Cannot delete the last admin role')
+    throw :abort
+  end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ApplicationRecord
 
   def the_only_admin?
     return false unless is_admin
-    return false if User.admin.unscope(:order).limit(2).count == 2
+    return false if User.admin.limit(2).count == 2
     User.admin.first.id == id
   end
 

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -27,14 +27,14 @@ class User < ApplicationRecord
 
   scope :admin, -> { where(is_admin: true) }
 
-  def the_last_admin?
+  def the_only_admin?
     return false unless is_admin
     return false if User.admin.unscope(:order).limit(2).count == 2
     User.admin.first.id == id
   end
 
   def stop_destroy
-    return unless the_last_admin?
+    return unless the_only_admin?
 
     errors.add(:base, 'Cannot delete the last admin role')
     throw :abort

--- a/myapp/app/views/admin/users/_form.html.erb
+++ b/myapp/app/views/admin/users/_form.html.erb
@@ -13,6 +13,7 @@
   <%= form_with(model: [:admin, user], local: true)do |form| %>
      <%= I18n.t('activerecord.attributes.user.name') %>: <%= form.text_field :name, class: 'form-control' %> <br>
      <%= I18n.t('activerecord.attributes.user.email') %>: <%= form.text_field :email, class: 'form-control' %> <br>
+     <%= I18n.t('activerecord.attributes.user.is_admin') %>: <%= form.check_box :is_admin %> <br>
 
     <%= form.submit I18n.t('helpers.submit.submit', model: I18n.t('activerecord.models.user')).capitalize, class: "btn btn-outline-secondary" %>
   <% end %>

--- a/myapp/config/locales/user/en.yml
+++ b/myapp/config/locales/user/en.yml
@@ -32,3 +32,4 @@ en:
             failed_message: User update failed
           destroy:
             success_message: User successfully deleted
+            failed_message: User deletion failed

--- a/myapp/config/locales/user/ja.yml
+++ b/myapp/config/locales/user/ja.yml
@@ -32,3 +32,4 @@ ja:
             failed_message: ユーザ更新失敗しました
           destroy:
             success_message: ユーザ削除しました
+            failed_message: ユーザ削除失敗しました

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -21,5 +21,9 @@ FactoryBot.define do
     email { Faker::Internet.unique.email }
     password_digest { BCrypt::Password.create('my password') }
     is_admin { false }
+
+    trait :admin do
+      is_admin { true }
+    end
   end
 end

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -38,4 +38,40 @@ RSpec.describe User, type: :model do
   describe 'has_many' do
     it { should have_many(:tasks) }
   end
+
+  describe '#the_last_admin?' do
+    let!(:admin_user) { create(:user, :admin) }
+    context 'when is the only admin user' do
+      it 'returns true' do
+        expect(admin_user.the_last_admin?).to be_truthy
+      end
+    end
+
+    context 'when other admin user exist' do
+      before { create(:user, :admin) }
+      it 'returns false' do
+        expect(admin_user.the_last_admin?).to be_falsy
+      end
+    end
+  end
+
+  describe 'callbacks' do
+    describe 'stop_destroy' do
+      let!(:admin_user) { create(:user, :admin) }
+
+      context 'when deletable' do
+        before { create(:user, :admin) }
+        it 'destroy the user' do
+          expect { admin_user.destroy }.to change(User, :count).by(-1)
+        end
+      end
+
+      context 'when not deletable' do
+        it 'does not destroy the user' do
+          expect { admin_user.destroy }.to change(User, :count).by(0)
+          expect(admin_user.errors.messages[:base]).to eq(['Cannot delete the last admin role'])
+        end
+      end
+    end
+  end
 end

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -39,18 +39,18 @@ RSpec.describe User, type: :model do
     it { should have_many(:tasks) }
   end
 
-  describe '#the_last_admin?' do
+  describe '#the_only_admin?' do
     let!(:admin_user) { create(:user, :admin) }
     context 'when is the only admin user' do
       it 'returns true' do
-        expect(admin_user.the_last_admin?).to be_truthy
+        expect(admin_user.the_only_admin?).to be_truthy
       end
     end
 
     context 'when other admin user exist' do
       before { create(:user, :admin) }
       it 'returns false' do
-        expect(admin_user.the_last_admin?).to be_falsy
+        expect(admin_user.the_only_admin?).to be_falsy
       end
     end
   end

--- a/myapp/spec/system/admin/tasks_spec.rb
+++ b/myapp/spec/system/admin/tasks_spec.rb
@@ -3,35 +3,51 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Task', type: :system do
-  describe '#index' do
-    let!(:user_1) { create(:user) }
-    let!(:user_2) { create(:user) }
-    let!(:task_1) { create(:task, user: user_1) }
-    let!(:task_2) { create(:task, user: user_1) }
-    let!(:task_3) { create(:task, user: user_2) }
+  context 'when admin user logged in' do
+    let(:admin_user) { create(:user, :admin) }
+    let(:rspec_session) { {user_id: admin_user.id} }
 
-    before { visit admin_tasks_path(user_1) }
+    describe '#index' do
+      let!(:user_1) { create(:user) }
+      let!(:user_2) { create(:user) }
+      let!(:task_1) { create(:task, user: user_1) }
+      let!(:task_2) { create(:task, user: user_1) }
+      let!(:task_3) { create(:task, user: user_2) }
 
-    it 'displays tasks associated with the user' do
-      expect(page).to have_content task_1.id
-      expect(page).to have_content task_1.title
-      expect(page).to have_content task_1.description
-      expect(page).to have_content task_1.due_date.strftime('%F')
-      expect(page).to have_content task_1.created_at.strftime('%F %T')
-      expect(page).to have_content task_1.status
-      expect(page).to have_content task_1.user.name
-      expect(page).to have_content task_2.id
-      expect(page).to have_content task_2.title
-      expect(page).to have_content task_2.description
-      expect(page).to have_content task_2.due_date.strftime('%F')
-      expect(page).to have_content task_2.created_at.strftime('%F %T')
-      expect(page).to have_content task_2.status
-      expect(page).to have_content task_2.user.name
+      before { visit admin_tasks_path(user_1) }
+
+      it 'displays tasks associated with the user' do
+        expect(page).to have_content task_1.id
+        expect(page).to have_content task_1.title
+        expect(page).to have_content task_1.description
+        expect(page).to have_content task_1.due_date.strftime('%F')
+        expect(page).to have_content task_1.created_at.strftime('%F %T')
+        expect(page).to have_content task_1.status
+        expect(page).to have_content task_1.user.name
+        expect(page).to have_content task_2.id
+        expect(page).to have_content task_2.title
+        expect(page).to have_content task_2.description
+        expect(page).to have_content task_2.due_date.strftime('%F')
+        expect(page).to have_content task_2.created_at.strftime('%F %T')
+        expect(page).to have_content task_2.status
+        expect(page).to have_content task_2.user.name
+      end
+
+      it 'does not display tasks of other users' do
+        expect(page).not_to have_content task_3.id
+        expect(page).not_to have_content task_3.user.name
+      end
     end
+  end
 
-    it 'does not display tasks of other users' do
-      expect(page).not_to have_content task_3.id
-      expect(page).not_to have_content task_3.user.name
+  context 'when non admin user logged in' do
+    let(:user) { create(:user) }
+    let(:rspec_session) { {user_id: user.id} }
+
+    it 'redirect user to root_path' do
+      visit admin_users_path
+
+      expect(page).to have_content 'Tasks List'
     end
   end
 end

--- a/myapp/spec/system/admin/users_spec.rb
+++ b/myapp/spec/system/admin/users_spec.rb
@@ -3,125 +3,157 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::User', type: :system do
-  describe '#index' do
-    it 'displays a create user link' do
-      create_user_button_text = I18n.t('helpers.submit.create', model: I18n.t('activerecord.models.user'))
+  context 'when admin user logged in' do
+    let(:admin_user) { create(:user, :admin) }
+    let(:rspec_session) { {user_id: admin_user.id} }
 
+    describe '#index' do
+      it 'displays a create user link' do
+        create_user_button_text = I18n.t('helpers.submit.create', model: I18n.t('activerecord.models.user'))
+
+        visit admin_users_path
+
+        expect(page).to have_link(create_user_button_text)
+      end
+
+      context 'when users already exist' do
+        let!(:user_1) { create(:user) }
+        let!(:user_2) { create(:user) }
+
+        it 'displays users infos' do
+          visit admin_users_path
+
+          expect(page).to have_content user_1.id
+          expect(page).to have_content user_1.name
+          expect(page).to have_content user_1.email
+          expect(page).to have_content user_1.is_admin
+          expect(page).to have_content user_2.id
+          expect(page).to have_content user_2.name
+          expect(page).to have_content user_2.email
+          expect(page).to have_content user_2.is_admin
+        end
+
+        it 'display user tasks count' do
+          create_list(:task, 3, user: user_1)
+
+          visit admin_users_path
+
+          expect(page).to have_content 3
+        end
+      end
+    end
+
+    describe '#new' do
+      let(:user_email) { 'taro.rakuten@mail.com' }
+      before { visit new_admin_user_path }
+      context 'when user with same email not exist' do
+        it 'creates a new user' do
+          fill_in 'user_name', with: 'Taro Rakuten'
+          fill_in 'user_email', with: user_email
+
+          expect { click_button 'Save user' }.to change(User, :count).by(1)
+
+          success_message = 'User successfully created'
+          expect(page).to have_content success_message
+        end
+      end
+
+      context 'when user with same email already exists' do
+        before { create(:user, email: user_email) }
+        it 'does not create a new user' do
+          fill_in 'user_name', with: 'Momo Rakuten'
+          fill_in 'user_email', with: user_email
+
+          expect { click_button 'Save user' }.to change(User, :count).by(0)
+
+          error_message = 'E-mail has already been taken'
+          expect(page).to have_content error_message
+        end
+      end
+    end
+
+    describe '#edit' do
+      let!(:user) { create(:user) }
+
+      before { visit edit_admin_user_path(user) }
+
+      it 'display the details of the user' do
+        expect(page).to have_field 'user_name', with: user.name
+        expect(page).to have_field 'user_email', with: user.email
+      end
+
+      context 'when input necessary user columns' do
+        it 'update user successfully' do
+          updated_user_name = 'Updated user name'
+          updated_user_email = 'new@mail.com'
+          page.check('user_is_admin')
+
+          fill_in 'user_name', with: updated_user_name
+          fill_in 'user_email', with: updated_user_email
+
+          click_button 'Save user'
+
+          expect(page).to have_content updated_user_name
+          expect(page).to have_content updated_user_email
+          expect(user.reload.is_admin).to be_truthy
+        end
+      end
+
+      context 'when mis-input necessary user column' do
+        it 'does not update user' do
+          updated_user_name = nil
+
+          fill_in 'user_name', with: updated_user_name
+
+          click_button 'Save user'
+
+          error_message = "User Name can't be blank"
+          expect(page).to have_content error_message
+        end
+      end
+    end
+
+    describe '#destroy' do
+      let!(:user) { create(:user) }
+
+      describe 'when user can be deleted' do
+        it 'destroys user successfully' do
+          visit admin_users_path
+
+          expect { find(:xpath, "(//a[text()='Delete'])[2]").click }.to change(User, :count).by(-1)
+        end
+
+        context 'when user has tasks' do
+          before { create_list(:task, 2, user: user) }
+          it 'destroys tasks created by user' do
+            visit admin_users_path
+
+            expect { find(:xpath, "(//a[text()='Delete'])[2]").click }.to change(Task, :count).by(-2)
+          end
+        end
+      end
+
+      describe 'when user cannot be deleted' do
+        it 'does not delete the user' do
+          visit admin_users_path
+
+          expect { find(:xpath, "(//a[text()='Delete'])[1]").click }.to change(User, :count).by(0)
+          error_message = 'User deletion failed'
+          expect(page).to have_content error_message
+        end
+      end
+    end
+  end
+
+  context 'when non admin user logged in' do
+    let(:user) { create(:user) }
+    let(:rspec_session) { {user_id: user.id} }
+
+    it 'redirect user to root_path' do
       visit admin_users_path
 
-      expect(page).to have_link(create_user_button_text)
-    end
-
-    context 'when users already exist' do
-      let!(:user_1) { create(:user) }
-      let!(:user_2) { create(:user) }
-
-      it 'displays users infos' do
-        visit admin_users_path
-
-        expect(page).to have_content user_1.id
-        expect(page).to have_content user_1.name
-        expect(page).to have_content user_1.email
-        expect(page).to have_content user_1.is_admin
-        expect(page).to have_content user_2.id
-        expect(page).to have_content user_2.name
-        expect(page).to have_content user_2.email
-        expect(page).to have_content user_2.is_admin
-      end
-
-      it 'display user tasks count' do
-        create_list(:task, 3, user: user_1)
-
-        visit admin_users_path
-
-        expect(first('.user-tasks_count').text).to eq '3'
-      end
-    end
-  end
-
-  describe '#new' do
-    let(:user_email) { 'taro.rakuten@mail.com' }
-    before { visit new_admin_user_path }
-    context 'when user with same email not exist' do
-      it 'creates a new user' do
-        fill_in 'user_name', with: 'Taro Rakuten'
-        fill_in 'user_email', with: user_email
-
-        expect { click_button 'Save user' }.to change(User, :count).by(1)
-
-        success_message = 'User successfully created'
-        expect(page).to have_content success_message
-      end
-    end
-
-    context 'when user with same email already exists' do
-      before { create(:user, email: user_email) }
-      it 'does not create a new user' do
-        fill_in 'user_name', with: 'Momo Rakuten'
-        fill_in 'user_email', with: user_email
-
-        expect { click_button 'Save user' }.to change(User, :count).by(0)
-
-        error_message = 'E-mail has already been taken'
-        expect(page).to have_content error_message
-      end
-    end
-  end
-
-  describe '#edit' do
-    let!(:user) { create(:user) }
-
-    before { visit edit_admin_user_path(user) }
-
-    it 'display the details of the user' do
-      expect(page).to have_field 'user_name', with: user.name
-      expect(page).to have_field 'user_email', with: user.email
-    end
-
-    context 'when input necessary user columns' do
-      it 'update user successfully' do
-        updated_user_name = 'Updated user name'
-        updated_user_email = 'new@mail.com'
-
-        fill_in 'user_name', with: updated_user_name
-        fill_in 'user_email', with: updated_user_email
-
-        click_button 'Save user'
-
-        expect(page).to have_content updated_user_name
-        expect(page).to have_content updated_user_email
-      end
-    end
-
-    context 'when mis-input necessary user column' do
-      it 'does not update user' do
-        updated_user_name = nil
-
-        fill_in 'user_name', with: updated_user_name
-
-        click_button 'Save user'
-
-        error_message = "User Name can't be blank"
-        expect(page).to have_content error_message
-      end
-    end
-  end
-
-  describe '#destroy' do
-    let!(:user) { create(:user) }
-    it 'destroys user successfully' do
-      visit admin_users_path
-
-      expect { click_link 'Delete' }.to change(User, :count).by(-1)
-    end
-
-    context 'when user has tasks' do
-      before { create_list(:task, 2, user: user) }
-      it 'destroys tasks created by user' do
-        visit admin_users_path
-
-        expect { click_link 'Delete' }.to change(Task, :count).by(-2)
-      end
+      expect(page).to have_content 'Tasks List'
+      expect(page).not_to have_content 'Users List'
     end
   end
 end


### PR DESCRIPTION
#### Description
- Let's make users distinguish between administrative users and general users
- Let's make only the admin user access the user admin tool
- Let's make it possible to select a role on the user management tool
- Let's control the deletion so that no administrative user is gone
- ref: [Step 19: Add a role to the user(Optional)](https://github.com/Fablic/training/blob/develop/steps_en.md#step-19-add-a-role-to-the-useroptional)

#### Stories
- [x] Add BaseController in Admin to prevent access not allowed
- [x] Allow to update user role in admin tool
- [x] Add validations when deleting the user
- [x] Write Specs

#### Related RSpecs
```
rspec spec/models/user_spec.rb:42:58 spec/system/admin/tasks_spec.rb spec/system/admin/users_spec.rb
```