### PR TITLE
[Yokogawa STEP14] Added pagination

### DIFF
--- a/myapp/.rubocop.yml
+++ b/myapp/.rubocop.yml
@@ -33,4 +33,4 @@ RSpec/NestedGroups:
   Max: 4
 
 RSpec/MultipleExpectations:
-  Max: 6
+  Max: 10

--- a/myapp/.rubocop.yml
+++ b/myapp/.rubocop.yml
@@ -33,4 +33,4 @@ RSpec/NestedGroups:
   Max: 4
 
 RSpec/MultipleExpectations:
-  Max: 10
+  Max: 20

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -46,6 +46,8 @@ gem 'bootsnap', require: false
 
 gem 'rails-i18n'
 
+gem 'kaminari'
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -27,8 +27,6 @@ gem 'stimulus-rails'
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jbuilder'
 
-gem 'fablicop', require: false
-
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 
@@ -72,6 +70,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'fablicop', require: false
 end
 
 group :test do

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -119,6 +119,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -282,6 +294,7 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails
   jbuilder
+  kaminari
   mysql2 (~> 0.5)
   pry-rails
   puma (~> 5.0)

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -13,7 +13,8 @@ class TasksController < ApplicationController
     end
 
     @tasks = @tasks.order("#{params[:sort_key]} #{sort_direction}") if params[:sort_key].present?
-    @tasks
+
+    @tasks = @tasks.page(params[:page])
   end
 
   def new

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -28,7 +28,7 @@ class TasksController < ApplicationController
       return redirect_to @task
     end
 
-    flash[:error] = I18n.t('flash.task.create.failure')
+    flash.now[:error] = I18n.t('flash.task.create.failure')
     render 'new', status: :unprocessable_entity
   end
 
@@ -44,7 +44,7 @@ class TasksController < ApplicationController
       return redirect_to @task
     end
 
-    flash[:error] = I18n.t('flash.task.update.failure')
+    flash.now[:error] = I18n.t('flash.task.update.failure')
     render 'edit', status: :unprocessable_entity
   end
 
@@ -52,7 +52,7 @@ class TasksController < ApplicationController
     if @task.destroy
       flash[:success] = I18n.t('flash.task.delete.success')
     else
-      flash[:error] = I18n.t('flash.task.delete.failure')
+      flash.now[:error] = I18n.t('flash.task.delete.failure')
     end
     redirect_to tasks_url
   end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
+  paginates_per 10
+
   validates :name, presence: true, length: { maximum: 50 }
   # description はDB上は65,535文字まで許容できるが、区切りよく決めで上限を設定する。
   # DBにアクセスしてエラーを吐くまでにモデルでバリデーションが働くようにしたい意図。

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -49,3 +49,5 @@
 </table>
 
 <%= link_to I18n.t('action.add'), new_task_path %>
+
+<%= paginate @tasks %>

--- a/myapp/config/locales/kaminari/ja.yml
+++ b/myapp/config/locales/kaminari/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      next: "次 &rsaquo;"
+      previous: "&lsaquo; 前"
+      truncate: "&hellip;"

--- a/myapp/db/migrate/20230306072646_add_index_to_status_of_tasks.rb
+++ b/myapp/db/migrate/20230306072646_add_index_to_status_of_tasks.rb
@@ -1,0 +1,5 @@
+class AddIndexToStatusOfTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_06_005646) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_06_072646) do
   create_table "tasks", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_06_005646) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_tasks_on_name"
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -245,27 +245,27 @@ RSpec.describe 'Tasks', type: :system do
     end
   end
 
-  describe "Pagenation" do
-    context "the number of tasks is 10 or below" do
+  describe 'Pagenation' do
+    context 'the number of tasks is 10 or below' do
       before do
-        10.times {create(:task)}
+        create_list(:task, 10)
         visit '/tasks'
       end
 
-      it "shows expected view" do
+      it 'shows expected view' do
         expect(page).not_to have_content '次'
         expect(page).not_to have_content '最後'
         expect(page.all('table tbody tr').length).to eq 10
       end
     end
 
-    context "the number of tasks is 11" do
+    context 'the number of tasks is 11' do
       before do
-        11.times {create(:task)}
+        create_list(:task, 11)
         visit '/tasks'
       end
 
-      it "shows expected view" do
+      it 'shows expected view' do
         expect(page).to have_content '次'
         expect(page).to have_content '最後'
         expect(page.all('.pagination .page').length).to eq 2
@@ -280,14 +280,14 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
 
-    context "Filtering & the number of tasks is 10 or below" do
+    context 'Filtering & the number of tasks is 10 or below' do
       before do
