### PR TITLE
[Koyama STEP18]ユーザの管理画面を実装しよう

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
       logger.info "ActiveRecord::RecordNotFound!: #{e.message}"
       logger.info e.backtrace.join("\n")
     end
-    redirect_to root_path, alert: t('error.messages.record_not_found')
+    redirect_to root_path, danger: t('error.messages.record_not_found')
   end
 end

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -6,7 +6,9 @@ class UsersController < ApplicationController
     @users = User.includes(:tasks).order(created_at: 'DESC').page(params[:page]).per(5)
   end
 
-  def show; end
+  def show
+    @tasks = @user.tasks
+  end
 
   def new
     @user = User.new

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -1,18 +1,49 @@
 class UsersController < ApplicationController
+  before_action :require_login
+  before_action :set_user_id, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @users = User.all.order(created_at: 'DESC').page(params[:page]).per(5)
+  end
+
+  def show; end
+
   def new
     @user = User.new
   end
 
+  def edit; end
+
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path, success: t('messages.create', model_name: t('activerecord.models.user'))
+      redirect_to users_path, success: t('messages.create', model_name: t('activerecord.models.user'))
     else
-      render 'new'
+      render :new
+    end
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to users_path, success: t('messages.update', model_name: t('activerecord.models.user'))
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @user.destroy
+      redirect_to users_path, success: t('messages.delete', model_name: t('activerecord.models.user'))
+    else
+      render :index
     end
   end
 
   private
+
+  def set_user_id
+    @user = User.find(params[:id])
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :set_user_id, only: [:show, :edit, :update, :destroy]
 
   def index
-    @users = User.all.order(created_at: 'DESC').page(params[:page]).per(5)
+    @users = User.includes(:tasks).order(created_at: 'DESC').page(params[:page]).per(5)
   end
 
   def show; end

--- a/myapp/app/views/sessions/new.html.erb
+++ b/myapp/app/views/sessions/new.html.erb
@@ -18,7 +18,6 @@
 
         <div class='submit-content'>
           <%= form.submit t('buttons.login'), class: 'btn btn-primary' %>
-          <%= link_to t('buttons.signin'), new_user_path, class: 'btn btn-link' %>
         </div>
       </div>
     <% end %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -6,7 +6,10 @@
       </div>
       <div class='collapse navbar-collapse'>
         <div class='navbar-nav'>
-          <%= link_to t('buttons.new'), new_task_path, class: 'nav-link' %>
+          <%= link_to t('activerecord.models.task') + t('buttons.new'), new_task_path, class: 'nav-link' %>
+        </div>
+        <div class='navbar-nav'>
+          <%= link_to t('activerecord.models.user') + t('buttons.list'), users_path, class: 'nav-link' %>
         </div>
       </div>
     </div>

--- a/myapp/app/views/users/_form.html.erb
+++ b/myapp/app/views/users/_form.html.erb
@@ -25,7 +25,7 @@
 
     <div class='submit-content'>
       <%= form.submit t('buttons.register'), class: 'btn btn-primary' %>
-      <%= link_to t('buttons.back_page'), login_path, class: 'btn btn-link' %>
+      <%= link_to t('buttons.back_page'), users_path, class: 'btn btn-link' %>
     </div>
   <% end %>
 </div>

--- a/myapp/app/views/users/edit.html.erb
+++ b/myapp/app/views/users/edit.html.erb
@@ -1,0 +1,8 @@
+<div class='text-content container' style='padding:10px;'>
+  <h2><%= t('activerecord.models.user') + t('buttons.edit') %></h2>
+
+  <div class='main'>
+
+    <%= render partial: 'form' %>
+  </div>
+</div>

