### PR TITLE
Step 13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/myapp/app/assets/stylesheets/task.scss
+++ b/myapp/app/assets/stylesheets/task.scss
@@ -1,3 +1,20 @@
 // Place all the styles related to the Task controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+.status-label {
+  padding: 5px 10px;
+  border-radius: 5px;
+  color: white;
+}
+
+.status-label.pending {
+  background-color: orange;
+}
+
+.status-label.in-progress {
+  background-color: blue;
+}
+
+.status-label.completed {
+  background-color: green;
+}

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -49,6 +49,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :description, :due)
+    params.require(:task).permit(:title, :description, :due, :status)
   end
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   def index
-    if !params.except(:controller, :action).empty?
+    if params.except(:controller, :action).present?
       Rails.logger.info(params.keys)
       sort_by = params[:sort_by]
       order = params[:order].downcase

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,9 +1,14 @@
 class TasksController < ApplicationController
   def index
     if params.except(:controller, :action).present?
-      Rails.logger.info(params.keys)
+      sort_by_whitelist = %w[due created_at]
+      order_whitelist = %w[desc asc]
+
       sort_by = params[:sort_by]
       order = params[:order].downcase
+
+      sort_by = sort_by_whitelist.include?(sort_by) ? sort_by : 'created_at'
+      order = order_whitelist.include?(order) ? order : 'desc'
 
       query_title = params[:query_title] || ''
       query_status = params[:query_status]

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -1,8 +1,17 @@
 class TasksController < ApplicationController
   def index
-    sort_by = params[:sort_by] || 'created_at'
-    order = (params[:order] || 'desc').downcase
-    @tasks = Task.order("#{sort_by} #{order}")
+    if !params.except(:controller, :action).empty?
+      Rails.logger.info(params.keys)
+      sort_by = params[:sort_by]
+      order = params[:order].downcase
+
+      query_title = params[:query_title] || ''
+      query_status = params[:query_status]
+    
+      @tasks = Task.search_with_sort(query_title, query_status, sort_by, order)
+    else
+      @tasks = Task.order(created_at: :desc)
+    end
   end
 
   def new 

--- a/myapp/app/helpers/task_helper.rb
+++ b/myapp/app/helpers/task_helper.rb
@@ -1,2 +1,12 @@
 module TaskHelper
+  def status_label(task)
+    case task.status
+    when 'pending'
+      content_tag(:span, 'Pending', class: 'status-label pending')
+    when 'in_progress'
+      content_tag(:span, 'In Progress', class: 'status-label in-progress')
+    when 'completed'
+      content_tag(:span, 'Completed', class: 'status-label completed')
+    end
+  end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,9 +1,12 @@
 require 'time'
 
 class Task < ApplicationRecord
+  enum status: { pending: 0, in_progress: 1, done: 2 }
+
   validates :title, length: { in: 5..30, too_short: 'please input more than %{count} characters', too_long: '%{count} characters is the maximum allowed' }
   validates :description, length: { in: 10..300, too_short: 'please input more than %{count} characters', too_long: '%{count} characters is the maximum allowed' }
   validates :due, presence: { message: 'must be specified!' }
+  validates :status, presence: { message: 'must be selected!'}
 
   validate :due_cannot_be_earlier_than_now, if: :due_changed?
 

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,7 +1,7 @@
 require 'time'
 
 class Task < ApplicationRecord
-  enum status: { pending: 0, in_progress: 1, done: 2 }
+  enum status: { pending: 0, in_progress: 1, completed: 2 }
 
   validates :title, length: { in: 5..30, too_short: 'please input more than %{count} characters', too_long: '%{count} characters is the maximum allowed' }
   validates :description, length: { in: 10..300, too_short: 'please input more than %{count} characters', too_long: '%{count} characters is the maximum allowed' }

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -10,6 +10,16 @@ class Task < ApplicationRecord
 
   validate :due_cannot_be_earlier_than_now, if: :due_changed?
 
+  def self.search_with_sort(query_title, query_status, sort_by, order)
+    if query_status.empty?
+      where('title LIKE ?', "%#{query_title}%").order("#{sort_by} #{order}")
+    else 
+      where('title LIKE ?', "%#{query_title}%").where(status: query_status).order("#{sort_by} #{order}")
+    end
+  end
+
+  private 
+
   def due_cannot_be_earlier_than_now
     if due.present? && due < Time.zone.now.beginning_of_minute
       errors.add(:due, "can't be earlier than now!")

--- a/myapp/app/views/tasks/edit.html.erb
+++ b/myapp/app/views/tasks/edit.html.erb
@@ -1,6 +1,10 @@
 <h1>Edit the task</h1>
 <%= form_with(model: @task, local: true, data: {turbo: false}) do |form| %>
 
