### PR TITLE
[Koyama STEP17]ログイン/ログアウト機能を実装しよう

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   around_action :switch_locale
+  add_flash_types :success, :danger
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  include SessionsHelper
 
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale

--- a/myapp/app/controllers/sessions_controller.rb
+++ b/myapp/app/controllers/sessions_controller.rb
@@ -1,0 +1,26 @@
+class SessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    user = User.find_by(email: session_params[:email])
+    if user&.authenticate(session_params[:password])
+      login(user)
+      redirect_to tasks_path, success: t('session.login.success')
+    else
+      flash.now[:danger] = t('session.login.failure')
+      render 'new'
+    end
+  end
+
+  def destroy
+    logout
+    redirect_to login_path, success: t('session.logout.success')
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
+  end
+end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -2,7 +2,6 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[edit update destroy show]
 
   def index
-    @tasks = Task.all.order(created_at: 'DESC').page(params[:page]).per(5)
   end
 
   def show; end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,7 +1,9 @@
 class TasksController < ApplicationController
+  before_action :require_login
   before_action :set_task, only: %i[edit update destroy show]
 
   def index
+    @tasks = Task.all.order(created_at: 'DESC').page(params[:page]).per(5)
   end
 
   def show; end
@@ -13,9 +15,9 @@ class TasksController < ApplicationController
   def edit; end
 
   def create
-    @task = Task.new(task_params)
+    @task = @current_user.tasks.new(task_params)
     if @task.save
-      redirect_to tasks_path, notice: t('messages.create', model_name: t('activerecord.models.task'))
+      redirect_to tasks_path, success: t('messages.create', model_name: t('activerecord.models.task'))
     else
       render :new
     end
@@ -23,7 +25,7 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to tasks_path, notice: t('messages.update', model_name: t('activerecord.models.task'))
+      redirect_to tasks_path, succeces: t('messages.update', model_name: t('activerecord.models.task'))
     else
       render :edit
     end
@@ -31,7 +33,7 @@ class TasksController < ApplicationController
 
   def destroy
     if @task.destroy
-      redirect_to tasks_path, notice: t('messages.delete', model_name: t('activerecord.models.task'))
+      redirect_to tasks_path, succeces: t('messages.delete', model_name: t('activerecord.models.task'))
     else
       render :index
     end
@@ -52,6 +54,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :content, :deadline, :status)
+    params.require(:task).permit(:title, :content, :deadline, :status).merge(user_id: current_user.id)
   end
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,9 +1,9 @@
 class TasksController < ApplicationController
   before_action :require_login
-  before_action :set_task, only: %i[edit update destroy show]
+  before_action :ensure_correct_user, only: %i[edit update destroy show]
 
   def index
-    @tasks = Task.all.order(created_at: 'DESC').page(params[:page]).per(5)
+    @tasks = @current_user.tasks.order(created_at: 'DESC').page(params[:page]).per(5)
   end
 
   def show; end
@@ -40,7 +40,7 @@ class TasksController < ApplicationController
   end
 
   def search
-    @tasks = Task.where_title(params[:title]).where_status(params[:status]).deadline_order(params[:deadline_order]).page(params[:page]).per(5)
+    @tasks = @current_user.tasks.where_title(params[:title]).where_status(params[:status]).deadline_order(params[:deadline_order]).page(params[:page]).per(5)
     @title = params[:title]
     @status = params[:status]
     @deadline_order = params[:deadline_order]
@@ -49,8 +49,11 @@ class TasksController < ApplicationController
 
   private
 
-  def set_task
+  def ensure_correct_user
     @task = Task.find(params[:id])
+    return if @task.user == @current_user
+
+    redirect_to root_path, danger: t('error.messages.no_authority')
   end
 
   def task_params

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -25,7 +25,7 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to tasks_path, succeces: t('messages.update', model_name: t('activerecord.models.task'))
+      redirect_to tasks_path, success: t('messages.update', model_name: t('activerecord.models.task'))
     else
       render :edit
     end
@@ -33,7 +33,7 @@ class TasksController < ApplicationController
 
   def destroy
     if @task.destroy
-      redirect_to tasks_path, succeces: t('messages.delete', model_name: t('activerecord.models.task'))
+      redirect_to tasks_path, success: t('messages.delete', model_name: t('activerecord.models.task'))
     else
       render :index
     end

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-
   def new
     @user = User.new
   end
@@ -15,7 +14,7 @@ class UsersController < ApplicationController
 
   private
 
-    def user_params
-      params.require(:user).permit(:name, :email, :password, :password_confirmation)
-    end
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
 end

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -1,0 +1,21 @@
+class UsersController < ApplicationController
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to login_path, success: t('messages.create', model_name: t('activerecord.models.user'))
+    else
+      render 'new'
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    end
+end

--- a/myapp/app/helpers/sessions_helper.rb
+++ b/myapp/app/helpers/sessions_helper.rb
@@ -1,0 +1,23 @@
+module SessionsHelper
+  def login(user)
+    session[:user_id] = user.id
+  end
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def logged_in?
+    current_user.present?
+  end
+
+  def logout
+    session[:user_id] = nil
+    @current_user = nil
+  end
+
+  def require_login
+    return if logged_in?
+    redirect_to login_path, danger: t('session.need_login')
+  end
+end

--- a/myapp/app/helpers/sessions_helper.rb
+++ b/myapp/app/helpers/sessions_helper.rb
@@ -18,6 +18,7 @@ module SessionsHelper
 
   def require_login
     return if logged_in?
+
     redirect_to login_path, danger: t('session.need_login')
   end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -4,5 +4,7 @@ class User < ApplicationRecord
   validates :name, presence: true
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }, format: { with: User::VALID_EMAIL_REGEX }
+
   has_secure_password
+  validates :password, presence: true, length: { minimum: 8 }
 end

--- a/myapp/app/views/sessions/new.html.erb
+++ b/myapp/app/views/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<div class='container' style='padding:10px;'>
+  <h2 class='text-center'>
+    <%= t('buttons.login') %>
+  </h2>
+
+  <%= form_with scope: :session, url: login_path, local: true do |form| %>
+
+      <div class='w-50 mx-auto'>
+        <div class='col-auto mb-3'>
+          <%= form.label :email, class: 'col-form-label' %>
+          <%= form.text_field :email, class: 'form-control' %>
+        </div>
+
+        <div class='col-auto mb-3'>
+          <%= form.label :password, class: 'col-form-label' %>
+          <%= form.password_field :password, class: 'form-control' %>
+        </div>
+
+        <div class='submit-content'>
+          <%= form.submit t('buttons.login'), class: 'btn btn-primary' %>
+          <%= link_to t('buttons.signin'), new_user_path, class: 'btn btn-link' %>
+        </div>
+      </div>
+    <% end %>
+</div>
+

