### PR TITLE
[Yokogawa In the middle of STEP13] Added status to Task Model

### DIFF
--- a/myapp/.rubocop.yml
+++ b/myapp/.rubocop.yml
@@ -23,3 +23,8 @@ Documentation:
 # see: https://docs.rubocop.org/rubocop/cops_naming.html
 Naming/BlockForwarding:
   EnforcedStyle: explicit
+
+# hash の key と value の変数名が同じ場合、value の変数名を省略するのが default になったらしいが、慣れないので OFF にする。
+# see: https://koic.hatenablog.com/entry/rubocop-supports-ruby-3-1-syntax
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never

--- a/myapp/.rubocop.yml
+++ b/myapp/.rubocop.yml
@@ -28,3 +28,9 @@ Naming/BlockForwarding:
 # see: https://koic.hatenablog.com/entry/rubocop-supports-ruby-3-1-syntax
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
+
+RSpec/NestedGroups:
+  Max: 4
+
+RSpec/MultipleExpectations:
+  Max: 6

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -69,6 +69,7 @@ class TasksController < ApplicationController
   def task_columns_with_sorting_direction
     Task.column_names.map do |column_name|
       next if column_name == 'description'
+
       {
         name: column_name,
         sort_direction: params[:sort_key] == column_name ? reversed_sort_direction : 'asc',

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -55,7 +55,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:name, :description, :deadline_at)
+    params.require(:task).permit(:name, :description, :status, :deadline_at)
   end
 
   def sort_direction

--- a/myapp/app/helpers/task_helper.rb
+++ b/myapp/app/helpers/task_helper.rb
@@ -1,10 +1,11 @@
 module TaskHelper
   def options_for_select_of_statuses
-    Task.statuses.map{|i| [I18n.t(i[0], scope: [:activerecord, :attributes, :task, :statuses]), i[1]]}
+    Task.statuses.map { |i| [I18n.t(i[0], scope: [:activerecord, :attributes, :task, :statuses]), i[1]] }
   end
 
   def value_with_i18n(task, column_name)
     return I18n.t(task.status, scope: [:activerecord, :enums, :task, :status]) if column_name == 'status'
+
     task.send(column_name)
   end
 end

--- a/myapp/app/helpers/task_helper.rb
+++ b/myapp/app/helpers/task_helper.rb
@@ -1,6 +1,6 @@
 module TaskHelper
   def options_for_select_of_statuses
-    Task.statuses.map { |i| [I18n.t(i[0], scope: [:activerecord, :attributes, :task, :statuses]), i[1]] }
+    Task.statuses.map { |i| [I18n.t(i[0], scope: [:activerecord, :enums, :task, :status]), i[1]] }
   end
 
   def value_with_i18n(task, column_name)

--- a/myapp/app/helpers/task_helper.rb
+++ b/myapp/app/helpers/task_helper.rb
@@ -2,4 +2,9 @@ module TaskHelper
   def options_for_select_of_statuses
     Task.statuses.map{|i| [I18n.t(i[0], scope: [:activerecord, :attributes, :task, :statuses]), i[1]]}
   end
+
+  def value_with_i18n(task, column_name)
+    return I18n.t(task.status, scope: [:activerecord, :enums, :task, :status]) if column_name == 'status'
+    task.send(column_name)
+  end
 end

--- a/myapp/app/helpers/task_helper.rb
+++ b/myapp/app/helpers/task_helper.rb
@@ -1,0 +1,5 @@
+module TaskHelper
+  def options_for_select_of_statuses
+    Task.statuses.map{|i| [I18n.t(i[0], scope: [:activerecord, :attributes, :task, :statuses]), i[1]]}
+  end
+end

--- a/myapp/app/helpers/task_helper.rb
+++ b/myapp/app/helpers/task_helper.rb
@@ -1,6 +1,6 @@
 module TaskHelper
   def options_for_select_of_statuses