-        5.times {create(:task, status: 'unstarted')}
-        10.times {create(:task, status: 'wip')}
+        create_list(:task, 5, status: 'unstarted')
+        create_list(:task, 10, status: 'wip')
         visit '/tasks'
       end
 
-      it "shows expected view" do
+      it 'shows expected view' do
         expect(page).to have_content '次'
         expect(page).to have_content '最後'
         expect(page.all('.pagination .page').length).to eq 2
@@ -303,14 +303,14 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
 
-    context "Filtering & the number of tasks is 11" do
+    context 'Filtering & the number of tasks is 11' do
       before do
-        10.times {create(:task, status: 'unstarted')}
-        11.times {create(:task, status: 'wip')}
+        create_list(:task, 10, status: 'unstarted')
+        create_list(:task, 11, status: 'wip')
         visit '/tasks'
       end
 
-      it "shows expected view" do
+      it 'shows expected view' do
         expect(page).to have_content '次'
         expect(page).to have_content '最後'
         expect(page.all('.pagination .page').length).to eq 3
@@ -332,5 +332,4 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
   end
-
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Tasks', type: :system do
     driven_by(:remote_chrome)
   end
 
-  # TODO: バリデーションの実装は後で行うので、異常系のテストも後回し
   describe 'GET /' do
     before do
       visit '/'

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -244,4 +244,93 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
   end
+
+  describe "Pagenation" do
+    context "the number of tasks is 10 or below" do
+      before do
+        10.times {create(:task)}
+        visit '/tasks'
+      end
+
+      it "shows expected view" do
+        expect(page).not_to have_content '次'
+        expect(page).not_to have_content '最後'
+        expect(page.all('table tbody tr').length).to eq 10
+      end
+    end
+
+    context "the number of tasks is 11" do
+      before do
+        11.times {create(:task)}
+        visit '/tasks'
+      end
+
+      it "shows expected view" do
+        expect(page).to have_content '次'
+        expect(page).to have_content '最後'
+        expect(page.all('.pagination .page').length).to eq 2
+        expect(page.all('table tbody tr').length).to eq 10
+
+        click_link('2')
+
+        expect(page).to have_content '前'
+        expect(page).to have_content '最初'
+        expect(page.all('.pagination .page').length).to eq 2
+        expect(page.all('table tbody tr').length).to eq 1
+      end
+    end
+
+    context "Filtering & the number of tasks is 10 or below" do
+      before do
+        5.times {create(:task, status: 'unstarted')}
+        10.times {create(:task, status: 'wip')}
+        visit '/tasks'
+      end
+
+      it "shows expected view" do
+        expect(page).to have_content '次'
+        expect(page).to have_content '最後'
+        expect(page.all('.pagination .page').length).to eq 2
+        expect(page.all('table tbody tr').length).to eq 10
+
+        select '着手中', from: 'status'
+        find('input[type="submit"]').click
+
+        expect(page).not_to have_content '次'
+        expect(page).not_to have_content '最後'
+        expect(page.all('.pagination .page').length).to eq 0
+        expect(page.all('table tbody tr').length).to eq 10
+      end
+    end
+
+    context "Filtering & the number of tasks is 11" do
+      before do
+        10.times {create(:task, status: 'unstarted')}
+        11.times {create(:task, status: 'wip')}
+        visit '/tasks'
+      end
+
+      it "shows expected view" do
+        expect(page).to have_content '次'
+        expect(page).to have_content '最後'
+        expect(page.all('.pagination .page').length).to eq 3
+        expect(page.all('table tbody tr').length).to eq 10
+
+        select '着手中', from: 'status'
+        find('input[type="submit"]').click
+
+        expect(page).to have_content '次'
+        expect(page).to have_content '最後'
+        expect(page.all('table tbody tr').length).to eq 10
+
+        click_link('2')
+
+        expect(page).to have_content '前'
+        expect(page).to have_content '最初'
+        expect(page.all('.pagination .page').length).to eq 2
+        expect(page.all('table tbody tr').length).to eq 1
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
## Overview
- done with `STEP14 Add pagination` of the [Rails training](https://github.com/Fablic/training/blob/develop/steps_jp.md)


## What's DONE
- Added pagination

## Supplement

- Added filter function of tasks

|  before  |  after  |
| ---- | ---- |
| <img width="877" alt="image" src="https://user-images.githubusercontent.com/37566073/223058137-0a112849-d30f-4a88-bfba-b8ad20b7c6ba.png">|  <img width="895" alt="image" src="https://user-images.githubusercontent.com/37566073/223058004-7ba3ab39-eebd-47b8-a192-326d465554b0.png"> |

## Memo
