### PR TITLE
Step 16, 17, add user and session management

### DIFF
--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -16,6 +16,8 @@ gem 'i18n'
 
 gem 'kaminari'
 
+gem "bcrypt"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.4', '>= 7.0.4.3'
 

--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -311,6 +312,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt
   bootsnap
   capybara
   debug

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,4 +1,19 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include SessionsHelper
+
+  private
+
+  def redirect_to_login_path_if_not_logged_in
+    unless logged_in?
+      redirect_to login_path
+    end
+  end
+
+  def redirect_to_root_path_if_logged_in
+    if logged_in?
+      redirect_to root_path
+    end
+  end
 end

--- a/myapp/app/controllers/sessions_controller.rb
+++ b/myapp/app/controllers/sessions_controller.rb
@@ -1,0 +1,30 @@
+require 'bcrypt'
+
+class SessionsController < ApplicationController
+  before_action :redirect_to_root_path_if_logged_in, only: [:new, :create]
+
+  def new
+  end
+
+  def create
+    @name = params[:session][:name]
+    password = params[:session][:password]
+
+    user = User.find_by(name: @name.downcase)
+    if !user.nil? && user.authenticate(password)
+      Rails.logger.info('login success')
+
+      log_in(user)
+      redirect_to root_path
+      return
+    end
+
+    flash.now[:danger] = I18n.t 'session.login_failed'
+    render :new, status: :unprocessable_entity
+  end
+
+  def destroy
+    log_out if logged_in?
+    redirect_to login_path
+  end
+end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -35,13 +35,11 @@ class TasksController < ApplicationController
   def show
     @task = Task.find_by(id: params[:id])
     return redirect_to error_path(404) if @task.nil?
-    return redirect_to error_path(401) if @task["user_id"] != current_user.id
+    return redirect_to error_path(401) if @task.user_id != current_user.id
   end
 
   def create
-    data = task_data(params)
-    data["user_id"] = current_user.id
-    @task = Task.new(data)
+    @task = Task.new(create_params)
     if @task.save
       flash[:success] = I18n.t 'msg_create_success'
       redirect_to root_path
@@ -57,17 +55,15 @@ class TasksController < ApplicationController
   def edit
     @task = Task.find_by(id: params[:id])
     return redirect_to error_path(404) if @task.nil?
-    return redirect_to error_path(401) if @task["user_id"] != current_user.id
+    return redirect_to error_path(401) if @task.user_id != current_user.id
   end
 
   def update
     @task = Task.find_by(id: params[:id])
     return redirect_to error_path(404) if @task.nil?
-    return redirect_to error_path(401) if @task["user_id"] != current_user.id
+    return redirect_to error_path(401) if @task.user_id != current_user.id
 
-    data = task_data(params)
-    data["user_id"] = current_user.id
-    if @task.update(data)
+    if @task.update(update_params)
       flash[:success] = I18n.t 'msg_update_success'
       redirect_to root_path
     else
@@ -82,21 +78,25 @@ class TasksController < ApplicationController
       flash[:danger] = I18n.t 'msg_delete_failure'
       return redirect_to root_path
     end
-    return redirect_to error_path(401) if @task["user_id"] != current_user.id
+    return redirect_to error_path(401) if @task.user_id != current_user.id
 
     @task.destroy
-    flash[:notice] = I18n.t 'msg_delete_success'
+    flash[:success] = I18n.t 'msg_delete_success'
     redirect_to root_path
   end
 
   private
 
-  def task_data(form_params)
-    {
-      title: form_params[:task][:title],
-      description: form_params[:task][:description],
-      due_date_at: form_params[:task][:due_date_at],
-      status: form_params[:task][:status].to_i
-    }
+  def create_params
+    # value coming from select field is string, convert it to int explcitly here
+    params[:task][:status] = params[:task][:status].to_i
+    params[:task][:user_id] = current_user.id
+    params.require(:task).permit(:title, :description, :due_date_at, :status, :user_id)
+  end
+
+  def update_params
+    # value coming from select field is string, convert it to int explcitly here
+    params[:task][:status] = params[:task][:status].to_i
+    params.require(:task).permit(:title, :description, :due_date_at, :status)
   end
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ require 'uri'
 
 # TaskController is a controller to handle basic CRUD operations for "task"
 class TasksController < ApplicationController
-  include ApplicationHelper
+  before_action :redirect_to_login_path_if_not_logged_in
 
   def index
     q = Task
@@ -26,7 +26,7 @@ class TasksController < ApplicationController
     # TODO: support ascending
     sort += ' DESC'
 
-    @tasks = q.order(sort).page(params[:page])
+    @tasks = q.where(user_id: current_user.id).order(sort).page(params[:page])
 
     # for new form
     @new_task = Task.new
@@ -34,11 +34,13 @@ class TasksController < ApplicationController
 
   def show
     @task = Task.find_by(id: params[:id])
-    redirect_to error_path(404) if @task.nil?
+    return redirect_to error_path(404) if @task.nil?
+    return redirect_to error_path(401) if @task["user_id"] != current_user.id
   end
 
   def create
     data = task_data(params)
+    data["user_id"] = current_user.id
     @task = Task.new(data)
     if @task.save
       flash[:success] = I18n.t 'msg_create_success'
