### PR TITLE
[Yokogawa STEP11] Add validation of Task model and others

### DIFF
--- a/myapp/.rubocop.yml
+++ b/myapp/.rubocop.yml
@@ -9,10 +9,11 @@ inherit_gem:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# bin 配下は自動生成されたコードたちなので無視する
+# rails が自動生成したコードたちなので無視する
 AllCops:
   Exclude:
     - "bin/*"
+    - "db/schema.rb"
 
 # 研修用の repogitory なので、アプリケーションが大きくならない想定なので、top-level documentation comment は不要そう
 Documentation:

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -14,14 +14,13 @@ class TasksController < ApplicationController
 
   def create
     @task = Task.new(task_params)
-    # TODO: add validation to Task model
     if @task.save
       flash[:success] = I18n.t('flash.task.create.success')
       return redirect_to @task
     end
 
     flash[:error] = I18n.t('flash.task.create.failure')
-    render 'new'
+    render 'new', status: :unprocessable_entity
   end
 
   def show
@@ -37,7 +36,7 @@ class TasksController < ApplicationController
     end
 
     flash[:error] = I18n.t('flash.task.update.failure')
-    render 'edit'
+    render 'edit', status: :unprocessable_entity
   end
 
   def destroy

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -68,10 +68,11 @@ class TasksController < ApplicationController
 
   def task_columns_with_sorting_direction
     Task.column_names.map do |column_name|
+      next if column_name == 'description'
       {
         name: column_name,
         sort_direction: params[:sort_key] == column_name ? reversed_sort_direction : 'asc',
       }
-    end
+    end.compact
   end
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -74,5 +74,4 @@ class TasksController < ApplicationController
       }
     end
   end
-
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,3 +1,6 @@
 class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
+  # description はDB上は65,535文字まで許容できるが、区切りよく決めで上限を設定する。
+  # DBにアクセスしてエラーを吐くまでにモデルでバリデーションが働くようにしたい意図。
+  validates :description, length: { maximum: 5000 }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,2 +1,3 @@
 class Task < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 255 }
 end