-    Task.statuses.map { |i| [I18n.t(i[0], scope: [:activerecord, :enums, :task, :status]), i[1]] }
+    Task.statuses.keys.map { |status| [I18n.t(status, scope: [:activerecord, :enums, :task, :status]), status] }
   end
 
   def value_with_i18n(task, column_name)

--- a/myapp/app/helpers/tasks_helper.rb
+++ b/myapp/app/helpers/tasks_helper.rb
@@ -1,4 +1,4 @@
-module TaskHelper
+module TasksHelper
   def options_for_select_of_statuses
     Task.statuses.keys.map { |status| [I18n.t(status, scope: [:activerecord, :enums, :task, :status]), status] }
   end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -4,5 +4,5 @@ class Task < ApplicationRecord
   # DBにアクセスしてエラーを吐くまでにモデルでバリデーションが働くようにしたい意図。
   validates :description, length: { maximum: 5000 }
 
-  enum status: { unstarted: 0, wip: 1, done: 2}
+  enum status: { unstarted: 0, wip: 1, done: 2 }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -3,4 +3,6 @@ class Task < ApplicationRecord
   # description はDB上は65,535文字まで許容できるが、区切りよく決めで上限を設定する。
   # DBにアクセスしてエラーを吐くまでにモデルでバリデーションが働くようにしたい意図。
   validates :description, length: { maximum: 5000 }
+
+  enum status: { unstarted: 0, wip: 1, done: 2}
 end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -5,6 +5,8 @@
   <%= form.text_field :name %>
   <p><%= I18n.t(:description, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.text_area :description %>
+  <p><%= I18n.t(:status, scope: [:activerecord, :attributes, :task]) %></p>
+  <%= form.select :status, options_for_select_of_statuses %>
   <p><%= I18n.t(:deadline_at, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.datetime_field :deadline_at %>
 

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -6,7 +6,7 @@
   <p><%= I18n.t(:description, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.text_area :description %>
   <p><%= I18n.t(:status, scope: [:activerecord, :attributes, :task]) %></p>
-  <%= form.select :status, options_for_select_of_statuses %>
+  <%= form.select :status, options_for_select_of_statuses, {selected: @task.status} %>
   <p><%= I18n.t(:deadline_at, scope: [:activerecord, :attributes, :task]) %></p>
   <%= form.datetime_field :deadline_at %>
 

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -18,9 +18,12 @@
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
-        <% task.attributes.except("description").values.each do |v| %>
-          <th><%= v %></th>
-        <% end %>
+        <th><%= task.id %></th>
+        <th><%= task.name %></th>
+        <th><%= I18n.t(task.status, scope: [:activerecord, :enums, :task, :status]) %></th>
+        <th><%= task.deadline_at %></th>
+        <th><%= task.created_at %></th>
+        <th><%= task.updated_at %></th>
         <th><%= link_to I18n.t('action.show'), task_path(task) %></th>
         <th><%= link_to I18n.t('action.edit'), edit_task_path(task) %></th>
         <th><%= link_to I18n.t('action.delete'), task_path(task), data: { turbo_method: :delete } %></th>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -5,7 +5,7 @@
     <% Task.column_names.each do |column_name| %>
       <tr>
         <th><%= I18n.t(column_name.to_sym, scope: [:activerecord, :attributes, :task]) %></th>
-        <td><%= @task.send(column_name) %></td>
+        <td><%= value_with_i18n(@task, column_name) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/myapp/config/application.rb
+++ b/myapp/config/application.rb
@@ -22,6 +22,6 @@ module Myapp
 
     config.i18n.available_locales = [:en, :ja]
     config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb, yml}')]
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb, yml}')]
   end
 end

--- a/myapp/config/locales/models/task/en.yml
+++ b/myapp/config/locales/models/task/en.yml
@@ -7,6 +7,13 @@ en:
         id: 'id'
         name: 'name'
         description: 'description'
+        status: 'status'
         deadline_at: 'deadline_at'
         created_at: 'created_at'
         updated_at: 'updated_at'
+    enums:
+      task:
+        status:
+          unstarted: 'unstarted'
+          wip: 'wip'
+          done: 'done'

--- a/myapp/config/locales/models/task/ja.yml
+++ b/myapp/config/locales/models/task/ja.yml
@@ -7,6 +7,13 @@ ja:
         id: 'id'
         name: '名前'
         description: '詳細'
+        status: 'ステータス'
         deadline_at: '締め切り日時'
         created_at: '作成日時'
         updated_at: '更新日時'
+    enums:
+      task:
+        status:
+          unstarted: '開始前'
+          wip: '着手中'
+          done: '完了'

--- a/myapp/db/migrate/20230302043513_add_status_to_tasks.rb
+++ b/myapp/db/migrate/20230302043513_add_status_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStatusToTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tasks, :status, :integer, null: false, default: 0, after: :description
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,12 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_002602) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_043513) do
   create_table "tasks", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