+  <button>
+    <%= link_to 'Back to home', tasks_path, method: :get %>
+  </button>
+
   <% if @task.errors.any? %>
     <div>
       <p>You have some invalid inputs!</p>
@@ -28,6 +32,19 @@
     <%= form.label :due %>
     <br>
     <%= form.datetime_local_field :due %>
+  </p>
+
+  <p>
+    <%= form.label :status, 'Select Status:' %>
+    <br>
+    <%= form.radio_button :status, 'pending' %>
+    <%= form.label :status_pending, 'Pending' %>
+    <br>
+    <%= form.radio_button :status, 'in_progress' %>
+    <%= form.label :status_in_progress, 'In Progress' %>
+    <br>
+    <%= form.radio_button :status, 'completed' %>
+    <%= form.label :status_completed, 'Completed' %>
   </p>
   
   <p>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -30,6 +30,8 @@
         <td><%= "##{task.id}" %></td>
         <td><%= l task.due %></td>
         <td><h3><%= task.title %></h3></td>
+        <td><%= status_label(task)%></td>
+
         <td><%= button_to "Delete", task_path(task), method: :delete, id: task.id %></td>
       </tr>
     <% end %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -1,16 +1,23 @@
 <h1>Task List</h1>
 <%= flash[:notice] %>
-<%= flash[:success] %>
-<%= flash[:alert] %>
 
 <%= form_with url: '#', method: :get, local: true do |form| %>
+  <%= form.label :query_title, 'Search Title:' %>
+  <%= form.search_field :query_title, maxlength: 20 %>
+
+  <%= form.label :query_status, 'Search Status:' %>
+  <%= form.select :query_status, [['All', ''], ['Pending', 'pending'], ['In Progress', 'in_progress'], ['Completed', 'completed']] %>
+
+  <br>
+  <br>
+
   <%= form.label :sort_by %>
   <%= form.select :sort_by, [['Create Date', 'created_at'], ['Due Date', 'due']], id: 'selected_sort_by' %>
 
   <%= form.label :order %>
   <%= form.select :order, ['Desc', 'Asc'], id: 'selected_order' %>
 
-  <%= form.submit 'Sort' %>
+  <%= form.submit 'Filter' %>
 <% end %>
 
 <br>
@@ -32,6 +39,8 @@
         <td><h3><%= task.title %></h3></td>
         <td><%= status_label(task)%></td>
 
+        <%# todo %>
+        <td><%= button_to "Edit", edit_task_path(task), method: :get, id: task.id %></td>
         <td><%= button_to "Delete", task_path(task), method: :delete, id: task.id %></td>
       </tr>
     <% end %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -40,8 +40,8 @@
         <td><%= status_label(task)%></td>
 
         <%# todo %>
-        <td><%= button_to "Edit", edit_task_path(task), method: :get, id: task.id %></td>
-        <td><%= button_to "Delete", task_path(task), method: :delete, id: task.id %></td>
+        <td><%= button_to "Edit", edit_task_path(task), method: :get, id: "Edit#{task.id}" %></td>
+        <td><%= button_to "Delete", task_path(task), method: :delete, id: "Delete#{task.id}" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/myapp/app/views/tasks/new.html.erb
+++ b/myapp/app/views/tasks/new.html.erb
@@ -30,6 +30,19 @@
   </p>
 
   <p>
+    <%= form.label :status, 'Select Status:' %>
+    <br>
+    <%= form.radio_button :status, 'pending' %>
+    <%= form.label :status_pending, 'Pending' %>
+    <br>
+    <%= form.radio_button :status, 'in_progress' %>
+    <%= form.label :status_in_progress, 'In Progress' %>
+    <br>
+    <%= form.radio_button :status, 'completed' %>
+    <%= form.label :status_completed, 'Completed' %>
+  </p>
+
+  <p>
     <%= form.submit %>
   </p>
 <% end %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -7,7 +7,17 @@
 
 <h2>Description</h2>
 <h3><%= @task.description %></h3>
+<br>
 
 <h2>Due</h2>
 <h3><%= l @task.due %></h3>
+<br>
 
+<h2>Status</h2>
+<%= status_label(@task) %>
+
+<br>
+
+<p>
+  <%= button_to 'Edit', edit_task_path(@task), method: :get %>
+</p>

--- a/myapp/db/migrate/20240527045120_add_status_to_tasks.rb
+++ b/myapp/db/migrate/20240527045120_add_status_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStatusToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :status, :integer, null: false
+  end
+end