@@ -47,21 +49,24 @@ class TasksController < ApplicationController
       flash.now[:danger] = I18n.t 'msg_create_failure'
 
       @new_task = @task
-      @tasks = Task.order('created_at DESC').page(params[:page])
+      @tasks = Task.where(user_id: current_user.id).order('created_at DESC').page(params[:page])
       render :index, status: :unprocessable_entity
     end
   end
 
   def edit
     @task = Task.find_by(id: params[:id])
-    redirect_to error_path(404) if @task.nil?
+    return redirect_to error_path(404) if @task.nil?
+    return redirect_to error_path(401) if @task["user_id"] != current_user.id
   end
 
   def update
     @task = Task.find_by(id: params[:id])
-    redirect_to error_path(404) if @task.nil?
+    return redirect_to error_path(404) if @task.nil?
+    return redirect_to error_path(401) if @task["user_id"] != current_user.id
 
     data = task_data(params)
+    data["user_id"] = current_user.id
     if @task.update(data)
       flash[:success] = I18n.t 'msg_update_success'
       redirect_to root_path
@@ -75,8 +80,9 @@ class TasksController < ApplicationController
     @task = Task.find_by(id: params[:id])
     if @task.nil?
       flash[:danger] = I18n.t 'msg_delete_failure'
-      redirect_to root_path
+      return redirect_to root_path
     end
+    return redirect_to error_path(401) if @task["user_id"] != current_user.id
 
     @task.destroy
     flash[:notice] = I18n.t 'msg_delete_success'

--- a/myapp/app/controllers/users_controller.rb
+++ b/myapp/app/controllers/users_controller.rb
@@ -1,0 +1,37 @@
+require 'bcrypt'
+
+class UsersController < ApplicationController
+  before_action :redirect_to_root_path_if_logged_in
+
+  def new
+    @user = User.new
+  end
+
+  # TODO:
+  # - add password confirmation
+  # - implement password rule like minimum:8, mix alphabet, digit and special chars
+  def create
+    data = {
+      name: params[:user][:name],
+      password: params[:user][:password],
+    }
+    @user = User.new(data)
+    if @user.save
+      flash[:success] = I18n.t 'msg_create_success'
+
+      user = User.find_by(name: data[:name])
+      log_in(user)
+
+      redirect_to root_path
+    else
+      flash.now[:danger] = I18n.t 'msg_create_failure'
+
+      @new_user = @user
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # update password
+  def update
+  end
+end

--- a/myapp/app/helpers/sessions_helper.rb
+++ b/myapp/app/helpers/sessions_helper.rb
@@ -1,0 +1,21 @@
+module SessionsHelper
+
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
+
+  def current_user
+    if session[:user_id]
+      @current_user ||= User.find_by(id: session[:user_id])
+    end
+  end
+
+  def logged_in?
+    !current_user.nil?
+  end
+end

--- a/myapp/app/helpers/users_helper.rb
+++ b/myapp/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -15,6 +15,8 @@ class DateTimeValidator < ActiveModel::EachValidator
 end
 
 class Task < ApplicationRecord
+  belongs_to :user
+
   enum :status, { status_not_started: 0, status_in_progress: 1, status_completed: 2 }, validate: true
 
   validates :title, presence: true, length: { maximum: 50 }

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ApplicationRecord
+  has_many :tasks
+
+  has_secure_password
+
+  validates :name, presence: true, length: { minimum: 5, maximum: 20 }, uniqueness: { case_sensitive: false }
+end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -2,6 +2,15 @@ class User < ApplicationRecord
   has_many :tasks
 
   has_secure_password