+    t.integer "status", default: 0, null: false
     t.datetime "deadline_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
 end

--- a/myapp/spec/helpers/tasks_helper_spec.rb
+++ b/myapp/spec/helpers/tasks_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe TasksHelper, type: :helper do
+  describe 'options_for_select_of_statuses' do
+    it 'returns expectedly' do
+      expect(helper.options_for_select_of_statuses).to eq([["開始前", "unstarted"], ["着手中", "wip"], ["完了", "done"]])
+    end
+  end
+
+  describe 'value_with_i18n' do
+    let(:task) { create(:task, name: 'hoge_task', status: 'done') }
+
+    context 'attributes except for status' do
+      it 'returns as it is' do
+        expect(helper.value_with_i18n(task, 'name')).to eq('hoge_task')
+      end
+    end
+
+    context 'status attribute' do
+      it 'returns converted value by i18n' do
+        expect(helper.value_with_i18n(task, 'status')).to eq('完了')
+      end
+    end
+
+  end
+end

--- a/myapp/spec/helpers/tasks_helper_spec.rb
+++ b/myapp/spec/helpers/tasks_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe TasksHelper, type: :helper do
   describe 'options_for_select_of_statuses' do
     it 'returns expectedly' do
-      expect(helper.options_for_select_of_statuses).to eq([["開始前", "unstarted"], ["着手中", "wip"], ["完了", "done"]])
+      expect(helper.options_for_select_of_statuses).to eq([['開始前', 'unstarted'], ['着手中', 'wip'], ['完了', 'done']])
     end
   end
 
@@ -21,6 +21,5 @@ RSpec.describe TasksHelper, type: :helper do
         expect(helper.value_with_i18n(task, 'status')).to eq('完了')
       end
     end
-
   end
 end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Task', type: :model do
       let(:task) {
         Task.new(name: 'sample_task',
                  description: 'hoge fuga',
+                 status: 'unstarted',
                  deadline_at: '2023-01-01T00:00')
       }
 
@@ -22,6 +23,7 @@ RSpec.describe 'Task', type: :model do
         let(:task) {
           Task.new(name: '',
                   description: 'hoge fuga',
+                  status: 'unstarted',
                   deadline_at: '2023-01-01T00:00')
         }
 
@@ -36,6 +38,7 @@ RSpec.describe 'Task', type: :model do
         let(:task) {
           Task.new(name: 'a',
                   description: 'hoge fuga',
+                  status: 'unstarted',
                   deadline_at: '2023-01-01T00:00')
         }
 
@@ -49,6 +52,7 @@ RSpec.describe 'Task', type: :model do
         let(:task) {
           Task.new(name: 'a' * 255,
                   description: 'hoge fuga',
+                  status: 'unstarted',
                   deadline_at: '2023-01-01T00:00')
         }
 
@@ -62,6 +66,7 @@ RSpec.describe 'Task', type: :model do
         let(:task) {
           Task.new(name: 'a' * 256,
                   description: 'hoge fuga',
+                  status: 'unstarted',
                   deadline_at: '2023-01-01T00:00')
         }
 
