### PR TITLE
step19 Implement Role Selection and Ensure At Least One Admin Remains

### DIFF
--- a/myapp/app/controllers/admin/users_controller.rb
+++ b/myapp/app/controllers/admin/users_controller.rb
@@ -2,6 +2,13 @@
 
 module Admin
   class UsersController < AdminController
+    before_action :set_user, only: %i[show edit update destroy]
+    before_action :ensure_an_admin_remains, only: %i[update destroy]
+
+    def set_user
+      @user = User.find(params[:id])
+    end
+
     def index
       @users = User.includes(:tasks).all
     end
@@ -29,14 +36,32 @@ module Admin
 
     def destroy
       @user = User.find(params[:id])
-      @user.destroy
-      redirect_to admin_users_path, notice: 'User was successfully destroyed.'
+      if @user.destroy
+        redirect_to admin_users_url, notice: t('notices.user_deleted')
+      else
+        redirect_to admin_users_url, alert: t('alerts.user_not_deleted')
+      end
+    end
+
+    def update
+      if @user.update(user_params)
+        redirect_to admin_users_url, notice: t('notices.user_updated')
+      else
+        render :edit, alert: t('alerts.user_update_failed')
+      end
     end
 
     private
 
+    def ensure_an_admin_remains
+      return unless User.where(admin: true).count <= 1 && @user.admin?
+
+      redirect_to admin_users_url, alert: t('alerts.last_admin_cannot_be_deleted')
+      nil
+    end
+
     def user_params
-      params.require(:user).permit(:name, :email, :password)
+      params.require(:user).permit(:name, :email, :password, :admin)
     end
   end
 end

--- a/myapp/app/views/admin/users/_form.html.erb
+++ b/myapp/app/views/admin/users/_form.html.erb
@@ -29,6 +29,11 @@
       <%= form.label :password_confirmation, 'パスワード確認' %>
       <%= form.password_field :password_confirmation, class: 'form-control' %>
     </div>
+
+    <div class="field">
+      <%= form.label :admin, '管理者権限' %>
+      <%= form.check_box :admin %>
+    </div>
   
     <%= form.submit user.new_record? ? '作成' : '更新', class: 'btn btn-primary' %>
   <% end %>

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -21,3 +21,9 @@ ja:
     task_updated: "タスクが正常に更新されました。"
     task_deleted: "タスクが正常に削除されました。"
     admin_required: '管理者権限が必要です。'
+    user_not_deleted: 'ユーザを削除できませんでした。'
+    user_update_failed: 'ユーザ情報の更新に失敗しました。'
+    last_admin_cannot_be_deleted: '最後の管理者は削除できません。'
+  notices:
+    user_deleted: 'ユーザが削除されました。'
+    user_updated: 'ユーザ情報が更新されました。'

--- a/myapp/spec/requests/admin/user_spec.rb
+++ b/myapp/spec/requests/admin/user_spec.rb
@@ -3,13 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Users', type: :request do
-  describe 'DELETE /admin/users/:id' do
-    let!(:admin) { User.create!(email: 'admin@example.com', password: 'password', admin: true, name: 'Admin') }
+  let!(:admin) { User.create!(email: 'admin@example.com', password: 'password', admin: true, name: 'Admin') }
+  let!(:other_admin) { User.create!(email: 'other_admin@example.com', password: 'password', admin: true, name: 'Admin2') }
+  let!(:user) { User.create!(email: 'user@example.com', password: 'password', admin: false, name: 'User') }
 
+  before do
+    # Manually sign in by setting the session
+    post login_path, params: { session: { email: admin.email, password: admin.password } }
+  end
+
+  describe 'DELETE /admin/users/:id' do
     context 'when trying to delete the last admin' do
       before do
-        # Manually sign in by setting the session
-        post login_path, params: { session: { email: admin.email, password: admin.password } }
+        other_admin.update(admin: false)
       end
 
       it 'does not allow deleting the last admin' do
@@ -22,5 +28,64 @@ RSpec.describe 'Admin::Users', type: :request do
         expect(response.body).to include('最後の管理者は削除できません。')
       end
     end