--- a/myapp/db/migrate/20240529081633_add_index_to_tasks.rb
+++ b/myapp/db/migrate/20240529081633_add_index_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_27_045120) do
+ActiveRecord::Schema.define(version: 2024_05_29_081633) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "label_name", null: false
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2024_05_27_045120) do
     t.datetime "updated_at", precision: 6, null: false
     t.timestamp "due", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "status", null: false
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_21_053640) do
+ActiveRecord::Schema.define(version: 2024_05_27_045120) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "label_name", null: false
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2024_05_21_053640) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.timestamp "due", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.integer "status", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/myapp/spec/models/tasks_spec.rb
+++ b/myapp/spec/models/tasks_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Task, type: :model do
       task = Task.new(
           title: 'more than 5 chars',
           description: 'more than 10 chars',
-          due: Time.zone.now + 5
+          due: Time.zone.now + 5,
+          status: 'pending'
       )
 
       expect(task).to be_valid
@@ -16,7 +17,8 @@ RSpec.describe Task, type: :model do
       task = Task.new(
         title: '< 5',
         description: 'more than 10 chars',
-        due: Time.zone.now + 5
+        due: Time.zone.now + 5,
+        status: 'pending'
       )
 
       expect(task).to_not be_valid
@@ -26,7 +28,8 @@ RSpec.describe Task, type: :model do
       task = Task.new(
         title: 't' * 40,
         description: 'more than 10 chars',
-        due: Time.zone.now + 5
+        due: Time.zone.now + 5,
+        status: 'pending'
       )
 
       expect(task).to_not be_valid
@@ -36,7 +39,8 @@ RSpec.describe Task, type: :model do
       task = Task.new(
         title: 'more than 5 chars',
         description: '< 10',
-        due: Time.zone.now + 5
+        due: Time.zone.now + 5,
+        status: 'pending'
       )
 
       expect(task).to_not be_valid
@@ -46,7 +50,8 @@ RSpec.describe Task, type: :model do
       task = Task.new(
         title: 'more than 5 chars',
         description: 'd' * 301,
-        due: Time.zone.now + 5
+        due: Time.zone.now + 5,
+        status: 'pending'
       )
 
       expect(task).to_not be_valid
@@ -55,7 +60,8 @@ RSpec.describe Task, type: :model do
     it 'is invalid with empty due date' do 
       task = Task.new(
         title: 'more than 5 chars',
-        description: 'more than 10 chars'
+        description: 'more than 10 chars',
+        status: 'pending'
       )
       
       expect(task).to_not be_valid
@@ -65,10 +71,187 @@ RSpec.describe Task, type: :model do
       task = Task.new(
         title: 'more than 5 chars',
         description: 'more than 10 chars',
-        due: Time.zone.now - 60
+        due: Time.zone.now - 60,
+        status: 'pending'
       )
       
       expect(task).to_not be_valid
