### PR TITLE
[Kaminaga step15] Add frontend page designs

### DIFF
--- a/myapp/app/assets/stylesheets/application.scss
+++ b/myapp/app/assets/stylesheets/application.scss
@@ -13,6 +13,9 @@
  */
 @import "bootstrap";
 
-.form-inline div {
-  display: inline-block
-}
+// Components
+@import "components/pagination";
+@import "components/toolbar";
+@import "components/navbar";
+@import "components/task_details";
+@import "components/task_list";

--- a/myapp/app/assets/stylesheets/components/_navbar.scss
+++ b/myapp/app/assets/stylesheets/components/_navbar.scss
@@ -1,0 +1,15 @@
+.navbar {
+  background-color: #e3f2fd;
+}
+
+.navbar__title {
+  margin-left: 10%;
+}
+
+.navbar__login_btn {
+  margin-right: 3%;
+}
+
+.navbar__sign_up_btn {
+  margin-right: 10%;
+}

--- a/myapp/app/assets/stylesheets/components/_pagination.scss
+++ b/myapp/app/assets/stylesheets/components/_pagination.scss
@@ -1,0 +1,34 @@
+.pagination {
+  margin: 20px auto 0;
+  width: 50%;
+  display: flex;
+  justify-content: center;
+
+  span {
+    text-align: center;
+    width: 50px;
+
+    :hover {
+      background-color: #f3f3f3;
+    }
+
+    a {
+      display: block;
+      width: 100%;
+      height: 100%;
+
+      :hover {
+        background-color: #f3f3f3;
+      }
+    }
+  }
+}
+
+.current {
+  color: #008CFF;
+}
+
+.gap {
+  background-color: white !important;
+}
+

--- a/myapp/app/assets/stylesheets/components/_task_details.scss
+++ b/myapp/app/assets/stylesheets/components/_task_details.scss
@@ -1,0 +1,17 @@
+.task_details__item_row {
+  margin: 1%;
+}
+
+.task_details__task_name {
+  border-bottom-style: ridge;
+}
+
+.task_details__expired_date {
+  font-size: 150%;
+}
+
+.task_details__description_wrapper {
+  background-color: #ffffcc;
+  border-left: 6px solid #ffeb3b;
+  color: black;
+}

--- a/myapp/app/assets/stylesheets/components/_task_list.scss
+++ b/myapp/app/assets/stylesheets/components/_task_list.scss
@@ -1,0 +1,7 @@
+.task_list__task_row {
+  width: 70%;
+}
+
+.task_list__task_name {
+  text-decoration: none;
+}

--- a/myapp/app/assets/stylesheets/components/_toolbar.scss
+++ b/myapp/app/assets/stylesheets/components/_toolbar.scss
@@ -1,0 +1,16 @@
+.toolbar {
+  margin: 1%
+}
+
+.toolbar__new_task_btn {
+  align-self: center;
+  padding-top: 1%;
+}
+
+.form-inline div {
+  display: inline-block
+}
+
+.task__actions {
+  display: inline-block;
+}

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -33,7 +33,7 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to tasks_path, flash: { success: t('flash_msgs.update_ok') }
+      redirect_to task_path(@task), flash: { success: t('flash_msgs.update_ok') }
     else
       render :edit, status: :unprocessable_entity
     end

--- a/myapp/app/views/tasks/_task.html.erb
+++ b/myapp/app/views/tasks/_task.html.erb
@@ -1,12 +1,18 @@
-<div class="task">
-  <%= link_to task.name, task_path(task) %>
-  <div class="task__actions">
-    <%= button_to t('pages.task_list_page.delete_task'),
-                  task_path(task),
-                  method: :delete,
-                  class: "btn btn-danger" %>
-    <%= link_to t('pages.task_list_page.edit_task'),
-                edit_task_path(task),
-                class: "btn btn-info" %>
-  </div>
-</div>
+<tr class="task">
+  <th scope="row" class="task_list__task_row">
+    <%= link_to task.name, task_path(task), class: "task_list__task_name" %>
+  </th>
+  <td>
+    <div class="task__actions">
+      <%= link_to t('pages.task_list_page.edit_task'),
+                  edit_task_path(task),
+                  class: "btn btn-outline-info" %>
+    </div>
+    <div class="task__actions">
+      <%= button_to t('pages.task_list_page.delete_task'),
+                    task_path(task),
+                    method: :delete,
+                    class: "btn btn-outline-danger" %>
+    </div>
+  </td>
+</tr>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,24 +1,55 @@
-<main class="container">
-  <div class="header">
+<nav class="navbar navbar-expand-lg">
+  <div class="container-fluid">
     <h1>
       <%= t('pages.task_list_page.title') %>
     </h1>