+  # 8~20, lowercase, uppercase, digit and special chars must be used at least once
+  PASSWORD_FORMAT = /\A(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[-+_!@#$%^&*.,?]).{8,20}\z/
 
   validates :name, presence: true, length: { minimum: 5, maximum: 20 }, uniqueness: { case_sensitive: false }
+  validates :password,
+    format: {
+      with: PASSWORD_FORMAT,
+      message: :invalid_password,
+      min: 8,
+      max: 20
+  }
 end

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -14,9 +14,14 @@
   <body class="bg-light">
     <div class="container">
     <header class="navbar navbar-expand-lg bd-navbar">
-      <%= link_to(root_path) do %>
-      <i class="bi bi-house" style="font-size: 2rem;" ></i>
-      <% end %>
+      <div class="container-fluid">
+        <%= link_to(root_path) do %>
+        <i class="bi bi-house" style="font-size: 2rem;" ></i>
+        <% end %>
+        <% if logged_in? %>
+        <%= button_to "Logout", logout_path, method: :delete, class: "btn btn-link" %>
+        <% end %>
+      </div>
     </header>
       <% flash.each do |message_type, message| %>
       <div class="flash-message alert alert-<%= message_type %>"><%= message %></div>

--- a/myapp/app/views/sessions/new.html.erb
+++ b/myapp/app/views/sessions/new.html.erb
@@ -1,0 +1,18 @@
+<%= form_with scope: :session, url: login_path do |f| %>
+  <div class="mb-3">
+    <div class="col-3">
+    <%= f.text_field :name, class: "form-control", placeholder: (t 'user.name'), value: @name %>
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <div class="col-3">
+    <%= f.password_field :password, class: "form-control", placeholder: (t 'user.password') %>
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <%= f.submit 'Login', class: "btn btn-primary", id: "btn-login" %>
+    <%= link_to "or Sign Up", users_path, class: "ms-2 align-bottom" %>
+  </div>
+<% end %>

--- a/myapp/app/views/users/new.html.erb
+++ b/myapp/app/views/users/new.html.erb
@@ -1,0 +1,31 @@
+<% if @user.errors.full_messages.any? %>
+<ul>
+    <% @user.errors.full_messages.each do |message| %>
+    <li class="text-danger small"><%= message %></li>
+    <% end %>
+</ul>
+<% end %>
+
+<div class="user-form">
+<%= form_with model: @user do |f| %>
+
+  <div class="mb-3">
+    <div class="col-3">
+    <%= f.text_field :name, class: "form-control", placeholder: (t 'user.name') %>
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <div class="col-3">
+    <%= f.password_field :password, class: "form-control", placeholder: (t 'user.password') %>
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <%= f.submit 'Sign Up', class: "btn btn-primary", id: "btn-signup" %>
+    <%= link_to "or Login", login_path, class: "ms-2 align-bottom" %>
+  </div>
+
+<% end %>
+</div>
+<script>

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -88,6 +88,7 @@ en:
         one: is the wrong length (should be %{count} character)
         other: is the wrong length (should be %{count} characters)
       record_invalid: 'Validation failed: %{errors}'
+      invalid_password: "must contain at lest one lowercase, uppercase, digit and symbol. length must be %{min} to %{max}"
 
   views:
     pagination:

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -48,6 +48,11 @@ en:
   status_completed: 'Completed'
   search_by_title: 'Search by title'
 
+  user:
+    name: 'username'
+    password: 'password'
+  session:
+    login_failed: 'The username or password is wrong'
   errors:
     format: "%{attribute} %{message}"
     messages:
@@ -82,6 +87,7 @@ en:
       wrong_length:
         one: is the wrong length (should be %{count} character)
         other: is the wrong length (should be %{count} characters)
+      record_invalid: 'Validation failed: %{errors}'
 
   views:
     pagination:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -82,6 +82,7 @@ ja:
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
       record_invalid: "バリデーションに失敗しました: %{errors}"
+      invalid_password: "は半角%{min}~%{max}文字英大文字・小文字・数字、シンボルをそれぞれ１文字以上含めてください"
 
   views:
     pagination:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -48,6 +48,11 @@ ja:
   status_completed: '完了'
   search_by_title: 'タイトルで検索'
 
+  user:
+    name: 'ユーザーネーム'
+    password: 'パスワード'
+  session:
+    login_failed: 'usernameまたはpasswordが正しくありません'
   errors:
     format: "%{attribute}%{message}"
     messages:
@@ -76,6 +81,7 @@ ja:
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
+      record_invalid: "バリデーションに失敗しました: %{errors}"
 
   views:
     pagination:

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -8,10 +8,19 @@ Rails.application.routes.draw do
 
   resources :tasks
 
+  # resources :users
+
+  get   '/users', '/users/new', to: 'users#new'
+  post  '/users', to: 'users#create'
+  patch '/users/:id', to: 'users#update'
+
+  get    '/login', to: 'sessions#new'
+  post   '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
+
   # overrirde default error pages
   get '/404', to: 'errors#not_found', as: :not_found, via: :all
   get '/500', to: 'errors#internal_server_error', as: :internal_server_error, via: :all
-
   get '/errors/:status', to: 'errors#show', as: :error
 
   match '*path', to: 'errors#not_found', via: :all

--- a/myapp/db/migrate/20240809092656_create_tasks.rb
+++ b/myapp/db/migrate/20240809092656_create_tasks.rb
@@ -2,7 +2,8 @@
 
 class CreateTasks < ActiveRecord::Migration[7.0]
   def change
-    create_table :tasks do |t|
+    create_table :tasks, id: false do |t|
+      t.primary_key :id, :unsigned_integer, limit: 8, null: false, auto_increment: true
       t.string :title, limit: 50
       t.string :description, limit: 500
 

--- a/myapp/db/migrate/20240905005923_create_users.rb
+++ b/myapp/db/migrate/20240905005923_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users, id: false do |t|
+      t.primary_key :id, :unsigned_integer, limit: 8, null: false, auto_increment: true
+      t.string :name, null: false, limit: 20
+      t.string :password_digest, null: false, limit: 72
+
+      t.timestamps
+    end
+    add_index :users, :name, unique: true
+  end
+end

--- a/myapp/db/migrate/20240905024449_add_user_id_to_tasks.rb
+++ b/myapp/db/migrate/20240905024449_add_user_id_to_tasks.rb
@@ -1,0 +1,9 @@
+class AddUserIdToTasks < ActiveRecord::Migration[7.0]
+  def up
+    add_column :tasks, :user_id, :integer, limit: 8, unsigned: true, null: false, default: 0, if_not_exists: true
+  end
+
+  def down
+    remove_column :tasks, :user_id, if_exists: true
+  end
+end

--- a/myapp/db/migrate/20240905031406_add_fk_to_tasks_for_users.rb
+++ b/myapp/db/migrate/20240905031406_add_fk_to_tasks_for_users.rb
@@ -1,0 +1,8 @@
+class AddFkToTasksForUsers < ActiveRecord::Migration[7.0]
+  def up
+    add_foreign_key :tasks, :users
+  end
+  def down
+    remove_foreign_key :tasks, :users, if_exists: true
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -18,17 +18,20 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_05_031406) do
     t.datetime "updated_at", null: false
     t.datetime "due_date_at"
     t.integer "status", limit: 1, default: 0, null: false, unsigned: true
+    t.bigint "user_id", default: 0, null: false, unsigned: true
     t.index ["due_date_at"], name: "index_tasks_on_due_date_at"
     t.index ["status"], name: "index_tasks_on_status"
     t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "fk_rails_4d2a9e4d7e"
   end
 
   create_table "users", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", force: :cascade do |t|
     t.string "name", limit: 20, null: false
-    t.string "password", limit: 72, null: false
+    t.string "password_digest", limit: 72, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_users_on_name", unique: true
   end
 
+  add_foreign_key "tasks", "users"
 end

--- a/myapp/db/seeds.rb
+++ b/myapp/db/seeds.rb
@@ -8,7 +8,10 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-Task.create(title: 'title 1', description: 'desc 1')
-Task.create(title: 'title 2', description: 'desc 2')
-Task.create(title: 'title 3', description: 'desc 3')
-Task.find(3).update(title: 'title 3.1', description: 'desc 3.1')
+User.create(name: "admin", password: "dummyPasswordForNow")
+
+Task.create(title: "title 1", description: "desc 1", user_id: 1)
+Task.create(title: "title 2", description: "desc 2", user_id: 1)
+Task.create(title: "title 3", description: "desc 3", due_date_at: '2024-12-31', user_id: 1)
+
+Task.find(3).update(title: "title 3.1", description: "desc 3.1")

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    # id { 1 }
+    sequence(:name) { |n| "JohnDoe#{n}" }
+    password { 'dummyPassword123!?' }
+  end
+end

--- a/myapp/spec/helpers/sessions_helper_spec.rb
+++ b/myapp/spec/helpers/sessions_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SessionsHelper. For example:
+#
+# describe SessionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SessionsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/helpers/users_helper_spec.rb
+++ b/myapp/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/models/task_spec.rb
+++ b/myapp/spec/models/task_spec.rb
@@ -4,10 +4,15 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe 'validation test' do
+    before do
+      @user_1 = create(:user)
+    end
+
     context 'title column' do
       it 'success' do
         t = Task.new(
-          title: 'ThisIsTitle'
+          title: 'ThisIsTitle',
+          user_id: @user_1.id,
         )
         expect(t).to be_valid
       end
@@ -33,7 +38,8 @@ RSpec.describe Task, type: :model do
       it 'success. blank is allowed' do
         t = Task.new(
           title: 'ThisIsTitle',
-          description: ''
+          description: '',
+          user_id: @user_1.id,
         )
         expect(t).to be_valid
       end
@@ -52,7 +58,8 @@ RSpec.describe Task, type: :model do
       it 'success.' do
         t = Task.new(
           title: 'ThisIsTitle',
-          due_date_at: '2024/08/31'
+          due_date_at: '2024/08/31',
+          user_id: @user_1.id,
         )
         expect(t).to be_valid
       end
@@ -82,7 +89,8 @@ RSpec.describe Task, type: :model do
       it 'success.' do
         t = Task.new(
           title: 'ThisIsTitle',
-          status: 2
+          status: 2,
+          user_id: @user_1.id,
         )
         expect(t).to be_valid
       end

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe 'validation test' do
+  describe 'validation' do
     context 'name column' do
       it 'success' do
         t = User.new(
@@ -58,14 +58,57 @@ RSpec.describe User, type: :model do
         expect(t.errors[:password]).to include('を入力してください')
       end
 
+      it 'failed when it is too short' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: 'Abc123!'
+        )
+        t.valid?
+        expect(t.errors[:password]).to include('は半角8~20文字英大文字・小文字・数字、シンボルをそれぞれ１文字以上含めてください')
+      end
+
       it 'failed when it is too long' do
         t = User.new(
           name: 'JohnDoe',
-          password: SecureRandom.alphanumeric(73),
+          password: 'Abcdefg1234567!?%tltr'
         )
         t.valid?
-        expect(t.errors[:password]).to include('は72文字以内で入力してください')
+        expect(t.errors[:password]).to include('は半角8~20文字英大文字・小文字・数字、シンボルをそれぞれ１文字以上含めてください')
       end
+
+      it 'failed when not containing lowercase' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: 'DUMMYPASSWORD123!?'
+        )
+        t.valid?
+        expect(t.errors[:password]).to include('は半角8~20文字英大文字・小文字・数字、シンボルをそれぞれ１文字以上含めてください')
+      end
+      it 'failed when not containing uppercase' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: 'dummypassword123!?'
+        )
+        t.valid?
+        expect(t.errors[:password]).to include('は半角8~20文字英大文字・小文字・数字、シンボルをそれぞれ１文字以上含めてください')
+      end
+      it 'failed when not containing digit' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: 'dummyPassword!?'
+        )
+        t.valid?
+        expect(t.errors[:password]).to include('は半角8~20文字英大文字・小文字・数字、シンボルをそれぞれ１文字以上含めてください')
+      end
+      it 'failed when not containing symbol' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: 'dummyPassword123'
+        )
+        t.valid?
+        expect(t.errors[:password]).to include('は半角8~20文字英大文字・小文字・数字、シンボルをそれぞれ１文字以上含めてください')
+      end
+
     end
   end
 end

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe User, type: :model do
       end
 
       it 'failed when it is already taken' do