--- a/myapp/app/views/shared/_error_messages.html.erb
+++ b/myapp/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div>
+    <ul>
+      <% model.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -4,10 +4,10 @@
   <p><%= I18n.t(:name, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.text_field :name %>
   <p><%= I18n.t(:description, scope: [:activerecord, :attributes, :task]) %></p>
-  <%= form.text_field :description %>
+  <%= form.text_area :description %>
   <p><%= I18n.t(:deadline_at, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.datetime_field :deadline_at %>
 
-  <%= link_to I18n.t('action.cancel'), tasks_path, {style: "display: block;"} %>
+  <%= link_to I18n.t('action.back'), :back, {style: "display: block;"} %>
   <%= form.submit %>
 <% end %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_with model: @task do |form| %>
+  <%= render partial: "shared/error_messages", locals: { model: @task } %>
+
   <p><%= I18n.t(:name, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.text_field :name %>
   <p><%= I18n.t(:description, scope: [:activerecord, :attributes, :task]) %></p>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -12,15 +12,16 @@
                 tasks_path(sort_key: column[:name], sort_direction: column[:sort_direction]) %>
         </th>
       <% end %>
-      <th colspan="2"></th>
+      <th colspan="3"></th>
     </tr>
   </thead>
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
-        <% task.attributes.values.each do |v| %>
+        <% task.attributes.except("description").values.each do |v| %>
           <th><%= v %></th>
         <% end %>
+        <th><%= link_to I18n.t('action.show'), task_path(task) %></th>
         <th><%= link_to I18n.t('action.edit'), edit_task_path(task) %></th>
         <th><%= link_to I18n.t('action.delete'), task_path(task), data: { turbo_method: :delete } %></th>
       </tr>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -18,3 +18,4 @@
 </table>
 
 <%= link_to I18n.t('action.list'), tasks_path, {style: "display: block;"} %>
+<%= link_to I18n.t('action.edit'), edit_task_path(@task), {style: "display: block;"} %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,21 +1,15 @@
 <h1><%= I18n.t('activerecord.models.task') %> <%= I18n.t('action.show') %></h1>
 
 <table>
-  <thead>
-    <tr>
-      <% Task.column_names.each do |column_name| %>
-        <th><%= I18n.t(column_name.to_sym, scope: [:activerecord, :attributes, :task]) %></th>
-      <% end %>
-    </tr>
-  </thead>
   <tbody>
-    <tr>
-      <% @task.attributes.values.each do |v| %>
-        <th><%= v %></th>
-      <% end %>
-    </tr>
+    <% Task.column_names.each do |column_name| %>
+      <tr>
+        <th><%= I18n.t(column_name.to_sym, scope: [:activerecord, :attributes, :task]) %></th>
+        <td><%= @task.send(column_name) %></td>
+      </tr>
+    <% end %>
   </tbody>
 </table>
 
-<%= link_to I18n.t('action.list'), tasks_path, {style: "display: block;"} %>
-<%= link_to I18n.t('action.edit'), edit_task_path(@task), {style: "display: block;"} %>
+<%= link_to I18n.t('action.list'), tasks_path %>
+<%= link_to I18n.t('action.edit'), edit_task_path(@task) %>

--- a/myapp/config/locales/views/tasks/en.yml
+++ b/myapp/config/locales/views/tasks/en.yml
@@ -9,6 +9,7 @@ en:
     new: 'new'
     add: 'add'
     show: 'show'
+    back: 'back'
 
   sort:
     created_at: 'Sort by created_at'

--- a/myapp/config/locales/views/tasks/ja.yml
+++ b/myapp/config/locales/views/tasks/ja.yml
@@ -9,6 +9,7 @@ ja:
     new: '新規'
     add: '追加'
     show: '詳細'
+    back: '戻る'
 
   sort:
     created_at: '作成日時で並び替え'

--- a/myapp/db/migrate/20230302002602_change_tasks_description_string_to_text_of.rb
+++ b/myapp/db/migrate/20230302002602_change_tasks_description_string_to_text_of.rb
@@ -1,0 +1,13 @@
+class ChangeTasksDescriptionStringToTextOf < ActiveRecord::Migration[7.0]
+  def up
+    change_table :tasks do |t|
+      t.change :description, :text
+    end
+  end
+
+  def down
+    change_table :tasks do |t|
+      t.change :description, :string
+    end
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_16_073750) do
-  create_table 'tasks', charset: 'utf8mb4', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'description'
-    t.datetime 'deadline_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_002602) do
+  create_table "tasks", charset: "utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "deadline_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :model do
-  describe 'validation' do
+  describe 'normal case' do
     context 'all valid parameters' do
       let(:task) {
         Task.new(name: 'sample_task',
@@ -14,58 +14,62 @@ RSpec.describe 'Task', type: :model do
         expect(task.errors.count).to eq 0
       end
     end
+  end
 
-    context 'invalid name, length is 0' do
-      let(:task) {
-        Task.new(name: '',
-                 description: 'hoge fuga',
-                 deadline_at: '2023-01-01T00:00')
-      }
+  describe 'validation' do
+    describe 'name' do
+      context 'length is 0' do
+        let(:task) {
+          Task.new(name: '',
+                  description: 'hoge fuga',
+                  deadline_at: '2023-01-01T00:00')
+        }
 
-      it 'has name validation error' do
-        task.valid?
-        expect(task.errors.count).to eq 1
-        expect(task.errors[:name].present?).to be true
+        it 'has name validation error' do
+          task.valid?
+          expect(task.errors.count).to eq 1
+          expect(task.errors[:name].present?).to be true
+        end
       end
-    end
 
-    context 'invalid name, length is 1' do
-      let(:task) {
-        Task.new(name: 'a',
-                 description: 'hoge fuga',
-                 deadline_at: '2023-01-01T00:00')
-      }
+      context 'length is 1' do
+        let(:task) {
+          Task.new(name: 'a',
+                  description: 'hoge fuga',
+                  deadline_at: '2023-01-01T00:00')
+        }
 
-      it 'has no error' do
-        task.valid?
-        expect(task.errors.count).to eq 0
+        it 'has no error' do
+          task.valid?
+          expect(task.errors.count).to eq 0
+        end
       end
-    end
 
-    context 'invalid name, length is 255' do
-      let(:task) {
-        Task.new(name: 'a' * 255,
-                 description: 'hoge fuga',
-                 deadline_at: '2023-01-01T00:00')
-      }
+      context 'length is 255' do
+        let(:task) {
+          Task.new(name: 'a' * 255,
+                  description: 'hoge fuga',
+                  deadline_at: '2023-01-01T00:00')
+        }
 
-      it 'has no error' do
-        task.valid?
-        expect(task.errors.count).to eq 0
+        it 'has no error' do
+          task.valid?
+          expect(task.errors.count).to eq 0
+        end
       end
-    end
 
-    context 'invalid name, over length limit' do
-      let(:task) {
-        Task.new(name: 'a' * 256,
-                 description: 'hoge fuga',
-                 deadline_at: '2023-01-01T00:00')
-      }
+      context 'length is 256' do
+        let(:task) {
+          Task.new(name: 'a' * 256,
+                  description: 'hoge fuga',
+                  deadline_at: '2023-01-01T00:00')
+        }
 
-      it 'has name validation error' do
-        task.valid?
-        expect(task.errors.count).to eq 1
-        expect(task.errors[:name].present?).to be true
+        it 'has name validation error' do
+          task.valid?
+          expect(task.errors.count).to eq 1
+          expect(task.errors[:name].present?).to be true
+        end
       end
     end
   end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Task', type: :model do
+
+  describe "validation" do
+    context "[Normal] valid parameters" do
+      let(:task) { Task.new(name: 'sample_task',
+        description: 'hoge fuga',
+        deadline_at: '2023-01-01T00:00')}
+
+      it "behaves like" do
+        task.valid?
+        expect(task.errors.count).to eq 0
+      end
+    end
+
+    context "[Exceptional] invalid name" do
+      let(:task) { Task.new(name: '',
+                            description: 'hoge fuga',
+                            deadline_at: '2023-01-01T00:00')}
+
+      it "behaves like" do
+        task.valid?
+        expect(task.errors.count).to eq 1
+        expect(task.errors[:name].present?).to eq true
+      end
+    end
+  end
+
+end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,64 +1,72 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :model do
+  describe 'validation' do
+    context 'all valid parameters' do
+      let(:task) {
+        Task.new(name: 'sample_task',
+                 description: 'hoge fuga',
+                 deadline_at: '2023-01-01T00:00')
+      }
 
-  describe "validation" do
-    context "all valid parameters" do
-      let(:task) { Task.new(name: 'sample_task',
-        description: 'hoge fuga',
-        deadline_at: '2023-01-01T00:00')}
-
-      it "has no error" do
+      it 'has no error' do
         task.valid?
         expect(task.errors.count).to eq 0
       end
     end
 
-    context "invalid name, length is 0" do
-      let(:task) { Task.new(name: '',
-                            description: 'hoge fuga',
-                            deadline_at: '2023-01-01T00:00')}
+    context 'invalid name, length is 0' do
+      let(:task) {
+        Task.new(name: '',
+                 description: 'hoge fuga',
+                 deadline_at: '2023-01-01T00:00')
+      }
 
-      it "has name validation error" do
+      it 'has name validation error' do
         task.valid?
         expect(task.errors.count).to eq 1
-        expect(task.errors[:name].present?).to eq true
+        expect(task.errors[:name].present?).to be true
       end
     end
 
-    context "invalid name, length is 1" do
-      let(:task) { Task.new(name: 'a',
-                            description: 'hoge fuga',
-                            deadline_at: '2023-01-01T00:00')}
+    context 'invalid name, length is 1' do
+      let(:task) {
+        Task.new(name: 'a',
+                 description: 'hoge fuga',
+                 deadline_at: '2023-01-01T00:00')
+      }
 
-      it "has no error" do
+      it 'has no error' do
         task.valid?
         expect(task.errors.count).to eq 0
       end
     end
 
-    context "invalid name, length is 255" do
-      let(:task) { Task.new(name: 'a'*255,
-                            description: 'hoge fuga',
-                            deadline_at: '2023-01-01T00:00')}
+    context 'invalid name, length is 255' do
+      let(:task) {
+        Task.new(name: 'a' * 255,
+                 description: 'hoge fuga',
+                 deadline_at: '2023-01-01T00:00')
+      }
 
-      it "has no error" do
+      it 'has no error' do
         task.valid?
         expect(task.errors.count).to eq 0
       end
     end
 
-    context "invalid name, over length limit" do
-      let(:task) { Task.new(name: 'a'*256,
-                            description: 'hoge fuga',
-                            deadline_at: '2023-01-01T00:00')}
+    context 'invalid name, over length limit' do
+      let(:task) {
+        Task.new(name: 'a' * 256,
+                 description: 'hoge fuga',
+                 deadline_at: '2023-01-01T00:00')
+      }
 
-      it "has name validation error" do
+      it 'has name validation error' do
         task.valid?
         expect(task.errors.count).to eq 1
-        expect(task.errors[:name].present?).to eq true
+        expect(task.errors[:name].present?).to be true
       end
     end
   end
-
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -3,23 +3,57 @@ require 'rails_helper'
 RSpec.describe 'Task', type: :model do
 
   describe "validation" do
-    context "[Normal] valid parameters" do
+    context "all valid parameters" do
       let(:task) { Task.new(name: 'sample_task',
         description: 'hoge fuga',
         deadline_at: '2023-01-01T00:00')}
 
-      it "behaves like" do
+      it "has no error" do
         task.valid?
         expect(task.errors.count).to eq 0
       end
     end
 
-    context "[Exceptional] invalid name" do
+    context "invalid name, length is 0" do
       let(:task) { Task.new(name: '',
                             description: 'hoge fuga',
                             deadline_at: '2023-01-01T00:00')}
 
-      it "behaves like" do
+      it "has name validation error" do
+        task.valid?
+        expect(task.errors.count).to eq 1
+        expect(task.errors[:name].present?).to eq true
+      end
+    end
+
+    context "invalid name, length is 1" do
+      let(:task) { Task.new(name: 'a',
+                            description: 'hoge fuga',
+                            deadline_at: '2023-01-01T00:00')}
+
+      it "has no error" do
+        task.valid?
+        expect(task.errors.count).to eq 0
+      end
+    end
+
+    context "invalid name, length is 255" do
+      let(:task) { Task.new(name: 'a'*255,
+                            description: 'hoge fuga',
+                            deadline_at: '2023-01-01T00:00')}
+
+      it "has no error" do
+        task.valid?
+        expect(task.errors.count).to eq 0
+      end
+    end
+
+    context "invalid name, over length limit" do
+      let(:task) { Task.new(name: 'a'*256,
+                            description: 'hoge fuga',
+                            deadline_at: '2023-01-01T00:00')}
+
+      it "has name validation error" do
         task.valid?
         expect(task.errors.count).to eq 1
         expect(task.errors[:name].present?).to eq true

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Task', type: :model do
                   deadline_at: '2023-01-01T00:00')
         }
 
-        it 'has name validation error' do
+        it 'has validation error' do
           task.valid?
           expect(task.errors.count).to eq 1
           expect(task.errors[:name].present?).to be true
@@ -65,10 +65,52 @@ RSpec.describe 'Task', type: :model do
                   deadline_at: '2023-01-01T00:00')
         }
 