--- a/myapp/app/views/shared/_flash_message.html.erb
+++ b/myapp/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,3 @@
 <% flash.each do |message_type, message| %>
-  <div class='alert alert-primary'><%= message %></div>
+  <div class='alert alert-<%= message_type %>'><%= message %></div>
 <% end %>

--- a/myapp/app/views/tasks/_search.html.erb
+++ b/myapp/app/views/tasks/_search.html.erb
@@ -8,9 +8,9 @@
       <%= form.select :status, options_for_select(Task.statuses.keys.map  {|k| [t("enums.task.status.#{k}"), k]}), { selected: @status }, { class: 'form-select', 'data-style': 'form-control' } %>
     </div>
 
-    <% form.hidden_field :deadline_order, value: @deadline_order  %>
+    <%= form.hidden_field :deadline_order, value: @deadline_order  %>
 
-    <div class='btn-group'>
+    <div class='btn-group mx-3'>
       <%= form.submit t('buttons.search'), id: 'search_submit', class: 'btn btn-outline-success' %>
       <%= link_to t('buttons.clear'), tasks_path, class: 'btn btn-outline-dark' %>
     </div>

--- a/myapp/app/views/tasks/_search.html.erb
+++ b/myapp/app/views/tasks/_search.html.erb
@@ -1,19 +1,17 @@
-<div class='collapse navbar-collapse'>
+<div class='input-group'>
   <%= form_with model: @task, url: search_tasks_path, class: 'd-flex', local: true, method: :get do |form| %>
-    <div div class='navbar-nav'>
+    <div div class='col-4'>
       <%= form.text_field :title, id: 'search_word', value: @title, class: 'form-control', placeholder: t('activerecord.attributes.task.title') %>
     </div>
 
-    <div class='navbar-nav'>
+    <div class='col-3'>
       <%= form.select :status, options_for_select(Task.statuses.keys.map  {|k| [t("enums.task.status.#{k}"), k]}), { selected: @status }, { class: 'form-select', 'data-style': 'form-control' } %>
     </div>
 
-    <div class='navbar-nav'>
-      <%= form.hidden_field :deadline_order, value: @deadline_order  %>
-    </div>
+    <% form.hidden_field :deadline_order, value: @deadline_order  %>
 
-    <div class='btn-group mr-3'>
-      <%= form.submit '検索', id: 'search_submit', class: 'btn btn-outline-success' %>
+    <div class='btn-group'>
+      <%= form.submit t('buttons.search'), id: 'search_submit', class: 'btn btn-outline-success' %>
       <%= link_to t('buttons.clear'), tasks_path, class: 'btn btn-outline-dark' %>
     </div>
   <% end %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -10,7 +10,13 @@
         </div>
       </div>
     </div>
-    <div class='container-fluid'>
+    <div class='container-sm justify-content-end'>
+        <% if logged_in? %>
+          <span class='d-flex align-items-center'><%= @current_user.name %></span>
+          <span class='d-flex align-items-center mx-2'><%= link_to t('buttons.logout'), logout_path, class: 'btn btn-danger', method: :delete %></span>
+        <% end %>
+      </div>
+    <div class='container'>
       <%= render partial: 'search' %>
     </div>
   </nav>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -35,23 +35,25 @@
       <th scope='col'><%= t('activerecord.attributes.task.created_at') %></th>
       <th scope='col'><%= t('activerecord.attributes.task.another') %></th>
     </tr>
-    <% @tasks.each do |task| %>
-      <tr scope='row'>
-        <td><%= task.id %></td>
-        <td class='task-title'>
-          <%= task.title %>
-        </td>
-        <td><%= task.content %></td>
-        <td><%= l task.deadline %></td>
-        <td><%= t("enums.task.status.#{task.status}") %></td>
-        <td><%= l task.created_at, format: :short %></td>
-        <td>
-          <%= link_to t('buttons.show'), task_path(task.id), class: 'btn btn-secondary' %>
-          <%= link_to t('buttons.edit'), edit_task_path(task.id), class: 'btn btn-secondary' %>
-          <%= link_to t('buttons.delete'), task_path(task.id), method: :delete, class: 'btn btn-danger' %>
-        </td>
-      </tr>
-    <% end %>
+    <tbody>
+      <% @tasks.each do |task| %>
+        <tr scope='row'>
+          <td><%= task.id %></td>
+          <td class='task-title'>
+            <%= task.title %>
+          </td>
+          <td><%= task.content %></td>
+          <td><%= l task.deadline %></td>
+          <td><%= t("enums.task.status.#{task.status}") %></td>
+          <td><%= l task.created_at, format: :short %></td>
+          <td>
+            <%= link_to t('buttons.show'), task_path(task.id), class: 'btn btn-secondary' %>
+            <%= link_to t('buttons.edit'), edit_task_path(task.id), class: 'btn btn-secondary' %>
+            <%= link_to t('buttons.delete'), task_path(task.id), method: :delete, class: 'btn btn-danger' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
   </table>
   <%= paginate @tasks, theme: 'bootstrap-5'%>
 </div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -31,8 +31,9 @@
           <%= link_to t('buttons.sort.asc'), search_tasks_path(deadline_order: 'asc') %>
           <%= link_to t('buttons.sort.desc'), search_tasks_path(deadline_order: 'desc') %>
       </th>
-      <th><%= t('activerecord.attributes.task.status') %></th>
+      <th scope='col'><%= t('activerecord.attributes.task.status') %></th>
       <th scope='col'><%= t('activerecord.attributes.task.created_at') %></th>
+      <th scope='col'><%= t('activerecord.attributes.user.name') %></th>
       <th scope='col'><%= t('activerecord.attributes.task.another') %></th>
     </tr>
     <tbody>
@@ -46,6 +47,7 @@
           <td><%= l task.deadline %></td>
           <td><%= t("enums.task.status.#{task.status}") %></td>
           <td><%= l task.created_at, format: :short %></td>
+          <td><%= task.user.name %></td>
           <td>
             <%= link_to t('buttons.show'), task_path(task.id), class: 'btn btn-secondary' %>
             <%= link_to t('buttons.edit'), edit_task_path(task.id), class: 'btn btn-secondary' %>