--- a/myapp/app/views/users/index.html.erb
+++ b/myapp/app/views/users/index.html.erb
@@ -1,0 +1,53 @@
+<div class='container rounded-2' style='padding:10px;'>
+  <nav class='navbar navbar-expand-lg navbar-light bg-light mb-3'>
+    <div class='container-fluid'>
+      <div class='navbar-brand'>
+        <%= t('activerecord.models.task') + t('commom.word.management') %>
+      </div>
+      <div class='collapse navbar-collapse'>
+        <div class='navbar-nav'>
+          <%= link_to t('activerecord.models.user') + t('buttons.new'), new_user_path, class: 'nav-link' %>
+        </div>
+        <div class='navbar-nav'>
+          <%= link_to t('activerecord.models.task') + t('buttons.list'), tasks_path, class: 'nav-link' %>
+        </div>
+      </div>
+    </div>
+    <div class='container-sm justify-content-end'>
+        <% if logged_in? %>
+          <span class='d-flex align-items-center'><%= @current_user.name %></span>
+          <span class='d-flex align-items-center mx-2'><%= link_to t('buttons.logout'), logout_path, class: 'btn btn-danger', method: :delete %></span>
+        <% end %>
+      </div>
+  </nav>
+
+  <table class='tasks table table-bordered'>
+    <tr>
+      <th scope='col'><%= t('activerecord.attributes.user.id') %></th>
+      <th scope='col'><%= t('activerecord.attributes.user.name') %></th>
+      <th scope='col'><%= t('activerecord.attributes.task.email') %></th>
+      <th scope='col'><%= t('activerecord.attributes.user.created_at') %></th>
+      <th scope='col'><%= t('activerecord.attributes.user.updated_at') %></th>
+      <th scope='col'><%= t('activerecord.attributes.user.another') %></th>
+    </tr>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr scope='row'>
+          <td><%= user.id %></td>
+          <td class='user-name'>
+            <%= user.name %>
+          </td>
+          <td><%= user.email %></td>
+          <td><%= l user.created_at, format: :short %></td>
+          <td><%= l user.updated_at, format: :short %></td>
+          <td>
+            <%= link_to t('buttons.show'), user_path(user.id), class: 'btn btn-secondary' %>
+            <%= link_to t('buttons.edit'), edit_user_path(user.id), class: 'btn btn-secondary' %>
+            <%= link_to t('buttons.delete'), user_path(user.id), method: :delete, class: 'btn btn-danger' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <%= paginate @users, theme: 'bootstrap-5'%>
+</div>

--- a/myapp/app/views/users/index.html.erb
+++ b/myapp/app/views/users/index.html.erb
@@ -44,7 +44,7 @@
           <td><%= l user.updated_at, format: :short %></td>
           <td>
             <%= link_to t('buttons.show'), user_path(user.id), class: 'btn btn-secondary' %>
-            <%= link_to t('buttons.edit'), edit_user_path(user.id), class: 'btn btn-secondary' %>
+            <%= link_to t('buttons.edit'), edit_user_path(user.id), class: 'btn btn-primary' %>
             <%= link_to t('buttons.delete'), user_path(user.id), method: :delete, class: 'btn btn-danger' %>
           </td>
         </tr>

--- a/myapp/app/views/users/index.html.erb
+++ b/myapp/app/views/users/index.html.erb
@@ -21,11 +21,12 @@
       </div>
   </nav>
 
-  <table class='tasks table table-bordered'>
+  <table class='users table table-bordered'>
     <tr>
       <th scope='col'><%= t('activerecord.attributes.user.id') %></th>
       <th scope='col'><%= t('activerecord.attributes.user.name') %></th>
       <th scope='col'><%= t('activerecord.attributes.task.email') %></th>
+      <th scope='col'><%= t('activerecord.attributes.user.user_task_count') %></th>
       <th scope='col'><%= t('activerecord.attributes.user.created_at') %></th>
       <th scope='col'><%= t('activerecord.attributes.user.updated_at') %></th>
       <th scope='col'><%= t('activerecord.attributes.user.another') %></th>
@@ -38,6 +39,7 @@
             <%= user.name %>
           </td>
           <td><%= user.email %></td>
+          <td><%= user.tasks.length %></td>
           <td><%= l user.created_at, format: :short %></td>
           <td><%= l user.updated_at, format: :short %></td>
           <td>

