### PR TITLE
[Yokogawa STEP21] Introduction of maintenance mode

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :render_maintenance, if: :maintenance_mode?
   around_action :switch_locale
   include SessionsHelper
 
@@ -14,5 +15,15 @@ class ApplicationController < ActionController::Base
 
   def render_404
     render file: Rails.public_path.join('404.html'), status: :not_found, layout: false, content_type: 'text/html'
+  end
+
+  def render_maintenance
+    render file: Rails.public_path.join('503.html'), status: :service_unavailable, layout: false, content_type: 'text/html'
+  end
+
+  private
+
+  def maintenance_mode?
+    File.exist?('tmp/maintenance.txt')
   end
 end

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -13,6 +13,6 @@ class ApplicationController < ActionController::Base
   end
 
   def render_404
-    render file: Rails.public_path.join('404.html'), status: 404, layout: false, content_type: 'text/html'
+    render file: Rails.public_path.join('404.html'), status: :not_found, layout: false, content_type: 'text/html'
   end
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -6,10 +6,11 @@ class TasksController < ApplicationController
     @task_columns_with_sorting_direction = task_columns_with_sorting_direction
 
     @tasks = @current_user.tasks.status(params[:status]).name_contain(params[:name]).tag_contain(params[:tag_id])
-    @tasks = @tasks.order("#{params[:sort_key]} #{sort_direction}") if params[:sort_key].present?
 
     # 特定のタグに紐づくタスクに絞り込んだ後、それぞれのタスクに紐づくタグをすべて表示したいので、再度 Task のクエリを実行する
     @tasks = Task.where(id: @tasks.map { |t| t.id }).includes(:tags).page(params[:page])
+
+    @tasks = @tasks.order("#{params[:sort_key]} #{sort_direction}") if params[:sort_key].present?
   end
 
   def new

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -9,7 +9,7 @@ class TasksController < ApplicationController
     @tasks = @tasks.order("#{params[:sort_key]} #{sort_direction}") if params[:sort_key].present?
 
     # 特定のタグに紐づくタスクに絞り込んだ後、それぞれのタスクに紐づくタグをすべて表示したいので、再度 Task のクエリを実行する
-    @tasks = Task.where(id: @tasks.map{|t| t.id}).includes(:tags).page(params[:page])
+    @tasks = Task.where(id: @tasks.map { |t| t.id }).includes(:tags).page(params[:page])
   end
 
   def new

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -13,7 +13,7 @@ class Task < ApplicationRecord
   scope :status, -> (status) { where(status: status) if status.present? }
   # see: https://api.rubyonrails.org/v7.0.4.2/classes/ActiveRecord/Sanitization/ClassMethods.html#method-i-sanitize_sql_like
   scope :name_contain, -> (name) { where('name like ?', "%#{sanitize_sql_like(name)}%") if name.present? }
-  scope :tag_contain, -> (tag_id) { joins(:tags).where(task_tags: {tag_id: tag_id}) if tag_id.present? }
+  scope :tag_contain, -> (tag_id) { joins(:tags).where(task_tags: { tag_id: tag_id }) if tag_id.present? }
 
   paginates_per 10
 end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,11 @@
+namespace :maintenance do
+  desc 'maintenance'
+  task :start do
+    File.open('tmp/maintenance.txt', 'w'){ |f| f.write('')}
+  end
+
+  task :finish do
+    next unless File.exist?('tmp/maintenance.txt')
+    File.delete('tmp/maintenance.txt')
+  end
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,11 +1,12 @@
 namespace :maintenance do
   desc 'maintenance'
   task :start do
-    File.open('tmp/maintenance.txt', 'w'){ |f| f.write('')}
+    File.write('tmp/maintenance.txt', '')
   end
 
   task :finish do
     next unless File.exist?('tmp/maintenance.txt')
+
     File.delete('tmp/maintenance.txt')
   end
 end

--- a/myapp/public/503.html
+++ b/myapp/public/503.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>[Under maintenance] We're sorry. (503)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body class="rails-default-error-page">
+  <!-- This file lives in public/500.html -->
+  <div class="dialog">
+    <div>
+      <h1>[Under maintenance] We're sorry. (503)</h1>
+    </div>
+  </div>
+</body>
+</html>

--- a/myapp/spec/lib/tasks/maintenance_spec.rb
+++ b/myapp/spec/lib/tasks/maintenance_spec.rb
@@ -19,7 +19,7 @@ describe 'maintenance' do
 
     context 'with maintenance.txt file' do
       before do
-        File.write('tmp/maintenance.txt', '')
+        File.write(file_path, '')
       end
 
       it 'just updates maintenance.txt and no error' do
@@ -41,7 +41,7 @@ describe 'maintenance' do
 
     context 'with maintenance.txt file' do
       before do
-        File.write('tmp/maintenance.txt', '')
+        File.write(file_path, '')
       end
 
       it 'deletes maintenance.txt' do

