### PR TITLE
[Koyama STEP10] タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: "DESC")
   end
 
   def new

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def index
-    @tasks = Task.all.order(created_at: "DESC")
+    @tasks = Task.all.order(created_at: 'DESC')
   end
 
   def new

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,6 +1,6 @@
 <div>
   <p><%= link_to '新規登録', new_task_path %></p>
-  <table border="1">
+  <table class='tasks' border='1'>
     <tr>
       <th>id</th>
       <td>件名</td>
@@ -11,7 +11,7 @@
     <% @tasks.each do |task| %>
       <tr>
         <td><%= task.id %></td>
-        <td><%= task.title %></td>
+        <td class='task-title'><%= task.title %></td>
         <td><%= task.content %></td>
         <td><%= l task.created_at, format: :short %></td>
         <td>

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -24,19 +24,6 @@ RSpec.describe Task, type: :system do
         expect(page).to have_link '削除'
       end
 
-      it 'DBに保存されたデータがなければ、新規登録ボタンのみ表示' do
-        visit root_path
-
-        expect(current_path).to eq root_path
-        expect(page).to have_no_content task.id
-        expect(page).to have_no_content task.title
-        expect(page).to have_no_content task.content
-        expect(page).to have_no_link '詳細'
-        expect(page).to have_no_link '編集'
-        expect(page).to have_no_link '削除'
-        expect(page).to have_link '新規登録'
-      end
-
       it 'タスクは日付降順で表示' do
         create(:task, title: 'task1', created_at: Time.current)
         create(:task, title: 'task2', created_at: Time.current - 1.hour)
@@ -47,6 +34,19 @@ RSpec.describe Task, type: :system do
           task_titles = all('.task-title').map(&:text)
           expect(task_titles).to eq %w[task3 task1 task2]
         end
+      end
+
+      it 'DBに保存されたデータがあれば、作成日の降順で一覧表示' do
+        visit root_path
+
+        expect(current_path).to eq root_path
+        expect(page).to have_no_content task.id
+        expect(page).to have_no_content task.title
+        expect(page).to have_no_content task.content
+        expect(page).to have_no_link '詳細'
+        expect(page).to have_no_link '編集'
+        expect(page).to have_no_link '削除'
+        expect(page).to have_link '新規登録'
       end
     end
 

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Task, type: :system do
         expect(page).to have_link '削除'
       end
 
-      it 'タスクは日付降順で表示' do
+      it 'DBに保存されたデータがあれば、作成日の降順で一覧表示' do
         create(:task, title: 'task1', created_at: Time.current)
         create(:task, title: 'task2', created_at: Time.current - 1.hour)
         create(:task, title: 'task3', created_at: Time.current + 1.hour)
@@ -36,7 +36,7 @@ RSpec.describe Task, type: :system do
         end
       end
 
-      it 'DBに保存されたデータがあれば、作成日の降順で一覧表示' do
+      it 'DBに保存されたデータがなければ、新規登録ボタンのみ表示' do
         visit root_path
 
         expect(current_path).to eq root_path

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Task, type: :system do
         visit task_path(task.id)
 
         expect(current_path).to eq root_path
-        expect(page).to have_content '該当するタスクがありませんでした。'
+        expect(page).to have_content '該当するリソースがありませんでした。'
       end
     end
   end
@@ -140,7 +140,7 @@ RSpec.describe Task, type: :system do
         visit edit_task_path(task.id)
 
         expect(current_path).to eq root_path
-        expect(page).to have_content '該当するタスクがありませんでした。'
+        expect(page).to have_content '該当するリソースがありませんでした。'
       end
     end
 
@@ -193,7 +193,7 @@ RSpec.describe Task, type: :system do
         click_button '登録'
 
         expect(current_path).to eq root_path
-        expect(page).to have_content '該当するタスクがありませんでした。'
+        expect(page).to have_content '該当するリソースがありませんでした。'
       end
     end
   end
@@ -212,14 +212,14 @@ RSpec.describe Task, type: :system do
       expect(page).not_to have_content task.title
     end
 
-    it '削除タスクがない場合、該当するタスクがないと表示' do
+    it '削除タスクがない場合、該当するリソースがないと表示' do
       visit root_path
 
       task.destroy
       click_on '削除'
 
       expect(current_path).to eq root_path
-      expect(page).to have_content '該当するタスクがありませんでした。'
+      expect(page).to have_content '該当するリソースがありませんでした。'
     end
   end
 end

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Task, type: :system do
         visit root_path
       end
 
-      it 'タスクは作成日の降順で表示' do
+      it '作成日降順で表示' do
         expect(current_path).to eq root_path
         expect(page).to have_content '1'
         expect(page).to have_content 'task1'

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe Task, type: :system do
         expect(page).to have_no_link '削除'
         expect(page).to have_link '新規登録'
       end
