### PR TITLE
[Kaminaga step11] Add validation

### DIFF
--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
 
+# some comments for task model
 class Task < ApplicationRecord
+  enum priority_type: {
+    Low: 0,
+    Medium: 1,
+    High: 2,
+  }
+  enum status_type: {
+    Todo: 0,
+    Doing: 1,
+    Done: 2,
+  }
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :description, length: { maximum: 1000 }
+  validates :priority, presence: true, numericality: { only_integer: true }
+  validates :status, presence: true, numericality: { only_integer: true }
 end

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -7,8 +7,8 @@
 
   <%= f.input :name, input_html: { autofocus: true } %>
   <%= f.input :description, input_html: { autofocus: true } %>
-  <%= f.input :priority, input_html: { autofocus: true } %>
+  <%= f.input :priority, collection: Task.priority_types.keys.zip(Task.priority_types.values), selected: 1, input_html: { autofocus: true } %>
   <%= f.input :expired_date, input_html: { autofocus: true } %>
-  <%= f.input :status, input_html: { autofocus: true } %>
+  <%= f.input :status, collection: Task.status_types.keys.zip(Task.priority_types.values), selected: 0, input_html: { autofocus: true } %>
   <%= f.submit class: "btn btn-primary" %>
 <% end %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -7,8 +7,8 @@
 
   <%= f.input :name, input_html: { autofocus: true } %>
   <%= f.input :description, input_html: { autofocus: true } %>
-  <%= f.input :priority, collection: Task.priority_types.keys.zip(Task.priority_types.values), selected: 1, input_html: { autofocus: true } %>
+  <%= f.input :priority, collection: Task.priority_types.keys.zip(Task.priority_types.values), selected: f.object.priority || 1, input_html: { autofocus: true } %>
   <%= f.input :expired_date, input_html: { autofocus: true } %>
-  <%= f.input :status, collection: Task.status_types.keys.zip(Task.priority_types.values), selected: 0, input_html: { autofocus: true } %>
+  <%= f.input :status, collection: Task.status_types.keys.zip(Task.status_types.values), selected: f.object.status || 0, input_html: { autofocus: true } %>
   <%= f.submit class: "btn btn-primary" %>
 <% end %>

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
         status: Status
         priority: Priority
         expired_date: Expired date
+  err_msgs:
+    too_long: The length of the task name should less than 255 characters
   flash_msgs:
     create_ok: Task was successfully created.
     update_ok: Task was successfully updated.

--- a/myapp/config/locales/jp.yml
+++ b/myapp/config/locales/jp.yml
@@ -1,4 +1,18 @@
 jp:
+  activerecord:
+    errors:
+      models:
+        task:
+          blank: を入れてください
+  errors:
+    messages:
+      too_long:
+        one: 最大1文字まで入れてください
+        other: 最大%{count}文字まで入れてください
+      wrong_length:
+        one: 文字数が誤っています（1文字である必要があります）
+        other: 文字数が誤っています（%{count}文字である必要があります）
+      not_a_number: 数字を入れてください
   models:
     task: タスク
   attributes:
@@ -79,3 +93,8 @@ jp:
       - :year
       - :month
       - :day