--- a/myapp/app/views/users/show.html.erb
+++ b/myapp/app/views/users/show.html.erb
@@ -1,0 +1,31 @@
+<div class='text-content container' style='padding:10px;'>
+  <h2><%= t('activerecord.models.user') + t('buttons.show') %></h2>
+
+  <table class='table'>
+    <tbody>
+      <tr>
+        <th class='w-25'><%= t('activerecord.attributes.user.id') %></th>
+        <td class='w-75'><%= @user.id %></td>
+      </tr>
+      <tr>
+        <th class='w-25'><%= t('activerecord.attributes.user.name') %></th>
+        <td class='w-75'><%= @user.name %></td>
+      </tr>
+      <tr>
+        <th class='w-25'><%= t('activerecord.attributes.user.email') %></th>
+        <td class='w-75'><%= @user.email %></td>
+      </tr>
+      <tr>
+        <th class='w-25'><%= t('activerecord.attributes.user.created_at') %></th>
+        <td class='w-75'><%= @user.created_at %></td>
+      </tr>
+      <tr>
+        <th class='w-25'><%= t('activerecord.attributes.user.updated_at') %></th>
+        <td class='w-75'><%= @user.updated_at %></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <%= link_to t('activerecord.models.user') + t('buttons.list'), users_path, class: 'btn btn-primary' %>
+  <%= link_to t('buttons.edit'), edit_user_path(@user), class: 'btn btn-primary' %>
+</div>

--- a/myapp/app/views/users/show.html.erb
+++ b/myapp/app/views/users/show.html.erb
@@ -28,4 +28,32 @@
 
   <%= link_to t('activerecord.models.user') + t('buttons.list'), users_path, class: 'btn btn-primary' %>
   <%= link_to t('buttons.edit'), edit_user_path(@user), class: 'btn btn-primary' %>
+
+    <h4 class="mt-5"><%= @user.name %><%= I18n.t('activerecord.models.task') %><%= t('buttons.list') %></h4>
+    <table class='tasks table table-bordered'>
+    <tr>
+      <th scope='col'><%= t('activerecord.attributes.task.id') %></th>
+      <th scope='col'><%= t('activerecord.attributes.task.title') %></th>
+      <th scope='col'><%= t('activerecord.attributes.task.content') %></th>
+      <th scope='col'><%= t('activerecord.attributes.task.deadline') %></th>
+      <th scope='col'><%= t('activerecord.attributes.task.status') %></th>
+      <th scope='col'><%= t('activerecord.attributes.task.created_at') %></th>
+      <th scope='col'><%= t('activerecord.attributes.user.updated_at') %></th>
+    </tr>
+    <tbody>
+      <% @tasks.each do |task| %>
+        <tr scope='row'>
+          <td><%= task.id %></td>
+          <td class='task-title'>
+            <%= task.title %>
+          </td>
+          <td><%= task.content %></td>
+          <td><%= l task.deadline %></td>
+          <td><%= t("enums.task.status.#{task.status}") %></td>
+          <td><%= l task.created_at, format: :short %></td>
+          <td><%= l task.updated_at, format: :short %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -33,6 +33,7 @@ ja:
     login: ログイン
     logout: ログアウト
     signin: サインイン
+    list: リスト
     sort:
       asc: 昇順
       desc: 降順

--- a/myapp/config/locales/models/user/ja.yml
+++ b/myapp/config/locales/models/user/ja.yml
@@ -9,3 +9,6 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード確認
+        created_at: 作成日
+        updated_at: 更新日
+        another: その他

--- a/myapp/config/locales/models/user/ja.yml
+++ b/myapp/config/locales/models/user/ja.yml
@@ -9,6 +9,7 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード確認
+        user_task_count: タスク件数
         created_at: 作成日
         updated_at: 更新日
         another: その他

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   resources :tasks do
     get :search, on: :collection
   end
-  resources :users, only: %i[new create]
+  resources :users, path: '/admin/users'
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -6,7 +6,7 @@ USER_NUM.times do |i|
   user = User.create!(
     name: name,
     email: "test#{i}@gmail.com",
-    password_digest: 'password',
+    password: 'password',
   )
   TASK_NUM.times do |j|
     deadline = Faker::Date.backward

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    name { Faker::Name }
-    email { Faker::Internet.email}
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
     password { 'password' }
   end
 end

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe User, type: :model do
       it '正常に登録できる' do
         expect(user).to be_valid
       end