-        create(:user)
+        create(:user, name: 'Nanashi')
 
         t = User.new(
-          name: 'JohnDoe',
+          name: 'Nanashi',
           password: 'dummyPassword123!?'
         )
         t.valid?

--- a/myapp/spec/models/user_spec.rb
+++ b/myapp/spec/models/user_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'validation test' do
+    context 'name column' do
+      it 'success' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: 'dummyPassword123!?'
+        )
+        expect(t).to be_valid
+      end
+
+      it 'failed when it is blank' do
+        t = User.new(
+          name: '',
+          password: 'dummyPassword123!?'
+        )
+        t.valid?
+        expect(t.errors[:name]).to include('を入力してください')
+      end
+
+      it 'failed when it is too long' do
+        t = User.new(
+          name: SecureRandom.alphanumeric(21),
+        )
+        t.valid?
+        expect(t.errors[:name]).to include('は20文字以内で入力してください')
+      end
+
+      it 'failed when it is already taken' do
+        create(:user)
+
+        t = User.new(
+          name: 'JohnDoe',
+          password: 'dummyPassword123!?'
+        )
+        t.valid?
+        expect(t.errors[:name]).to include('はすでに存在します')
+      end
+    end
+
+    context 'password column' do
+      it 'success' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: 'dummyPassword123!?'
+        )
+        expect(t).to be_valid
+      end
+
+      it 'failed when it is blank' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: ''
+        )
+        t.valid?
+        expect(t.errors[:password]).to include('を入力してください')
+      end
+
+      it 'failed when it is too long' do
+        t = User.new(
+          name: 'JohnDoe',
+          password: SecureRandom.alphanumeric(73),
+        )
+        t.valid?
+        expect(t.errors[:password]).to include('は72文字以内で入力してください')
+      end
+    end
+  end
+end