+  support:
+    array:
+      words_connector: ","
+      two_words_connector: " & "
+      last_word_connector: " & "

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Task do
+  describe 'validaton' do
+    it 'create task successfully' do
+      task = build(:task)
+      expect(task).to be_valid
+    end
+
+    it 'no error messages when task created successfully' do
+      task = build(:task)
+      task.valid?
+      expect(task.errors).to be_empty
+    end
+
+    it 'task cannot be created without name' do
+      task = build(:task, name: '')
+      expect(task).to be_invalid
+    end
+
+    it 'show error messages if name is empty' do
+      task = build(:task, name: '')
+      task.valid?
+      expect(task.errors[:name]).to eq ["can't be blank"]
+    end
+
+    it 'task cannot be created with name longer than 255 characters' do
+      task = build(:task, name: 'a' * 256)
+      expect(task).to be_invalid
+    end
+
+    it 'show error messages if name is longer than 255 characters' do
+      task = build(:task, name: 'a' * 256)
+      task.valid?
+      expect(task.errors[:name]).to eq ['is too long (maximum is 255 characters)']
+    end
+
+    it 'task cannot be created with description longer than 1000 characters' do
+      task = build(:task, description: 'a' * 1001)
+      expect(task).to be_invalid
+    end
+
+    it 'show error messages if description is longer than 1000 characters' do
+      task = build(:task, description: 'a' * 1001)
+      task.valid?
+      expect(task.errors[:description]).to eq ['is too long (maximum is 1000 characters)']
+    end
+
+    it 'task cannot be created without status' do
+      task = build(:task, status: nil)
+      expect(task).to be_invalid
+    end
+
+    it 'show error messages if status is empty' do
+      task = build(:task, status: nil)
+      task.valid?
+      expect(task.errors[:status]).to eq ["can't be blank", 'is not a number']
+    end
+
+    it 'task cannot be created if status is not a number' do
+      task = build(:task, status: 'string')
+      expect(task).to be_invalid
+    end
+
+    it 'show error messages if status is not a number' do
+      task = build(:task, status: 'string')
+      task.valid?
+      expect(task.errors[:status]).to eq ['is not a number']
+    end
+
+    it 'task cannot be created without priority' do
+      task = build(:task, priority: nil)
+      expect(task).to be_invalid
+    end
+
+    it 'show error messages if priority is empty' do
+      task = build(:task, priority: nil)
+      task.valid?
+      expect(task.errors[:priority]).to eq ["can't be blank", 'is not a number']
+    end
+
+    it 'task cannot be created if priority is not a number' do
+      task = build(:task, priority: 'string')
+      expect(task).to be_invalid
+    end
+
+    it 'show error messages if priority is not a number' do
+      task = build(:task, priority: 'string')
+      task.valid?
+      expect(task.errors[:priority]).to eq ['is not a number']
+    end
+  end
+end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe 'Tasks' do
       click_link('New task')
       fill_in 'task[name]', with: 'a_new_task'
       fill_in 'task[description]', with: 'new task description'
-      fill_in 'task[priority]', with: '1'
-      fill_in 'task[status]', with: '1'
+      select('Low', from: 'task[priority]')
+      select('Todo', from: 'task[status]')
       click_on 'Create task'
       expect(page).to have_link 'a_new_task'
     end
@@ -56,10 +56,21 @@ RSpec.describe 'Tasks' do
       click_link('New task')
       fill_in 'task[name]', with: 'a_new_task'
       fill_in 'task[description]', with: 'new task description'
-      fill_in 'task[priority]', with: '1'
-      fill_in 'task[status]', with: '1'
+      select('Low', from: 'task[priority]')
+      select('Todo', from: 'task[status]')
       click_on 'Create task'
       expect(page).to have_content 'Task was successfully created.'
+    end
+
+    it 'task failed to be created due to empty name' do
+      visit '/'
+      click_link('New task')
+      fill_in 'task[name]', with: ''
+      fill_in 'task[description]', with: 'new task description'
+      select('Low', from: 'task[priority]')
+      select('Todo', from: 'task[status]')
+      click_on 'Create task'
+      expect(page).to have_content 'Name can\'t be blank'
     end
   end
 
@@ -93,6 +104,14 @@ RSpec.describe 'Tasks' do
       fill_in 'task[description]', with: 'description after'
       click_on 'Update task'
       expect(page).to have_content 'Task was successfully updated.'
+    end
+
+    it 'task failed to be updated due to empty name' do
+      visit '/'
+      click_on('Edit')
+      fill_in 'task[name]', with: ''
+      click_on 'Update task'
+      expect(page).to have_content 'Name can\'t be blank'
     end
   end
 


### PR DESCRIPTION
# Description

Added validation to the task model according to the step11 of the training.

Rails training process link: [step 11](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)
Jira: [RAKUTRA-5326](https://jira.rakuten-it.com/jira/browse/RAKUTRA-5326)

# Done

- Added validations to the task model(null check, length check, type check)
- Set the status&priority as enum type, also changed the frontend part from input box to select box to make it more robust and clear
- Added locale mappings for error messages
- Added system specs for task creation/update failure
- Added model tests for task model

# Demo & test result



https://github.com/Fablic/training/assets/27290480/178bf861-c365-4044-8c4e-b28cb33ba3b9


For test results & rubocop lint check, please see the CI result.