+
+      it 'emailが255文字以下なら正常に登録できる' do
+        user.email = 'a' * 243 + '@example.com'
+        expect(user).to be_valid
+      end
     end
 
     context 'nameのバリデーション' do
@@ -28,8 +33,7 @@ RSpec.describe User, type: :model do
       end
 
       it 'emailの長さが256文字以上だと無効' do
-        text = 'a' * 256
-        user.email = "#{text}" + '@example.com'
+        user.email = 'a' * 244 + '@example.com'
 
         expect(user).not_to be_valid
         expect(user.errors.full_messages).to include('メールアドレスは255文字以内で入力してください')

--- a/myapp/spec/system/task_spec.rb
+++ b/myapp/spec/system/task_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe Task, type: :system do
         expect(page).to have_link '削除'
         expect(page).to have_link '昇順', href: search_tasks_path(deadline_order: 'asc')
         expect(page).to have_link '降順', href: search_tasks_path(deadline_order: 'desc')
+        expect(page).to have_link 'タスク新規登録'
+        expect(page).to have_link 'ユーザーリスト'
         expect(page).to have_field 'title'
         expect(page).to have_select(options: ['未着手', '着手中', '完了'])
         expect(page).to have_button '検索'

--- a/myapp/spec/system/user_spec.rb
+++ b/myapp/spec/system/user_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe User, type: :system do
     before do
       visit new_user_path
       fill_in 'user[name]', with: 'test子'
-      fill_in 'user[email]', with: 'test@test.com'
+      fill_in 'user[email]', with: 'a' * 246 + '@test.com'
       fill_in 'user[password]', with: 'password'
       fill_in 'user[password_confirmation]', with: 'password'
     end
@@ -445,13 +445,12 @@ RSpec.describe User, type: :system do
   describe 'ユーザー削除' do
     let!(:task) { create(:task, user_id: user_jiro.id) }
 
+    before do
+      visit users_path
+    end
+
     context '削除ユーザーがある' do
       it 'ユーザーの削除に成功' do
-        expect(User.all.length).to eq 2
-        expect(Task.all.length).to eq 1
-
-        visit users_path
-
         expect(page).to have_link '削除'
         click_link '削除', href: "/admin/users/#{user_jiro.id}"
 
@@ -465,11 +464,6 @@ RSpec.describe User, type: :system do
 
     context '削除タスクがない' do
       it '該当するリソースがないと表示' do
-        expect(User.all.length).to eq 2
-        expect(Task.all.length).to eq 1
-
-        visit users_path
-
         user_jiro.destroy
         click_link '削除', href: "/admin/users/#{user_jiro.id}"
 

--- a/myapp/spec/system/user_spec.rb
+++ b/myapp/spec/system/user_spec.rb
@@ -1,11 +1,125 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :system do
-  let(:user_taro) { create(:user, name: 'hogehoge', email: Faker::Internet.email, password: 'password') }
-  let(:user_jiro) { create(:user, name: 'testest', email: Faker::Internet.email, password: 'password') }
+  let!(:user_taro) { create(:user, name: 'hogehoge', email: 'hoge@hoge.com', password: 'password') }
+  let!(:user_jiro) { create(:user, name: 'testest', email: 'test@hoge.com', password: 'password') }
 
   before do
     login(user_taro.email, user_taro.password)