--- a/myapp/app/views/users/_form.html.erb
+++ b/myapp/app/views/users/_form.html.erb
@@ -1,0 +1,31 @@
+<div class='users-form align-items-center'>
+  <%= form_with model: @user, local: true do |form| %>
+    <%= render 'shared/error_messages', object: form.object %>
+
+    <div class='form-group'>
+      <div class='col-auto mb-3'>
+        <%= form.label :name , class: 'col-form-label' %>
+        <%= form.text_field :name, class: 'form-control' %>
+      </div>
+
+      <div class='col-auto mb-3'>
+        <%= form.label :email, class: 'col-form-label' %>
+        <%= form.text_field :email, class: 'form-control' %>
+      </div>
+
+      <div class='col-auto mb-3'>
+        <%= form.label :password, class: 'col-form-label' %>
+        <%= form.text_field :password, class: 'form-control' %>
+      </div>
+
+      <div class='col-auto mb-3'>
+        <%= form.label :password_confirmationt, class: 'col-form-label' %>
+        <%= form.text_field :password_confirmation, class: 'form-control' %>
+      </div>
+
+    <div class='submit-content'>
+      <%= form.submit t('buttons.register'), class: 'btn btn-primary' %>
+      <%= link_to t('buttons.back_page'), login_path, class: 'btn btn-link' %>
+    </div>
+  <% end %>
+</div>

--- a/myapp/app/views/users/_form.html.erb
+++ b/myapp/app/views/users/_form.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <div class='col-auto mb-3'>
-        <%= form.label :password_confirmationt, class: 'col-form-label' %>
+        <%= form.label :password_confirmation, class: 'col-form-label' %>
         <%= form.text_field :password_confirmation, class: 'form-control' %>
       </div>
 

--- a/myapp/app/views/users/new.html.erb
+++ b/myapp/app/views/users/new.html.erb
@@ -1,0 +1,8 @@
+<div class='text-content container' style='padding:10px;'>
+  <h2><%= t('activerecord.models.user') + t('buttons.register') %></h2>
+
+  <div class='main'>
+
+    <%= render partial: 'form' %>
+  </div>
+</div>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -26,8 +26,20 @@ ja:
     edit: 編集
     delete: 削除
     clear: クリア
+    search: 検索
     back_page: もどる
     register: 登録
+    login: ログイン
+    logout: ログアウト
+    signin: サインイン
     sort:
       asc: 昇順
       desc: 降順
+
+  session:
+    login:
+      success: 'ログインしました。'
+      failure: 'ログインに失敗しました。メールアドレスとパスワードの組み合わせが不正です。'
+    logout:
+      success: 'ログアウトしました。'
+    need_login: 'ログインが必要です。'

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -9,6 +9,7 @@ ja:
       create: '%{model_name}の登録に失敗しました。'
       update: '%{model_name}の更新に失敗しました。'
       record_not_found: '該当するリソースがありませんでした。'
+      no_authority: 'アクセスする権限がありません。'
 
   time:
     formats:

--- a/myapp/config/locales/models/user/ja.yml
+++ b/myapp/config/locales/models/user/ja.yml
@@ -8,4 +8,4 @@ ja:
         name: 氏名
         email: メールアドレス
         password: パスワード
-        password_confirmationt: パスワード確認
+        password_confirmation: パスワード確認

--- a/myapp/config/locales/models/user/ja.yml
+++ b/myapp/config/locales/models/user/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+
+    attributes:
+      user:
+        name: 氏名
+        email: メールアドレス
+        password: パスワード
+        password_confirmationt: パスワード確認

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
+  get 'sessions/create'
   root to: 'tasks#index'
   resources :tasks do
     get :search, on: :collection
   end
+  resources :users, only: %i[new create]
+
+  get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
 end

--- a/myapp/spec/factories/tasks.rb
+++ b/myapp/spec/factories/tasks.rb
@@ -6,5 +6,7 @@ FactoryBot.define do
     content { Faker::Lorem.word }
     status  { 1 }
     deadline { Faker::Date.backward }
+
+    association :user
   end
 end

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     name { Faker::Name }
-    email { 'hoge@example.com'}
-    password_digest { Faker::Lorem.word }
+    email { Faker::Internet.email}
+    password { 'password' }
   end
 end

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe User, type: :model do
         user.name = ''
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Nameを入力してください')
+        expect(user.errors.full_messages).to include('氏名を入力してください')
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe User, type: :model do
         user.email = ''
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Emailを入力してください', 'Emailは不正な値です')
+        expect(user.errors.full_messages).to include('メールアドレスを入力してください', 'メールアドレスは不正な値です')
       end
 
       it 'emailの長さが256文字以上だと無効' do
@@ -32,7 +32,7 @@ RSpec.describe User, type: :model do
         user.email = "#{text}" + '@example.com'
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Emailは255文字以内で入力してください')
+        expect(user.errors.full_messages).to include('メールアドレスは255文字以内で入力してください')
       end
 
       it '同じものが2つ以上あると無効' do
@@ -40,42 +40,60 @@ RSpec.describe User, type: :model do
         user.email = user_exist.email
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Emailはすでに存在します')
+        expect(user.errors.full_messages).to include('メールアドレスはすでに存在します')
       end
 
       it '@から始まるものは無効' do
         user.email = '@example.com'
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Emailは不正な値です')
+        expect(user.errors.full_messages).to include('メールアドレスは不正な値です')
       end
 
       it '@がないものは無効' do
         user.email = 'hugaexample.com'
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Emailは不正な値です')
+        expect(user.errors.full_messages).to include('メールアドレスは不正な値です')
       end
 
       it '2次ドメインが入っていないものは無効' do
         user.email = 'huga@.com'
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Emailは不正な値です')
+        expect(user.errors.full_messages).to include('メールアドレスは不正な値です')
       end
 
       it 'ドットがないものは無効' do
         user.email = 'huga@examplecom'
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Emailは不正な値です')
+        expect(user.errors.full_messages).to include('メールアドレスは不正な値です')
       end
 
       it 'トップレベルドメインがないものは無効' do
         user.email = 'huga@example.'
 
         expect(user).not_to be_valid
-        expect(user.errors.full_messages).to include('Emailは不正な値です')
+        expect(user.errors.full_messages).to include('メールアドレスは不正な値です')
+      end
+    end
+
+    context 'passwordのバリデーション' do
+      it 'パスワードが空なら無効' do
+        user.password = ''
+        user.password_confirmation = ''
+
+        expect(user).not_to be_valid
+        expect(user.errors.full_messages).to include('パスワード確認とパスワードの入力が一致しません')
+      end
+
+      it 'パスワードが7文字以下なら無効' do
+        user.password = 'passwor'
+        user.password_confirmation = 'passwor'
+
+        expect(user).not_to be_valid
+        expect(user.errors.full_messages).to include('パスワードは8文字以上で入力してください')
       end
     end
   end

