### PR TITLE
[Yokogawa STEP10] Add sorting function by created_at

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,12 +3,13 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.all
-    @sort_order = 'desc'
+    @sort_order = 'asc'
 
+    return @tasks = @tasks.order(created_at: :desc) if params[:sort_created_at] == "desc"
+
+    @sort_order = 'desc'
     return @tasks = @tasks.order(created_at: :asc) if params[:sort_created_at] == "asc"
 
-    @tasks = @tasks.order(created_at: :desc) if params[:sort_created_at] == "desc"
-    @sort_order = 'asc'
   end
 
   def new

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,6 +3,12 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.all
+    @sort_order = 'desc'
+
+    return @tasks = @tasks.order(created_at: :asc) if params[:sort_created_at] == "asc"
+
+    @tasks = @tasks.order(created_at: :desc) if params[:sort_created_at] == "desc"
+    @sort_order = 'asc'
   end
 
   def new

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,7 +1,8 @@
 <h1><%= t('activerecord.models.task') %> <%= t('action.list') %></h1>
 
-<p><%= link_to "日本語", "/tasks" %></p>
-<p><%= link_to "English", "/tasks?locale=en" %></p>
+<p><%= link_to "日本語", tasks_path(locale: 'ja') %></p>
+<p><%= link_to "English", tasks_path(locale: 'en') %></p>
+<p><%= link_to t('sort.created_at'), tasks_path(sort_created_at: @sort_order) %></p>
 
 <table>
   <thead>

--- a/myapp/config/locales/views/tasks/en.yml
+++ b/myapp/config/locales/views/tasks/en.yml
@@ -10,6 +10,9 @@ en:
     add: 'add'
     show: 'show'
 
+  sort:
+    created_at: 'Sort by created_at'
+
   flash:
     task:
       create:

--- a/myapp/config/locales/views/tasks/ja.yml
+++ b/myapp/config/locales/views/tasks/ja.yml
@@ -10,6 +10,9 @@ ja:
     add: '追加'
     show: '詳細'
 
+  sort:
+    created_at: '作成日時で並び替え'
+
   flash:
     task:
       create:

--- a/myapp/spec/factories/task.rb
+++ b/myapp/spec/factories/task.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :task do
-    name { 'name' }
+    name { 'sample_task' }
   end
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -17,10 +17,12 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'GET /tasks' do
-    let!(:task) { create(:task) }
+    before do
+      create(:task)
+      visit '/tasks'
+    end
 
     it 'renders a successful response' do
-      visit '/tasks'
       expect(page).to have_content 'タスク 一覧'
       expect(page).to have_content 'sample_task'
     end
@@ -85,10 +87,12 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'Deleting a task successfully' do
-    let!(:task) { create(:task) }
+    before do
+      create(:task)
+      visit '/tasks'
+    end
 
     it 'successfully update a task' do
-      visit '/tasks'
       expect(Task.all.length).to eq 1
       click_link('削除')
       expect(page).to have_content 'タスクが正常に削除されました。'

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -143,4 +143,29 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
   end