-  </div>
-  <div>
-    <div style="display: inline-block">
-      <%= simple_form_for :search, url: '/tasks', method: "GET", html: { class: 'form-inline' } do |f| %>
-        <%= f.input :name, input_html: { value: @search_name } %>
-        <%= f.input :status, collection: Task.enums_i18n(:status).keys, include_blank: true, selected: @search_status %>
-        <%= f.input :column, collection: Task.column_names.excluding("id"), selected: Task.column_names.include?(@sort_column) ? @sort_column : 'created_at' %>
-        <%= f.input :direction, collection: %w[ASC DESC], selected: @sort_direction || "ASC" %>
-        <%= f.submit class: "btn btn-primary" %>
-      <% end %>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0"></ul>
+      <div class="navbar__login_btn">
+        <a class="nav-link active" aria-current="page" href="#">Login</a>
+      </div>
+      <div class="navbar__sign_up_btn">
+        <a class="nav-link active" aria-current="page" href="#">Sign up</a>
+      </div>
     </div>
   </div>
-  <%= link_to t('pages.task_list_page.new_task'),
-              new_task_path,
-              class: "btn btn-primary" %>
-  <%= flash.now[:success] %>
-  <%= render @tasks %>
+</nav>
+<main class="container">
+  <div class="header">
+    <%= flash.now[:success] %>
+  </div>
+  <div class="container">
+    <div class="row toolbar">
+      <div class="col-2 offset-1 toolbar__new_task_btn">
+        <div>
+          <%= link_to t('pages.task_list_page.new_task'),
+                      new_task_path,
+                      class: "btn btn-primary" %>
+        </div>
+      </div>
+      <div class="col-8">
+        <div>
+          <%= simple_form_for :search, url: '/tasks', method: "GET", html: { class: 'form-inline' } do |f| %>
+            <%= f.input :name, input_html: { value: @search_name } %>
+            <%= f.input :status, collection: Task.enums_i18n(:status).keys, include_blank: true, selected: @search_status %>
+            <%= f.input :column, collection: Task.column_names.excluding("id"), selected: Task.column_names.include?(@sort_column) ? @sort_column : 'created_at' %>
+            <%= f.input :direction, collection: %w[ASC DESC], selected: @sort_direction || "ASC" %>
+            <%= f.submit class: "btn btn-primary" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <table class="table table-striped table-hover align-middle">
+    <thead>
+    <tr>
+      <th scope="col">Task name</th>
+      <th scope="col">Handle</th>
+    </tr>
+    </thead>
+    <tbody>
+    <%= render @tasks %>
+    </tbody>
+  </table>
   <%= paginate @tasks %>
 </main>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -1,31 +1,77 @@
-<main class="container">
-  <%= link_to sanitize("&larr; #{t('back')}"), tasks_path %>
-  <div class="header">
-    <h1>
+<nav class="navbar navbar-expand-lg">
+  <div class="container-fluid">
+    <h1 class="navbar__title">
       <%= t('pages.task_detail_page.title') %>
     </h1>