@@ -78,6 +83,7 @@ RSpec.describe 'Task', type: :model do
         let(:task) {
           Task.new(name: 'sample_task',
                   description: '',
+                  status: 'unstarted',
                   deadline_at: '2023-01-01T00:00')
         }
 
@@ -91,6 +97,7 @@ RSpec.describe 'Task', type: :model do
         let(:task) {
           Task.new(name: 'sample_task',
                   description: 'a'*5000,
+                  status: 'unstarted',
                   deadline_at: '2023-01-01T00:00')
         }
 
@@ -104,6 +111,7 @@ RSpec.describe 'Task', type: :model do
         let(:task) {
           Task.new(name: 'sample_task',
                   description: 'a'*5001,
+                  status: 'unstarted',
                   deadline_at: '2023-01-01T00:00')
         }
 

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe 'Task', type: :model do
       context 'length is 0' do
         let(:task) {
           Task.new(name: '',
-                  description: 'hoge fuga',
-                  status: 'unstarted',
-                  deadline_at: '2023-01-01T00:00')
+                   description: 'hoge fuga',
+                   status: 'unstarted',
+                   deadline_at: '2023-01-01T00:00')
         }
 
         it 'has validation error' do
@@ -37,9 +37,9 @@ RSpec.describe 'Task', type: :model do
       context 'length is 1' do
         let(:task) {
           Task.new(name: 'a',
-                  description: 'hoge fuga',
-                  status: 'unstarted',
-                  deadline_at: '2023-01-01T00:00')
+                   description: 'hoge fuga',
+                   status: 'unstarted',
+                   deadline_at: '2023-01-01T00:00')
         }
 
         it 'has no error' do
@@ -51,9 +51,9 @@ RSpec.describe 'Task', type: :model do
       context 'length is 255' do
         let(:task) {
           Task.new(name: 'a' * 255,
-                  description: 'hoge fuga',
-                  status: 'unstarted',
-                  deadline_at: '2023-01-01T00:00')
+                   description: 'hoge fuga',
+                   status: 'unstarted',
+                   deadline_at: '2023-01-01T00:00')
         }
 
         it 'has no error' do
@@ -65,9 +65,9 @@ RSpec.describe 'Task', type: :model do
       context 'length is 256' do
         let(:task) {
           Task.new(name: 'a' * 256,
-                  description: 'hoge fuga',
-                  status: 'unstarted',
-                  deadline_at: '2023-01-01T00:00')
+                   description: 'hoge fuga',
+                   status: 'unstarted',
+                   deadline_at: '2023-01-01T00:00')
         }
 
         it 'has validation error' do
@@ -82,9 +82,9 @@ RSpec.describe 'Task', type: :model do
       context 'length is 0' do
         let(:task) {
           Task.new(name: 'sample_task',
-                  description: '',
-                  status: 'unstarted',
-                  deadline_at: '2023-01-01T00:00')
+                   description: '',
+                   status: 'unstarted',
+                   deadline_at: '2023-01-01T00:00')
         }
 
         it 'has no error' do
@@ -96,9 +96,9 @@ RSpec.describe 'Task', type: :model do
       context 'length is 5000' do
         let(:task) {
           Task.new(name: 'sample_task',
-                  description: 'a'*5000,
-                  status: 'unstarted',
-                  deadline_at: '2023-01-01T00:00')
+                   description: 'a' * 5000,
+                   status: 'unstarted',
+                   deadline_at: '2023-01-01T00:00')
         }
 
         it 'has no error' do
@@ -110,9 +110,9 @@ RSpec.describe 'Task', type: :model do
       context 'length is 5001' do
         let(:task) {
           Task.new(name: 'sample_task',
-                  description: 'a'*5001,
-                  status: 'unstarted',
-                  deadline_at: '2023-01-01T00:00')
+                   description: 'a' * 5001,
+                   status: 'unstarted',
+                   deadline_at: '2023-01-01T00:00')
         }
 
         it 'has validation error' do

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -59,30 +59,45 @@ RSpec.describe 'Tasks', type: :system do
     before do
       visit '/tasks'
       click_link('追加')