+  end
+
+  describe 'ユーザー一覧画面表示' do
+    before do
+      visit users_path
+    end
+
+    context 'ユーザー一覧ページにアクセスしたとき' do
+      it 'ユーザー一覧の画面が表示される' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_content user_taro.id
+        expect(page).to have_content user_taro.name
+        expect(page).to have_content user_taro.email
+        expect(page).to have_content user_taro.tasks.length
+        expect(page).to have_content (I18n.l(user_taro.created_at, format: :short))
+        expect(page).to have_content (I18n.l(user_taro.updated_at, format: :short))
+        expect(page).to have_link '詳細', href: "/admin/users/#{user_taro.id}"
+        expect(page).to have_link '編集', href: "/admin/users/#{user_taro.id}/edit"
+        expect(page).to have_link '削除', href: "/admin/users/#{user_taro.id}"
+        expect(page).to have_content user_jiro.id
+        expect(page).to have_content user_jiro.name
+        expect(page).to have_content user_jiro.email
+        expect(page).to have_content user_jiro.tasks.length
+        expect(page).to have_content (I18n.l(user_jiro.created_at, format: :short))
+        expect(page).to have_content (I18n.l(user_jiro.updated_at, format: :short))
+        expect(page).to have_link '詳細', href: "/admin/users/#{user_jiro.id}"
+        expect(page).to have_link '編集', href: "/admin/users/#{user_jiro.id}/edit"
+        expect(page).to have_link '削除', href: "/admin/users/#{user_jiro.id}"
+        expect(page).to have_link 'ユーザー新規登録'
+        expect(page).to have_link 'タスクリスト'
+        expect(page).to have_selector('span', text: "#{user_taro.name}")
+        expect(page).to have_link 'ログアウト'
+
+        within '.users' do
+          users_name = all('.user-name').map(&:text)
+          expect(users_name).to eq %w[testest hogehoge]
+        end
+      end
+    end
+  end
+
+  describe 'ページング機能' do
+    before do
+      create(:user, name: 'user1')
+      create(:user, name: 'user2')
+      create(:user, name: 'user3')
+      create(:user, name: 'user4')
+      visit users_path
+    end
+
+    context 'ユーザー情報が５件以上あったとき' do
+      it '２ページ目にユーザーが表示される' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_selector('a', text: 'Next')
+        expect(page).to have_link 'Next'
+        expect(page).to have_selector('a', text: 'Last')
+        expect(page).to have_link 'Last'
+        expect(page).to have_selector('a', text: '2')
+        expect(page).to have_link '2'
+
+        within '.users' do
+          users_name = all('.user-name').map(&:text)
+          expect(users_name).to eq %w[user4 user3 user2 user1 testest]
+        end
+
+        find_link('2').click
+
+        expect(page).to have_content user_taro.id
+        expect(page).to have_content user_taro.name
+        expect(page).to have_content user_taro.email
+        expect(page).to have_content user_taro.tasks.length
+        expect(page).to have_content (I18n.l(user_taro.created_at, format: :short))
+        expect(page).to have_content (I18n.l(user_taro.updated_at, format: :short))
+        expect(page).to have_link '詳細', href: "/admin/users/#{user_taro.id}"
+        expect(page).to have_link '編集', href: "/admin/users/#{user_taro.id}/edit"
+        expect(page).to have_link '削除', href: "/admin/users/#{user_taro.id}"
+        expect(page).to have_link 'First'
+        expect(page).to have_link 'Previous'
+        expect(page).to have_link '1'
+      end
+    end
+  end
+
+  describe 'ユーザー詳細画面表示' do
+    before do
+      visit user_path(user_taro.id)
+    end
+
+    context 'ユーザー詳細ページにアクセスしたとき' do
+      it 'ユーザー詳細の画面が表示される' do
+        expect(page).to have_current_path user_path(user_taro.id), ignore_query: true
+        expect(page).to have_content user_taro.id
+        expect(page).to have_content user_taro.name
+        expect(page).to have_content user_taro.email
+        expect(page).to have_content user_taro.tasks.length
+        expect(page).to have_content user_taro.created_at
+        expect(page).to have_content user_taro.updated_at
+        expect(page).to have_link '編集', href: "/admin/users/#{user_taro.id}/edit"
+        expect(page).to have_link 'ユーザーリスト', href: '/admin/users'
+      end
+    end
+
+    context 'ユーザー情報がないとき' do
+      before do
+        visit users_path
+        user_jiro.destroy
+        click_link '詳細', href: "/admin/users/#{user_jiro.id}"
+      end
+
+      it 'ユーザー情報の詳細ページ表示されない' do
+        expect(page).to have_current_path root_path, ignore_query: true
+        expect(page).to have_content '該当するリソースがありませんでした。'
+      end
+    end
   end
 
   describe 'ユーザー新規登録画面表示' do
@@ -14,7 +128,7 @@ RSpec.describe User, type: :system do
     end
 
     context 'ユーザー新規登録ページにアクセスしたとき' do
