### PR TITLE
Step 19: ユーザにロールを追加しよう ★ スキップ可能

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  include SessionsHelper, TaskHelper
+  include SessionsHelper, TaskHelper, UsersHelper
 end

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  include UsersHelper
+  before_action :redirect_if_not_admin
+
   def admin
     @users_with_count = User.with_tasks_count
   end

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -34,13 +34,24 @@ class UsersController < ApplicationController
 
   def edit 
     @user = find_user_by_id
-    redirect_to admin_path, notice: 'User not found!' unless @user 
+    redirect_to admin_path, notice: 'User not found!' unless @user
+    @myself = params[:id].to_i == session[:user_id]
   end
 
-  def update
+  def update_info
     @user = find_user_by_id
     redirect_to admin_path, notice: 'User not found!' unless @user 
-    if @user.update(user_params)
+    if @user.update(user_params_info)
+      redirect_to admin_path, notice: "Successfully updated user #{@user.username}"
+    else 
+      render :edit
+    end
+  end
+
+  def update_password
+    @user = find_user_by_id
+    redirect_to admin_path, notice: 'User not found!' unless @user 
+    if @user.update(user_params_password)
       redirect_to admin_path, notice: "Successfully updated user #{@user.username}"
     else 
       render :edit
@@ -62,7 +73,11 @@ class UsersController < ApplicationController
     User.find_by(id: params[:id])
   end
 
-  def user_params
-    params.require(:user).permit(:username, :password, :password_confirmation)
+  def user_params_info
+    params.require(:user).permit(:username, :admin)
+  end
+
+  def user_params_password
+    params.require(:user).permit(:password, :password_confirmation)
   end
 end

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-  include UsersHelper
   before_action :redirect_if_not_admin
 
   def admin

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -41,7 +41,12 @@ class UsersController < ApplicationController
   def update_info
     @user = find_user_by_id
     redirect_to admin_path, notice: 'User not found!' unless @user 
-    if @user.update(user_params_info)
+
+    info = user_params_info
+    # when resigning the last one admin user
+    if @user.admin && !info[:admin] && (admin_count == 1)
+      redirect_to admin_path, notice: "Should keep at least one admin user!"
+    elsif @user.update(info)
       redirect_to admin_path, notice: "Successfully updated user #{@user.username}"
     else 
       render :edit
@@ -79,5 +84,9 @@ class UsersController < ApplicationController
 
   def user_params_password
     params.require(:user).permit(:password, :password_confirmation)
+  end
+
+  def admin_count
+    User.where(admin: true).count
   end
 end

--- a/myapp/app/helpers/users_helper.rb
+++ b/myapp/app/helpers/users_helper.rb
@@ -1,9 +1,9 @@
 module UsersHelper
-  def admin_user?(id)
-    User.find_by(id: id).admin
+  def admin_user?
+    User.find_by(id: session[:user_id]).admin
   end
 
   def redirect_if_not_admin
-    redirect_to tasks_path, notice: 'No permissioin to access admin page!' unless admin_user?(session[:user_id])
+    redirect_to tasks_path, notice: 'No permissioin to access admin page!' unless admin_user?
   end
 end

--- a/myapp/app/helpers/users_helper.rb
+++ b/myapp/app/helpers/users_helper.rb
@@ -1,0 +1,9 @@
+module UsersHelper
+  def admin_user?(id)
+    User.find_by(id: id).admin
+  end
+
+  def redirect_if_not_admin
+    redirect_to tasks_path, notice: 'No permissioin to access admin page!' unless admin_user?(session[:user_id])
+  end
+end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,11 +1,17 @@
 class User < ApplicationRecord
   has_secure_password
   validates :username, uniqueness: { case_sensitive: true }, format: { with: /\A[^\s]*\z/ }, length: { in: 3..20 }
-  validates :password, presence: true, confirmation: true, format: { with: /\A[^\s]*\z/ }, length: { in: 5..15 }
+  validates :password, presence: true, confirmation: true, format: { with: /\A[^\s]*\z/ }, length: { in: 5..15 }, if: :password_exists?
 
   has_many :tasks, dependent: :destroy
 
   def self.with_tasks_count
     left_joins(:tasks).select('users.id, users.username, COUNT(tasks.id) as tasks_count').group('users.id')
+  end
+
+  private 
+
+  def password_exists?
+    password.present? || password_confirmation.present?
   end
 end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
 
   def self.with_tasks_count
-    left_joins(:tasks).select('users.id, users.username, COUNT(tasks.id) as tasks_count').group('users.id')
+    left_joins(:tasks).select('users.id, users.username, users.admin, COUNT(tasks.id) as tasks_count').group('users.id')
   end
 
   private 

