### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,10 +3,10 @@ class TasksController < ApplicationController
 
   # GET /tasks or /tasks.json
   def index
-    @tasks = Task.all
-                 .search_title(params[:title])
-                 .search_status(params[:status])
-                 .default_order
+    @tasks = Task
+             .search_title(params[:title])
+             .search_status(params[:status])
+             .default_order
   end
 
   # GET /tasks/1 or /tasks/1.json

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,7 +3,10 @@ class TasksController < ApplicationController
 
   # GET /tasks or /tasks.json
   def index
-      @tasks = Task.all.search_title(params[:title]).search_status(params[:status]).default_order
+    @tasks = Task.all
+                 .search_title(params[:title])
+                 .search_status(params[:status])
+                 .default_order
   end
 
   # GET /tasks/1 or /tasks/1.json

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
 
   # GET /tasks or /tasks.json
   def index
-    @tasks = Task.all.order(created_at: :desc)
+      @tasks = Task.all.search_title(params[:title]).search_status(params[:status]).default_order
   end
 
   # GET /tasks/1 or /tasks/1.json

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -10,6 +10,6 @@ class Task < ApplicationRecord
   validates :details, length: { maximum: 1000 }
 
   scope :default_order, -> { order(created_at: :desc) }
-  scope :search_title, ->(title = nil) { where('title LIKE ?', "%#{sanitize_sql_like(title)}%") if title.present? }
-  scope :search_status, ->(status = nil) { where(status:) if status.present? }
+  scope :search_title, ->(title) { where('title LIKE ?', "%#{sanitize_sql_like(title)}%") if title.present? }
+  scope :search_status, ->(status) { where(status:) if status.present? }
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -1,20 +1,15 @@
 # Taskモデルは、タスクのタイトルと詳細を管理します。
 # タイトルは必須であり、空であってはなりません。
 class Task < ApplicationRecord
-  enum status: { not_started: 0, in_progress: 1, completed: 2 }
-  enum priority: { high: 0, middle: 1, low: 2 }
+  enum status: { not_started: 0, in_progress: 1, completed: 2 }, _default: :not_started
+  enum priority: { high: 0, middle: 1, low: 2 }, _default: :middle
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :status, presence: true
   validates :priority, presence: true
   validates :details, length: { maximum: 1000 }
 
-  after_initialize :set_defaults, unless: :persisted?
-
-  private
-
-  def set_defaults
-    self.status ||= :not_started
-    self.priority ||= :middle
-  end
+  scope :default_order, -> { order(created_at: :desc) }
+  scope :search_title, ->(title = nil) { where('title LIKE ?', "%#{sanitize_sql_like(title)}%") if title.present? }
+  scope :search_status, ->(status = nil) { where(status:) if status.present? }
 end

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -3,38 +3,53 @@
     <h1><%= t('views.tasks.index.title') %></h1>
     <button id="logout" class="btn btn-outline-secondary"><%= t('views.common.login') %></button>
   </div>