-      it 'ユーザー新規登録の画面が表示されること' do
+      it 'ユーザー新規登録の画面が表示される' do
         expect(page).to have_current_path new_user_path, ignore_query: true
         expect(page).to have_field 'user[name]'
         expect(page).to have_field 'user[email]'
@@ -152,7 +266,7 @@ RSpec.describe User, type: :system do
     end
 
     context 'ユーザー編集ページにアクセスしたとき' do
-      it 'ユーザー編集の画面が表示されること' do
+      it 'ユーザー編集の画面が表示される' do
         expect(page).to have_current_path edit_user_path(user_jiro.id), ignore_query: true
         expect(page).to have_field 'user[name]'
         expect(page).to have_field 'user[email]'
@@ -160,6 +274,19 @@ RSpec.describe User, type: :system do
         expect(page).to have_field 'user[password_confirmation]'
         expect(page).to have_button '登録'
         expect(page).to have_link 'もどる'
+      end
+    end
+
+    context '編集するユーザー情報がないとき' do
+      before do
+        visit users_path
+        user_jiro.destroy
+        click_link '編集', href: "/admin/users/#{user_jiro.id}/edit"
+      end
+
+      it 'ユーザー情報の編集ページが表示されない' do
+        expect(page).to have_current_path root_path, ignore_query: true
+        expect(page).to have_content '該当するリソースがありませんでした。'
       end
     end
   end
@@ -297,27 +424,41 @@ RSpec.describe User, type: :system do
   end
 
   describe 'ユーザー削除' do
+    let!(:task) { create(:task, user_id: user_jiro.id) }
+
     context '削除ユーザーがある' do
       it 'ユーザーの削除に成功' do
+        expect(User.all.length).to eq 2
+        expect(Task.all.length).to eq 1
+
         visit users_path
 
         expect(page).to have_link '削除'
-        click_link '削除',  href: "admin/users/#{user_jiro.id}"
+        click_link '削除', href: "/admin/users/#{user_jiro.id}"
 
         expect(page).to have_current_path users_path, ignore_query: true
         expect(page).to have_selector('.alert-success', text: I18n.t('messages.delete', model_name: I18n.t('activerecord.models.user')))
+        expect(page).not_to have_content user_jiro.email
+        expect(User.all.length).to eq 1
+        expect(Task.all.length).to eq 0
       end
     end
 
     context '削除タスクがない' do
       it '該当するリソースがないと表示' do
-        # visit root_path
+        expect(User.all.length).to eq 2
+        expect(Task.all.length).to eq 1
 
-        # task.destroy
-        # click_on '削除'
+        visit users_path
 
-        # expect(page).to have_current_path root_path, ignore_query: true
-        # expect(page).to have_content '該当するリソースがありませんでした。'
+        user_jiro.destroy
+        click_link '削除', href: "/admin/users/#{user_jiro.id}"
+
+        expect(page).to have_current_path root_path, ignore_query: true
+        expect(page).to have_selector('.alert-danger', text: I18n.t('error.messages.record_not_found'))
+        expect(page).not_to have_content user_jiro.email
+        expect(User.all.length).to eq 1
+        expect(Task.all.length).to eq 0
       end
     end
   end

--- a/myapp/spec/system/user_spec.rb
+++ b/myapp/spec/system/user_spec.rb
@@ -1,9 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :system do
-  let!(:user) { create(:user, name: 'MM', email: 'hoge@hoge.com', password: 'password') }
+  let(:user_taro) { create(:user, name: 'hogehoge', email: Faker::Internet.email, password: 'password') }
+  let(:user_jiro) { create(:user, name: 'testest', email: Faker::Internet.email, password: 'password') }
 
-  describe '画面表示' do
+  before do
+    login(user_taro.email, user_taro.password)
+  end
+
+  describe 'ユーザー新規登録画面表示' do
     before do
       visit new_user_path
     end
@@ -36,7 +41,7 @@ RSpec.describe User, type: :system do
       end
 
       it 'ユーザー登録できる' do