+    end
+
+    it 'is invalid with no status specified' do 
+      task = Task.new(
+        title: 'title',
+        description: 'description',
+        due: Time.zone.now + 5
+      )
+
+      expect(task).to_not be_valid 
+    end
+  end
+
+  describe 'class method' do 
+    context '.search_with_sort' do 
+      it 'when query_status is empty' do 
+        task1 = Task.create!(
+          title: 'Task 1',
+          description: 'Description 1',
+          due: Time.zone.now + 5,
+          status: 'pending'
+        )
+
+        task2 = Task.create!(
+          title: 'Task 2',
+          description: 'Description 2',
+          due: Time.zone.now + 10,
+          status: 'in_progress'
+        )
+
+        task3 = Task.create!(
+          title: 'No title',
+          description: 'Description 3',
+          due: Time.zone.now + 15,
+          status: 'completed'
+        )
+
+        result = Task.search_with_sort('Task', '', 'created_at', 'desc')
+
+        expect(result).to eq([task2, task1])
+      end
+
+      it 'when query_status is not empty' do 
+        task1 = Task.create!(
+          title: 'Task 1',
+          description: 'Description 1',
+          due: Time.zone.now + 5,
+          status: 'pending'
+        )
+
+        task2 = Task.create!(
+          title: 'Task 2',
+          description: 'Description 2',
+          due: Time.zone.now + 10,
+          status: 'in_progress'
+        )
+
+        task3 = Task.create!(
+          title: 'No title',
+          description: 'Description 3',
+          due: Time.zone.now + 15,
+          status: 'completed'
+        )
+
+        result = Task.search_with_sort('Task', 'pending', 'created_at', 'desc')
+
+        expect(result).to eq([task1])
+      end
+
+      it 'sort by created_at in desc order without title and status specified' do 
+        task1 = Task.create!(
+          title: 'Task 1',
+          description: 'Description 1',
+          due: Time.zone.now + 5,
+          status: 'pending'
+        )
+
+        task2 = Task.create!(
+          title: 'Task 2',
+          description: 'Description 2',
+          due: Time.zone.now + 10,
+          status: 'in_progress'
+        )
+
+        task3 = Task.create!(
+          title: 'No title',
+          description: 'Description 3',
+          due: Time.zone.now + 15,
+          status: 'completed'
+        )
+
+        result = Task.search_with_sort('', '', 'created_at', 'desc')
+
+        expect(result).to eq([task3, task2, task1])
+      end
+
+      it 'sort by created_at in asc order without title and status specified' do 
+        task1 = Task.create!(
+          title: 'Task 1',
+          description: 'Description 1',
+          due: Time.zone.now + 5,
+          status: 'pending'
+        )
+
+        task2 = Task.create!(
+          title: 'Task 2',
+          description: 'Description 2',
+          due: Time.zone.now + 10,
+          status: 'in_progress'
+        )
+
+        task3 = Task.create!(
+          title: 'No title',
+          description: 'Description 3',
+          due: Time.zone.now + 15,
+          status: 'completed'
+        )
+
+        result = Task.search_with_sort('', '', 'created_at', 'asc')
+
+        expect(result).to eq([task1, task2, task3])
+      end
+
+      it 'sort by due in desc order without title and status specified' do 
+        task1 = Task.create!(
+          title: 'Task 1',
+          description: 'Description 1',
+          due: Time.zone.now + 10,
+          status: 'pending'
+        )
+
+        task2 = Task.create!(
+          title: 'Task 2',
+          description: 'Description 2',
+          due: Time.zone.now + 1000,
+          status: 'in_progress'
+        )
+
+        task3 = Task.create!(
+          title: 'No title',
+          description: 'Description 3',
+          due: Time.zone.now + 100,
+          status: 'completed'
+        )
+
+        result = Task.search_with_sort('', '', 'due', 'desc')
+
+        expect(result).to eq([task2, task3, task1])
+      end
+
+      it 'sort by due in asc order without title and status specified' do 
+        task1 = Task.create!(
+          title: 'Task 1',
+          description: 'Description 1',
+          due: Time.zone.now + 10,
+          status: 'pending'
+        )
+
+        task2 = Task.create!(
+          title: 'Task 2',
+          description: 'Description 2',
+          due: Time.zone.now + 1000,
+          status: 'in_progress'
+        )
+
+        task3 = Task.create!(
+          title: 'No title',
+          description: 'Description 3',
+          due: Time.zone.now + 100,
+          status: 'completed'
+        )
+
+        result = Task.search_with_sort('', '', 'due', 'asc')
+
+        expect(result).to eq([task1, task3, task2])
+      end
     end
   end
 end

--- a/myapp/spec/models/tasks_spec.rb
+++ b/myapp/spec/models/tasks_spec.rb
@@ -89,169 +89,167 @@ RSpec.describe Task, type: :model do
     end
   end
 
-  describe 'class method' do 
-    context '.search_with_sort' do 
-      it 'when query_status is empty' do 
-        task1 = Task.create!(
-          title: 'Task 1',
-          description: 'Description 1',
-          due: Time.zone.now + 5,
-          status: 'pending'
-        )
+  describe '.search_with_sort' do 
+    it 'sorted without status' do 
+      task1 = Task.create!(
+        title: 'Task 1',
+        description: 'Description 1',
+        due: Time.zone.now + 5,
+        status: 'pending'
+      )
 
-        task2 = Task.create!(
-          title: 'Task 2',
-          description: 'Description 2',
-          due: Time.zone.now + 10,
-          status: 'in_progress'
-        )
+      task2 = Task.create!(
+        title: 'Task 2',
+        description: 'Description 2',
+        due: Time.zone.now + 10,
+        status: 'in_progress'
+      )
 
-        task3 = Task.create!(
-          title: 'No title',
-          description: 'Description 3',
-          due: Time.zone.now + 15,
-          status: 'completed'
-        )
+      task3 = Task.create!(
+        title: 'No title',
+        description: 'Description 3',
+        due: Time.zone.now + 15,
+        status: 'completed'
+      )
 
-        result = Task.search_with_sort('Task', '', 'created_at', 'desc')
+      result = Task.search_with_sort('Task', '', 'created_at', 'desc')
 
-        expect(result).to eq([task2, task1])
-      end
+      expect(result).to eq([task2, task1])
+    end
 
-      it 'when query_status is not empty' do 
-        task1 = Task.create!(
-          title: 'Task 1',
-          description: 'Description 1',
-          due: Time.zone.now + 5,
-          status: 'pending'
-        )
+    it 'sorted with status specified' do 
+      task1 = Task.create!(
+        title: 'Task 1',
+        description: 'Description 1',
+        due: Time.zone.now + 5,
+        status: 'pending'
+      )
 