--- a/myapp/spec/lib/tasks/maintenance_spec.rb
+++ b/myapp/spec/lib/tasks/maintenance_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 describe 'maintenance' do
   let(:file_path) { 'tmp/maintenance.txt' }
 
+  after do
+    File.delete(file_path) if File.exist?(file_path) # celan up after test
+  end
+
   describe 'start' do
     let(:rake) { Rake.application['maintenance:start'] }
 
@@ -10,19 +14,17 @@ describe 'maintenance' do
       it 'creates maintenance.txt' do
         rake.execute
         expect(File).to exist(file_path)
-        File.delete(file_path) if File.exist?(file_path) # celan up after test
       end
     end
 
     context 'with maintenance.txt file' do
       before do
-        File.open('tmp/maintenance.txt', 'w'){ |f| f.write('')}
+        File.write('tmp/maintenance.txt', '')
       end
 
       it 'just updates maintenance.txt and no error' do
         rake.execute
         expect(File).to exist(file_path)
-        File.delete(file_path) if File.exist?(file_path) # celan up after test
       end
     end
   end
@@ -39,7 +41,7 @@ describe 'maintenance' do
 
     context 'with maintenance.txt file' do
       before do
-        File.open('tmp/maintenance.txt', 'w'){ |f| f.write('')}
+        File.write('tmp/maintenance.txt', '')
       end
 
       it 'deletes maintenance.txt' do

--- a/myapp/spec/lib/tasks/maintenance_spec.rb
+++ b/myapp/spec/lib/tasks/maintenance_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe 'maintenance' do
+  let(:file_path) { 'tmp/maintenance.txt' }
+
+  describe 'start' do
+    let(:rake) { Rake.application['maintenance:start'] }
+
+    context 'without maintenance.txt file' do
+      it 'creates maintenance.txt' do
+        rake.execute
+        expect(File).to exist(file_path)
+        File.delete(file_path) if File.exist?(file_path) # celan up after test
+      end
+    end
+
+    context 'with maintenance.txt file' do
+      before do
+        File.open('tmp/maintenance.txt', 'w'){ |f| f.write('')}
+      end
+
+      it 'just updates maintenance.txt and no error' do
+        rake.execute
+        expect(File).to exist(file_path)
+        File.delete(file_path) if File.exist?(file_path) # celan up after test
+      end
+    end
+  end
+
+  describe 'finish' do
+    let(:rake) { Rake.application['maintenance:finish'] }
+
+    context 'without maintenance.txt file' do
+      it 'has no error' do
+        rake.execute
+        expect(File).not_to exist(file_path)
+      end
+    end
+
+    context 'with maintenance.txt file' do
+      before do
+        File.open('tmp/maintenance.txt', 'w'){ |f| f.write('')}
+      end
+
+      it 'deletes maintenance.txt' do
+        rake.execute
+        expect(File).not_to exist(file_path)
+      end
+    end
+  end
+end

--- a/myapp/spec/rails_helper.rb
+++ b/myapp/spec/rails_helper.rb
@@ -97,6 +97,11 @@ RSpec.configure do |config|
       Bullet.end_request
     end
   end
+
+  # load rake tasks
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
 end
 
 Capybara.register_driver :remote_chrome do |app|

--- a/myapp/spec/system/maintenance_spec.rb
+++ b/myapp/spec/system/maintenance_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Maintenance', type: :system do
+  before do
+    driven_by(:remote_chrome)
+  end
+
+  let(:file_path) { 'tmp/maintenance.txt' }
+
+  after do
+    File.delete(file_path) if File.exist?(file_path) # celan up after test
+  end
+
+  describe 'render_maintenance' do
+    context 'maintenance_mode? is true' do
+      before do
+        File.write('tmp/maintenance.txt', '')
+      end
+
+      it 'shows maintenance mode view' do
+        visit '/login'
+        expect(page).to have_content '[Under maintenance] We\'re sorry. (503)'
+      end
+    end
+
+    context 'maintenance_mode? is false' do
+      it 'shows login page' do
+        visit '/login'
+        expect(page).to have_content 'ログイン'
+        expect(page).to have_content 'メールアドレス'
+        expect(page).to have_content 'パスワード'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview
- done with `STEP21 Introduction of maintenance mode`
	- ref: [Rails training](https://github.com/Fablic/training/blob/develop/steps_jp.md)

## What's DONE
- Introduction of maintenance mode
- bug fix
	- sorting did not work after [this change](https://github.com/Fablic/training/pull/1530/files#diff-e75236d23a45a89b1d77b043070dcb62d0202e7897322cbef5381cc0e71d4339R8-R12) ...
	- it seems like i forget to run test after making change.

## Supplement
- captures
	- when maintenance mode is on
		- 
![image](https://user-images.githubusercontent.com/37566073/226825522-aeff406a-e337-4bb0-b062-8ad872c402f1.png)

rake command to switch maintenance mode on/off

```
# docker compose exec web bundle exec rake maintenance:start
# docker compose exec web bundle exec rake maintenance:finish
```



## Memo