--- a/myapp/spec/rails_helper.rb
+++ b/myapp/spec/rails_helper.rb
@@ -32,6 +32,8 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 
+Dir[Rails.root.join('spec/supports/**/*.rb')].each { |f| require f }
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures')

--- a/myapp/spec/requests/sessions_spec.rb
+++ b/myapp/spec/requests/sessions_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/myapp/spec/requests/users_spec.rb
+++ b/myapp/spec/requests/users_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/myapp/spec/supports/login_helper.rb
+++ b/myapp/spec/supports/login_helper.rb
@@ -1,0 +1,9 @@
+module LoginHelper
+  def log_in(user)
+    # user = create(:user)
+    visit login_path
+    fill_in 'session[name]', with: user.name
+    fill_in 'session[password]', with: user.password
+    click_on 'btn-login'
+  end
+end

--- a/myapp/spec/system/sessions_spec.rb
+++ b/myapp/spec/system/sessions_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe SessionsController, type: :system do
         expect(page).to have_button 'Login'
       end
     end
+    context 'when user is logged-in' do
+      before do
+        user_1 = create(:user)
+        log_in(user_1)
+        visit login_path
+      end
+
+      it 'user should be redirected to root path' do
+        expect(current_path).to eq root_path
+        expect(page).not_to have_button 'Login'
+      end
+    end
   end
 
   describe '#create' do
@@ -72,6 +84,5 @@ RSpec.describe SessionsController, type: :system do
         expect(current_path).to eq login_path
       end
     end
-
   end
 end

--- a/myapp/spec/system/sessions_spec.rb
+++ b/myapp/spec/system/sessions_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :system do
+  include LoginHelper
+
+  describe '#new' do
+    context 'when user is anonymous' do
+      before { visit login_path }
+
+      it 'shows user login form' do
+        expect(page).to have_field 'ユーザーネーム'
+        expect(page).to have_field 'パスワード'
+        expect(page).to have_button 'Login'
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'when user is anonymous' do
+      let!(:user_1) { create(:user) }
+
+      before { visit login_path }
+
+      it 'login successfully' do
+        fill_in 'session[name]', with: user_1.name
+        fill_in 'session[password]', with: user_1.password
+        click_on 'btn-login'
+
+        expect(current_path).to eq root_path
+      end
+
+      it 'failed to login due to blank name' do
+        fill_in 'session[name]', with: ''
+        fill_in 'session[password]', with: user_1.password
+        click_on 'btn-login'
+
+        expect(page).to have_content 'usernameまたはpasswordが正しくありません'
+        expect(current_path).to eq login_path
+      end
+      it 'failed to login due to blank password' do
+        fill_in 'session[name]', with: user_1.name
+        fill_in 'session[password]', with: ''
+        click_on 'btn-login'
+
+        expect(page).to have_content 'usernameまたはpasswordが正しくありません'
+        expect(current_path).to eq login_path
+      end
+      it 'failed to login due to wrong password' do
+        fill_in 'session[name]', with: user_1.name
+        fill_in 'session[password]', with: 'someRandomPass'
+        click_on 'btn-login'
+
+        expect(page).to have_content 'usernameまたはpasswordが正しくありません'
+        expect(current_path).to eq login_path
+      end
+    end
+  end
+
+  describe '#destroy' do
+    before do
+      user = create(:user)
+      log_in(user)
+    end
+
+    context 'when user is logged in' do
+      it 'logout successfully' do
+        visit root_path
+
+        expect(current_path).to eq root_path
+        click_on 'Logout'
+
+        expect(current_path).to eq login_path
+      end
+    end
+
+  end
+end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :system do
+  include LoginHelper
+
   describe '#index' do