--- a/myapp/spec/rails_helper.rb
+++ b/myapp/spec/rails_helper.rb
@@ -45,11 +45,11 @@ RSpec.configure do |config|
   end
 
   if Bullet.enable?
-    config.before(:each) do
+    config.before do
       Bullet.start_request
     end
 
-    config.after(:each) do
+    config.after do
       Bullet.perform_out_of_channel_notifications if Bullet.notification? # Bulletによる通知をRSpecの結果に表示
       Bullet.end_request
     end

--- a/myapp/spec/requests/sessions_spec.rb
+++ b/myapp/spec/requests/sessions_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+include SessionsHelper
+
+RSpec.describe 'Sessions', type: :request do
+  describe 'GET /new' do
+    it 'ログイン画面の表示に成功すること' do
+      get login_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/myapp/spec/support/login_support.rb
+++ b/myapp/spec/support/login_support.rb
@@ -1,0 +1,12 @@
+module LoginSupport
+  def login(email, password)
+    visit login_path
+    fill_in 'session[email]', with: email
+    fill_in 'session[password]', with: password
+    click_button 'ログイン'
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/myapp/spec/system/login_spec.rb
+++ b/myapp/spec/system/login_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'ログイン機能', type: :system do
+  let!(:user) { create(:user, name: 'MM', email: 'test@test.com', password: 'password') }
+
+  describe '画面表示' do
+    before do
+      visit root_path
+    end
+
+    context 'ログインせずに他のページへアクセスしたとき' do
+      it 'ログイン画面が表示されること' do
+        expect(page).to have_current_path login_path, ignore_query: true
+        expect(page).to have_selector('.alert-danger', text: I18n.t('session.need_login'))
+        expect(page).to have_field 'session[email]'
+        expect(page).to have_field 'session[password]'
+        expect(page).to have_button 'ログイン'
+        expect(page).to have_link 'サインイン'
+      end
+    end
+  end
+
+  describe 'ログイン処理' do
+    before do
+      visit login_path
+      fill_in 'session[email]', with: login_email
+      fill_in 'session[password]', with: 'password'
+      click_button 'ログイン'
+    end
+
+    context '正しい情報を入力したとき' do
+      let(:login_email) { 'test@test.com' }
+
+      it 'ログインできる' do
+        expect(page).to have_current_path tasks_path, ignore_query: true
+        expect(page).to have_selector('.alert-success', text: I18n.t('session.login.success'))
+      end
+    end
+
+    context '誤った情報を入力したとき' do
+      let(:login_email) { 'test@hoge.com' }
+
+      it 'ログインできない' do
+        expect(page).to have_current_path login_path, ignore_query: true
+        expect(page).to have_selector('.alert-danger', text: I18n.t('session.login.failure'))
+      end
+    end
+  end
+
+  describe 'ログアウト処理' do
+    before do
+      visit login_path
+      fill_in 'session[email]', with: 'test@test.com'
+      fill_in 'session[password]', with: 'password'
+      click_button 'ログイン'
+    end
+
+    context 'ログアウトを選択したとき' do
+      before do
+        click_link 'ログアウト'
+      end
+
+      it 'ログアウトできる' do
+        expect(page).to have_current_path login_path, ignore_query: true
+        expect(page).to have_selector('.alert-success', text: I18n.t('session.logout.success'))
+      end
+    end
+  end
+end

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -2,25 +2,28 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :system do
   let(:task) { create(:task) }
-  let(:user) { create(:user, name: 'hogehoge', email: Faker::Internet.email, password: 'password') }
+  let(:user_taro) { create(:user, name: 'hogehoge', email: Faker::Internet.email, password: 'password') }
+  let(:user_jiro) { create(:user, name: 'testest', email: Faker::Internet.email, password: 'password') }
 
   before do
-    login(user.email, user.password)
+    login(user_taro.email, user_taro.password)
   end
 
   describe 'タスク表示' do
     context 'DBに保存されたデータがある' do
       before do
         create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/04/27',
-                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user.id)
+                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user_taro.id)
         create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/26',
-                      status: :start, created_at: '2023/04/27 08:00', user_id: user.id)
+                      status: :start, created_at: '2023/04/27 08:00', user_id: user_taro.id)
         create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/28',
-                      status: :completed, created_at: '2023/04/27 10:00', user_id: user.id)
+                      status: :completed, created_at: '2023/04/27 10:00', user_id: user_taro.id)
+        create(:task, title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
+                      status: :completed, created_at: '2023/04/27 10:00', user_id: user_jiro.id)
         visit root_path
       end
 
-      it '一覧ページに作成日降順で表示' do
+      it '自分のタスクのみ一覧ページに作成日降順で表示' do
         expect(page).to have_current_path root_path, ignore_query: true
         expect(page).to have_content '1'
         expect(page).to have_content 'task1'
@@ -51,7 +54,7 @@ RSpec.describe Task, type: :system do
         expect(page).to have_button '検索'
         expect(page).to have_link 'クリア'
         expect(page).to have_link 'ログアウト'
-        expect(page).to have_content user.name
+        expect(page).to have_content user_taro.name
 
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
@@ -63,17 +66,17 @@ RSpec.describe Task, type: :system do
     context '作成日順ソートでページングが動作' do
       before do
         create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
-                      created_at: '2023/04/26 01:00', user_id: user.id)
+                      created_at: '2023/04/26 01:00', user_id: user_taro.id)
         create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
-                      created_at: '2023/04/27 02:00', user_id: user.id)
+                      created_at: '2023/04/27 02:00', user_id: user_taro.id)
         create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
-                      created_at: '2023/04/28 03:00', user_id: user.id)
+                      created_at: '2023/04/28 03:00', user_id: user_taro.id)
         create(:task, title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
-                      created_at: '2023/04/29 04:00', user_id: user.id)
+                      created_at: '2023/04/29 04:00', user_id: user_taro.id)
         create(:task, title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
-                      created_at: '2023/04/30 05:00', user_id: user.id)
+                      created_at: '2023/04/30 05:00', user_id: user_taro.id)
         create(:task, title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
-                      created_at: '2023/05/01 06:00', user_id: user.id)
+                      created_at: '2023/05/01 06:00', user_id: user_taro.id)
         visit root_path
       end
 