-        task2 = Task.create!(
-          title: 'Task 2',
-          description: 'Description 2',
-          due: Time.zone.now + 10,
-          status: 'in_progress'
-        )
+      task2 = Task.create!(
+        title: 'Task 2',
+        description: 'Description 2',
+        due: Time.zone.now + 10,
+        status: 'in_progress'
+      )
 
-        task3 = Task.create!(
-          title: 'No title',
-          description: 'Description 3',
-          due: Time.zone.now + 15,
-          status: 'completed'
-        )
+      task3 = Task.create!(
+        title: 'No title',
+        description: 'Description 3',
+        due: Time.zone.now + 15,
+        status: 'completed'
+      )
 
-        result = Task.search_with_sort('Task', 'pending', 'created_at', 'desc')
+      result = Task.search_with_sort('Task', 'pending', 'created_at', 'desc')
 
-        expect(result).to eq([task1])
-      end
+      expect(result).to eq([task1])
+    end
 
-      it 'sort by created_at in desc order without title and status specified' do 
-        task1 = Task.create!(
-          title: 'Task 1',
-          description: 'Description 1',
-          due: Time.zone.now + 5,
-          status: 'pending'
-        )
+    it 'sorted by created_at in desc order without title and status specified' do 
+      task1 = Task.create!(
+        title: 'Task 1',
+        description: 'Description 1',
+        due: Time.zone.now + 5,
+        status: 'pending'
+      )
 
-        task2 = Task.create!(
-          title: 'Task 2',
-          description: 'Description 2',
-          due: Time.zone.now + 10,
-          status: 'in_progress'
-        )
+      task2 = Task.create!(
+        title: 'Task 2',
+        description: 'Description 2',
+        due: Time.zone.now + 10,
+        status: 'in_progress'
+      )
 
-        task3 = Task.create!(
-          title: 'No title',
-          description: 'Description 3',
-          due: Time.zone.now + 15,
-          status: 'completed'
-        )
+      task3 = Task.create!(
+        title: 'No title',
+        description: 'Description 3',
+        due: Time.zone.now + 15,
+        status: 'completed'
+      )
 
-        result = Task.search_with_sort('', '', 'created_at', 'desc')
+      result = Task.search_with_sort('', '', 'created_at', 'desc')
 
-        expect(result).to eq([task3, task2, task1])
-      end
+      expect(result).to eq([task3, task2, task1])
+    end
 
-      it 'sort by created_at in asc order without title and status specified' do 
-        task1 = Task.create!(
-          title: 'Task 1',
-          description: 'Description 1',
-          due: Time.zone.now + 5,
-          status: 'pending'
-        )
+    it 'sorted by created_at in asc order without title and status specified' do 
+      task1 = Task.create!(
+        title: 'Task 1',
+        description: 'Description 1',
+        due: Time.zone.now + 5,
+        status: 'pending'
+      )
 
-        task2 = Task.create!(
-          title: 'Task 2',
-          description: 'Description 2',
-          due: Time.zone.now + 10,
-          status: 'in_progress'
-        )
+      task2 = Task.create!(
+        title: 'Task 2',
+        description: 'Description 2',
+        due: Time.zone.now + 10,
+        status: 'in_progress'
+      )
 
-        task3 = Task.create!(
-          title: 'No title',
-          description: 'Description 3',
-          due: Time.zone.now + 15,
-          status: 'completed'
-        )
+      task3 = Task.create!(
+        title: 'No title',
+        description: 'Description 3',
+        due: Time.zone.now + 15,
+        status: 'completed'
+      )
 
-        result = Task.search_with_sort('', '', 'created_at', 'asc')
+      result = Task.search_with_sort('', '', 'created_at', 'asc')
 
-        expect(result).to eq([task1, task2, task3])
-      end
+      expect(result).to eq([task1, task2, task3])
+    end
 
-      it 'sort by due in desc order without title and status specified' do 
-        task1 = Task.create!(
-          title: 'Task 1',
-          description: 'Description 1',
-          due: Time.zone.now + 10,
-          status: 'pending'
-        )
+    it 'sorted by due in desc order without title and status specified' do 
+      task1 = Task.create!(
+        title: 'Task 1',
+        description: 'Description 1',
+        due: Time.zone.now + 10,
+        status: 'pending'
+      )
 
-        task2 = Task.create!(
-          title: 'Task 2',
-          description: 'Description 2',
-          due: Time.zone.now + 1000,
-          status: 'in_progress'
-        )
+      task2 = Task.create!(
+        title: 'Task 2',
+        description: 'Description 2',
+        due: Time.zone.now + 1000,
+        status: 'in_progress'
+      )
 