-    include LoginHelper
     context 'when user is not logged in' do
       before do
-        user_1 = create(:user)
         visit root_path
       end
 
@@ -28,7 +28,7 @@ RSpec.describe TasksController, type: :system do
         end
 
         it "doesn't show any task" do
-          expect(page).to have_no_button 'Delete'
+          expect(page).to have_selector('tbody tr', count: 0)
         end
       end
 
@@ -41,7 +41,6 @@ RSpec.describe TasksController, type: :system do
         it 'shows one task' do
           expect(current_path).to eq root_path
           expect(page).to have_content @task_1.title
-          expect(page).to have_content @task_1.description
           expect(page).to have_link @task_1.title, href: task_path(@task_1)
           expect(page).to have_button 'Delete'
         end
@@ -60,51 +59,56 @@ RSpec.describe TasksController, type: :system do
           expect(page.all('tbody tr')[2]).to have_content(@tasks[0].title)
         end
       end
-    end
 
-    context 'when task is filtered' do
-      let!(:tasks) { create_list(:task, 5) }
+      context 'when task is filtered' do
+        before do
+          @tasks = create_list(:task, 5, user: @user_1)
+          visit root_path
+        end
 
-      before { visit root_path }
+        it 'search by title' do
+          fill_in 'query', with: 'ThisIsTitle3'
+          click_on 'btn-search'
 
-      it 'search by title' do
-        fill_in 'query', with: 'ThisIsTitle3'
-        click_on 'btn-search'
+          expect(current_path).to eq root_path
+          expect(page).to have_selector('tbody tr', count: 1)
+        end
 
-        expect(current_path).to eq root_path
-        expect(page).to have_selector('tbody tr', count: 1)
-      end
+        it 'search by status' do
+          # add extra items with various status
+          create(:task, :status => Task.statuses[:status_not_started], user: @user_1)
+          create_list(:task, 3, status: Task.statuses[:status_in_progress], user: @user_1)
+          create_list(:task, 2, status: Task.statuses[:status_completed], user: @user_1)
+          select I18n.t(:status_completed), from: 'search-status'
+          click_on 'btn-search'
 
-      it 'search by status' do
-        # add extra items with various status
-        create(:task, status: Task.statuses[:status_not_started])
-        create_list(:task, 3, status: Task.statuses[:status_in_progress])
-        create_list(:task, 2, status: Task.statuses[:status_completed])
-        select I18n.t(:status_completed), from: 'search-status'
-        click_on 'btn-search'
+          expect(current_path).to eq root_path
+          expect(page).to have_selector('tbody tr', count: 2)
+        end
 
-        expect(current_path).to eq root_path
-        expect(page).to have_selector('tbody tr', count: 2)
-      end
+        it 'search by title and status' do
+          # add extra items with various status
+          create(:task, status: Task.statuses[:status_in_progress], user: @user_1)
+          create(:task, status: Task.statuses[:status_completed], user: @user_1)
+          create(:task, title: 'some random title', status: Task.statuses[:status_completed], user: @user_1)
+          fill_in 'query', with: 'rand'
+          select I18n.t(:status_completed), from: 'search-status'
+          click_on 'btn-search'
 
-      it 'search by title and status' do
-        # add extra items with various status
-        create(:task, status: Task.statuses[:status_in_progress])
-        create(:task, status: Task.statuses[:status_completed])
-        create(:task, title: 'some random title', status: Task.statuses[:status_completed])
-        fill_in 'query', with: 'rand'
-        select I18n.t(:status_completed), from: 'search-status'
-        click_on 'btn-search'
-
-        expect(current_path).to eq root_path
-        expect(page).to have_selector('tbody tr', count: 1)
+          expect(current_path).to eq root_path
+          expect(page).to have_selector('tbody tr', count: 1)
+        end
       end
     end
   end
 
   describe '#create' do
     context 'when submit a new task' do
-      before { visit root_path }
+      before do
+        @user_1 = create(:user)
+        log_in(@user_1)
+        visit root_path
+      end
 
       it 'creates a task successfully' do
         new_title = 'test title 1'
@@ -189,14 +193,19 @@ RSpec.describe TasksController, type: :system do
   end
 
   describe '#show' do
+    before do
+      @user_1 = create(:user)
+      log_in(@user_1)
+    end
+
     context 'when there is a valid task' do
-      let!(:task_1) { create(:task) }
+      let!(:task_1) { create(:task, user: @user_1) }
 
       it 'shows details and edit link' do
         visit task_path(task_1)
         expect(page).to have_content task_1.title
         expect(page).to have_content task_1.description
-        # expect(page).to have_content sm[task_1.status]
+        expect(page).to have_content Task.statuses[task_1.status]
         expect(page).to have_link 'Edit', href: edit_task_path(task_1)
         expect(current_path).to eq task_path(task_1)
         click_link 'Edit'
