### PR TITLE
[Yokogawa STEP10] Add sorting function by created_at

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,12 +3,9 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.all
-    @reversed_sort_direction = reversed_sort_direction
-    @sort_key = params[:sort_key]
+    @task_columns_with_sorting_direction = task_columns_with_sorting_direction
 
-    if params[:sort_key].present?
-      @tasks = @tasks.order("#{params[:sort_key]} #{sort_direction}")
-    end
+    @tasks = @tasks.order("#{params[:sort_key]} #{sort_direction}") if params[:sort_key].present?
   end
 
   def new
@@ -68,6 +65,15 @@ class TasksController < ApplicationController
 
   def reversed_sort_direction
     sort_direction == "asc" ? "desc" : "asc"
+  end
+
+  def task_columns_with_sorting_direction
+    Task.column_names.map do |column_name|
+      {
+        name: column_name,
+        sort_direction: params[:sort_key] == column_name ? reversed_sort_direction : "asc",
+      }
+    end
   end
 
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,13 +3,8 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.all
-    @sort_order = 'asc'
-
-    return @tasks = @tasks.order(created_at: :desc) if params[:sort_created_at] == "desc"
-
-    @sort_order = 'desc'
-    return @tasks = @tasks.order(created_at: :asc) if params[:sort_created_at] == "asc"
-
+    @sort_order = reversed_sort_direction
+    @tasks = @tasks.order(created_at: sort_direction.to_sym)
   end
 
   def new
@@ -62,4 +57,13 @@ class TasksController < ApplicationController
   def task_params
     params.require(:task).permit(:name, :description, :deadline_at)
   end
+
+  def sort_direction
+    %w[asc desc].include?(params[:sort_created_at]) ? params[:sort_created_at] : 'asc'
+  end
+
+  def reversed_sort_direction
+    sort_direction == "asc" ? "desc" : "asc"
+  end
+
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -16,11 +16,11 @@ class TasksController < ApplicationController
     @task = Task.new(task_params)
     # TODO: add validation to Task model
     if @task.save
-      flash[:success] = t('flash.task.create.success')
+      flash[:success] = I18n.t('flash.task.create.success')
       return redirect_to @task
     end
 
-    flash[:error] = t('flash.task.create.failure')
+    flash[:error] = I18n.t('flash.task.create.failure')
     render 'new'
   end
 
@@ -32,19 +32,19 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      flash[:success] = t('flash.task.update.success')
+      flash[:success] = I18n.t('flash.task.update.success')
       return redirect_to @task
     end
 
-    flash[:error] = t('flash.task.update.failure')
+    flash[:error] = I18n.t('flash.task.update.failure')
     render 'edit'
   end
 
   def destroy
     if @task.destroy
-      flash[:success] = t('flash.task.delete.success')
+      flash[:success] = I18n.t('flash.task.delete.success')
     else
-      flash[:error] = t('flash.task.delete.failure')
+      flash[:error] = I18n.t('flash.task.delete.failure')
     end
     redirect_to tasks_url
   end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,12 +3,13 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.all
-    @sort_order = 'desc'
+    @sort_order = 'asc'
 
+    return @tasks = @tasks.order(created_at: :desc) if params[:sort_created_at] == "desc"
+
+    @sort_order = 'desc'
     return @tasks = @tasks.order(created_at: :asc) if params[:sort_created_at] == "asc"
 
-    @tasks = @tasks.order(created_at: :desc) if params[:sort_created_at] == "desc"
-    @sort_order = 'asc'
   end
 
   def new

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,8 +3,12 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.all
-    @sort_order = reversed_sort_direction
-    @tasks = @tasks.order(created_at: sort_direction.to_sym)
+    @reversed_sort_direction = reversed_sort_direction
+    @sort_key = params[:sort_key]
+
+    if params[:sort_key].present?
+      @tasks = @tasks.order("#{params[:sort_key]} #{sort_direction}")
+    end
   end
 
   def new
@@ -59,7 +63,7 @@ class TasksController < ApplicationController
   end
 
   def sort_direction