--- a/myapp/app/views/tasks/_log_out.html.erb
+++ b/myapp/app/views/tasks/_log_out.html.erb
@@ -1,6 +1,9 @@
-<div class='container d-flex justify-content-end'>
+<div class='mb-5 container d-flex justify-content-end'>
   <div>
     <div class='mb-2' style='text-align:center'><%= current_user.username %></div>
-    <div><%= button_to t('views.buttons.logout'), logout_path, method: :delete, class: 'btn btn-outline-danger' %></div>
+    <div class='mb-2'><%= button_to t('views.buttons.logout'), logout_path, method: :delete, class: 'btn btn-outline-danger' %></div>
+    <% if admin_user? %>
+      <div><%= button_to t('views.buttons.admin'), admin_path, method: :get, class: 'btn btn-outline-dark' %></div>
+    <% end %>
   </div>
 </div>

--- a/myapp/app/views/users/admin.html.erb
+++ b/myapp/app/views/users/admin.html.erb
@@ -5,8 +5,13 @@
 <%= render 'common_components/notice_display' %>
 
 <div class='mb-5 container'>
-  <div class='mb-4 d-flex justify-content-end'>
-    <%= button_to 'New User', new_user_path, method: :get, class: 'btn btn-primary' %>
+  <div class='mb-4 row justify-content-between'>
+    <div class='col-4'>
+      <%= button_to 'Back to index page', tasks_path, method: :get , class: 'btn btn-outline-secondary' %>
+    </div>
+    <div class='col-4'>
+      <%= button_to 'New User', new_user_path, method: :get, class: 'btn btn-primary float-end' %>
+    </div>
   </div>
 
   <table class='table table-striped table-hover'>
@@ -23,8 +28,8 @@
       <% @users_with_count.each do |user| %>
         <tr>
           <td><%= "##{user.id}" %></td>
-          <td><%= link_to user.username, edit_user_path(user), class: 'btn link-without-underline' %></td>
-          <td><%= link_to user.tasks_count, user_tasks_path(user), class: 'btn link-without-underline' %></td>
+          <td><%= link_to user.username, edit_user_path(user) %></td>
+          <td><%= link_to user.tasks_count, user_tasks_path(user) %></td>
           <td><%= button_to 'Delete', user_path(user), method: :delete, class: 'btn btn-danger' %></td>
         </tr>
       <% end %>

--- a/myapp/app/views/users/admin.html.erb
+++ b/myapp/app/views/users/admin.html.erb
@@ -18,6 +18,7 @@
     <thead>
       <tr style='text-align:center'>
         <td><h3><%= t('views.texts.user_id') %></h3></td>
+        <td><h3><%= t('views.texts.admin') %></h3></td>
         <td><h3><%= t('views.texts.username') %></h3></td>
         <td><h3><%= t('views.texts.number_tasks') %></h3></td>
         <td><h3></h3><td>
@@ -28,6 +29,7 @@
       <% @users_with_count.each do |user| %>
         <tr>
           <td><%= "##{user.id}" %></td>
+          <td><% if user.admin %>◯<% end %></td>
           <td><%= link_to user.username, edit_user_path(user) %></td>
           <td><%= link_to user.tasks_count, user_tasks_path(user) %></td>
           <td><%= button_to t('views.buttons.delete'), user_path(user), method: :delete, class: 'btn btn-danger' %></td>

--- a/myapp/app/views/users/admin.html.erb
+++ b/myapp/app/views/users/admin.html.erb
@@ -1,5 +1,5 @@
 <div class='mt-5 mb-5 container', style='text-align:center'>
-  <h1>Admin page</h1>
+  <h1><%= t('views.titles.admin') %></h1>
 </div>
 
 <%= render 'common_components/notice_display' %>
@@ -7,19 +7,19 @@
 <div class='mb-5 container'>
   <div class='mb-4 row justify-content-between'>
     <div class='col-4'>
-      <%= button_to 'Back to index page', tasks_path, method: :get , class: 'btn btn-outline-secondary' %>
+      <%= button_to t('views.buttons.back_to_index'), tasks_path, method: :get , class: 'btn btn-outline-secondary' %>
     </div>
     <div class='col-4'>
-      <%= button_to 'New User', new_user_path, method: :get, class: 'btn btn-primary float-end' %>
+      <%= button_to t('views.buttons.new_user'), new_user_path, method: :get, class: 'btn btn-primary float-end' %>
     </div>
   </div>
 
   <table class='table table-striped table-hover'>
     <thead>
       <tr style='text-align:center'>