@@ -218,8 +227,13 @@ RSpec.describe TasksController, type: :system do
   end
 
   describe '#edit' do
+    before do
+      @user_1 = create(:user)
+      log_in(@user_1)
+    end
+
     context 'when there is a valid task' do
-      let!(:task_1) { create(:task) }
+      let!(:task_1) { create(:task, user: @user_1) }
 
       it 'shows edit form' do
         visit edit_task_path(task_1)
@@ -247,8 +261,13 @@ RSpec.describe TasksController, type: :system do
   end
 
   describe '#update' do
+    before do
+      @user_1 = create(:user)
+      log_in(@user_1)
+    end
+
     context 'when update a task' do
-      let!(:task_1) { create(:task) }
+      let!(:task_1) { create(:task, user: @user_1) }
 
       # success case
       it 'updated a task successfully' do
@@ -328,12 +347,16 @@ RSpec.describe TasksController, type: :system do
   end
 
   describe '#destroy' do
-    let!(:task_1) { create(:task) }
-    before { visit root_path }
+    before do
+      @user_1 = create(:user)
+      @task_1 = create(:task, user: @user_1)
+      log_in(@user_1)
+      visit root_path
+    end
 
     context 'when delete a task' do
       it 'deletes a task successfully' do
-        expect(page).to have_content task_1.title
+        expect(page).to have_content @task_1.title
         click_on 'Delete'
 
         # redirected to root
@@ -341,7 +364,7 @@ RSpec.describe TasksController, type: :system do
         expect(page).to have_content '削除に成功しました'
 
         # make sure the task was deleted
-        expect(page).to have_no_content task_1.title
+        expect(page).to have_no_content @task_1.title
         expect(page).to have_no_button 'Delete'
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -214,14 +214,26 @@ RSpec.describe TasksController, type: :system do
     end
 
     context 'when record not found' do
-      it 'redirected to root path due to not existing id' do
-        visit task_path(99_999)
+      it 'redirected to 404 error page due to not existing id' do
+        visit task_path(99999)
         expect(current_path).to eq error_path(404)
       end
 
-      it 'redirected to root path due to invalid id format' do
+      it 'redirected to 404 error page due to invalid id format' do
         visit task_path('invalid_path')
         expect(current_path).to eq error_path(404)
+      end
+    end
+
+    context "when the task is other users'" do
+      before do
+        @user_2 = create(:user)
+        @task_2 = create(:task, user_id: @user_2.id)
+        visit task_path(@task_2)
+      end
+
+      it 'redirected to 401 error page' do
+        expect(current_path).to eq error_path(401)
       end
     end
   end
@@ -256,6 +268,18 @@ RSpec.describe TasksController, type: :system do
       it 'redirected to root path due to invalid id format' do
         visit edit_task_path('invalid_path')
         expect(current_path).to eq error_path(404)
+      end
+    end
+
+    context "when the task is other users'" do
+      before do
+        @user_2 = create(:user)
+        @task_2 = create(:task, user_id: @user_2.id)
+        visit edit_task_path(@task_2)
+      end
+
+      it 'redirected to 401 error page' do
+        expect(current_path).to eq error_path(401)
       end
     end
   end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -2,38 +2,63 @@
 
 require 'rails_helper'
 
-RSpec.describe Task, type: :system do
+RSpec.describe TasksController, type: :system do
   describe '#index' do
-    context "when task doesn't exist" do
-      before { visit root_path }
+    include LoginHelper
+    context 'when user is not logged in' do
+      before do
+        user_1 = create(:user)
+        visit root_path
+      end
 
-      it "doesn't show any task" do
-        expect(page).to have_no_button 'Delete'
+      it 'user should be redirected to login path' do
+        expect(current_path).to eq login_path
       end
     end
 
-    context 'when one task exists' do
-      let!(:task_1) { create(:task) }
-
-      before { visit root_path }
-
-      it 'shows one task' do
-        expect(page).to have_content task_1.title
-        expect(page).to have_link task_1.title, href: task_path(task_1)
-        expect(page).to have_button 'Delete'
+    context 'when user is logged in' do
+      before do
+        @user_1 = create(:user)
+        log_in(@user_1)
       end
-    end
 
-    context 'when multiple tasks exist' do
-      let!(:tasks) { create_list(:task, 3) }
+      context "when task doesn't exist" do
+        before do
+          visit root_path
+        end
 
-      before { visit root_path }
+        it "doesn't show any task" do
+          expect(page).to have_no_button 'Delete'
+        end
+      end
 
-      it 'shows task list in created_at descending order' do
-        expect(page).to have_selector('tbody tr', count: 3)
-        expect(page.all('tbody tr')[0]).to have_content(tasks[2].title)
-        expect(page.all('tbody tr')[1]).to have_content(tasks[1].title)
-        expect(page.all('tbody tr')[2]).to have_content(tasks[0].title)
+      context 'when one task exists' do
+        before do
+          @task_1 = create(:task, user: @user_1)
+          visit root_path
+        end
+
+        it 'shows one task' do
+          expect(current_path).to eq root_path
+          expect(page).to have_content @task_1.title
+          expect(page).to have_content @task_1.description
+          expect(page).to have_link @task_1.title, href: task_path(@task_1)
+          expect(page).to have_button 'Delete'
+        end
+      end
+
+      context 'when multiple tasks exist' do
+        before do
+          @tasks = create_list(:task, 3, user: @user_1)
+          visit root_path
+        end
+
+        it 'shows task list in created_at descending order' do
+          expect(page).to have_selector('tbody tr', count: 3)
+          expect(page.all('tbody tr')[0]).to have_content(@tasks[2].title)
+          expect(page.all('tbody tr')[1]).to have_content(@tasks[1].title)
+          expect(page.all('tbody tr')[2]).to have_content(@tasks[0].title)
+        end
       end
     end
 
