### PR TITLE
ステップ21: メンテナンス機能を作ろう

### DIFF
--- a/myapp/app/middlewares/maintenance_mode_filter.rb
+++ b/myapp/app/middlewares/maintenance_mode_filter.rb
@@ -1,0 +1,13 @@
+class MaintenanceModeFilter # rubocop:disable Style/Documentation
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if File.exist?(Rails.root.join('tmp', 'maintenance_mode_on'))
+      [302, { 'Location' => '/maintenance' }, []]
+    else
+      @app.call(env)
+    end
+  end
+end

--- a/myapp/bin/maintenance_mode
+++ b/myapp/bin/maintenance_mode
@@ -1,0 +1,10 @@
+#!/bin/bash
+MAINTENANCE_FILE="tmp/maintenance_mode_on"
+echo "$1"
+if [ "$1" == "1" ]; then
+  touch $MAINTENANCE_FILE
+elif [ "$1" == "0" ]; then
+  rm -f $MAINTENANCE_FILE
+else
+  echo "オgプション：1（メンテオン）、０（メンテオフ）"
+fi

--- a/myapp/config/application.rb
+++ b/myapp/config/application.rb
@@ -1,5 +1,5 @@
 require_relative 'boot'
-
+require_relative '../app/middlewares/maintenance_mode_filter'
 require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
@@ -23,5 +23,6 @@ module Myapp
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.middleware.use MaintenanceModeFilter
   end
 end

--- a/myapp/public/maintenance.html
+++ b/myapp/public/maintenance.html
@@ -1,0 +1,14 @@
+<!-- app/views/mente/maintenance.html.erb -->
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <title>メンテナンス中</title>
+</head>
+
+<body>
+  <h1>ステップ２１：メンテナンス中ですね</h1>
+</body>
+
+</html>

--- a/myapp/spec/system/mente_spec.rb
+++ b/myapp/spec/system/mente_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Mente' do
+  let(:maintenance_file) { Rails.root.join('tmp', 'maintenance_mode_on') }
+  context 'when maintenance_mode_on' do
+    before do
+      FileUtils.rm_f(maintenance_file)
+      FileUtils.touch(maintenance_file)
+    end
+
+    it 'redirects to /maintenance' do
+      visit tasks_path
+
+      expect(page).to have_content('ステップ２１：メンテナンス中ですね')
+    end
+  end
+
+  context 'when maintenance_mode_off' do
+    before do
+      FileUtils.rm_f(maintenance_file)
+    end
+
+    it 'calls the app' do
+      visit tasks_path
+
+      expect(page).to have_selector('h2', text: I18n.t('views.common.login'))
+      expect(page).to have_field(I18n.t('helpers.label.login.username'))
+      expect(page).to have_field(I18n.t('helpers.label.login.password'))
+      expect(page).to have_button(I18n.t('views.common.login'))
+    end
+  end
+end


### PR DESCRIPTION
### ステップ21: メンテナンス機能を作ろう

- メンテナンスを開始／終了するバッチを作ってみましょう
- メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
- 追加のGemを使わず、自分で実装してみましょう

---



https://github.com/Fablic/training/assets/166586164/361695aa-0546-4528-8453-ab87161f603d