-        expect(page).to have_current_path login_path, ignore_query: true
+        expect(page).to have_current_path users_path, ignore_query: true
         expect(page).to have_selector('.alert-success', text: I18n.t('messages.create', model_name: I18n.t('activerecord.models.user')))
       end
     end
@@ -80,7 +85,7 @@ RSpec.describe User, type: :system do
 
     context '登録済みのメールアドレスを入力したとき' do
       before do
-        fill_in 'user[email]', with: 'hoge@hoge.com'
+        fill_in 'user[email]', with: user_taro.email
         click_button '登録'
       end
 
@@ -137,6 +142,182 @@ RSpec.describe User, type: :system do
       it 'ユーザー登録できない' do
         expect(page).to have_current_path users_path, ignore_query: true
         expect(page).to have_content 'パスワード確認とパスワードの入力が一致しません'
+      end
+    end
+  end
+
+  describe 'ユーザー編集画面表示' do
+    before do
+      visit edit_user_path(user_jiro.id)
+    end
+
+    context 'ユーザー編集ページにアクセスしたとき' do
+      it 'ユーザー編集の画面が表示されること' do
+        expect(page).to have_current_path edit_user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_field 'user[name]'
+        expect(page).to have_field 'user[email]'
+        expect(page).to have_field 'user[password]'
+        expect(page).to have_field 'user[password_confirmation]'
+        expect(page).to have_button '登録'
+        expect(page).to have_link 'もどる'
+      end
+    end
+  end
+
+  describe 'ユーザー編集' do
+    before do
+      visit edit_user_path(user_jiro.id)
+      fill_in 'user[name]', with: 'test男'
+      fill_in 'user[email]', with: 'test@test.com'
+      fill_in 'user[password]', with: 'password'
+      fill_in 'user[password_confirmation]', with: 'password'
+    end
+
+    context '正しい情報を入力したとき' do
+      before do
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができる' do
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_selector('.alert-success', text: I18n.t('messages.update', model_name: I18n.t('activerecord.models.user')))
+      end
+    end
+
+    context 'nameを入力しなかったとき' do
+      before do
+        fill_in 'user[name]', with: ''
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_content '氏名を入力してください'
+      end
+    end
+
+    context 'emailを入力しなかったとき' do
+      before do
+        fill_in 'user[email]', with: ''
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_content 'メールアドレスを入力してください'
+        expect(page).to have_content 'メールアドレスは不正な値です'
+      end
+    end
+
+    context 'emailに256文字以上入力したとき' do
+      before do
+        fill_in 'user[email]', with: "#{'a' * 256}" + '@test.com'
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_content 'メールアドレスは255文字以内で入力してください'
+      end
+    end
+
+    context '登録済みのメールアドレスを入力したとき' do
+      before do
+        fill_in 'user[email]', with: user_taro.email
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_content 'メールアドレスはすでに存在します'
+      end
+    end
+
+    context 'メールアドレスフォーマット以外を入力したとき' do
+      before do
+        fill_in 'user[email]', with: '@testtest.com'
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_content 'メールアドレスは不正な値です'
+      end
+    end
+
+    context 'パスワードが空欄のとき' do
+      before do
+        fill_in 'user[password]', with: ''
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_content 'パスワードを入力してください'
+      end
+    end
+
+    context 'パスワードが7文字で入力したとき' do
+      before do
+        fill_in 'user[password]', with: 'passwor'
+        fill_in 'user[password_confirmation]', with: 'passwor'
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_content 'パスワードは8文字以上で入力してください'
+      end
+    end
+
+    context 'パスワード、パスワード確認が異なる値で入力されたとき' do
+      before do
+        fill_in 'user[password]', with: 'password'
+        fill_in 'user[password_confirmation]', with: 'passwor'
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path user_path(user_jiro.id), ignore_query: true
+        expect(page).to have_content 'パスワード確認とパスワードの入力が一致しません'
+      end
+    end
+
+    context '更新するユーザー情報がないとき' do
+      before do
+        user_jiro.destroy
+        click_button '登録'
+      end
+
+      it 'ユーザー情報の更新ができない' do
+        expect(page).to have_current_path root_path, ignore_query: true
+        expect(page).to have_content '該当するリソースがありませんでした。'
+      end
+    end
+  end
+
+  describe 'ユーザー削除' do
+    context '削除ユーザーがある' do
+      it 'ユーザーの削除に成功' do
+        visit users_path
+
+        expect(page).to have_link '削除'
+        click_link '削除',  href: "admin/users/#{user_jiro.id}"
+
+        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_selector('.alert-success', text: I18n.t('messages.delete', model_name: I18n.t('activerecord.models.user')))
+      end
+    end
+
+    context '削除タスクがない' do
+      it '該当するリソースがないと表示' do
+        # visit root_path
+
+        # task.destroy
+        # click_on '削除'
+
+        # expect(page).to have_current_path root_path, ignore_query: true
+        # expect(page).to have_content '該当するリソースがありませんでした。'
       end
     end
   end