-    %w[asc desc].include?(params[:sort_created_at]) ? params[:sort_created_at] : 'asc'
+    %w[asc desc].include?(params[:sort_direction]) ? params[:sort_direction] : 'asc'
   end
 
   def reversed_sort_direction

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,6 +3,12 @@ class TasksController < ApplicationController
 
   def index
     @tasks = Task.all
+    @sort_order = 'desc'
+
+    return @tasks = @tasks.order(created_at: :asc) if params[:sort_created_at] == "asc"
+
+    @tasks = @tasks.order(created_at: :desc) if params[:sort_created_at] == "desc"
+    @sort_order = 'asc'
   end
 
   def new

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -64,14 +64,14 @@ class TasksController < ApplicationController
   end
 
   def reversed_sort_direction
-    sort_direction == "asc" ? "desc" : "asc"
+    sort_direction == 'asc' ? 'desc' : 'asc'
   end
 
   def task_columns_with_sorting_direction
     Task.column_names.map do |column_name|
       {
         name: column_name,
-        sort_direction: params[:sort_key] == column_name ? reversed_sort_direction : "asc",
+        sort_direction: params[:sort_key] == column_name ? reversed_sort_direction : 'asc',
       }
     end
   end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,11 +1,11 @@
 <%= form_with model: @task do |form| %>