-        task3 = Task.create!(
-          title: 'No title',
-          description: 'Description 3',
-          due: Time.zone.now + 100,
-          status: 'completed'
-        )
+      task3 = Task.create!(
+        title: 'No title',
+        description: 'Description 3',
+        due: Time.zone.now + 100,
+        status: 'completed'
+      )
 
-        result = Task.search_with_sort('', '', 'due', 'desc')
+      result = Task.search_with_sort('', '', 'due', 'desc')
 
-        expect(result).to eq([task2, task3, task1])
-      end
+      expect(result).to eq([task2, task3, task1])
+    end
 
-      it 'sort by due in asc order without title and status specified' do 
-        task1 = Task.create!(
-          title: 'Task 1',
-          description: 'Description 1',
-          due: Time.zone.now + 10,
-          status: 'pending'
-        )
+    it 'sorted by due in asc order without title and status specified' do 
+      task1 = Task.create!(
+        title: 'Task 1',
+        description: 'Description 1',
+        due: Time.zone.now + 10,
+        status: 'pending'
+      )
 
-        task2 = Task.create!(
-          title: 'Task 2',
-          description: 'Description 2',
-          due: Time.zone.now + 1000,
-          status: 'in_progress'
-        )
+      task2 = Task.create!(
+        title: 'Task 2',
+        description: 'Description 2',
+        due: Time.zone.now + 1000,
+        status: 'in_progress'
+      )
 
-        task3 = Task.create!(
-          title: 'No title',
-          description: 'Description 3',
-          due: Time.zone.now + 100,
-          status: 'completed'
-        )
+      task3 = Task.create!(
+        title: 'No title',
+        description: 'Description 3',
+        due: Time.zone.now + 100,
+        status: 'completed'
+      )
 
-        result = Task.search_with_sort('', '', 'due', 'asc')
+      result = Task.search_with_sort('', '', 'due', 'asc')
 
-        expect(result).to eq([task1, task3, task2])
-      end
+      expect(result).to eq([task1, task3, task2])
     end
   end
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -3,37 +3,60 @@ require 'rails_helper'
 RSpec.describe 'Tasks', type: :system do 
   describe 'index page' do 
     it 'show page title, list and delete buttons' do 
-      Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
-      Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 5)
+      Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
+      Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 5, status: 'pending')
 
       visit tasks_path
 
+      # page title
       expect(page).to have_content('Task List')
 
+      # filter field
+      ## search title
+      expect(page).to have_field('Search Title:')
+      ## search status
+      expect(page).to have_select('Search Status:')
+      ## sort by
+      expect(page).to have_select('Sort by')
+      ## sort order
+      expect(page).to have_select('Order')
+      ## filter button
+      expect(page).to have_button('Filter')
+
+      # tasks' title
       expect(page).to have_content('Test title 1')
       expect(page).to have_content('Test title 2')
 
-      expect(page).to have_selector("input[type='submit'][value='Delete']", count: 2)
+      expect(page).to have_button('Delete', count: 2)
     end
 
-    context 'delete a task' do
-      it "delete the task with button" do 
-        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+    context 'interact with buttons' do
+      it 'delete the task when clicking Delete button' do 
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
         visit tasks_path
-        click_on task.id.to_s
+        click_on "Delete#{task.id}"
 
         expect(page).to have_no_content('Task Detail 1')
         expect(Task.all.length).to eq(0)
         expect(page).to have_content('Deleted task successfully!')
       end
+
+      it 'jump to edit page when clicking Edit button' do 
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
+
+        visit tasks_path
+        click_on "Edit#{task.id}"
+
+        expect(current_path).to eq(edit_task_path(task))
+      end
     end
 
     context 'show tasks in specified order' do
       it 'show tasks in created date in desc order by default' do 
-        Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
-        Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 5)
-        Task.create!(title: 'Test title 3', description: 'Test Description 3', due: Time.zone.now + 5)
+        Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
+        Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 5, status: 'pending')
+        Task.create!(title: 'Test title 3', description: 'Test Description 3', due: Time.zone.now + 5, status: 'pending')
 
         visit tasks_path 
 
@@ -45,14 +68,14 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'show tasks in created date in asc order when specified' do 
-        Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
-        Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 5)
-        Task.create!(title: 'Test title 3', description: 'Test Description 3', due: Time.zone.now + 5)
+        Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
+        Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 5, status: 'pending')
+        Task.create!(title: 'Test title 3', description: 'Test Description 3', due: Time.zone.now + 5, status: 'pending')
         
         visit tasks_path
 
         select 'Asc', from: 'Order'
-        click_on 'Sort'
+        click_on 'Filter'
 
         titles = find('tbody').all('tr')
 