+
+  describe 'Sorting by created_at' do
+    before do
+      @task1 = create(:task, name: 'hoge_task', created_at: Time.current.yesterday)
+      @task2 = create(:task, name: 'fuga_task', created_at: Time.current)
+    end
+
+    context 'Sorting asc => desc' do
+      it 'sorts successfully' do
+        visit '/tasks'
+        expect(page).to have_content %r{#{@task1.name}[\s\S]*#{@task2.name}}
+        click_link('作成日時で並び替え')
+        expect(page).to have_content %r{#{@task2.name}[\s\S]*#{@task1.name}}
+      end
+    end
+
+    context 'Sorting desc => asc' do
+      it 'sorts successfully' do
+        visit '/tasks?sort_created_at=desc'
+        expect(page).to have_content %r{#{@task2.name}[\s\S]*#{@task1.name}}
+        click_link('作成日時で並び替え')
+        expect(page).to have_content %r{#{@task1.name}[\s\S]*#{@task2.name}}
+      end
+    end
+  end
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it 'renders a successful response' do
+      visit '/tasks'
       expect(page).to have_content 'タスク 一覧'
       expect(page).to have_content 'sample_task'
     end
@@ -93,6 +94,7 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it 'successfully update a task' do
+      visit '/tasks'
       expect(Task.all.length).to eq 1
       click_link('削除')
       expect(page).to have_content 'タスクが正常に削除されました。'
@@ -160,3 +162,4 @@ RSpec.describe 'Tasks', type: :system do
     end
   end
 end
+

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -17,46 +17,37 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'GET /tasks' do
-    before do
-      create(:task, name: 'sample_task')
-      visit '/tasks'
-    end
+    let!(:task) { create(:task) }
 
     it 'renders a successful response' do
+      visit '/tasks'
       expect(page).to have_content 'タスク 一覧'
       expect(page).to have_content 'sample_task'
     end
   end
 
   describe 'GET /tasks/:id' do
-    before do
-      @tasks = create(:task, name: 'sample_task')
-      visit "/tasks/#{@tasks.id}"
-    end
+    let(:task) { create(:task) }
 
     it 'renders a successful response' do
+      visit "/tasks/#{task.id}"
       expect(page).to have_content 'タスク 詳細'
       expect(page).to have_content 'sample_task'
     end
   end
 
   describe 'GET /tasks/new' do
-    before do
-      visit '/tasks/new'
-    end
-
     it 'renders tasks list page' do
+      visit '/tasks/new'
       expect(page).to have_content 'タスク 新規'
     end
   end
 
   describe 'GET /tasks/:id/edit' do
-    before do
-      @tasks = create(:task, name: 'sample_task')
-      visit "/tasks/#{@tasks.id}/edit"
-    end
+    let(:task) { create(:task) }
 
     it 'renders a successful response' do
+      visit "/tasks/#{task.id}/edit"
       expect(page).to have_content 'タスク 編集'
       expect(page).to have_selector 'input[value="sample_task"]'
     end
@@ -80,12 +71,10 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'Updating a task successfully' do
-    before do
-      @tasks = create(:task, name: 'sample_task')
-      visit "/tasks/#{@tasks.id}/edit"
-    end
+    let(:task) { create(:task) }
 
     it 'successfully update a task' do
+      visit "/tasks/#{task.id}/edit"
       fill_in 'task[name]', with: 'hoge_task'
       find('input[type="submit"]').click
       expect(page).to have_content 'タスクが正常に更新されました。'
@@ -96,12 +85,10 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'Deleting a task successfully' do
-    before do
-      create(:task, name: 'sample_task')
-      visit '/tasks'
-    end
+    let!(:task) { create(:task) }
 
     it 'successfully update a task' do
+      visit '/tasks'
       expect(Task.all.length).to eq 1
       click_link('削除')
       expect(page).to have_content 'タスクが正常に削除されました。'
@@ -169,3 +156,4 @@ RSpec.describe 'Tasks', type: :system do
     end
   end
 end
+

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it 'renders a successful response' do
-      visit '/tasks'
       expect(page).to have_content 'タスク 一覧'
       expect(page).to have_content 'sample_task'
     end
@@ -94,7 +93,6 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it 'successfully update a task' do
-      visit '/tasks'
       expect(Task.all.length).to eq 1
       click_link('削除')
       expect(page).to have_content 'タスクが正常に削除されました。'

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -160,4 +160,3 @@ RSpec.describe 'Tasks', type: :system do
     end
   end
 end
-

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'Tasks', type: :system do
 
   describe 'Deleting a task successfully' do
     before do
-      @tasks = create(:task, name: 'sample_task')
+      create(:task, name: 'sample_task')
       visit '/tasks'
     end
 


### PR DESCRIPTION
## Overview
- Completed the `STEP10 Add sorting function by created_at` of the [Rails training](https://github.com/Fablic/training/blob/develop/steps_jp.md)

## What's DONE
 
- Add sorting function by created_at
- Add E2E test cases about sorting

## Supplement

- default
  - ![image](https://user-images.githubusercontent.com/37566073/221737435-18f99036-61e2-4361-aede-89628da64658.png)

- sorted by created_at desc
  - ![image](https://user-images.githubusercontent.com/37566073/221737480-e14c26bc-e1cc-4ec0-b61c-b68277dd6dd8.png)


## Memo