@@ -110,17 +113,17 @@ RSpec.describe Task, type: :system do
     context '終了期限の昇順ソートでページングが動作' do
       before do
         create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
-                      created_at: '2023/04/26 01:00', user_id: user.id)
+                      created_at: '2023/04/26 01:00', user_id: user_taro.id)
         create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
-                      created_at: '2023/04/27 02:00', user_id: user.id)
+                      created_at: '2023/04/27 02:00', user_id: user_taro.id)
         create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
-                      created_at: '2023/04/28 03:00', user_id: user.id)
+                      created_at: '2023/04/28 03:00', user_id: user_taro.id)
         create(:task, title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
-                      created_at: '2023/04/29 04:00', user_id: user.id)
+                      created_at: '2023/04/29 04:00', user_id: user_taro.id)
         create(:task, title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
-                      created_at: '2023/04/30 05:00', user_id: user.id)
+                      created_at: '2023/04/30 05:00', user_id: user_taro.id)
         create(:task, title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
-                      created_at: '2023/05/01 06:00', user_id: user.id)
+                      created_at: '2023/05/01 06:00', user_id: user_taro.id)
         visit root_path
       end
 
@@ -156,17 +159,17 @@ RSpec.describe Task, type: :system do
     context '終了期限の降順ソートでページングが動作' do
       before do
         create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
-                      created_at: '2023/04/26 01:00', user_id: user.id)
+                      created_at: '2023/04/26 01:00', user_id: user_taro.id)
         create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
-                      created_at: '2023/04/27 02:00', user_id: user.id)
+                      created_at: '2023/04/27 02:00', user_id: user_taro.id)
         create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
-                      created_at: '2023/04/28 03:00', user_id: user.id)
+                      created_at: '2023/04/28 03:00', user_id: user_taro.id)
         create(:task, title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
-                      created_at: '2023/04/29 04:00', user_id: user.id)
+                      created_at: '2023/04/29 04:00', user_id: user_taro.id)
         create(:task, title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
-                      created_at: '2023/04/30 05:00', user_id: user.id)
+                      created_at: '2023/04/30 05:00', user_id: user_taro.id)
         create(:task, title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
-                      created_at: '2023/05/01 06:00', user_id: user.id)
+                      created_at: '2023/05/01 06:00', user_id: user_taro.id)
         visit root_path
       end
 
@@ -202,11 +205,11 @@ RSpec.describe Task, type: :system do
     context '一覧ページの終了期限の昇順ボタンが押された' do
       before do
         create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/04/29',
-                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user.id)
+                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user_taro.id)
         create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/28',
-                      status: :start, created_at: '2023/04/27 08:00', user_id: user.id)
+                      status: :start, created_at: '2023/04/27 08:00', user_id: user_taro.id)
         create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/27',
-                      status: :completed, created_at: '2023/04/27 10:00', user_id: user.id)
+                      status: :completed, created_at: '2023/04/27 10:00', user_id: user_taro.id)
         visit root_path
       end
 
@@ -224,11 +227,11 @@ RSpec.describe Task, type: :system do
     context '一覧ページの終了期限の降順ボタンが押された' do
       before do
         create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/04/29',
-                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user.id)
+                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user_taro.id)
         create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/28',
-                      status: :start, created_at: '2023/04/27 08:00', user_id: user.id)
+                      status: :start, created_at: '2023/04/27 08:00', user_id: user_taro.id)
         create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/27',
-                      status: :completed, created_at: '2023/04/27 10:00', user_id: user.id)
+                      status: :completed, created_at: '2023/04/27 10:00', user_id: user_taro.id)
         visit root_path
       end
 
@@ -288,11 +291,13 @@ RSpec.describe Task, type: :system do
   end
 
   describe '検索エリア' do
+    let!(:task_A1) { create(:task, title: 'titleA1', status: :not_started, deadline: '2023/04/27', created_at: '2023/01/30 09:00', user_id: user_taro.id) }
+    let!(:task_A2) { create(:task, title: 'titleA2', status: :start, deadline: '2023/04/28', created_at: '2023/02/29 09:00', user_id: user_taro.id) }
+    let!(:task_B1) { create(:task, title: 'titleB1', status: :not_started, deadline: '2023/04/29', created_at: '2023/03/28 09:00', user_id: user_taro.id) }
+    let!(:task_B2) { create(:task, title: 'titleB2', status: :start, deadline: '2023/04/30', created_at: '2023/04/27 09:00', user_id: user_taro.id) }
+    let!(:task_C1) { create(:task, title: 'titleC1', status: :not_started, user_id: user_jiro.id) }
+
     context 'statusのみ指定して検索' do
-      let!(:task_A1) { create(:task, title: 'titleA1', status: :not_started) }
-      let!(:task_A2) { create(:task, title: 'titleA2', status: :start) }
-      let!(:task_B1) { create(:task, title: 'titleB1', status: :not_started) }
-      let!(:task_B2) { create(:task, title: 'titleB2', status: :start) }
       let(:conditions) { { status: '未着手' } }
 
       it '検索結果の件数が一致すること' do
@@ -344,13 +349,19 @@ RSpec.describe Task, type: :system do
 
         expect(page).not_to have_content 'titleB2'
       end
+
+      it 'titleC1が表示されないこと' do
+        visit root_path
+
+        fill_in 'title', with: ''
+        select(value = conditions[:status], from: 'status')
+        click_on '検索'
+
+        expect(page).not_to have_content 'titleC1'
+      end
     end
 
     context 'title、statusを指定して検索' do
-      let!(:task_A1) { create(:task, title: 'titleA1', status: :not_started) }
-      let!(:task_A2) { create(:task, title: 'titleA2', status: :start) }
-      let!(:task_B1) { create(:task, title: 'titleB1', status: :not_started) }
-      let!(:task_B2) { create(:task, title: 'titleB2', status: :start) }
       let(:conditions) { { title: 'A', status: '未着手' } }
 
       it '検索結果の件数が一致すること' do
@@ -405,10 +416,7 @@ RSpec.describe Task, type: :system do
     end
 
     context '終了期日のソート条件が無いまま、検索できること' do
-      let!(:task_A1) { create(:task, title: 'titleA1', status: :not_started, deadline: '2023/04/27', created_at: '2023/01/30 09:00') }
-      let!(:task_A2) { create(:task, title: 'titleA2', status: :start, deadline: '2023/04/28', created_at: '2023/02/29 09:00') }
-      let!(:task_B1) { create(:task, title: 'titleB1', status: :not_started, deadline: '2023/04/29', created_at: '2023/03/28 09:00') }
-      let!(:task_B2) { create(:task, title: 'titleB2', status: :not_started, deadline: '2023/04/30', created_at: '2023/04/27 09:00') }
+      let!(:task_A2) { create(:task, title: 'titleA2', status: :not_started, deadline: '2023/04/28', created_at: '2023/08/29 09:00', user_id: user_taro.id) }
       let(:conditions) { { status: '未着手' } }
 
       it '検索結果の件数が一致すること' do