-  <p><%= t(:name, scope: [:activerecord, :attributes, :task]) %></p>
+  <p><%= I18n.t(:name, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.text_field :name %>
-  <p><%= t(:description, scope: [:activerecord, :attributes, :task]) %></p>
+  <p><%= I18n.t(:description, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.text_field :description %>
-  <p><%= t(:deadline_at, scope: [:activerecord, :attributes, :task]) %></p>
+  <p><%= I18n.t(:deadline_at, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.datetime_field :deadline_at %>
 
-  <%= link_to t('action.cancel'), tasks_path, {style: "display: block;"} %>
+  <%= link_to I18n.t('action.cancel'), tasks_path, {style: "display: block;"} %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -1,3 +1,3 @@
-<h1><%= t('activerecord.models.task') %> <%= t('action.edit') %></h1>
+<h1><%= I18n.t('activerecord.models.task') %> <%= I18n.t('action.edit') %></h1>
 
 <%= render partial: "form" %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -6,10 +6,10 @@
 <table>
   <thead>
     <tr>
-      <% Task.column_names.each do |column_name| %>
+      <% @task_columns_with_sorting_direction.each do |column| %>
         <th>
-          <%= link_to t(column_name.to_sym, scope: [:activerecord, :attributes, :task]),
-                tasks_path(sort_key: column_name, sort_direction: @sort_key == column_name ? @reversed_sort_direction : "asc") %>
+          <%= link_to t(column[:name].to_sym, scope: [:activerecord, :attributes, :task]),
+                tasks_path(sort_key: column[:name], sort_direction: column[:sort_direction]) %>
         </th>
       <% end %>
       <th colspan="2"></th>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,7 +1,8 @@
 <h1><%= t('activerecord.models.task') %> <%= t('action.list') %></h1>
 
-<p><%= link_to "日本語", "/tasks" %></p>
-<p><%= link_to "English", "/tasks?locale=en" %></p>
+<p><%= link_to "日本語", tasks_path(locale: 'ja') %></p>
+<p><%= link_to "English", tasks_path(locale: 'en') %></p>
+<p><%= link_to t('sort.created_at'), tasks_path(sort_created_at: @sort_order) %></p>
 
 <table>
   <thead>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -2,13 +2,15 @@
 
 <p><%= link_to "日本語", tasks_path(locale: 'ja') %></p>
 <p><%= link_to "English", tasks_path(locale: 'en') %></p>
-<p><%= link_to t('sort.created_at'), tasks_path(sort_created_at: @sort_order) %></p>
 
 <table>
   <thead>
     <tr>
       <% Task.column_names.each do |column_name| %>
-        <th><%= t(column_name.to_sym, scope: [:activerecord, :attributes, :task]) %></th>
+        <th>
+          <%= link_to t(column_name.to_sym, scope: [:activerecord, :attributes, :task]),
+                tasks_path(sort_key: column_name, sort_direction: @sort_key == column_name ? @reversed_sort_direction : "asc") %>
+        </th>
       <% end %>
       <th colspan="2"></th>
     </tr>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('activerecord.models.task') %> <%= t('action.list') %></h1>
+<h1><%= I18n.t('activerecord.models.task') %> <%= I18n.t('action.list') %></h1>
 
 <p><%= link_to "日本語", tasks_path(locale: 'ja') %></p>
 <p><%= link_to "English", tasks_path(locale: 'en') %></p>
@@ -8,7 +8,7 @@
     <tr>
       <% @task_columns_with_sorting_direction.each do |column| %>
         <th>
-          <%= link_to t(column[:name].to_sym, scope: [:activerecord, :attributes, :task]),
+          <%= link_to I18n.t(column[:name].to_sym, scope: [:activerecord, :attributes, :task]),
                 tasks_path(sort_key: column[:name], sort_direction: column[:sort_direction]) %>
         </th>
       <% end %>
@@ -21,11 +21,11 @@
         <% task.attributes.values.each do |v| %>
           <th><%= v %></th>
         <% end %>
-        <th><%= link_to t('action.edit'), edit_task_path(task) %></th>
-        <th><%= link_to t('action.delete'), task_path(task), data: { turbo_method: :delete } %></th>
+        <th><%= link_to I18n.t('action.edit'), edit_task_path(task) %></th>
+        <th><%= link_to I18n.t('action.delete'), task_path(task), data: { turbo_method: :delete } %></th>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%= link_to t('action.add'), new_task_path %>
+<%= link_to I18n.t('action.add'), new_task_path %>

--- a/myapp/app/views/tasks/new.html.erb
+++ b/myapp/app/views/tasks/new.html.erb
@@ -1,3 +1,3 @@
-<h1><%= t('activerecord.models.task') %> <%= t('action.new') %></h1>
+<h1><%= I18n.t('activerecord.models.task') %> <%= I18n.t('action.new') %></h1>
 
 <%= render partial: "form" %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,10 +1,10 @@
-<h1><%= t('activerecord.models.task') %> <%= t('action.show') %></h1>
+<h1><%= I18n.t('activerecord.models.task') %> <%= I18n.t('action.show') %></h1>
 
 <table>
   <thead>
     <tr>
       <% Task.column_names.each do |column_name| %>
-        <th><%= t(column_name.to_sym, scope: [:activerecord, :attributes, :task]) %></th>
+        <th><%= I18n.t(column_name.to_sym, scope: [:activerecord, :attributes, :task]) %></th>
       <% end %>
     </tr>
   </thead>
@@ -17,4 +17,4 @@
   </tbody>
 </table>
 
-<%= link_to t('action.list'), tasks_path, {style: "display: block;"} %>
+<%= link_to I18n.t('action.list'), tasks_path, {style: "display: block;"} %>

--- a/myapp/config/locales/views/tasks/en.yml
+++ b/myapp/config/locales/views/tasks/en.yml
@@ -10,6 +10,9 @@ en:
     add: 'add'
     show: 'show'
 
+  sort:
+    created_at: 'Sort by created_at'
+
   flash:
     task:
       create:

--- a/myapp/config/locales/views/tasks/ja.yml
+++ b/myapp/config/locales/views/tasks/ja.yml
@@ -10,6 +10,9 @@ ja:
     add: '追加'
     show: '詳細'
 
+  sort:
+    created_at: '作成日時で並び替え'
+
   flash:
     task:
       create:

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -136,26 +136,24 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'Sorting by created_at' do
-    before do
-      @task1 = create(:task, name: 'hoge_task', created_at: Time.current.yesterday)
-      @task2 = create(:task, name: 'fuga_task', created_at: Time.current)
-    end
+    let!(:task1) { create(:task, name: 'hoge_task', created_at: Time.current.yesterday) }
+    let!(:task2) { create(:task, name: 'fuga_task', created_at: Time.current) }
 
     context 'Sorting asc => desc' do
       it 'sorts successfully' do
         visit '/tasks?sort_direction=asc&sort_key=created_at'
-        expect(page).to have_content %r{#{@task1.name}[\s\S]*#{@task2.name}}
+        expect(page).to have_content %r{#{task1.name}[\s\S]*#{task2.name}}
         click_link('作成日時')
-        expect(page).to have_content %r{#{@task2.name}[\s\S]*#{@task1.name}}
+        expect(page).to have_content %r{#{task2.name}[\s\S]*#{task1.name}}
       end
     end
 
     context 'Sorting desc => asc' do
       it 'sorts successfully' do
         visit '/tasks?sort_direction=desc&sort_key=created_at'
-        expect(page).to have_content %r{#{@task2.name}[\s\S]*#{@task1.name}}
+        expect(page).to have_content %r{#{task2.name}[\s\S]*#{task1.name}}
         click_link('作成日時')
-        expect(page).to have_content %r{#{@task1.name}[\s\S]*#{@task2.name}}
+        expect(page).to have_content %r{#{task1.name}[\s\S]*#{task2.name}}
       end
     end
   end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -134,4 +134,29 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
   end
+
+  describe 'Sorting by created_at' do
+    before do
+      @task1 = create(:task, name: 'hoge_task', created_at: Time.current.yesterday)
+      @task2 = create(:task, name: 'fuga_task', created_at: Time.current)
+    end
+
+    context 'Sorting asc => desc' do
+      it 'sorts successfully' do
+        visit '/tasks'
+        expect(page).to have_content %r{#{@task1.name}[\s\S]*#{@task2.name}}
+        click_link('作成日時で並び替え')
+        expect(page).to have_content %r{#{@task2.name}[\s\S]*#{@task1.name}}
+      end
+    end
+
+    context 'Sorting desc => asc' do
+      it 'sorts successfully' do
+        visit '/tasks?sort_created_at=desc'
+        expect(page).to have_content %r{#{@task2.name}[\s\S]*#{@task1.name}}
+        click_link('作成日時で並び替え')
+        expect(page).to have_content %r{#{@task1.name}[\s\S]*#{@task2.name}}
+      end
+    end
+  end
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -143,18 +143,18 @@ RSpec.describe 'Tasks', type: :system do
 
     context 'Sorting asc => desc' do
       it 'sorts successfully' do
-        visit '/tasks'
+        visit '/tasks?sort_direction=asc&sort_key=created_at'
         expect(page).to have_content %r{#{@task1.name}[\s\S]*#{@task2.name}}
-        click_link('作成日時で並び替え')
+        click_link('作成日時')
         expect(page).to have_content %r{#{@task2.name}[\s\S]*#{@task1.name}}
       end
     end
 
     context 'Sorting desc => asc' do
       it 'sorts successfully' do
-        visit '/tasks?sort_created_at=desc'
+        visit '/tasks?sort_direction=desc&sort_key=created_at'
         expect(page).to have_content %r{#{@task2.name}[\s\S]*#{@task1.name}}
-        click_link('作成日時で並び替え')
+        click_link('作成日時')
         expect(page).to have_content %r{#{@task1.name}[\s\S]*#{@task2.name}}
       end
     end


### PR DESCRIPTION
## Overview
- Completed the `STEP10 Add sorting function by created_at` of the [Rails training](https://github.com/Fablic/training/blob/develop/steps_jp.md)

## What's DONE
 
- Add sorting function by created_at
- Add E2E test cases about sorting

## Supplement

- default
  - ![image](https://user-images.githubusercontent.com/37566073/221737435-18f99036-61e2-4361-aede-89628da64658.png)

- sorted by created_at desc
  - ![image](https://user-images.githubusercontent.com/37566073/221737480-e14c26bc-e1cc-4ec0-b61c-b68277dd6dd8.png)


## Memo