--- a/myapp/spec/system/user_spec.rb
+++ b/myapp/spec/system/user_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe User, type: :system do
   end
 
   describe 'ユーザー詳細画面表示' do
+    let!(:task1) { create(:task, user_id: user_jiro.id) }
+    let!(:task2) { create(:task, user_id: user_taro.id) }
+    let!(:task3) { create(:task, user_id: user_taro.id) }
+
     before do
       visit user_path(user_taro.id)
     end
@@ -105,6 +109,21 @@ RSpec.describe User, type: :system do
         expect(page).to have_content user_taro.updated_at
         expect(page).to have_link '編集', href: "/admin/users/#{user_taro.id}/edit"
         expect(page).to have_link 'ユーザーリスト', href: '/admin/users'
+
+        expect(page).to have_content task2.id
+        expect(page).to have_content task2.title
+        expect(page).to have_content task2.content
+        expect(page).to have_content (I18n.l(task2.deadline, format: :short))
+        expect(page).to have_content (I18n.t("enums.task.status.#{task2.status}"))
+        expect(page).to have_content (I18n.l(task2.created_at, format: :short))
+        expect(page).to have_content (I18n.l(task2.updated_at, format: :short))
+        expect(page).to have_content task3.id
+        expect(page).to have_content task3.title
+        expect(page).to have_content task3.content
+        expect(page).to have_content (I18n.l(task3.deadline, format: :short))
+        expect(page).to have_content (I18n.t("enums.task.status.#{task2.status}"))
+        expect(page).to have_content (I18n.l(task3.created_at, format: :short))
+        expect(page).to have_content (I18n.l(task3.updated_at, format: :short))
       end
     end
 


### PR DESCRIPTION
## Jiraチケット
https://jira.rakuten-it.com/jira/browse/RAKUTRA-5188
## 行うこと
- 画面上に管理メニューを追加しましょう
- 管理画面にはかならず /admin というURLを先頭につけるようにしましょう
   - routes.rb に追加する前に、あらかじめURLやルーティング名（ *_path となる名前）を想定して設計してみましょう
- ユーザ一覧・作成・更新・削除を実装しましょう
- ユーザを削除したら、そのユーザが抱えているタスクを削除するようにしてみましょう
- ユーザの一覧画面で、ユーザが持っているタスクの数を表示するようにしてみましょう
- ユーザが作成したタスクの一覧が見られるようにしてみましょう

## URL
[Rails 研修](https://github.com/Fablic/training/blob/develop/steps_jp.md)「ステップ18: ユーザの管理画面を実装しよう」を実施しました
## 行ったこと
- user関連のURLの先頭に`admin`を追加してPath名変更
- ユーザー情報の一覧・登録・編集更新・削除の実装
- Userモデルテスト
- loginモデルテスト

## 動作確認
### ユーザー登録・編集更新
![ユーザー登録編集更新](https://github.com/Fablic/training/assets/129723112/9012961f-300a-4e70-b52c-4d93a1f4419d)

### ユーザー詳細
![ユーザー詳細ページ](https://github.com/Fablic/training/assets/129723112/a2e0e01d-7a13-4b1b-b01f-b2f7341cd0b8)


### ユーザーを削除すると関連タスクを削除
![ユーザーを消すとタスクも消える](https://github.com/Fablic/training/assets/129723112/fa17bfcd-3c61-4c0a-9b7f-490c04d870a1)