@@ -322,3 +347,4 @@ RSpec.describe Task, type: :system do
     end
   end
 end
+

--- a/myapp/spec/system/users_spec.rb
+++ b/myapp/spec/system/users_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :system do
+  include LoginHelper
+
   describe '#new' do
     context 'when user is anonymous' do
       before { visit users_path }
@@ -9,6 +11,18 @@ RSpec.describe User, type: :system do
         expect(page).to have_field 'ユーザーネーム'
         expect(page).to have_field 'パスワード'
         expect(page).to have_button 'Sign Up'
+      end
+    end
+    context 'when user is logged-in' do
+      before do
+        user_1 = create(:user)
+        log_in(user_1)
+        visit users_path
+      end
+
+      it 'user should be redirected to root path' do
+        expect(current_path).to eq root_path
+        expect(page).not_to have_button 'Sign Up'
       end
     end
   end

--- a/myapp/spec/system/users_spec.rb
+++ b/myapp/spec/system/users_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :system do
+  describe '#new' do
+    context 'when user is anonymous' do
+      before { visit users_path }
+
+      it 'shows user creation form' do
+        expect(page).to have_field 'ユーザーネーム'
+        expect(page).to have_field 'パスワード'
+        expect(page).to have_button 'Sign Up'
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'when user is anonymous' do
+      before { visit users_path }
+
+      it 'creates new user successfully' do
+        new_user_name = 'JohnDoe'
+        new_user_password = 'dummyPassword123!?'
+        fill_in 'user[name]', with: new_user_name
+        fill_in 'user[password]', with: new_user_password
+        click_on 'btn-signup'
+
+        expect(page).to have_content '作成に成功しました'
+        expect(current_path).to eq root_path
+      end
+
+      it 'failed to create a user due to blank name' do
+        new_user_name = ''
+        new_user_password = 'dummyPassword123!?'
+        fill_in 'user[name]', with: new_user_name
+        fill_in 'user[password]', with: new_user_password
+        click_on 'btn-signup'
+
+        expect(page).to have_content '作成に失敗しました'
+        expect(page).to have_content 'を入力してください'
+        expect(current_path).to eq users_path
+      end
+      it 'failed to create a user due to short name length' do
+        new_user_name = 'foo'
+        new_user_password = 'dummyPassword123!?'
+        fill_in 'user[name]', with: new_user_name
+        fill_in 'user[password]', with: new_user_password
+        click_on 'btn-signup'
+
+        expect(page).to have_content '作成に失敗しました'
+        expect(page).to have_content '5文字以上で入力してください'
+        expect(current_path).to eq users_path
+      end
+      it 'failed to create a user due to blank password' do
+        new_user_name = 'JohnDoe'
+        new_user_password = ''
+        fill_in 'user[name]', with: new_user_name
+        fill_in 'user[password]', with: new_user_password
+        click_on 'btn-signup'
+
+        expect(page).to have_content '作成に失敗しました'
+        expect(page).to have_content 'を入力してください'
+        expect(current_path).to eq users_path
+      end
+    end
+  end
+
+  describe '#update' do
+  end
+end


### PR DESCRIPTION
Completed step 16(user) and 17(authentication) in the same branch, as those functionalities are really tied together.

>ステップ16: 複数人で利用できるようにしよう（ユーザの導入）
ステップ17: ログイン/ログアウト機能を実装しよう

What I've done overall in these steps are
- Created User Model with foreign key relationship(user_id) with tasks table.
- Created Users Controller for new user signup, simply username and password for now.
- Created Sessions Controller for login/logout. The user session is saved into cookie.

Here are screenshots with some notes

signup page (/users or /users/new)
- user will be redirected to main page if already logged-in
![signup](https://github.com/user-attachments/assets/eb847b63-2538-4a3d-a89a-3d173a931d3b)

signup failure
- username must be unique
- password must contain at least one lowercase, one uppercase, one digit and one special chars. and length must be 8 - 20
![signup_failure](https://github.com/user-attachments/assets/81b3eaeb-2888-43e7-8627-bf483665e8f7)

login page (/login)
- user will be redirected to main page if already logged-in
![login](https://github.com/user-attachments/assets/7213288d-44a4-4004-aed4-1c9aa6b2052e)
login failure
- just have generic message
![login_failure](https://github.com/user-attachments/assets/0f311db2-196a-4379-9936-f573e56ef13c)

main page (/ or /tasks)
- user will be redirected to this page once login or signup succeeded.
- have logout link on top right.
- only the tasks this user created are showing up
![main_with_logout_link](https://github.com/user-attachments/assets/96ff9a97-5824-4c24-aada-00c83970fa9e)
