### PR TITLE
[Clover step-14] Add Pagination to Task List View

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -33,6 +33,9 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# Use kaminari for pagination
+gem 'kaminari'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -91,6 +91,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -244,6 +256,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   factory_bot_rails
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
   puma (~> 4.1)

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,14 +1,22 @@
 class TasksController < ApplicationController
   def index
     @tasks = Task.all
-    @tasks = Task.search_by_name_and_status(params[:name], params[:status]) if params[:name].present? || params[:status].present?
-    
+  
+    # Apply the search filters if they are present
+    if params[:name].present? || params[:status].present?
+      @tasks = @tasks.search_by_name_and_status(params[:name], params[:status])
+    end
+  
+    # Apply sorting based on sort_by and sort_order parameters
     case params[:sort_by]
     when 'created_at'
       @tasks = @tasks.order(created_at: params[:sort_order] || :desc)
     when 'deadline'
       @tasks = @tasks.order(deadline: params[:sort_order] || :desc)
     end
+  
+    # Paginate the results
+    @tasks = @tasks.page(params[:page])
   end
 
   def show

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -59,6 +59,8 @@
       <% end %>
     </tbody>
   </table>
+  
+  <%= paginate @tasks %>
 <% else %>
   <p><%= t('task.no_tasks_found') %> <%= link_to 'Back to home', tasks_path %> </p>
 <% end %>

--- a/myapp/config/initializers/kaminari.rb
+++ b/myapp/config/initializers/kaminari.rb
@@ -1,0 +1,4 @@
+# config/initializers/kaminari.rb
+Kaminari.configure do |config|
+  config.default_per_page = 5
+end


### PR DESCRIPTION
### Summary/概要

Description:
Implemented pagination using the Kaminari gem to improve the user experience on the task list page. 
Added pagination links at the bottom of the list to allow users to navigate through multiple pages of tasks. 

Changes Made:
- Added the Kaminari gem to the Gemfile and ran bundle install to install the gem.
- Updated the index action in the TasksController to use Kaminari's `page` method for pagination.
- Modified the view template (app/views/tasks/index.html.erb) to display pagination links using Kaminari's `paginate` helper.

How to check the behavior/動作確認
- Frist page with limited tasks of 5
  <img width="891" alt="image" src="https://github.com/Fablic/training/assets/88306119/65a417f0-719f-4c00-9003-5f11f2b1d5b0">

- Last page
  <img width="829" alt="image" src="https://github.com/Fablic/training/assets/88306119/fbbecc40-e891-40de-a1de-b25bd6377d4d">