-        <td><h3>User ID</h3></td>
-        <td><h3>Username</h3></td>
-        <td><h3>Number of Tasks</h3></td>
+        <td><h3><%= t('views.texts.user_id') %></h3></td>
+        <td><h3><%= t('views.texts.username') %></h3></td>
+        <td><h3><%= t('views.texts.number_tasks') %></h3></td>
         <td><h3></h3><td>
       </tr>
     </thead>
@@ -30,7 +30,7 @@
           <td><%= "##{user.id}" %></td>
           <td><%= link_to user.username, edit_user_path(user) %></td>
           <td><%= link_to user.tasks_count, user_tasks_path(user) %></td>
-          <td><%= button_to 'Delete', user_path(user), method: :delete, class: 'btn btn-danger' %></td>
+          <td><%= button_to t('views.buttons.delete'), user_path(user), method: :delete, class: 'btn btn-danger' %></td>
         </tr>
       <% end %>
     </tbody>

--- a/myapp/app/views/users/edit.html.erb
+++ b/myapp/app/views/users/edit.html.erb
@@ -4,11 +4,11 @@
 
 
 <div class='container'>
-  <button class='mb-4 btn btn-outline-secondary'>
+  <button class='mb-5 btn btn-outline-secondary'>
     <%= link_to t('views.buttons.back_to_admin'), admin_path, method: :get , class: 'link-without-underline link-secondary' %>
   </button>
   
-  <%= form_with model: @user, local: true, data: { turbo: false } do |form| %>
+  <%= form_with model: @user, url: user_info_path, local: true, data: { turbo: false } do |form| %>
 
     <%= render partial: 'common_components/error_display', locals: { model: @user } %>
 
@@ -17,12 +17,35 @@
       <%= form.text_field :username, class: 'form-control' %>
     </div> 
 
+    <div class='mb-4'>
+      <%= form.label :admin, t('views.labels.select_role'), class: 'form-label' %>
+
+      <div class='form-check'>
+        <%= form.radio_button :admin, false, disabled: @myself %>
+        <%= form.label :admin_false, t('views.selects.admin_false') %>
+      </div>
+
+      <div class='form-check'>
+        <%= form.radio_button :admin, true, disabled: @myself %>
+        <%= form.label :admin_true, t('views.selects.admin_true') %>
+      </div>
+    </div> 
+
+    <div class='mb-5'>
+      <%= form.submit t('views.buttons.update'), class: 'btn btn-primary' %>
+    </div>
+  <% end %>
+
+  <%= form_with model: @user, url: user_password_path, local: true, data: { turbo: false } do |form| %>
+
+    <%= render partial: 'common_components/error_display', locals: { model: @user } %>
+
     <div class='mb-3 w-75'>
       <%= form.label :password, class: 'form-label' %>
       <%= form.password_field :password, class: 'form-control' %>
     </div>
 
-    <div class='mb-3 w-75'>
+    <div class='mb-4 w-75'>
       <%= form.label :password_confirmation, class: 'form-label' %>
       <%= form.password_field :password_confirmation, class: 'form-control' %>
     </div> 

--- a/myapp/app/views/users/edit.html.erb
+++ b/myapp/app/views/users/edit.html.erb
@@ -1,11 +1,11 @@
 <div class='mt-5 mb-5 container', style='text-align:center'>
-  <h1>Edit the task</h1>
+  <h1><%= t('views.titles.edit_user') %></h1>
 </div>
 
 
 <div class='container'>
   <button class='mb-4 btn btn-outline-secondary'>
-    <%= link_to 'Back to admin page', admin_path, method: :get , class: 'link-without-underline link-secondary' %>
+    <%= link_to t('views.buttons.back_to_admin'), admin_path, method: :get , class: 'link-without-underline link-secondary' %>
   </button>
   
   <%= form_with model: @user, local: true, data: { turbo: false } do |form| %>
@@ -28,7 +28,7 @@
     </div> 
 
     <div>
-      <%= form.submit 'Update', class: 'btn btn-primary' %>
+      <%= form.submit t('views.buttons.update'), class: 'btn btn-primary' %>
     </div>
   <% end %>
 </div>

--- a/myapp/app/views/users/new_user.html.erb
+++ b/myapp/app/views/users/new_user.html.erb
@@ -1,9 +1,9 @@
 <div class='mt-5 mb-5 container', style='text-align:center'>
-  <h1>Admin page: Create User</h1>
+  <h1><%= t('views.titles.create_user') %></h1>
 </div>
 
 <div class='container'>