@@ -420,17 +428,14 @@ RSpec.describe Task, type: :system do
 
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
-          expect(task_titles).to eq %w[titleB2 titleB1 titleA1]
+          expect(task_titles).to eq %w[titleA2 titleB1 titleA1]
         end
         expect(all('tbody tr').size).to be(3)
       end
     end
 
     context '終了期日の昇順ソートのまま、検索できること' do
-      let!(:task_A1) { create(:task, title: 'titleA1', status: :not_started, deadline: '2023/04/27') }
-      let!(:task_A2) { create(:task, title: 'titleA2', status: :not_started, deadline: '2023/04/28') }
-      let!(:task_B1) { create(:task, title: 'titleB1', status: :not_started, deadline: '2023/04/29') }
-      let!(:task_B2) { create(:task, title: 'titleB2', status: :start, deadline: '2023/04/30') }
+      let!(:task_A2) { create(:task, title: 'titleA2', status: :not_started, deadline: '2023/04/28', created_at: '2023/08/29 09:00', user_id: user_taro.id) }
       let(:conditions) { { status: '未着手' } }
 
       it '昇順ソートで検索結果の件数が一致すること' do
@@ -450,10 +455,7 @@ RSpec.describe Task, type: :system do
     end
 
     context '終了期日の降順並びのまま、検索できること' do
-      let!(:task_A1) { create(:task, title: 'titleA1', status: :not_started, deadline: '2023/04/27', created_at: '2023/04/30 00:00') }
-      let!(:task_A2) { create(:task, title: 'titleA2', status: :not_started, deadline: '2023/04/28', created_at: '2023/04/29 00:00') }
-      let!(:task_B1) { create(:task, title: 'titleB1', status: :not_started, deadline: '2023/04/29', created_at: '2023/04/28 00:00') }
-      let!(:task_B2) { create(:task, title: 'titleB2', status: :start, deadline: '2023/04/30', created_at: '2023/04/27 00:00') }
+      let!(:task_A2) { create(:task, title: 'titleA2', status: :not_started, deadline: '2023/04/28', created_at: '2023/08/29 09:00', user_id: user_taro.id) }
       let(:conditions) { { status: '未着手' } }
 
       it '降順ソートで検索結果の件数が一致すること' do
@@ -575,7 +577,7 @@ RSpec.describe Task, type: :system do
   end
 
   describe 'タスク編集' do
-    let!(:task) { create(:task) }
+    let!(:task) { create(:task, user_id: user_taro.id) }
 
     context '編集タスクがある' do
       it '編集ページの表示に成功' do
@@ -707,7 +709,7 @@ RSpec.describe Task, type: :system do
   end
 
   describe 'タスク削除' do
-    let!(:task) { create(:task) }
+    let!(:task) { create(:task, user_id: user_taro.id) }
 
     context '削除タスクがある' do
       it 'タスクの削除に成功' do

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -268,6 +268,8 @@ RSpec.describe Task, type: :system do
     end
 
     context '詳細タスクがある' do
+      let!(:task) { create(:task, user_id: user_taro.id) }
+
       it '詳細ページの表示' do
         visit task_path(task.id)
 
@@ -286,6 +288,17 @@ RSpec.describe Task, type: :system do
 
         expect(page).to have_current_path root_path, ignore_query: true
         expect(page).to have_content '該当するリソースがありませんでした。'
+      end
+    end
+
+    context '自分以外のタスクの詳細ページにアクセス' do
+      let!(:task) { create(:task, user_id: user_jiro.id) }
+
+      it 'アクセス権限がないと表示' do
+        visit task_path(task.id)
+
+        expect(page).to have_current_path root_path, ignore_query: true
+        expect(page).to have_content 'アクセスする権限がありません。'
       end
     end
   end
@@ -605,6 +618,17 @@ RSpec.describe Task, type: :system do
 
         expect(page).to have_current_path root_path, ignore_query: true
         expect(page).to have_content '該当するリソースがありませんでした。'
+      end
+    end
+
+    context '自分以外のタスクの編集ページにアクセス' do
+      let!(:task) { create(:task, user_id: user_jiro.id) }
+
+      it 'アクセス権限がないと表示' do
+        visit edit_task_path(task.id)
+
+        expect(page).to have_current_path root_path, ignore_query: true
+        expect(page).to have_content 'アクセスする権限がありません。'
       end
     end
 

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -2,16 +2,21 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :system do
   let(:task) { create(:task) }
+  let(:user) { create(:user, name: 'hogehoge', email: Faker::Internet.email, password: 'password') }
+
+  before do
+    login(user.email, user.password)
+  end
 
   describe 'タスク表示' do
     context 'DBに保存されたデータがある' do
       before do
-        create(:task, id: '1', title: 'task1', content: 'task_contetnt1', deadline: '2023/04/27',
-                      status: :not_started, created_at: '2023/04/27 09:00')
-        create(:task, id: '2', title: 'task2', content: 'task_contetnt2', deadline: '2023/04/26',
-                      status: :start, created_at: '2023/04/27 08:00')
-        create(:task, id: '3', title: 'task3', content: 'task_contetnt3', deadline: '2023/04/28',
-                      status: :completed, created_at: '2023/04/27 10:00')
+        create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/04/27',
+                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user.id)
+        create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/26',
+                      status: :start, created_at: '2023/04/27 08:00', user_id: user.id)
+        create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/28',
+                      status: :completed, created_at: '2023/04/27 10:00', user_id: user.id)
         visit root_path
       end
 
@@ -45,6 +50,8 @@ RSpec.describe Task, type: :system do
         expect(page).to have_select(options: ['未着手', '着手中', '完了'])
         expect(page).to have_button '検索'
         expect(page).to have_link 'クリア'
+        expect(page).to have_link 'ログアウト'
+        expect(page).to have_content user.name
 
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
@@ -55,27 +62,27 @@ RSpec.describe Task, type: :system do
 
     context '作成日順ソートでページングが動作' do
       before do