-        it 'has name validation error' do
+        it 'has validation error' do
           task.valid?
           expect(task.errors.count).to eq 1
           expect(task.errors[:name].present?).to be true
+        end
+      end
+    end
+
+    describe 'description' do
+      context 'length is 0' do
+        let(:task) {
+          Task.new(name: 'sample_task',
+                  description: '',
+                  deadline_at: '2023-01-01T00:00')
+        }
+
+        it 'has no error' do
+          task.valid?
+          expect(task.errors.count).to eq 0
+        end
+      end
+
+      context 'length is 5000' do
+        let(:task) {
+          Task.new(name: 'sample_task',
+                  description: 'a'*5000,
+                  deadline_at: '2023-01-01T00:00')
+        }
+
+        it 'has no error' do
+          task.valid?
+          expect(task.errors.count).to eq 0
+        end
+      end
+
+      context 'length is 5001' do
+        let(:task) {
+          Task.new(name: 'sample_task',
+                  description: 'a'*5001,
+                  deadline_at: '2023-01-01T00:00')
+        }
+
+        it 'has validation error' do
+          task.valid?
+          expect(task.errors.count).to eq 1
+          expect(task.errors[:description].present?).to be true
         end
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -142,18 +142,18 @@ RSpec.describe 'Tasks', type: :system do
     context 'Sorting asc => desc' do
       it 'sorts successfully' do
         visit '/tasks?sort_direction=asc&sort_key=created_at'