+      fill_in 'task[name]', with: 'sample_task'
+      fill_in 'task[description]', with: 'sample description'
+      select '完了', from: 'task_status'
+      fill_in 'task[deadline_at]', with: Time.zone.local(2023, 2, 3, 12, 34)
+      find('input[type="submit"]').click
     end
 
     it 'successfully create a task' do
-      expect(Task.all.length).to eq 0
-      fill_in 'task[name]', with: 'sample_task'
-      find('input[type="submit"]').click
       expect(page).to have_content 'タスクが正常に登録されました。'
       expect(page).to have_content 'タスク 詳細'
       expect(page).to have_content 'sample_task'
-      expect(Task.all.length).to eq 1
+      expect(page).to have_content 'sample description'
+      expect(page).to have_content '完了'
+      expect(page).to have_content '2023-02-03 12:34:00 +0900'
     end
   end
 
   describe 'Updating a task successfully' do
-    let(:task) { create(:task) }
+    let(:task) { create(:task, name: 'sample_task',
+                               description: 'sample description',
+                               status: 'wip',
+                               deadline_at: '2023-02-03T12:34') }
+
+    before do
+      visit "/tasks/#{task.id}/edit"
+      fill_in 'task[name]', with: 'sample_task_updated'
+      fill_in 'task[description]', with: 'sample description updated'
+      select '完了', from: 'task_status'
+      fill_in 'task[deadline_at]', with: Time.zone.local(2023, 3, 4, 13, 56)
+      find('input[type="submit"]').click
+    end
 
     it 'successfully update a task' do
-      visit "/tasks/#{task.id}/edit"
-      fill_in 'task[name]', with: 'hoge_task'
-      find('input[type="submit"]').click
       expect(page).to have_content 'タスクが正常に更新されました。'
       expect(page).to have_content 'タスク 詳細'
-      expect(page).to have_content 'hoge_task'
-      expect(Task.all.length).to eq 1
+      expect(page).to have_content 'sample_task_updated'
+      expect(page).to have_content 'sample description updated'
+      expect(page).to have_content '完了'
+      expect(page).to have_content '2023-03-04 13:56:00 +0900'
     end
   end
 

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -77,10 +77,12 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'Updating a task successfully' do
-    let(:task) { create(:task, name: 'sample_task',
-                               description: 'sample description',
-                               status: 'wip',
-                               deadline_at: '2023-02-03T12:34') }
+    let(:task) {
+      create(:task, name: 'sample_task',
+                    description: 'sample description',
+                    status: 'wip',
+                    deadline_at: '2023-02-03T12:34')
+    }
 
     before do
       visit "/tasks/#{task.id}/edit"


### PR DESCRIPTION
## Overview
- Done with the middle of `STEP13 Add status to Task model` of the [Rails training](https://github.com/Fablic/training/blob/develop/steps_jp.md)
- I'll work on adding search function in a subsequent PR.

## What's DONE
 
- Added status to Task model
  - It's enum type in Rails Application level and integer type in DB level.
  - `Status` has 3 options below
    - `unstarted` (To be honest, I wanted name 'new' but it is obviously reserved words.)
    - `wip` (Work In Progress)
    - `done`
- Fixed the system spec and model spec
- Configured rubocop

## Supplement

- Added status to Task model

|  before  |  after  |
| ---- | ---- |
| <img width="470" alt="image" src="https://user-images.githubusercontent.com/37566073/222633254-c87248a1-2bef-4074-9b78-1351f5176a51.png">| <img width="482" alt="image" src="https://user-images.githubusercontent.com/37566073/222633101-7f7eb371-ab8c-4d67-bb0f-13d6988b88b3.png"> |

## Memo

- Also can configure rubocop like this
  - https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code