-  <%= button_to 'Back to admin page', admin_path, method: :get, class: 'mb-4 btn btn-outline-secondary' %>
+  <%= button_to t('views.buttons.back_to_admin'), admin_path, method: :get, class: 'mb-4 btn btn-outline-secondary' %>
 
   <%= form_with scope: :user, url: admin_path, local: true, data: { turbo: false } do |form| %>
     <%= render partial: 'common_components/error_display', locals: { model: @user } %>
@@ -24,7 +24,7 @@
     </div> 
 
     <div>
-      <%= form.submit 'Create', class: 'btn btn-primary' %>
+      <%= form.submit t('views.buttons.create'), class: 'btn btn-primary' %>
     </div>
   <% end %>
 </div>

--- a/myapp/app/views/users/user_tasks.html.erb
+++ b/myapp/app/views/users/user_tasks.html.erb
@@ -1,18 +1,18 @@
 <div class='mt-5 mb-5 container', style='text-align:center'>
-  <h1>User Tasks</h1>
+  <h1><%= t('views.titles.user_tasks') %></h1>
 </div>
 
 <div class='container'>
   <button class='mb-4 btn btn-outline-secondary'>
-    <%= link_to 'Back to admin page', admin_path, method: :get , class: 'link-without-underline link-secondary' %>
+    <%= link_to t('views.buttons.back_to_admin'), admin_path, method: :get , class: 'link-without-underline link-secondary' %>
   </button>
 
   <table class='table table-striped table-hover'>
     <thead>
       <tr style="text-align:center">
-        <td><h2>Title</h3></td>
-        <td><h2>Due</h2></td>
-        <td><h2>Status</h3></td>
+        <td><h2><%= t('views.texts.title') %></h3></td>
+        <td><h2><%= t('views.texts.due') %></h2></td>
+        <td><h2><%= t('views.texts.status') %></h3></td>
       </tr>
     </head> 
 

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -18,6 +18,7 @@ ja:
       back_to_home: "ホーム画面に戻る"
       create: "新規作成"
       update: "アップデート"
+      admin: '管理画面'
     titles:
       login: "ログイン"
       signup: "ユーザー登録"

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -18,7 +18,10 @@ ja:
       back_to_home: "ホーム画面に戻る"
       create: "新規作成"
       update: "アップデート"
-      admin: '管理画面'
+      admin: "管理画面"
+      back_to_index: "ホーム画面に戻る"
+      new_user: "ユーザー作成"
+      back_to_admin: "管理画面に戻る"
     titles:
       login: "ログイン"
       signup: "ユーザー登録"
@@ -26,6 +29,10 @@ ja:
       new_task: "新規作成"
       edit_task: "タスク編集"
       show_task: "タスク詳細"
+      admin: "管理画面"
+      edit_user: "ユーザー情報編集"
+      create_user: "ユーザー作成"
+      user_tasks: "ユーザータスク一覧"
     texts:
       to_signup_1: "まだアカウントを持っていません？"
       to_signup_2: "をクリックして登録してください。"
@@ -33,6 +40,9 @@ ja:
       title: "タイトル"
       due: "期限日"
       status: "ステータス"
+      user_id: "ID"
+      username: "ユーザー名"
+      number_tasks: "タスク数"
     labels:
       username: "ユーザー名"
       password: "パスワード"

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -43,6 +43,7 @@ ja:
       user_id: "ID"
       username: "ユーザー名"
       number_tasks: "タスク数"
+      admin: "管理権限"
     labels:
       username: "ユーザー名"
       password: "パスワード"

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -51,6 +51,7 @@ ja:
       sort_by: "期限で並替"
       order: "順番"
       select_status: "ステータスを選択"
+      select_role: "ロールを選択"
     selects:
       status_all: "全部"
       status_pending: "保留中"
@@ -60,6 +61,8 @@ ja:
       sort_due_date: "期限日時"
       order_asc: "昇順"
       order_desc: "降順"
+      admin_false: "普通ユーザー"
+      admin_true: "管理者"
   time:
     formats:
       default: "%Y-%m-%d %H:%M:%S"

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -20,7 +20,11 @@ Rails.application.routes.draw do
     get ':id/tasks', to: 'users#user_tasks', as: :user_tasks
     # admin new user
     get 'new', to: 'users#new_user', as: :new_user
-    resources :users, only: [:edit, :update, :destroy]
+    # admin update user info
+    patch 'users/:id/info', to: 'users#update_info', as: :user_info
+    # admin update user password
+    patch 'users/:id/password', to: 'users#update_password', as: :user_password
+    resources :users, only: [:edit, :destroy]
   end
   resources :tasks
 end