@@ -62,14 +85,14 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'show tasks in due date in desc order when specified' do 
-        Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
-        Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 10)
-        Task.create!(title: 'Test title 3', description: 'Test Description 3', due: Time.zone.now + 15)
+        Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
+        Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 10, status: 'pending')
+        Task.create!(title: 'Test title 3', description: 'Test Description 3', due: Time.zone.now + 15, status: 'pending')
         
         visit tasks_path
 
         select 'Due Date', from: 'Sort by'
-        click_on 'Sort'
+        click_on 'Filter'
 
         titles = find('tbody').all('tr')
 
@@ -79,15 +102,15 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'show tasks in due date in asc order when specified' do 
-        Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
-        Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 10)
-        Task.create!(title: 'Test title 3', description: 'Test Description 3', due: Time.zone.now + 15)
+        Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
+        Task.create!(title: 'Test title 2', description: 'Test Description 2', due: Time.zone.now + 10, status: 'pending')
+        Task.create!(title: 'Test title 3', description: 'Test Description 3', due: Time.zone.now + 15, status: 'pending')
         
         visit tasks_path
 
         select 'Due Date', from: 'Sort by'
         select 'Asc', from: 'Order'
-        click_on 'Sort'
+        click_on 'Filter'
 
         titles = find('tbody').all('tr')
 
@@ -97,6 +120,74 @@ RSpec.describe 'Tasks', type: :system do
       end 
     end
 
+    context 'search by title or status' do 
+      it 'search title' do 
+        Task.create!(
+          title: 'Task 1',
+          description: 'Description 1',
+          due: Time.zone.now + 5,
+          status: 'pending'
+        )
+
+        Task.create!(
+          title: 'Task 2',
+          description: 'Description 2',
+          due: Time.zone.now + 5,
+          status: 'in_progress'
+        )
+
+        Task.create!(
+          title: 'No title',
+          description: 'Description 3',
+          due: Time.zone.now + 5,
+          status: 'completed'
+        )
+
+        visit tasks_path 
+
+        fill_in 'Search Title:', with: 'Task'
+
+        click_on 'Filter'
+
+        titles = titles = find('tbody').all('tr')
+
+        expect(titles[0]).to have_content('Task 2')
+        expect(titles[1]).to have_content('Task 1')
+      end
+      
+      it 'search status' do 
+        Task.create!(
+          title: 'Task 1',
+          description: 'Description 1',
+          due: Time.zone.now + 5,
+          status: 'pending'
+        )
+
+        Task.create!(
+          title: 'Task 2',
+          description: 'Description 2',
+          due: Time.zone.now + 5,
+          status: 'in_progress'
+        )
+
+        Task.create!(
+          title: 'No title',
+          description: 'Description 3',
+          due: Time.zone.now + 5,
+          status: 'completed'
+        )
+
+        visit tasks_path 
+
+        select 'Pending', from: 'Search Status:'
+
+        click_on 'Filter'
+
+        titles = titles = find('tbody').all('tr')
+
+        expect(titles[0]).to have_content('Task 1')
+      end
+    end
   end
 
   describe 'new page and create task' do 
@@ -109,7 +200,11 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_field('Description')
       expect(page).to have_field('Due')
 
-      expect(page).to have_selector("input[type='submit'][value='Submit Task']")
+      expect(page).to have_selector("input[type='radio'][value='pending']")
+      expect(page).to have_selector("input[type='radio'][value='in_progress']")
+      expect(page).to have_selector("input[type='radio'][value='completed']")
+
+      expect(page).to have_button('Submit Task')
     end
 
     it 'create new task and show flash message' do 
@@ -119,6 +214,7 @@ RSpec.describe 'Tasks', type: :system do
       fill_in 'Description', with: 'New Task Description'
       new_time = Time.zone.now + 5
       fill_in 'Due', with: new_time
+      choose 'Pending'
 
       click_on 'Submit Task'
 
@@ -131,6 +227,7 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_content('New Task Title')
       expect(page).to have_content('New Task Description')
       expect(page).to have_content(I18n.l new_time)
+      expect(page).to have_content('Pending')
     end
 
     context 'input invalid value' do 
@@ -139,6 +236,7 @@ RSpec.describe 'Tasks', type: :system do
 
         fill_in 'Description', with: 'New Task Description'
         fill_in 'Due', with: Time.zone.now + 5
+        choose 'Pending'
 
         click_on 'Submit Task'
 
@@ -152,6 +250,7 @@ RSpec.describe 'Tasks', type: :system do
         fill_in 'Title', with: 't' * 31
         fill_in 'Description', with: 'New Task Description'
         fill_in 'Due', with: Time.zone.now + 5
+        choose 'Pending'
 
         click_on 'Submit Task'
 
@@ -164,6 +263,7 @@ RSpec.describe 'Tasks', type: :system do
 
         fill_in 'Title', with: 'New Task Title'
         fill_in 'Due', with: Time.zone.now + 5