-  <% if @tasks.any? %>
-    <input type="text" class="form-control w-25" placeholder="<%= t('views.common.search') %>" id="search">
-    <table class="table table-striped table-hover">
-      <thead class="thead-light">
-        <tr>
-          <th><%= t('helpers.label.task.title') %></th>
-          <th><%= t('helpers.label.task.assignee') %></th>
-          <th><%= t('helpers.label.task.label') %></th>
-          <th><%= t('helpers.label.task.due_date') %></th>
-          <th><%= t('helpers.label.task.status') %></th>
-          <th><%= t('helpers.label.task.priority') %></th>
-          <th><%= t('helpers.label.task.created_at') %></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @tasks.each do |task| %>
+  <div class="container mt-2 mb-2">
+    <%= form_with url: tasks_path, method: :get, local: true, class: "form-inline" do %>
+      <div class="form-group row mt-2 mb-2">
+        <div class="col">
+          <%= text_field_tag :title, params[:title], placeholder: t('activerecord.attributes.task.title'), class: "form-control" %>
+        </div>
+        <div class="col">
+          <%= select_tag :status, options_for_select([[t('views.common.all_status'), '']] + Task.statuses.keys.map { |status| [t(%(activerecord.attributes.task.status.#{status})), status] }, params[:status]), class: "form-select" %>
+        </div>
+        <div class="col">
+          <%= submit_tag t('views.common.search'), class: "btn btn-outline-primary" %>
+          <%= link_to t('views.common.reset'), tasks_path, class: "btn btn-outline-secondary" %>
+        </div>
+      </div>
+    <% end %>
+    <% if @tasks.any? %>
+      <table class="table table-striped table-hover">
+        <thead class="thead-light">
           <tr>
-            <td class="text-truncate" style="max-width: 200px;"><%= link_to task.title, task_path(task) %></td>
-            <td><%= task.user_id || 'Ryu Seungwoo | sam | ECID' %></td>
-            <td></td>
-            <td><%= task.due_date&.strftime('%Y/%m/%d')  %></td>
-            <td><%= t(%(activerecord.attributes.task.status.#{task.status})) %></td>
-            <td><%= t(%(activerecord.attributes.task.priority.#{task.priority})) %></td>
-            <td><%= task.created_at.strftime('%Y/%m/%d %H:%M:%S') %></td>
+            <th><%= t('helpers.label.task.title') %></th>
+            <th><%= t('helpers.label.task.assignee') %></th>
+            <th><%= t('helpers.label.task.label') %></th>
+            <th><%= t('helpers.label.task.due_date') %></th>
+            <th><%= t('helpers.label.task.status') %></th>
+            <th><%= t('helpers.label.task.priority') %></th>
+            <th><%= t('helpers.label.task.created_at') %></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  <% else %>
-    <p class="text-center"><%= t('views.tasks.index.no_tasks') %></p>
-  <% end %>
-  <div class="d-flex justify-content-end">
-    <%= link_to t('views.common.add'), new_task_path, class: "btn btn-primary" %>
+        </thead>
+        <tbody>
+          <% @tasks.each do |task| %>
+            <tr>
+              <td class="text-truncate" style="max-width: 200px;"><%= link_to task.title, task_path(task) %></td>
+              <td><%= task.user_id || 'Ryu Seungwoo | sam | ECID' %></td>
+              <td></td>
+              <td><%= task.due_date&.strftime('%Y/%m/%d')  %></td>
+              <td><%= t(%(activerecord.attributes.task.status.#{task.status})) %></td>
+              <td><%= t(%(activerecord.attributes.task.priority.#{task.priority})) %></td>
+              <td><%= task.created_at.strftime('%Y/%m/%d %H:%M:%S') %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="text-center"><%= t('views.tasks.index.no_tasks') %></p>
+    <% end %>
+    <div class="d-flex justify-content-end">
+      <%= link_to t('views.common.add'), new_task_path, class: "btn btn-primary" %>
+    </div>
   </div>
 </div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -10,7 +10,7 @@
           <%= text_field_tag :title, params[:title], placeholder: t('activerecord.attributes.task.title'), class: "form-control" %>
         </div>
         <div class="col">
-          <%= select_tag :status, options_for_select([[t('views.common.all_status'), '']] + Task.statuses.keys.map { |status| [t(%(activerecord.attributes.task.status.#{status})), status] }, params[:status]), class: "form-select" %>
+          <%= select_tag :status, options_for_select(Task.statuses.keys.map { |status| [t(%(activerecord.attributes.task.status.#{status})), status] }, params[:status]), prompt: t('views.common.all_status'), class: "form-select" %>
         </div>
         <div class="col">
           <%= submit_tag t('views.common.search'), class: "btn btn-outline-primary" %>

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -61,6 +61,8 @@ en:
       delete: "Delete"
       edit: "Edit"
       confirm: "Are you sure?"
+      reset: "Reset"
+      all_status: "All status"
   flash:
     common:
       success: "%{model} was successful."

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -61,6 +61,8 @@ ja:
       delete: "削除"
       edit: "編集"
       confirm: "本当ですか？"
+      reset: "初期化"
+      all_status: "全てのステータス"
   flash:
     common:
       success: "%{model}に成功しました。"

--- a/myapp/db/migrate/20240607075212_add_index_to_task.rb
+++ b/myapp/db/migrate/20240607075212_add_index_to_task.rb
@@ -1,0 +1,6 @@
+class AddIndexToTask < ActiveRecord::Migration[7.0] # rubocop:disable Style/Documentation
+  def change
+    add_index :tasks, :title
+    add_index :tasks, :status
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_04_083311) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_07_075212) do
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "title", null: false
     t.integer "user_id"
@@ -21,6 +21,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_04_083311) do
     t.text "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_tasks_on_status"
+    t.index ["title"], name: "index_tasks_on_title"
   end
 
 end

--- a/myapp/spec/model/tesk_spec.rb
+++ b/myapp/spec/model/tesk_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Task, type: :model do
       end
 
       it 'search title' do
-        task_list = Task.search_title
+        task_list = Task.search_title('')
         expect(task_list.count).to eq 3
         expect(task_list[0]).to eq @task1
         expect(task_list[1]).to eq @task2
@@ -66,7 +66,7 @@ RSpec.describe Task, type: :model do
       end
 
       it 'search status' do
-        task_list = Task.search_status
+        task_list = Task.search_status(nil)
         expect(task_list.count).to eq 3
         expect(task_list[0]).to eq @task1
         expect(task_list[1]).to eq @task2

--- a/myapp/spec/model/tesk_spec.rb
+++ b/myapp/spec/model/tesk_spec.rb
@@ -33,4 +33,52 @@ RSpec.describe Task, type: :model do
       end
     end
   end
+
+  describe 'Test for Search' do
+    before do
+      @task1 = Task.create!(title: 'ryu title1', details: 'ryu details1', status: :not_started, created_at: 1.day.ago)
+      @task2 = Task.create!(title: 'ryu title2', details: 'ryu details2', status: :in_progress, created_at: 2.days.ago)
+      @task3 = Task.create!(title: 'ryu title3', details: 'ryu details3', status: :completed, created_at: Time.now)
+    end
+
+    context 'title' do
+      it 'lists results by default order (create_at desc)' do
+        task_list = Task.default_order
+        expect(task_list.count).to eq 3
+        expect(task_list[0]).to eq @task3
+        expect(task_list[1]).to eq @task1
+        expect(task_list[2]).to eq @task2
+      end
+
+      it 'search title' do
+        task_list = Task.search_title
+        expect(task_list.count).to eq 3
+        expect(task_list[0]).to eq @task1
+        expect(task_list[1]).to eq @task2
+        expect(task_list[2]).to eq @task3
+
+        task_list = Task.search_title(@task3.title)
+        expect(task_list.count).to eq 1
+        expect(task_list[0]).to eq @task3
+
+        task_list = Task.search_title('Non title')
+        expect(task_list.count).to eq 0
+      end
+
+      it 'search status' do
+        task_list = Task.search_status
+        expect(task_list.count).to eq 3
+        expect(task_list[0]).to eq @task1
+        expect(task_list[1]).to eq @task2
+        expect(task_list[2]).to eq @task3
+
+        task_list = Task.search_status(@task3.status)
+        expect(task_list.count).to eq 1
+        expect(task_list[0]).to eq @task3
+
+        task_list = Task.search_status('Non status')
+        expect(task_list.count).to eq 0
+      end
+    end
+  end
 end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -7,6 +7,15 @@ RSpec.describe 'Tasks', type: :system do
         expect(page).to have_selector('h1', text: I18n.t('views.tasks.index.title'))
         expect(page).to have_link(I18n.t('views.common.add'))
         expect(page).to have_button(I18n.t('views.common.login'))
+        expect(page).to have_button(I18n.t('views.common.search'))
+        expect(page).to have_link(I18n.t('views.common.reset'))
+        expect(page).to have_field(I18n.t('activerecord.attributes.task.title'))
+        expect(page).to have_select('status', options: [
+                                      I18n.t('views.common.all_status'),
+                                      I18n.t('activerecord.attributes.task.status.not_started'),
+                                      I18n.t('activerecord.attributes.task.status.in_progress'),
+                                      I18n.t('activerecord.attributes.task.status.completed')
+                                    ])
       end
     end
 
@@ -31,7 +40,6 @@ RSpec.describe 'Tasks', type: :system do
 
       it_behaves_like 'Checking component'
       it 'displays Items in the correct order' do
-        expect(page).to have_field(I18n.t('views.common.search'))
         expect(page).to have_selector('tr>th', text: I18n.t('helpers.label.task.title'))
         expect(find('tbody tr:nth-child(1)')).to have_link(@task3.title)
         expect(find('tbody tr:nth-child(2)')).to have_link(@task1.title)
@@ -220,6 +228,87 @@ RSpec.describe 'Tasks', type: :system do
         expect(page).to have_selector('h1', text: I18n.t('views.tasks.edit.title'))
         expect(page).to have_content(I18n.t('flash.common.failure', model: I18n.t('actions.update')))
         expect(page).to have_content(I18n.t('activerecord.attributes.task.title') + I18n.t('activerecord.errors.messages.too_long', count: 100))
+      end
+    end
+  end
+
+  describe 'Test for Search' do
+    let!(:task1) { Task.create!(title: 'Task@1', status: :not_started) }
+    let!(:task2) { Task.create!(title: 'Task%2', status: :in_progress) }
+    let!(:task3) { Task.create!(title: 'Task-3', status: :completed) }
+
+    context 'Case Search button' do
+      it 'has the hitted tasks witg no condition ' do
+        visit tasks_path
+        click_button I18n.t('views.common.search')
+
+        expect(page).to have_content(task2.title)
+        expect(page).to have_content(task1.title)
+        expect(page).to have_content(task3.title)
+      end
+
+      it 'has the hitted tasks only with Status condition ' do
+        visit tasks_path
+        select I18n.t('activerecord.attributes.task.status.in_progress'), from: 'status'
+        click_button I18n.t('views.common.search')
+
+        expect(page).to have_content(task2.title)
+        expect(page).not_to have_content(task1.title)
+        expect(page).not_to have_content(task3.title)
+      end
+
+      it 'has the hitted tasks only with Title condition' do
+        visit tasks_path
+        fill_in 'title', with: '-3'
+        click_button I18n.t('views.common.search')
+
+        expect(page).to have_content(task3.title)
+        expect(page).not_to have_content(task1.title)
+        expect(page).not_to have_content(task2.title)
+      end
+
+      it 'has the hitted tasks with both' do
+        visit tasks_path
+        fill_in 'title', with: 'Task'
+        select I18n.t('activerecord.attributes.task.status.not_started'), from: 'status'
+        click_button I18n.t('views.common.search')
+
+        expect(page).to have_content(task1.title)
+        expect(page).not_to have_content(task2.title)
+        expect(page).not_to have_content(task3.title)
+      end
+
+      it 'has the hitted tasks with both' do
+        visit tasks_path
+        fill_in 'title', with: 'Task@'
+        select I18n.t('activerecord.attributes.task.status.not_started'), from: 'status'
+        click_button I18n.t('views.common.search')
+
+        expect(page).to have_content(task1.title)
+        expect(page).not_to have_content(task2.title)
+        expect(page).not_to have_content(task3.title)
+      end
+
+      it 'has no hitted' do
+        visit tasks_path
+        fill_in 'title', with: '-4'
+        select I18n.t('activerecord.attributes.task.status.completed'), from: 'status'
+        click_button I18n.t('views.common.search')
+
+        expect(page).to have_content(I18n.t('views.tasks.index.no_tasks'))
+      end
+    end
+
+    context 'Case Reset button' do
+      it 'shows all tasks list' do
+        visit tasks_path
+        fill_in 'title', with: 'k%'
+        select I18n.t('activerecord.attributes.task.status.in_progress'), from: 'status'
+        click_link I18n.t('views.common.reset')
+
+        expect(page).to have_content(task1.title)
+        expect(page).to have_content(task2.title)
+        expect(page).to have_content(task3.title)
       end
     end
   end


### PR DESCRIPTION
### ステップ13: ステータスを追加して、検索できるようにしよう

- [x] ステータス（未着手・着手中・完了）を追加してみよう
  - 【オプション要件】初学者ではない場合はstateを管理するGemを導入しても構いません
- [x] 一覧画面でタイトルとステータスで検索ができるようにしよう
  - 【オプション要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構いません
- [x] 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
  - 以降のステップでも必要に応じて確認する癖をつけましょう
- [x] 検索インデックスを貼りましょう
- [x] 検索に対してmodel specを追加してみよう（system specも拡充しておきましょう）


---
#### Issued-SQL
<img width="1133" alt="image" src="https://github.com/Fablic/training/assets/166586164/6ebddbc5-1751-4af9-a1e6-508c703c0f6b">

#### Screen
<img width="849" alt="image" src="https://github.com/Fablic/training/assets/166586164/9156a7a7-1f7d-43e3-84f3-d27eee00a302">

<img width="847" alt="image" src="https://github.com/Fablic/training/assets/166586164/f4728f8c-364a-441d-88bc-352e06194b71">

<img width="867" alt="image" src="https://github.com/Fablic/training/assets/166586164/30ab29eb-e4ca-4be1-886a-312147ada5f6">