-    <h2>
-      <%= t('attributes.model.task.name') %>
-    </h2>
-    <%= @task.name %>
-    <div>
-
-      <h2>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0"></ul>
+      <div class="d-flex navbar__login_btn">
+        <a class="nav-link active" aria-current="page" href="#">Login</a>
+      </div>
+      <div class="d-flex navbar__sign_up_btn">
+        <a class="nav-link active" aria-current="page" href="#">Sign up</a>
+      </div>
+    </div>
+  </div>
+</nav>
+<main class="container">
+  <%= link_to sanitize("&larr; #{t('back')}"), tasks_path %>
+  <div class="header"></div>
+  <%= flash.now[:success] %>
+  <div>
+    <div class="row task_details__item_row">
+      <div class="col-8">
+        <h2 class="task_details__task_name">
+          <%= @task.name %>
+        </h2>
+      </div>
+      <div class="col-4">
+        <%= link_to t('pages.task_list_page.edit_task'),
+                    edit_task_path(@task),
+                    class: "btn btn-warning btn-lg" %>
+      </div>
+    </div>
+    <div class="row task_details__item_row">
+      <div class="col-4">
+        <h3>
+          <%= t('attributes.model.task.priority') %>
+          <span class="badge bg-primary">
+            <%= @task.enum_i18n(:priority) %>
+          </span>
+        </h3>
+      </div>
+      <div class="col-4">
+        <h3>
+          <%= t('attributes.model.task.status') %>
+          <span class="badge bg-info">
+            <%= @task.enum_i18n(:status) %>
+          </span>
+        </h3>
+      </div>
+    </div>
+    <div class="row task_details__item_row">
+      <div class="col-2">
+        <h3>
+          <%= t('attributes.model.task.expired_date') %>
+        </h3>
+      </div>
+      <div class="col-2 task_details__expired_date">
+        <%= @task.expired_date %>
+      </div>
+    </div>
+    <div class="row task_details__item_row">
+      <h3>
         <%= t('attributes.model.task.description') %>
-      </h2>
-      <%= @task.description %>
-      <h2>
-        <%= t('attributes.model.task.priority') %>
-      </h2>
-      <%= @task.enum_i18n(:priority) %>
-      <h2>
-        <%= t('attributes.model.task.expired_date') %>
-      </h2>
-      <%= @task.expired_date %>
-      <h2>
-        <%= t('attributes.model.task.status') %>
-      </h2>
-      <%= @task.enum_i18n(:status) %>
+      </h3>
+    </div>
+    <div class="row task_details__item_row">
+      <div class="col-8">
+        <div class="card">
+          <div class="card-body task_details__description_wrapper">
+            <%= @task.description %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </main>

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -79,30 +79,32 @@ RSpec.describe 'Tasks' do
       create(:task, name: 'task_before_edit', description: 'description before')
     end
 
-    it 'task name updated successfully' do
+    it 'task name updated successfully from task lists page', :aggregate_failures do
       visit '/'
       click_on('Edit')
       fill_in 'task[name]', with: 'task_after_edit'
       click_on 'Update task'
-      expect(page).to have_link 'task_after_edit'
+      expect(page).to have_content 'task_after_edit'
+      expect(page).to have_content 'Task was successfully updated.'
     end
 
-    it 'task description updated successfully' do
+    it 'task name updated successfully from task details page', :aggregate_failures do
+      visit '/'
+      click_link('task_before_edit')
+      click_on('Edit')
+      fill_in 'task[name]', with: 'task_after_edit'
+      click_on 'Update task'
+      expect(page).to have_content 'task_after_edit'
+      expect(page).to have_content 'Task was successfully updated.'
+    end
+
+    it 'task description updated successfully', :aggregate_failures do
       visit '/'
       click_on('Edit')
       fill_in 'task[name]', with: 'task_after_edit'
       fill_in 'task[description]', with: 'description after'
       click_on 'Update task'
-      click_link('task_after_edit')
       expect(page).to have_content 'description after'
-    end
-
-    it 'show flash message when task updated' do
-      visit '/'
-      click_on('Edit')
-      fill_in 'task[name]', with: 'task_after_edit'
-      fill_in 'task[description]', with: 'description after'
-      click_on 'Update task'
       expect(page).to have_content 'Task was successfully updated.'
     end
 


### PR DESCRIPTION
# Description

Added page designs according to the step15 of the training.

Rails training process link: [step 15](https://github.com/Fablic/training/blob/develop/steps_jp.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%92%E5%BD%93%E3%81%A6%E3%82%88%E3%81%86--%E3%82%B9%E3%82%AD%E3%83%83%E3%83%97%E5%8F%AF%E8%83%BD)
Jira: [RAKUTRA-5345](https://jira.rakuten-it.com/jira/browse/RAKUTRA-5345)

# Done 
- changed the redirect path after task update (before:task list page -> after: task detail page)
- added page designs

# Demo & test result

https://github.com/Fablic/training/assets/27290480/38c59b57-63cc-47df-95f5-03df72de8f9c

For test results & rubocop lint check, please see the CI result.