+        choose 'Pending'
 
         click_on 'Submit Task'
 
@@ -177,6 +277,7 @@ RSpec.describe 'Tasks', type: :system do
         fill_in 'Title', with: 'New Task Title'
         fill_in 'Description', with: 'd' * 301
         fill_in 'Due', with: Time.zone.now + 5
+        choose 'Pending'
 
         click_on 'Submit Task'
 
@@ -189,6 +290,7 @@ RSpec.describe 'Tasks', type: :system do
 
         fill_in 'Title', with: 'New Task Title'
         fill_in 'Description', with: 'New Task Description'
+        choose 'Pending'
 
         click_on 'Submit Task'
 
@@ -202,6 +304,7 @@ RSpec.describe 'Tasks', type: :system do
         fill_in 'Title', with: 'New Task Title'
         fill_in 'Description', with: 'New Task Description'
         fill_in 'Due', with: Time.zone.now - 60
+        choose 'Pending'
 
         click_on 'Submit Task'
 
@@ -214,7 +317,7 @@ RSpec.describe 'Tasks', type: :system do
   describe 'detail page' do
     it 'show the detail of the task' do 
       new_time = Time.zone.now + 5
-      task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: new_time)
+      task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: new_time, status: 'pending')
       
       visit task_path(task)
 
@@ -223,13 +326,14 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_content('Title')
       expect(page).to have_content('Test title 1')
       expect(page).to have_content(I18n.l(new_time))
+      expect(page).to have_content('Pending')
     end
   end
 
   describe 'edit task page' do 
     it 'show fileds with values inside' do 
       previous_time = Time.zone.now + 5
-      task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: previous_time)
+      task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: previous_time, status: 'pending')
       
       visit edit_task_path(task)
 
@@ -243,7 +347,7 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it 'redirect to index page after submit' do 
-      task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+      task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
       visit edit_task_path(task)
 
@@ -251,6 +355,7 @@ RSpec.describe 'Tasks', type: :system do
       fill_in 'Description', with: 'Edit Task Description'
       edit_time = Time.zone.now + 5
       fill_in 'Due', with: edit_time
+      choose 'In Progress'
 
       click_on 'Update Task'
 
@@ -262,11 +367,12 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_content('Edit Task Title')
       expect(page).to have_content('Edit Task Description')
       expect(page).to have_content(I18n.l(edit_time))
+      expect(page).to have_content('In Progress')
     end
 
     context 'edit with invalid inputs' do 
       it 'should show error message for title less than 5 chars' do 
-        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
         visit edit_task_path(task)
 
@@ -279,7 +385,7 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'should show error message for title more than 30 chars' do 
-        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
         visit edit_task_path(task)
 
@@ -292,7 +398,7 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'should show error message for description less than 10 chars' do 
-        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
         visit edit_task_path(task)
 
@@ -305,7 +411,7 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'should show error message for description more than 300 chars' do 
-        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
         visit edit_task_path(task)
 
@@ -318,7 +424,7 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'should show error message for empty due date' do 
-        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
         visit edit_task_path(task)
 
@@ -331,7 +437,7 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'should show error message for past due date' do 
-        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
         visit edit_task_path(task)
 
@@ -344,7 +450,7 @@ RSpec.describe 'Tasks', type: :system do
       end
 
       it 'should NOT show error message if not change due date' do 
-        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5)
+        task = Task.create!(title: 'Test title 1', description: 'Test Description 1', due: Time.zone.now + 5, status: 'pending')
 
         visit edit_task_path(task)
 


### PR DESCRIPTION
## Requirements 

- ステータス（未着手・着手中・完了）を追加してみよう
- 一覧画面でタイトルとステータスで検索ができるようにしよう
- 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
- 検索インデックスを貼りましょう
- 検索に対してmodel specを追加してみよう（system specも拡充しておきましょう）

## Behaviors

- **Status on each page**
  - **_Index page_**
<img src="https://github.com/Fablic/training/assets/167514427/a8fcf49f-8b03-483f-8331-9cb42deaaad8" width=400>

---

  - **_New page_**
 <img src="https://github.com/Fablic/training/assets/167514427/ad4299eb-1f86-4bd4-a1d1-6aa87e7030e5" width=300>

---

  - **_Show page_**
<img src="https://github.com/Fablic/training/assets/167514427/33b2b9bd-8b50-4475-bcf2-446d6b48303d" width=300>

---

  - **_Edit page_**
  <img src="https://github.com/Fablic/training/assets/167514427/fb113dcf-663a-49c0-a067-8dcceae38a00" width=300>

---

- **Search results**
 <video src="https://github.com/Fablic/training/assets/167514427/0778a659-75e2-4375-9b00-c67f5d5ac63c">