--- a/myapp/db/migrate/20240613092628_add_role_to_users.rb
+++ b/myapp/db/migrate/20240613092628_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_06_014336) do
+ActiveRecord::Schema.define(version: 2024_06_13_092628) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "label_name", null: false
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2024_06_06_014336) do
     t.text "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false, null: false
     t.index ["username"], name: "index_users_on_username", unique: true, length: 20
   end
 

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,12 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_07_030329) do
-
-  create_table "admins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.index ["user_id"], name: "index_admins_on_user_id"
-  end
+ActiveRecord::Schema.define(version: 2024_06_06_014336) do
 
   create_table "labels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "label_name", null: false
@@ -43,6 +38,5 @@ ActiveRecord::Schema.define(version: 2024_06_07_030329) do
     t.index ["username"], name: "index_users_on_username", unique: true, length: 20
   end
 
-  add_foreign_key "admins", "users"
   add_foreign_key "tasks", "users"
 end

--- a/myapp/spec/system/admin_spec.rb
+++ b/myapp/spec/system/admin_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :system do 
+  before do
+    @admin_user = User.create(
+      username: 'admin_user',
+      password: 'password',
+      admin: true
+    )
+
+    @normal_user = User.create(
+      username: 'normal_user',
+      password: 'password',
+      admin: false
+    )
+
+    visit login_path 
+
+    fill_in 'username', with: 'admin_user'
+    fill_in 'password', with: 'password'
+    click_on 'commit'
+  end
+  
+  describe 'admin page' do 
+    it 'admin user should get access to admin page' do 
+      visit admin_path
+
+      expect(current_path).to eq(admin_path)
+    end
+
+    it 'normal user should not get access to admin page' do 
+      click_on I18n.t('views.buttons.logout')
+
+      fill_in 'username', with: 'normal_user'
+      fill_in 'password', with: 'password'
+      click_on 'commit'
+
+      visit admin_path 
+
+      expect(current_path).to eq(tasks_path)
+      expect(page).to have_content('No permissioin to access admin page!')
+    end
+
+    it 'should show admin permission for each user' do 
+      visit admin_path 
+
+      users = find('tbody').all('tr')
+
+      expect(users[0]).to have_content('◯')
+      expect(users[1]).to_not have_content('◯')
+    end
+
+    it 'should jump to edit page when clicking user name' do 
+      visit admin_path 
+
+      click_on @admin_user.username 
+
+      expect(current_path).to eq(edit_user_path(@admin_user))
+    end
+
+    it 'should jump to user"s tasks page when clicking number of tasks' do 
+      visit admin_path
+
+      first_row = find('tbody').all('tr')[0]
+      first_row.all('td')[3].find('a').click
+
+      expect(current_path).to eq(user_tasks_path(@admin_user))
+    end
+    
+    it 'should delete user when clicking delete button' do 
+      visit admin_path
+      
+      users = find('tbody').all('tr')
+
+      second_row = users[1]
+      second_row.all('td')[4].find("input[value='#{I18n.t('views.buttons.delete')}']").click
+
+      expect(users).to_not have_content(@normal_user.username)
+    end
+
+
+  end
+
+  describe 'admin edit page' do 
+    it 'should have two forms and not be able to self-select role' do 
+      visit edit_user_path(@admin_user)
+
+      expect(page).to have_button('commit', count: 2)
+
+      expect(page).to have_selector('input[id="user_admin_false"][disabled]')
+      expect(page).to have_selector('input[id="user_admin_true"][disabled]')
+    end
+  end
+end


### PR DESCRIPTION
## Requirements

- ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
- 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
- ユーザ管理画面でロールを選択できるようにしましょう
- 管理ユーザが1人もいなくならないように削除の制御をしましょう
- ※ Gemの使用・不使用は自由です

## Behaviors

- [x] Add role to users
- [x] Limit access to admin page
    <video src="https://github.com/Fablic/training/assets/167514427/af5ef12c-1884-477b-96b9-16bd232f26d8" />
---
- [x] Separate edit form into two (username and password part)
- [x] Enable selecting role on edit page
    <video src="https://github.com/Fablic/training/assets/167514427/ca66d916-8c56-4173-b5d7-a9a0271e0cae" />
---
- [x] Prevent self assigning/resigning
- [x] Manage to keep at least one admin
    <video src="https://github.com/Fablic/training/assets/167514427/fdd922a4-f296-4b55-bae1-ccd6eb0f063b" />