### PR TITLE
Step 21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   def check_maintenance_mode
     tmp_file_path = Rails.root.join('tmp', 'maintenance_tmp.txt')
     if File.exist?(tmp_file_path)
-      if request.path != maintenance_path || (current_user && !current_user.admin)
+      if current_user && !current_user.admin
         render file: Rails.public_path.join('503.html'), status: :service_unavailable
       end
     end

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,3 +1,15 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper, TaskHelper, UsersHelper
+  before_action :check_maintenance_mode
+
+  private 
+
+  def check_maintenance_mode
+    tmp_file_path = Rails.root.join('tmp', 'maintenance_tmp.txt')
+    if File.exist?(tmp_file_path)
+      if request.path != maintenance_path || (current_user && !current_user.admin)
+        render file: Rails.public_path.join('503.html'), status: :service_unavailable
+      end
+    end
+  end
 end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,13 @@
+namespace :maintenance do 
+  desc 'Create a tmp file to start maintenance'
+  task start: :environment do 
+    FileUtils.touch(Rails.root.join('tmp', 'maintenance_tmp.txt'))
+    Rails.logger.info 'Tmp file Created.'
+  end
+
+  desc 'Delete the tmp file to end maintenance'
+  task end: :environment do 
+    FileUtils.rm_f(Rails.root.join('tmp', 'maintenance_tmp.txt'))
+    Rails.logger.info 'Tmp file deleted.'
+  end
+end

--- a/myapp/public/503.html
+++ b/myapp/public/503.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, the server is in maintenance now. (503)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+
+<body style="background-color: mistyrose;">
+  <!-- This file lives in public/500.html -->
+  <div class="dialog" style="border: 3px solid; margin:50px; text-align:center;">
+    <div>
+      <h1 style="color:red">503</h1>
+      <h1>
+        Server is in maintenance now.
+        <br>
+        Please wait until service turns to be available.
+      </h1>
+    </div>
+    <p>Check the logs or contact to the website owner to get more information.</p>
+  </div>
+</body>
+</html>

--- a/myapp/spec/system/admin_spec.rb
+++ b/myapp/spec/system/admin_spec.rb
@@ -91,4 +91,55 @@ RSpec.describe 'Users', type: :system do
       expect(page).to have_selector('input[id="user_admin_true"][disabled]')
     end
   end
+
+  describe 'mantenance feature' do 
+    before do 
+      Rails.application.load_tasks
+      @tmp_file_path = Rails.root.join('tmp', 'maintenance_tmp.txt')
+    end
+
+    it 'should create and delete a tmp file when start and end task executed' do
+      Rake::Task['maintenance:start'].invoke 
+      assert_equal(File.exist?(@tmp_file_path), true)
+      Rake::Task['maintenance:start'].reenable
+
+      Rake::Task['maintenance:end'].invoke 
+      assert_equal(File.exist?(@tmp_file_path), false)
+      Rake::Task['maintenance:start'].reenable
+    end
+
+    context 'when in maintenance mode' do 
+      it 'should be able to visit task page if is admin user' do 
+        Rake::Task['maintenance:start'].invoke 
+        Rake::Task['maintenance:start'].reenable
+  
+        visit current_path
+
+        expect(page).to have_content(I18n.t('views.titles.task_list'))
+
+        Rake::Task['maintenance:end'].invoke
+        Rake::Task['maintenance:start'].reenable
+      end
+  
+      it 'should render 503 page if is normal user' do 
+        click_on I18n.t('views.buttons.logout')
+  
+        fill_in 'username', with: 'normal_user'
+        fill_in 'password', with: 'password'
+        click_on 'commit'      
+  
+        Rake::Task['maintenance:start'].invoke 
+        Rake::Task['maintenance:start'].reenable
+  
+        visit current_path
+  
+        expect(page).to have_content('503')
+        expect(page).to have_content('Server is in maintenance now.')
+        expect(page).to have_content('Please wait until service turns to be available.')
+
+        Rake::Task['maintenance:end'].invoke
+        Rake::Task['maintenance:start'].reenable
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Requirements

- メンテナンスを開始／終了するバッチを作ってみましょう
- メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
- 追加のGemを使わず、自分で実装してみましょう

## Behaviors

- [x] Rake task to start maintenance
- [x] Rake task to end maintenance
- [x] Redirect if not admin user
    <video src="https://github.com/Fablic/training/assets/167514427/bf3e03db-96ff-42d1-af1d-7ab2f102a0f6" />

## Tests

<kbd>
<img src="https://github.com/Fablic/training/assets/167514427/17affb16-0760-43b8-8c20-190010d28389" width=500 />
</kdb>