+
+      it 'タスクは日付降順で表示' do
+        create(:task, title: 'task1')
+        create(:task, title: 'task2')
+        create(:task, title: 'task3')
+        visit root_path
+
+        within '.tasks' do
+          task_titles = all('.task-title').map(&:text)
+          expect(task_titles).to eq %w[task3 task2 task1]
+        end
+      end
     end
 
     context '詳細' do

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -4,39 +4,42 @@ RSpec.describe Task, type: :system do
   let(:task) { create(:task) }
 
   describe 'タスク表示' do
-    context '一覧' do
-      it 'DBに保存されたデータがあれば一覧表示' do
-        task_list = create_list(:task, 3)
+    context 'DBに保存されたデータがある時' do
+      before do
+        create(:task, id: '1', title: 'task1', content: 'task_contetnt1', created_at: '2023/04/27 09:00')
+        create(:task, id: '2', title: 'task2', content: 'task_contetnt2', created_at: '2023/04/27 08:00')
+        create(:task, id: '3', title: 'task3', content: 'task_contetnt3', created_at: '2023/04/27 10:00')
         visit root_path
+      end
 
+      it 'タスクは作成日の降順で表示' do
         expect(current_path).to eq root_path
-        expect(page).to have_content task_list[0].id
-        expect(page).to have_content task_list[0].title
-        expect(page).to have_content task_list[0].content
-        expect(page).to have_content task_list[1].id
-        expect(page).to have_content task_list[1].title
-        expect(page).to have_content task_list[1].content
-        expect(page).to have_content task_list[2].id
-        expect(page).to have_content task_list[2].title
-        expect(page).to have_content task_list[2].content
+        expect(page).to have_content '1'
+        expect(page).to have_content 'task1'
+        expect(page).to have_content 'task_contetnt1'
+        expect(page).to have_content '2023/04/27 09:00'
+        expect(page).to have_content '2'
+        expect(page).to have_content 'task2'
+        expect(page).to have_content 'task_contetnt2'
+        expect(page).to have_content '2023/04/27 08:00'
+        expect(page).to have_content '3'
+        expect(page).to have_content 'task3'
+        expect(page).to have_content 'task_contetnt3'
+        expect(page).to have_content '2023/04/27 10:00'
+
         expect(page).to have_link '詳細'
         expect(page).to have_link '編集'
         expect(page).to have_link '削除'
-      end
-
-      it 'DBに保存されたデータがあれば、作成日の降順で一覧表示' do
-        create(:task, title: 'task1', created_at: Time.current)
-        create(:task, title: 'task2', created_at: Time.current - 1.hour)
-        create(:task, title: 'task3', created_at: Time.current + 1.hour)
-        visit root_path
 
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
           expect(task_titles).to eq %w[task3 task1 task2]
         end
       end
+    end
 
-      it 'DBに保存されたデータがなければ、新規登録ボタンのみ表示' do
+    context 'DBに保存されたデータがない時' do
+      it '新規登録ボタンのみ表示' do
         visit root_path
 
         expect(current_path).to eq root_path

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe Task, type: :system do
       end
 
       it 'タスクは日付降順で表示' do
-        create(:task, title: 'task1')
-        create(:task, title: 'task2')
-        create(:task, title: 'task3')
+        create(:task, title: 'task1', created_at: Time.current)
+        create(:task, title: 'task2', created_at: Time.current - 1.hour)
+        create(:task, title: 'task3', created_at: Time.current + 1.hour)
         visit root_path
 
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
-          expect(task_titles).to eq %w[task3 task2 task1]
+          expect(task_titles).to eq %w[task3 task1 task2]
         end
       end
     end


### PR DESCRIPTION
## Jiraチケット
https://jira.rakuten-it.com/jira/browse/RAKUTRA-5177
## 行うこと
- 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
- 並び替えがうまく行っていることをsystem specで書いてみましょう
## URL
[Rails 研修](https://github.com/Fablic/training/blob/develop/steps_jp.md)「ステップ10: タスク一覧を作成日時の順番で並び替えましょう」を実施しました
## 行ったこと
- 一覧表示を作成日時の降順に並び替えた
<img width="490" alt="スクリーンショット 2023-04-27 10 48 24" src="https://user-images.githubusercontent.com/129723112/234739720-31229ce5-c81d-473b-986e-515c5150ccd5.png">

- system specで並び替えの確認テストを実施した
<img width="457" alt="スクリーンショット 2023-04-27 10 54 05" src="https://user-images.githubusercontent.com/129723112/234740248-02b94f4c-92bc-4331-8980-580a9fc9bbcd.png">