-        expect(page).to have_content %r{#{task1.name}[\s\S]*#{task2.name}}
+        expect(page).to have_content(/#{task1.name}[\s\S]*#{task2.name}/)
         click_link('作成日時')
-        expect(page).to have_content %r{#{task2.name}[\s\S]*#{task1.name}}
+        expect(page).to have_content(/#{task2.name}[\s\S]*#{task1.name}/)
       end
     end
 
     context 'Sorting desc => asc' do
       it 'sorts successfully' do
         visit '/tasks?sort_direction=desc&sort_key=created_at'
-        expect(page).to have_content %r{#{task2.name}[\s\S]*#{task1.name}}
+        expect(page).to have_content(/#{task2.name}[\s\S]*#{task1.name}/)
         click_link('作成日時')
-        expect(page).to have_content %r{#{task1.name}[\s\S]*#{task2.name}}
+        expect(page).to have_content(/#{task1.name}[\s\S]*#{task2.name}/)
       end
     end
   end


### PR DESCRIPTION
## Overview
- Completed the `STEP11 Add validation` of the [Rails training](https://github.com/Fablic/training/blob/develop/steps_jp.md)

## What's DONE
 
- Added validation of Task model
- Changed description column data type to text from string
  - so that user can enter long sentences for descriptions 
- Hid description of tasks in task list page
  - becauce the list page layout is off if some tasks's description are long
- Changed show page design

## Supplement

- Hide description of tasks in task list page

|  before  |  after  |
| ---- | ---- |
|  <img width="1376" alt="image" src="https://user-images.githubusercontent.com/37566073/222323472-5f37fde0-4fa6-446a-9c5e-1d753ac8b40d.png">  |  <img width="834" alt="image" src="https://user-images.githubusercontent.com/37566073/222323399-323b7ffb-b522-46b5-940a-15d54c15b240.png"> |

- Change show page design

|  before  |  after  |
| ---- | ---- |
| <img width="1236" alt="image" src="https://user-images.githubusercontent.com/37566073/222323620-ed5f6ba7-7bb7-4f71-960d-e5b6cbb6c3ec.png"> | <img width="715" alt="image" src="https://user-images.githubusercontent.com/37566073/222323657-db4d4a17-f507-4f36-a849-743729db3774.png">|


## Memo