-        create(:task, id: '1', title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
-                      created_at: '2023/04/26 01:00')
-        create(:task, id: '2', title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
-                      created_at: '2023/04/27 02:00')
-        create(:task, id: '3', title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
-                      created_at: '2023/04/28 03:00')
-        create(:task, id: '4', title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
-                      created_at: '2023/04/29 04:00')
-        create(:task, id: '5', title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
-                      created_at: '2023/04/30 05:00')
-        create(:task, id: '6', title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
-                      created_at: '2023/05/01 06:00')
+        create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
+                      created_at: '2023/04/26 01:00', user_id: user.id)
+        create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
+                      created_at: '2023/04/27 02:00', user_id: user.id)
+        create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
+                      created_at: '2023/04/28 03:00', user_id: user.id)
+        create(:task, title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
+                      created_at: '2023/04/29 04:00', user_id: user.id)
+        create(:task, title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
+                      created_at: '2023/04/30 05:00', user_id: user.id)
+        create(:task, title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
+                      created_at: '2023/05/01 06:00', user_id: user.id)
         visit root_path
       end
 
       it '２ページ目のタスクが表示されている' do
-        expect(page).to have_selector('span', text: 'Next')
+        expect(page).to have_selector('a', text: 'Next')
         expect(page).to have_link 'Next'
-        expect(page).to have_selector('span', text: 'Last')
+        expect(page).to have_selector('a', text: 'Last')
         expect(page).to have_link 'Last'
-        expect(page).to have_selector('span', text: '2')
+        expect(page).to have_selector('a', text: '2')
         expect(page).to have_link '2'
         within '.tasks' do
           task_titles = all('.task-title').map(&:text)
@@ -94,9 +101,7 @@ RSpec.describe Task, type: :system do
         expect(page).to have_link '削除'
         expect(page).to have_link '昇順', href: search_tasks_path(deadline_order: 'asc')
         expect(page).to have_link '降順', href: search_tasks_path(deadline_order: 'desc')
-        expect(page).to have_css '.first'
         expect(page).to have_link 'First'
-        expect(page).to have_css '.prev'
         expect(page).to have_link 'Previous'
         expect(page).to have_link '1'
       end
@@ -104,18 +109,18 @@ RSpec.describe Task, type: :system do
 
     context '終了期限の昇順ソートでページングが動作' do
       before do
-        create(:task, id: '1', title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
-                      created_at: '2023/04/26 01:00')
-        create(:task, id: '2', title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
-                      created_at: '2023/04/27 02:00')
-        create(:task, id: '3', title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
-                      created_at: '2023/04/28 03:00')
-        create(:task, id: '4', title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
-                      created_at: '2023/04/29 04:00')
-        create(:task, id: '5', title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
-                      created_at: '2023/04/30 05:00')
-        create(:task, id: '6', title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
-                      created_at: '2023/05/01 06:00')
+        create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
+                      created_at: '2023/04/26 01:00', user_id: user.id)
+        create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
+                      created_at: '2023/04/27 02:00', user_id: user.id)
+        create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
+                      created_at: '2023/04/28 03:00', user_id: user.id)
+        create(:task, title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
+                      created_at: '2023/04/29 04:00', user_id: user.id)
+        create(:task, title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
+                      created_at: '2023/04/30 05:00', user_id: user.id)
+        create(:task, title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
+                      created_at: '2023/05/01 06:00', user_id: user.id)
         visit root_path
       end
 
@@ -139,29 +144,29 @@ RSpec.describe Task, type: :system do
         expect(page).to have_link '削除'
         expect(page).to have_link '昇順', href: search_tasks_path(deadline_order: 'asc')
         expect(page).to have_link '降順', href: search_tasks_path(deadline_order: 'desc')
-        expect(page).to have_selector('span', text: 'First')
+        expect(page).to have_selector('a', text: 'First')
         expect(page).to have_link 'First'
-        expect(page).to have_selector('span', text: 'Previous')
+        expect(page).to have_selector('a', text: 'Previous')
         expect(page).to have_link 'Previous'
-        expect(page).to have_selector('span', text: '1')
+        expect(page).to have_selector('a', text: '1')
         expect(page).to have_link '1'
       end
     end
 
     context '終了期限の降順ソートでページングが動作' do
       before do
-        create(:task, id: '1', title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
-                      created_at: '2023/04/26 01:00')
-        create(:task, id: '2', title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
-                      created_at: '2023/04/27 02:00')
-        create(:task, id: '3', title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
-                      created_at: '2023/04/28 03:00')
-        create(:task, id: '4', title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
-                      created_at: '2023/04/29 04:00')
-        create(:task, id: '5', title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
-                      created_at: '2023/04/30 05:00')
-        create(:task, id: '6', title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
-                      created_at: '2023/05/01 06:00')
+        create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/05/01',
+                      created_at: '2023/04/26 01:00', user_id: user.id)
+        create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/30',
+                      created_at: '2023/04/27 02:00', user_id: user.id)
+        create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/29',
+                      created_at: '2023/04/28 03:00', user_id: user.id)
+        create(:task, title: 'task4', content: 'task_contetnt4', deadline: '2023/04/28',
+                      created_at: '2023/04/29 04:00', user_id: user.id)
+        create(:task, title: 'task5', content: 'task_contetnt5', deadline: '2023/04/27',
+                      created_at: '2023/04/30 05:00', user_id: user.id)
+        create(:task, title: 'task6', content: 'task_contetnt6', deadline: '2023/04/26',
+                      created_at: '2023/05/01 06:00', user_id: user.id)
         visit root_path
       end
 
@@ -185,23 +190,23 @@ RSpec.describe Task, type: :system do
         expect(page).to have_link '削除'
         expect(page).to have_link '昇順', href: search_tasks_path(deadline_order: 'asc')
         expect(page).to have_link '降順', href: search_tasks_path(deadline_order: 'desc')
-        expect(page).to have_selector('span', text: 'First')
+        expect(page).to have_selector('a', text: 'First')
         expect(page).to have_link 'First'
-        expect(page).to have_selector('span', text: 'Previous')
+        expect(page).to have_selector('a', text: 'Previous')
         expect(page).to have_link 'Previous'
-        expect(page).to have_selector('span', text: '1')
+        expect(page).to have_selector('a', text: '1')
         expect(page).to have_link '1'
       end
     end
 
     context '一覧ページの終了期限の昇順ボタンが押された' do
       before do