+
+    context 'when deleting a non-admin user' do
+      it 'allows deleting the user' do
+        expect do
+          delete admin_user_path(user)
+        end.to change(User, :count).by(-1)
+
+        expect(response).to redirect_to(admin_users_path)
+      end
+    end
+
+    context 'when deleting a non-last admin user' do
+      it 'allows deleting the admin' do
+        expect do
+          delete admin_user_path(other_admin)
+        end.to change(User, :count).by(-1)
+
+        expect(response).to redirect_to(admin_users_path)
+      end
+    end
+  end
+
+  describe 'PATCH /admin/users/:id' do
+    context 'when trying to change the last admin to a non-admin' do
+      before do
+        other_admin.update(admin: false)
+      end
+
+      it 'does not allow changing the last admin to a non-admin' do
+        patch admin_user_path(admin), params: { user: { admin: false } }
+
+        expect(response).to redirect_to(admin_users_path)
+        follow_redirect!
+        expect(response.body).to include('最後の管理者は削除できません。')
+        admin.reload
+        expect(admin.admin).to be true
+      end
+    end
+
+    context 'when changing a non-admin user to an admin' do
+      it 'allows changing the user to an admin' do
+        patch admin_user_path(user), params: { user: { admin: true } }
+
+        expect(response).to redirect_to(admin_users_path)
+        user.reload
+        expect(user.admin).to be true
+      end
+    end
+
+    context 'when changing a non-last admin user to a non-admin' do
+      it 'allows changing the admin to a non-admin' do
+        patch admin_user_path(other_admin), params: { user: { admin: false } }
+
+        expect(response).to redirect_to(admin_users_path)
+        other_admin.reload
+        expect(other_admin.admin).to be false
+      end
+    end
   end
 end
+

--- a/myapp/spec/requests/admin/user_spec.rb
+++ b/myapp/spec/requests/admin/user_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Users", type: :request do
+  describe "DELETE /admin/users/:id" do
+    let!(:admin) { User.create!(email: 'admin@example.com', password: 'password', admin: true, name: "Admin") }
+
+    context "when trying to delete the last admin" do
+      before do
+        # Manually sign in by setting the session
+        post login_path, params: { session: { email: admin.email, password: admin.password } }
+      end
+
+      it "does not allow deleting the last admin" do
+        expect {
+          delete admin_user_path(admin)
+        }.not_to change(User, :count)
+
+        expect(response).to redirect_to(admin_users_path)
+        follow_redirect!
+        expect(response.body).to include("最後の管理者は削除できません。")
+      end
+    end
+  end
+end

--- a/myapp/spec/requests/admin/user_spec.rb
+++ b/myapp/spec/requests/admin/user_spec.rb
@@ -1,23 +1,25 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Admin::Users", type: :request do
-  describe "DELETE /admin/users/:id" do
-    let!(:admin) { User.create!(email: 'admin@example.com', password: 'password', admin: true, name: "Admin") }
+RSpec.describe 'Admin::Users', type: :request do
+  describe 'DELETE /admin/users/:id' do
+    let!(:admin) { User.create!(email: 'admin@example.com', password: 'password', admin: true, name: 'Admin') }
 
-    context "when trying to delete the last admin" do
+    context 'when trying to delete the last admin' do
       before do
         # Manually sign in by setting the session
         post login_path, params: { session: { email: admin.email, password: admin.password } }
       end
 
-      it "does not allow deleting the last admin" do
-        expect {
+      it 'does not allow deleting the last admin' do
+        expect do
           delete admin_user_path(admin)
-        }.not_to change(User, :count)
+        end.not_to change(User, :count)
 
         expect(response).to redirect_to(admin_users_path)
         follow_redirect!
-        expect(response.body).to include("最後の管理者は削除できません。")
+        expect(response.body).to include('最後の管理者は削除できません。')
       end
     end
   end


### PR DESCRIPTION
### Summary
This PR focuses on enhancing user management by allowing role selection during user creation and edits, and implementing checks to ensure that at least one administrator always remains in the system. These features are critical to maintaining the operational integrity and security of the platform.

### Features
- Role Selection in User Management Interface: Administrators can now assign and change roles directly from the user management interface. This update includes changes to the user form where admins can select whether a user should have admin rights.
- Ensuring at Least One Administrator: Added logic to prevent the removal of admin rights from the last existing administrator in the system. This prevents scenarios where the system could become unmanageable.

<img width="1509" alt="截屏2024-06-26 13 35 27" src="https://github.com/Fablic/training/assets/102937509/1e5fe7ad-1240-49d3-a75d-b99506a09061">
<img width="1511" alt="截屏2024-06-26 13 35 35" src="https://github.com/Fablic/training/assets/102937509/ac1bb441-1ebe-48dd-95a3-5bd6eb677e32">

### ステップ19: ユーザにロールを追加しよう ★ スキップ可能

- ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう (step18で実装した)
- 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう(step18で実装した)
- ユーザ管理画面でロールを選択できるようにしましょう
- 管理ユーザが1人もいなくならないように削除の制御をしましょう
- ※ Gemの使用・不使用は自由です