### PR TITLE
Step 10: タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @tasks = Task.order(due: :desc)
   end
 
   def new; end

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -4,17 +4,23 @@
 <%= flash[:danger] %>
 <%= form_with(model: @task, local: true, data: {turbo: false}) do |form| %>
   <p>
-    <%= form.label :title, required: true %>
+    <%= form.label :title %>
     <br>
     <%= form.text_field :title, required: true %>   
   </p>
 
   <p>
-    <%= form.label :description, required: true %>
+    <%= form.label :description %>
     <br>
     <%= form.text_area :description, required: true %>
   </p>
 
+  <p>
+    <%= form.label :due %>
+    <br>
+    <%= form.datetime_field :due, required: true %>
+  </p>
+  
   <p>
     <%= form.submit %>
   </p>

--- a/myapp/db/migrate/20240521053640_add_due_to_tasks.rb
+++ b/myapp/db/migrate/20240521053640_add_due_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDueToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :due, :timestamp, null: false
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_14_023425) do
+ActiveRecord::Schema.define(version: 2024_05_21_053640) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "label_name", null: false
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2024_05_14_023425) do
     t.text "description", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.timestamp "due", default: -> { "CURRENT_TIMESTAMP" }, null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe 'Tasks', type: :system do
 
   describe 'detail page' do
     it 'show the detail of the task' do 
-      visit task_path(@task1)
+      task = Task.create!(title: 'Test title 1', description: 'Test Description 1')
+      
+      visit task_path(task)
 
       expect(page).to have_content('Task Detail')
 
@@ -86,7 +88,9 @@ RSpec.describe 'Tasks', type: :system do
 
   describe 'edit task page' do 
     it 'show page title' do 
-      visit edit_task_path(@task1)
+      task = Task.create!(title: 'Test title 1', description: 'Test Description 1')
+      
+      visit edit_task_path(task)
 
       expect(page).to have_content('Edit the task')
 
@@ -97,7 +101,9 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it 'redirect to index page after submit' do 
-      visit edit_task_path(@task1)
+      task = Task.create!(title: 'Test title 1', description: 'Test Description 1')
+
+      visit edit_task_path(task)
 
       fill_in 'Title', with: 'Edit Task Title'
       fill_in 'Description', with: 'Edit Task Description'
@@ -107,14 +113,10 @@ RSpec.describe 'Tasks', type: :system do
       expect(current_path).to eq(tasks_path)
       expect(page).to have_content('Edit task successfully!')
 
-      visit task_path(@task1)
+      visit task_path(task)
 
       expect(page).to have_content('Edit Task Title')
       expect(page).to have_content('Edit Task Description')
     end
   end
-
-
-
-  
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it 'show tasks in due date order' do 
-      task1 = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: '2024-04-01 20:00:00')
-      task2 = Task.create!(title: 'Test title 2', description: 'Test Description 2', due: '2024-04-02 20:00:00')
-      task3 = Task.create!(title: 'Test title 3', description: 'Test Description 3', due: '2024-04-03 20:00:00')
+      Task.create!(title: 'Test title 1', description: 'Test Description 1', due: '2024-04-01 20:00:00')
+      Task.create!(title: 'Test title 2', description: 'Test Description 2', due: '2024-04-02 20:00:00')
+      Task.create!(title: 'Test title 3', description: 'Test Description 3', due: '2024-04-03 20:00:00')
       
       visit tasks_path
 

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -1,13 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe 'Tasks', type: :system do
-  before do
-    @task1 = Task.create!(title: 'Test title 1', description: 'Test Description 1')
-    @task2 = Task.create!(title: 'Test title 2', description: 'Test Description 2')
-  end 
-
+RSpec.describe 'Tasks', type: :system do 
   describe 'index page' do 
     it 'show page title, list and delete buttons' do 
+      Task.create!(title: 'Test title 1', description: 'Test Description 1')
+      Task.create!(title: 'Test title 2', description: 'Test Description 2')
       visit tasks_path
 
       expect(page).to have_content('Task List')
@@ -20,13 +17,25 @@ RSpec.describe 'Tasks', type: :system do
 
     context 'delete a task' do
       it "delete the task with button" do 
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1')
+
         visit tasks_path
-        click_on @task1.id.to_s
+        click_on task.id.to_s
 
         expect(page).to have_no_content('Task Detail 1')
         expect(Task.all.length).to eq(1)
         expect(page).to have_content('Deleted task successfully!')
       end
+    end
+
+    it 'show tasks in due date order' do 
+      task1 = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: '2024-04-01 20:00:00')
+      task2 = Task.create!(title: 'Test title 2', description: 'Test Description 2', due: '2024-04-02 20:00:00')
+      task3 = Task.create!(title: 'Test title 3', description: 'Test Description 3', due: '2024-04-03 20:00:00')
+      
+      visit tasks_path
+
+      expect(page.text).to match(/Test title 3.*\n.*Test title 2.*\n.*Test title 1/)
     end
   end
 
@@ -104,6 +113,8 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_content('Edit Task Description')
     end
   end
+
+
 
   
 end


### PR DESCRIPTION
## Requirements

- 現在IDの順で並んでいますが、これを~作成日時~ **締め切り日時**の降順で並び替えてみましょう
- 並び替えがうまく行っていることをsystem specで書いてみましょう

## Done

- Added `due` column into `tasks` table
- Confirmed tasks are listed in desc order of `due`
![image](https://github.com/Fablic/training/assets/167514427/583a3d4e-a0fe-4239-9502-e01ead36bb9c)