-        create(:task, id: '1', title: 'task1', content: 'task_contetnt1', deadline: '2023/04/29',
-                      status: :not_started, created_at: '2023/04/27 09:00')
-        create(:task, id: '2', title: 'task2', content: 'task_contetnt2', deadline: '2023/04/28',
-                      status: :start, created_at: '2023/04/27 08:00')
-        create(:task, id: '3', title: 'task3', content: 'task_contetnt3', deadline: '2023/04/27',
-                      status: :completed, created_at: '2023/04/27 10:00')
+        create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/04/29',
+                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user.id)
+        create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/28',
+                      status: :start, created_at: '2023/04/27 08:00', user_id: user.id)
+        create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/27',
+                      status: :completed, created_at: '2023/04/27 10:00', user_id: user.id)
         visit root_path
       end
 
@@ -218,12 +223,12 @@ RSpec.describe Task, type: :system do
 
     context '一覧ページの終了期限の降順ボタンが押された' do
       before do
-        create(:task, id: '1', title: 'task1', content: 'task_contetnt1', deadline: '2023/04/29',
-                      status: :not_started, created_at: '2023/04/27 09:00')
-        create(:task, id: '2', title: 'task2', content: 'task_contetnt2', deadline: '2023/04/28',
-                      status: :start, created_at: '2023/04/27 08:00')
-        create(:task, id: '3', title: 'task3', content: 'task_contetnt3', deadline: '2023/04/27',
-                      status: :completed, created_at: '2023/04/27 10:00')
+        create(:task, title: 'task1', content: 'task_contetnt1', deadline: '2023/04/29',
+                      status: :not_started, created_at: '2023/04/27 09:00', user_id: user.id)
+        create(:task, title: 'task2', content: 'task_contetnt2', deadline: '2023/04/28',
+                      status: :start, created_at: '2023/04/27 08:00', user_id: user.id)
+        create(:task, title: 'task3', content: 'task_contetnt3', deadline: '2023/04/27',
+                      status: :completed, created_at: '2023/04/27 10:00', user_id: user.id)
         visit root_path
       end
 

--- a/myapp/spec/system/user_spec.rb
+++ b/myapp/spec/system/user_spec.rb
@@ -1,4 +1,143 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :system do
+  let!(:user) { create(:user, name: 'MM', email: 'hoge@hoge.com', password: 'password') }
+
+  describe '画面表示' do
+    before do
+      visit new_user_path
+    end
+
+    context 'ユーザー新規登録ページにアクセスしたとき' do
+      it 'ユーザー新規登録の画面が表示されること' do
+        expect(page).to have_current_path new_user_path, ignore_query: true
+        expect(page).to have_field 'user[name]'
+        expect(page).to have_field 'user[email]'
+        expect(page).to have_field 'user[password]'
+        expect(page).to have_field 'user[password_confirmation]'
+        expect(page).to have_button '登録'
+        expect(page).to have_link 'もどる'
+      end
+    end
+  end
+
+  describe 'ユーザー登録' do
+    before do
+      visit new_user_path
+      fill_in 'user[name]', with: 'test子'
+      fill_in 'user[email]', with: 'test@test.com'
+      fill_in 'user[password]', with: 'password'
+      fill_in 'user[password_confirmation]', with: 'password'
+    end
+
+    context '正しい情報を入力したとき' do
+      before do
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できる' do
+        expect(page).to have_current_path login_path, ignore_query: true
+        expect(page).to have_selector('.alert-success', text: I18n.t('messages.create', model_name: I18n.t('activerecord.models.user')))
+      end
+    end
+
+    context 'nameを入力しなかったとき' do
+      before do
+        fill_in 'user[name]', with: ''
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できない' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content '氏名を入力してください'
+      end
+    end
+
+    context 'emailを入力しなかったとき' do
+      before do
+        fill_in 'user[email]', with: ''
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できない' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content 'メールアドレスを入力してください'
+        expect(page).to have_content 'メールアドレスは不正な値です'
+      end
+    end
+
+    context 'emailに256文字以上入力したとき' do
+      before do
+        fill_in 'user[email]', with: "#{'a' * 256}" + '@test.com'
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できない' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content 'メールアドレスは255文字以内で入力してください'
+      end
+    end
+
+    context '登録済みのメールアドレスを入力したとき' do
+      before do
+        fill_in 'user[email]', with: 'hoge@hoge.com'
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できない' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content 'メールアドレスはすでに存在します'
+      end
+    end
+
+    context 'メールアドレスフォーマット以外を入力したとき' do
+      before do
+        fill_in 'user[email]', with: '@testtest.com'
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できない' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content 'メールアドレスは不正な値です'
+      end
+    end
+
+    context 'パスワードが空欄のとき' do
+      before do
+        fill_in 'user[password]', with: ''
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できない' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content 'パスワードを入力してください'
+      end
+    end
+
+    context 'パスワードが7文字で入力したとき' do
+      before do
+        fill_in 'user[password]', with: 'passwor'
+        fill_in 'user[password_confirmation]', with: 'passwor'
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できない' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content 'パスワードは8文字以上で入力してください'
+      end
+    end
+
+    context 'パスワード、パスワード確認が異なる値で入力されたとき' do
+      before do
+        fill_in 'user[password]', with: 'password'
+        fill_in 'user[password_confirmation]', with: 'passwor'
+        click_button '登録'
+      end
+
+      it 'ユーザー登録できない' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content 'パスワード確認とパスワードの入力が一致しません'
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Jiraチケット
https://jira.rakuten-it.com/jira/browse/RAKUTRA-5185
## 行うこと
 - 追加のGemを使わず、自分で実装してみましょう
   - DeviseなどのGemを使わないことで、HTTPのCookieやRailsにおけるSessionなどの仕組みについて理解を深めることが目的です
   - また、一般的な認証についての理解を深めることも目的にしています（パスワードの取り扱いについてなど）
- ログイン画面を実装しましょう
- ログインしていない場合は、タスク管理のページに遷移できないようにしましょう
- 自分が作成したタスクだけを表示するようにしましょう
- ログアウト機能を実装しましょう
## URL
[Rails 研修](https://github.com/Fablic/training/blob/develop/steps_jp.md)「ステップ17: ログイン/ログアウト機能を実装しよう」を実施しました
## 行ったこと
- ログインページの作成
- ユーザー登録機能（Step18）
→パスワードの暗号化部分がコンソールからうまくいなかったため、先行して実装しました。実装分のテストは
　行ったものの、Step18の内容を全て網羅されていないため、Step18で改めて確認テストを行います。
- Userモデルテスト
- loginモデルテスト
- sessionリクエストテスト

## 動作確認
### ログイン・ログアウト
![202305251123](https://github.com/Fablic/training/assets/129723112/9f18d232-57b5-4291-97dc-00d1ee486d8e)