### PR TITLE
RoR training, step 20, 21: add labels, maintenance mode

### DIFF
--- a/myapp/app/controllers/admin/settings_controller.rb
+++ b/myapp/app/controllers/admin/settings_controller.rb
@@ -1,0 +1,28 @@
+class Admin::SettingsController < ApplicationController
+  before_action :redirect_to_login_path_if_not_logged_in, :redirect_to_root_path_if_normal_role
+
+  def index
+    @maintenance = Maintenance.last
+    if @maintenance.nil?
+      @maintenance = Maintenance.new
+    end
+  end
+
+  def create
+    @maintenance = Maintenance.new(create_params)
+    if @maintenance.save
+      flash[:success] = I18n.t 'msg_update_success'
+
+      redirect_to admin_settings_path
+    else
+      flash.now[:danger] = I18n.t 'msg_update_failure'
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  def create_params
+    params[:maintenance][:is_maintenance] = Maintenance.is_maintenances[params[:maintenance][:is_maintenance]].to_i
+    params.require(:maintenance).permit(:is_maintenance, :started_at, :ended_at)
+  end
+
+end

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -22,4 +22,16 @@ class ApplicationController < ActionController::Base
       redirect_to root_path
     end
   end
+
+  def redirect_to_maintenance
+    @maintenance = Maintenance.last
+    return if @maintenance.nil?
+
+    if @maintenance.on?
+      cur = DateTime.now
+      if @maintenance.started_at <= cur && cur <= @maintenance.ended_at
+        redirect_to maintenance_path
+      end
+    end
+  end
 end

--- a/myapp/app/controllers/errors_controller.rb
+++ b/myapp/app/controllers/errors_controller.rb
@@ -12,6 +12,10 @@ class ErrorsController < ApplicationController
     redirect_to '/errors/500'
   end
 
+  def maintenance
+    render template: 'errors/maintenance', layout: 'error'
+  end
+
   def show
     @status_code = params[:status]
     status_codes = Rack::Utils::HTTP_STATUS_CODES

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -12,6 +12,12 @@ class TasksController < ApplicationController
     unless params[:query].to_s.empty?
       # TODO: fix this. this fuzzy search might cause performance degradation.
       q = q.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(params[:query].to_s)}%")
+
+      # find if there is matched label
+      labels = TasksLabel.joins(:label).where('labels.name': params[:query].to_s).pluck('task_id')
+      if labels.any?
+        q = q.or(Task.where(id: labels))
+      end
     end
 
     q = q.where(status: params[:status]) unless params[:status].to_s.empty?
@@ -35,12 +41,19 @@ class TasksController < ApplicationController
   def show
     @task = Task.find_by(id: params[:id])
     return redirect_to error_path(404) if @task.nil?
-    return redirect_to error_path(401) if @task.user_id != current_user.id
+    return redirect_to error_path(401) if @task.user_id != current_user.id && (!current_user.role_moderator? and !current_user.role_admin?)
+
+    @labels = Label.joins(:tasks_labels).where('tasks_labels.task_id': params[:id])
   end
 
   def create
     @task = Task.new(create_params)
     if @task.save
+
+      # insert labels, this func doesn't throw error for now in order to proceed
+      # main process to create task, then we could make it async later
+      add_labels(@task, params[:task][:labels])
+
       flash[:success] = I18n.t 'msg_create_success'
       redirect_to root_path
     else
@@ -56,6 +69,15 @@ class TasksController < ApplicationController
     @task = Task.find_by(id: params[:id])
     return redirect_to error_path(404) if @task.nil?
     return redirect_to error_path(401) if @task.user_id != current_user.id
+
+    @labels_value = ''
+    labels = Label.joins(:tasks_labels).where('tasks_labels.task_id': params[:id])
+    if labels.any?
+      labels.each do |label|
+        @labels_value += ' ' unless @labels_value.empty?
+        @labels_value += label.name
+      end
+    end
   end
 
   def update
@@ -64,6 +86,12 @@ class TasksController < ApplicationController
     return redirect_to error_path(401) if @task.user_id != current_user.id
 
     if @task.update(update_params)
+
+      # delete them all first and re-create, should be better performance than select and update for each
+      if delete_labels?(@task)
+        add_labels(@task, params[:task][:labels])
+      end
+
       flash[:success] = I18n.t 'msg_update_success'
       redirect_to root_path
     else
@@ -99,4 +127,56 @@ class TasksController < ApplicationController
     params[:task][:status] = params[:task][:status].to_i
     params.require(:task).permit(:title, :description, :due_date_at, :status)
   end
+
+  def add_labels(task, labels)
+    return if labels.empty? || labels.nil?
+
+    labels = labels.split(/[\s|,]/)
+    # too many labels, limit to 50, or should return error?
+    # TODO, the val is hard-coded here for now, but make it configurable
+    max_labels = 50
+    if labels.length >= max_labels
+      labels = labels[0..(max_labels - 1)]
+    end
+
+    labels_map = {}
+    labels.each do |v|
+      labels_map[v] = 1
+    end
+
+    res = Label.where(name: labels)
+
+    # construct `data` for bulk insert
+    data = []
+    # for existing labels
+    res.each do |item|
+      data.push({ "label_id": item.id, "task_id": task.id })
+      labels_map.delete(item.name) if labels_map.key?(item.name)
+    end
+
+    result = ActiveRecord::Base.transaction do
+      # for new labels
+      # insert them one by one in order to get the id, mysql w/ AR doesn't support returning object for bulk insert
+      if labels_map.length > 0
+        labels_map.each do |item, v|
+          l = Label.new({ name: item })
+          res = l.save
+          data.push({ "label_id": l.id, "task_id": task.id }) if res
+        end
+      end
+
+      # bulk insert labels for this task
+      TasksLabel.insert_all data
+    end
+
+    unless result
+      # should return error?
+      Rails.logger.error("failed to insert lables, error: #{result}")
+    end
+  end
+
+  def delete_labels?(task)
+    TasksLabel.where(task_id: task.id).destroy_all
+  end
+
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ require 'uri'
 
 # TaskController is a controller to handle basic CRUD operations for "task"
 class TasksController < ApplicationController
-  before_action :redirect_to_login_path_if_not_logged_in
+  before_action :redirect_to_login_path_if_not_logged_in, :redirect_to_maintenance
 
   def index
     q = Task

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -15,9 +15,7 @@ class TasksController < ApplicationController
 tasks = Task.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(params[:query].to_s)}%")
       # find if there is matched label
       labels = TasksLabel.joins(:label).where('labels.name': params[:query].to_s).pluck('task_id')
-      if labels.any?
-        q = q.or(Task.where(id: labels))
-      end
+      q = q.or(Task.where(id: labels)) if labels.any?
     end
 
     q = q.where(status: params[:status]) unless params[:status].to_s.empty?
@@ -72,7 +70,7 @@ tasks = Task.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(para
 
     @labels_value = ''
     labels = Label.joins(:tasks_labels).where('tasks_labels.task_id': params[:id])
-        @labels_value = labels.map(&:name).join(' ') if labels.any?
+    @labels_value = labels.map(&:name).join(' ') if labels.any?
   end
 
   def update
@@ -81,11 +79,8 @@ tasks = Task.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(para
     return redirect_to error_path(401) if @task.user_id != current_user.id
 
     if @task.update(update_params)
-
       # delete them all first and re-create, should be better performance than select and update for each
-      if delete_labels?(@task)
-        add_labels(@task, params[:task][:labels])
-      end
+      add_labels(@task, params[:task][:labels]) if delete_labels?(@task)
 
       flash[:success] = I18n.t 'msg_update_success'
       redirect_to root_path
@@ -131,9 +126,7 @@ tasks = Task.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(para
     # too many labels, limit to 50, or should return error?
     # TODO, the val is hard-coded here for now, but make it configurable
     max_labels = 50
-    if labels.length >= max_labels
-      labels = labels[0..(max_labels - 1)]
-    end
+    labels = labels[0..(max_labels - 1)] if labels.length >= max_labels
 
     labels_map = {}
     labels.each do |v|
@@ -154,7 +147,7 @@ tasks = Task.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(para
       # for new labels
       # insert them one by one in order to get the id, mysql w/ AR doesn't support returning object for bulk insert
       if labels_map.length > 0
-        labels_map.each do |item, v|
+        labels_map.each do |item, _v|
           l = Label.new({ name: item })
           res = l.save
           data.push({ "label_id": l.id, "task_id": task.id }) if res
@@ -165,14 +158,13 @@ tasks = Task.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(para
       TasksLabel.insert_all data
     end
 
-    unless result
-      # should return error?
-      Rails.logger.error("failed to insert lables, error: #{result}")
-    end
+    return if result
+
+    # should return error?
+    Rails.logger.error("failed to insert lables, error: #{result}")
   end
 
   def delete_labels?(task)
     TasksLabel.where(task_id: task.id).destroy_all
   end
-
 end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -12,7 +12,7 @@ class TasksController < ApplicationController
     unless params[:query].to_s.empty?
       # TODO: fix this. this fuzzy search might cause performance degradation.
       q = q.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(params[:query].to_s)}%")
-
+tasks = Task.where('title LIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(params[:query].to_s)}%")
       # find if there is matched label
       labels = TasksLabel.joins(:label).where('labels.name': params[:query].to_s).pluck('task_id')
       if labels.any?

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -131,7 +131,8 @@ class TasksController < ApplicationController
   def add_labels(task, labels)
     return if labels.empty? || labels.nil?
 
-    labels = labels.split(/[\s|,]/)
+    labels = labels.split(/[\s|,]/).reject { |s| s.empty? }
+
     # too many labels, limit to 50, or should return error?
     # TODO, the val is hard-coded here for now, but make it configurable
     max_labels = 50

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -72,12 +72,7 @@ class TasksController < ApplicationController
 
     @labels_value = ''
     labels = Label.joins(:tasks_labels).where('tasks_labels.task_id': params[:id])
-    if labels.any?
-      labels.each do |label|
-        @labels_value += ' ' unless @labels_value.empty?
-        @labels_value += label.name
-      end
-    end
+        @labels_value = labels.map(&:name).join(' ') if labels.any?
   end
 
   def update

--- a/myapp/app/helpers/admin/settings_helper.rb
+++ b/myapp/app/helpers/admin/settings_helper.rb
@@ -1,0 +1,2 @@
+module Admin::SettingsHelper
+end

--- a/myapp/app/models/label.rb
+++ b/myapp/app/models/label.rb
@@ -1,0 +1,3 @@
+class Label < ApplicationRecord
+  has_many :tasks_labels
+end

--- a/myapp/app/models/maintenance.rb
+++ b/myapp/app/models/maintenance.rb
@@ -1,0 +1,5 @@
+class Maintenance < ApplicationRecord
+  enum :is_maintenance, { off: 0, on: 1 }, validate: true
+
+  validates :ended_at, comparison: { greater_than: :started_at }
+end

--- a/myapp/app/models/maintenance.rb
+++ b/myapp/app/models/maintenance.rb
@@ -1,5 +1,9 @@
 class Maintenance < ApplicationRecord
   enum :is_maintenance, { off: 0, on: 1 }, validate: true
 
-  validates :ended_at, comparison: { greater_than: :started_at }
+  validates :ended_at, comparison: { greater_than: :started_at }, if: :maintenance_on?
+
+  def maintenance_on?
+    Maintenance.is_maintenances[is_maintenance] == Maintenance.is_maintenances[:on]
+  end
 end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -16,6 +16,7 @@ end
 
 class Task < ApplicationRecord
   belongs_to :user
+  has_many :tasks_labels
 
   acts_as_paranoid
 

--- a/myapp/app/models/tasks_label.rb
+++ b/myapp/app/models/tasks_label.rb
@@ -1,0 +1,4 @@
+class TasksLabel < ApplicationRecord
+  belongs_to :label
+  belongs_to :task
+end

--- a/myapp/app/views/admin/settings/index.html.erb
+++ b/myapp/app/views/admin/settings/index.html.erb
@@ -1,0 +1,35 @@
+<div class="h5"><%= t 'Settings' %></div>
+
+<div class="bg-white rounded p-3 mb-3">
+  <div class="h6"><%= t 'Maintenance' %></div>
+  <% if @maintenance.errors.full_messages.any? %>
+  <ul>
+      <% @maintenance.errors.full_messages.each do |message| %>
+      <li class="text-danger small"><%= message %></li>
+      <% end %>
+  </ul>
+  <% end %>
+  <%= form_with model: @maintenance, url: admin_settings_path, method: "POST" do |f| %>
+    <div class="mb-3">
+      <div class="col-3">
+      <%= f.radio_button :is_maintenance, Maintenance.is_maintenances.key(0) %>
+      <%= f.label :is_maintenance, "off", value: Maintenance.is_maintenances.key(0) %>
+      <%= f.radio_button :is_maintenance, Maintenance.is_maintenances.key(1) %>
+      <%= f.label :is_maintenance, "on", value: Maintenance.is_maintenances.key(1) %>
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <div class="col-3">
+      <%= f.label :started_at, "Start" %>
+      <%= f.datetime_field :started_at, class: "form-control" %>
+      <%= f.label :ended_at, "End" %>
+      <%= f.datetime_field :ended_at, class: "form-control" %>
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <%= f.submit 'Submit', class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/myapp/app/views/admin/tasks/index.html.erb
+++ b/myapp/app/views/admin/tasks/index.html.erb
@@ -4,7 +4,6 @@
     <tr>
       <th scope="col"><%= t "title" %></th>
       <th scope="col"><%= t "status" %></th>
-      <th scope="col"><%= t "detail" %></th>
       <th scope="col"><%= t 'due_date_at' %></th>
       <th scope="col"><%= t 'created_at' %></th>
       <th scope="col"><%= t 'updated_at' %></th>
@@ -15,9 +14,8 @@
   <tbody>
 <% @tasks.each do |task| %>
     <tr class="<%= 'table-danger' unless task.deleted_at.nil? %>" id="task-<%= task.id %>">
-      <td><%= task.title %></td>
+      <td><%= link_to task.title, task_path(task) %></td>
       <td><%= t task.status %></td>
-      <td><%= task.description %></td>
       <td><%= task.due_date_at %></td>
       <td><%= task.created_at %></td>
       <td><%= task.updated_at %></td>

--- a/myapp/app/views/admin/users/edit.html.erb
+++ b/myapp/app/views/admin/users/edit.html.erb
@@ -1,1 +1,2 @@
+<div class="h5"><%= t @user.name %></div>
 <%= render "form", user: @user, action: :update, btn_label: "Update" %>

--- a/myapp/app/views/errors/maintenance.html.erb
+++ b/myapp/app/views/errors/maintenance.html.erb
@@ -1,0 +1,12 @@
+<section class="py-3 py-md-5 min-vh-100 d-flex justify-content-center align-items-center">
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+        <div class="text-center">
+          <h3 class="h2 mb-2"><%= t 'msg_maintenance' %></h3>
+          <%= link_to "Back to Home", root_path, class: "btn bsb-btn-5xl btn-dark rounded-pill px-5 fs-6 m-0" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/myapp/app/views/layouts/application.html.erb
+++ b/myapp/app/views/layouts/application.html.erb
@@ -27,8 +27,15 @@
         </div>
         </li>
         <% if !current_user.role_normal? %>
-        <li class="nav-item">
-        <%= link_to "admin", admin_users_path, class: "btn btn-link" %>
+        <li class="nav-item dropdown">
+
+          <button class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+          admin
+          </button>
+          <ul class="dropdown-menu dropdown-menu-light">
+            <li><%= link_to "users", admin_users_path, class: "dropdown-item" %></li>
+            <li><%= link_to "settings", admin_settings_path, class: "dropdown-item" %></li>
+          </ul>
         </li>
         <% end %>
         <li class="nav-item">

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -26,6 +26,10 @@
       </div>
     </div>
 
+    <div class="mb-3">
+    <%= f.text_area :labels, class: "form-control", placeholder: (t 'labels'), value: @labels_value %>
+    </div>
+
     <div class="">
       <%= f.submit btn_label, class: "btn btn-primary" %>
     </div>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -3,7 +3,7 @@
     <%= form_with url: root_path, method: :get do |f| %>
       <div class="mb-3 mt-3">
         <div class="input-group">
-          <%= f.text_field :query, class: "form-control", placeholder: t('search_by_title'), value: params[:query] %>
+          <%= f.text_field :query, class: "form-control", value: params[:query] %>
           <%= f.button raw('<i class="bi bi-search"></i>'), name: nil, class: "btn btn-light border-light-subtle", id: "btn-search" %>
           <% unless params[:sort].to_s.empty? %>
           <%= f.hidden_field :sort, value: params[:sort] %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -25,6 +25,18 @@
             <th><%= t 'updated_at' %></th>
             <td><%= @task.updated_at %></td>
         </tr>
+        <tr>
+            <th><%= t 'labels' %></th>
+            <td>
+                <% if @labels.any? %>
+                <% @labels.each do |label| %>
+                <span>#<%= label.name %></span>
+                <% end %>
+                <% end %>
+            </td>
+        </tr>
     </tbody>
 </table>
+<% if @task.user_id == current_user.id %>
 <%= link_to 'Edit', edit_task_path(@task) %>
+<% end %>

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
   deleted_at: 'deleted'
   due_date_at: 'due date'
   status: 'status'
+  labels: 'labels'
   msg_create_success: 'Created a task successfully.'
   msg_create_failure: 'Failed to create a task.'
   msg_update_success: 'Updated a task successfully.'

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
   role_normal: 'normal'
   role_admin: 'admin'
   role_moderator: 'moderator'
+  msg_maintenance: 'under maintenance...'
 
   user:
     name: 'username'

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -37,6 +37,7 @@ ja:
   deleted_at: '削除日時'
   due_date_at: '期限'
   status: 'ステータス'
+  labels: 'ラベル'
   msg_create_success: '作成に成功しました'
   msg_create_failure: '作成に失敗しました'
   msg_update_success: '更新に成功しました'

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -54,6 +54,7 @@ ja:
   role_normal: '通常'
   role_admin: 'admin'
   role_moderator: 'moderator'
+  msg_maintenance: 'メンテナンス中です'
 
   user:
     name: 'ユーザーネーム'

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -23,11 +23,15 @@ Rails.application.routes.draw do
 
     get '/users/:id/tasks', to: 'tasks#index', as: 'user_tasks'
     delete '/tasks/:id', to: 'tasks#destroy', as: 'task'
+
+    get '/settings', to: 'settings#index'
+    post '/settings', to: 'settings#create'
   end
 
   # overrirde default error pages
   get '/404', to: 'errors#not_found', as: :not_found, via: :all
   get '/500', to: 'errors#internal_server_error', as: :internal_server_error, via: :all
+  get '/maintenance', to: 'errors#maintenance', as: :maintenance
   get '/errors/:status', to: 'errors#show', as: :error
 
   match '*path', to: 'errors#not_found', via: :all

--- a/myapp/db/migrate/20240913060042_create_labels.rb
+++ b/myapp/db/migrate/20240913060042_create_labels.rb
@@ -1,0 +1,11 @@
+class CreateLabels < ActiveRecord::Migration[7.0]
+  def change
+    create_table :labels, id: false do |t|
+      t.primary_key :id, :unsigned_integer, limit: 8, null: false, auto_increment: true
+      t.string :name, limit: 20
+
+      t.timestamps
+    end
+    add_index :labels, :name
+  end
+end

--- a/myapp/db/migrate/20240913061653_create_tasks_labels.rb
+++ b/myapp/db/migrate/20240913061653_create_tasks_labels.rb
@@ -1,0 +1,11 @@
+class CreateTasksLabels < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tasks_labels, id: false do |t|
+      t.primary_key :id, :unsigned_integer, limit: 8, null: false, auto_increment: true
+      t.integer :task_id, unsigned: true, limit: 8, null: false, default: 0
+      t.integer :label_id, unsigned: true, limit: 8, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/migrate/20240913064431_add_fk_to_tasks_labels.rb
+++ b/myapp/db/migrate/20240913064431_add_fk_to_tasks_labels.rb
@@ -1,0 +1,11 @@
+class AddFkToTasksLabels < ActiveRecord::Migration[7.0]
+  def up
+    add_foreign_key :tasks_labels, :tasks
+    add_foreign_key :tasks_labels, :labels
+  end
+
+  def down
+    remove_foreign_key :tasks_labels, :tasks, if_exists: true
+    remove_foreign_key :tasks_labels, :labels, if_exists: true
+  end
+end

--- a/myapp/db/migrate/20240917035539_create_maintenances.rb
+++ b/myapp/db/migrate/20240917035539_create_maintenances.rb
@@ -1,0 +1,11 @@
+class CreateMaintenances < ActiveRecord::Migration[7.0]
+  def change
+    create_table :maintenances do |t|
+      t.integer "is_maintenance", limit: 1, default: 0, null: false, unsigned: true
+      t.datetime "started_at"
+      t.datetime "ended_at"
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_11_073508) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_13_064431) do
+  create_table "labels", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", force: :cascade do |t|
+    t.string "name", limit: 20
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_labels_on_name"
+  end
+
   create_table "tasks", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", force: :cascade do |t|
     t.string "title", limit: 50, null: false
     t.string "description", limit: 500
@@ -27,6 +34,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_11_073508) do
     t.index ["user_id"], name: "fk_rails_4d2a9e4d7e"
   end
 
+  create_table "tasks_labels", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "task_id", default: 0, null: false, unsigned: true
+    t.bigint "label_id", default: 0, null: false, unsigned: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["label_id"], name: "fk_rails_ec4ff48c18"
+    t.index ["task_id"], name: "fk_rails_30e46383d5"
+  end
+
   create_table "users", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", force: :cascade do |t|
     t.string "name", limit: 20, null: false
     t.string "password_digest", limit: 72, null: false
@@ -39,4 +55,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_11_073508) do
   end
 
   add_foreign_key "tasks", "users"
+  add_foreign_key "tasks_labels", "labels"
+  add_foreign_key "tasks_labels", "tasks"
 end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,12 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_13_064431) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_17_035539) do
   create_table "labels", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", force: :cascade do |t|
     t.string "name", limit: 20
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_labels_on_name"
+  end
+
+  create_table "maintenances", charset: "utf8mb4", force: :cascade do |t|
+    t.integer "is_maintenance", limit: 1, default: 0, null: false, unsigned: true
+    t.datetime "started_at"
+    t.datetime "ended_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tasks", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", force: :cascade do |t|

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,24 @@
+namespace :maintenance do
+  desc 'manage maintenance'
+  # turn on or off maintenance with given datetime
+  # args:
+  # :is_maintenance... enum(off, on)
+  # :started_at... ISO-8601, e.g. 2024-09-27T:12:00:00Z, 2014-10-10T13:50:40+09:00...etc
+  # :ended_at... ISO-8601, e.g. 2024-09-27T:12:00:00Z, 2014-10-10T13:50:40+09:00...etc
+  #
+  # example:
+  # rail maintenance:run[on,2024-09-27T:12:00:00Z,2024-09-30Y12:00:00Z]
+  # rail maintenance:run[off,2024-09-27T:12:00:00Z,2024-09-30Y12:00:00Z]
+  task :run, [:is_maintenance, :started_at, :ended_at] => :environment do |_, args|
+    begin
+      @maintenance = Maintenance.new({
+                                       is_maintenance: args.is_maintenance,
+                                       started_at: args.started_at,
+                                       ended_at: args.ended_at,
+                                     })
+      @maintenance.save!
+    rescue => e
+      puts e.message
+    end
+  end
+end

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,22 +1,34 @@
 namespace :maintenance do
-  desc 'manage maintenance'
-  # turn on or off maintenance with given datetime
+  desc 'Turn on maintenance with given datetime'
   # args:
-  # :is_maintenance... enum(off, on)
   # :started_at... ISO-8601, e.g. 2024-09-27T:12:00:00Z, 2014-10-10T13:50:40+09:00...etc
   # :ended_at... ISO-8601, e.g. 2024-09-27T:12:00:00Z, 2014-10-10T13:50:40+09:00...etc
   #
   # example:
-  # rail maintenance:run[on,2024-09-27T:12:00:00Z,2024-09-30Y12:00:00Z]
-  # rail maintenance:run[off,2024-09-27T:12:00:00Z,2024-09-30Y12:00:00Z]
-  task :run, [:is_maintenance, :started_at, :ended_at] => :environment do |_, args|
+  # rails maintenance:run[2024-09-27T:12:00:00Z,2024-09-30T12:00:00Z]
+  # rails maintenance:run[2024-09-27T:12:00:00Z,2024-09-30T12:00:00Z]
+  task :on, [:started_at, :ended_at] => :environment do |task, args|
     begin
       @maintenance = Maintenance.new({
-                                       is_maintenance: args.is_maintenance,
+                                       is_maintenance: Maintenance.is_maintenances[:on],
                                        started_at: args.started_at,
                                        ended_at: args.ended_at,
                                      })
       @maintenance.save!
+      puts "task '#{task}' executed with args started_at:#{args.started_at}, ended_at:#{args.ended_at}"
+    rescue => e
+      puts e.message
+    end
+  end
+
+  desc 'Turn off maintenance'
+  task :off => :environment do |task, _|
+    begin
+      @maintenance = Maintenance.new({
+                                       is_maintenance: Maintenance.is_maintenances[:off],
+                                     })
+      @maintenance.save!
+      puts "task '#{task}' executed"
     rescue => e
       puts e.message
     end

--- a/myapp/spec/factories/labels.rb
+++ b/myapp/spec/factories/labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :label do
+    sequence(:name) { |n| "label#{n}" }
+  end
+end

--- a/myapp/spec/factories/maintenances.rb
+++ b/myapp/spec/factories/maintenances.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :maintenance do
+    
+  end
+end

--- a/myapp/spec/factories/tasks_labels.rb
+++ b/myapp/spec/factories/tasks_labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tasks_label do
+    
+  end
+end

--- a/myapp/spec/factories/tasks_labels.rb
+++ b/myapp/spec/factories/tasks_labels.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :tasks_label do
-    
   end
 end

--- a/myapp/spec/factories/users.rb
+++ b/myapp/spec/factories/users.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :user do
-    # id { 1 }
     sequence(:name) { |n| "JohnDoe#{n}" }
     password { 'dummyPassword123!?' }
   end

--- a/myapp/spec/helpers/admin/settings_helper_spec.rb
+++ b/myapp/spec/helpers/admin/settings_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Admin::SettingsHelper. For example:
+#
+# describe Admin::SettingsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Admin::SettingsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/models/label_spec.rb
+++ b/myapp/spec/models/label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/models/maintenance_spec.rb
+++ b/myapp/spec/models/maintenance_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Maintenance, type: :model do
+  describe 'validation' do
+    context 'is_maintenance column' do
+      it 'success' do
+        t = Maintenance.new(
+          is_maintenance: 1,
+          started_at: '2024-09-01T15:00',
+          ended_at: '2024-09-01T15:15',
+        )
+        expect(t).to be_valid
+      end
+
+      it 'failed when it is invalid value' do
+        expect do
+          Maintenance.new(
+            is_maintenance: 999,
+            started_at: '2024-09-01T15:00',
+            ended_at: '2024-09-01T15:15',
+          )
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'started_at, ened_at column' do
+      it 'failed when started_at is greater than ended_at' do
+        t = Maintenance.new(
+          is_maintenance: 1,
+          started_at: '2024-09-01T15:15',
+          ended_at: '2024-09-01T15:00',
+        )
+        t.valid?
+        expect(t.errors[:ended_at]).to include('は2024-09-01 15:15:00 +0900より大きい値にしてください')
+      end
+    end
+  end
+end

--- a/myapp/spec/models/tasks_label_spec.rb
+++ b/myapp/spec/models/tasks_label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TasksLabel, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/requests/admin/settings_spec.rb
+++ b/myapp/spec/requests/admin/settings_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Settings", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/myapp/spec/system/admin/settings_spec.rb
+++ b/myapp/spec/system/admin/settings_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SettingsController, type: :system do
+  include LoginHelper
+
+  describe '#index' do
+    context 'when user is anonymous' do
+      before do
+        visit admin_settings_path
+      end
+
+      it 'user should be redirected to login page' do
+        expect(current_path).to eq login_path
+      end
+    end
+    context 'when user is normal user' do
+      before do
+        user_1 = create(:user)
+        log_in(user_1)
+        visit admin_settings_path
+      end
+
+      it 'user should be redirected to root path' do
+        expect(current_path).to eq root_path
+      end
+    end
+
+    context 'when user has permission' do
+      before do
+        @moderator_1 = create(:user, role: User.roles[:role_moderator])
+        log_in(@moderator_1)
+        visit admin_settings_path
+      end
+
+      it 'user should access admin settings page' do
+        expect(current_path).to eq admin_settings_path
+
+        expect(page).to have_field 'maintenance[is_maintenance]'
+        expect(page).to have_checked_field 'off'
+        expect(page).to have_no_checked_field 'on'
+        expect(page).to have_field 'maintenance[started_at]'
+        expect(page).to have_field 'maintenance[ended_at]'
+        expect(page).to have_button 'Submit'
+      end
+
+      context 'when there is a maintenance schedule' do
+        before do
+          @maintenance_1 = create(:maintenance, is_maintenance: 1, started_at: '2024-09-01T15:00:00', ended_at: '2024-09-01T15:15:00')
+          visit admin_settings_path
+        end
+
+        it 'user should see current maintenance schedule' do
+          expect(page).to have_field 'maintenance[is_maintenance]'
+          expect(page).to have_checked_field 'on'
+          expect(page).to have_no_checked_field 'off'
+          expect(page).to have_field 'maintenance[started_at]', with: '2024-09-01T15:00:00'
+          expect(page).to have_field 'maintenance[ended_at]', with: '2024-09-01T15:15:00'
+          expect(page).to have_button 'Submit'
+        end
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'when user has permission' do
+      before do
+        @moderator_1 = create(:user, role: User.roles[:role_moderator])
+        log_in(@moderator_1)
+        visit admin_settings_path
+      end
+
+      it 'set new maintenance schedule successfully' do
+        choose 'maintenance_is_maintenance_on'
+        fill_in 'maintenance[started_at]', with: '2024-09-01T15:15:00'
+        fill_in 'maintenance[ended_at]', with: '2024-09-01T15:30:00'
+        click_on 'Submit'
+
+        expect(current_path).to eq admin_settings_path
+        expect(page).to have_content '更新に成功しました'
+        expect(page).to have_field 'maintenance[is_maintenance]'
+        expect(page).to have_checked_field 'on'
+        expect(page).to have_no_checked_field 'off'
+        expect(page).to have_field 'maintenance[started_at]', with: '2024-09-01T15:15:00'
+        expect(page).to have_field 'maintenance[ended_at]', with: '2024-09-01T15:30:00'
+        expect(page).to have_button 'Submit'
+      end
+
+      context 'when user creation is failed' do
+        before do
+          visit admin_settings_path
+
+          choose 'maintenance_is_maintenance_on'
+          fill_in 'maintenance[started_at]', with: '2024-09-01T15:15:00'
+          fill_in 'maintenance[ended_at]', with: '2024-09-01T15:00:00'
+          click_on 'Submit'
+        end
+
+        it 'error message is shown on the same page' do
+          expect(current_path).to eq admin_settings_path
+          expect(page).to have_content '更新に失敗しました'
+          expect(page).to have_content 'より大きい値にしてください'
+
+          expect(page).to have_field 'maintenance[is_maintenance]'
+          expect(page).to have_checked_field 'on'
+          expect(page).to have_no_checked_field 'off'
+          expect(page).to have_field 'maintenance[started_at]', with: '2024-09-01T15:15:00'
+          expect(page).to have_field 'maintenance[ended_at]', with: '2024-09-01T15:00:00'
+        end
+      end
+    end
+  end
+
+end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -393,5 +393,34 @@ RSpec.describe TasksController, type: :system do
       end
     end
   end
-end
 
+  describe '#add_labels' do
+    before do
+      @user_1 = create(:user)
+      create(:label, id: 1, name: 'work')
+      create(:label, id: 2, name: 'hobby')
+      create(:label, id: 3, name: 'baseball')
+
+      log_in(@user_1)
+      visit root_path
+    end
+
+    context 'when creating a task with existing label' do
+      it 'create a task with labels successfully' do
+        new_title = 'test title 1'
+        Task.statuses[:status_in_progress]
+        fill_in 'task[title]', with: new_title
+        fill_in 'task[labels]', with: 'work hobby game food ramen'
+        click_on 'Create'
+
+        # redirected back to root page
+        expect(current_path).to eq root_path
+        expect(page).to have_content '作成に成功しました'
+
+        # make sure new task is there
+        expect(page).to have_content new_title
+      end
+    end
+  end
+
+end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe TasksController, type: :system do
       context 'when task is filtered' do
         before do
           @tasks = create_list(:task, 5, user: @user_1)
+          @label = create(:label, id: 1, name: 'work')
           visit root_path
         end
 
@@ -97,6 +98,20 @@ RSpec.describe TasksController, type: :system do
 
           expect(current_path).to eq root_path
           expect(page).to have_selector('tbody tr', count: 1)
+        end
+
+        it 'search by label' do
+          # add extra items with various status
+          create(:task, title: 'working', user: @user_1)
+          create(:task, user: @user_1)
+          task_3 = create(:task, user: @user_1)
+          create(:tasks_label, task_id: task_3.id, label_id: @label.id)
+
+          fill_in 'query', with: @label.name
+          click_on 'btn-search'
+
+          expect(current_path).to eq root_path
+          expect(page).to have_selector('tbody tr', count: 2)
         end
       end
     end

--- a/myapp/spec/system/tasks_spec.rb
+++ b/myapp/spec/system/tasks_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'active_support/time'
 
 RSpec.describe TasksController, type: :system do
   include LoginHelper
@@ -112,6 +113,17 @@ RSpec.describe TasksController, type: :system do
 
           expect(current_path).to eq root_path
           expect(page).to have_selector('tbody tr', count: 2)
+        end
+      end
+
+      context 'when it is under maintenance' do
+        before do
+          create(:maintenance, is_maintenance: 1, started_at: Time.now.ago(5.minutes).to_s, ended_at: Time.now.since(5.minutes).to_s)
+          visit root_path
+        end
+
+        it 'should be redirected to maintenance page' do
+          expect(current_path).to eq maintenance_path
         end
       end
     end


### PR DESCRIPTION
> ### ステップ20: タスクにラベルをつけられるようにしよう
> 
> - タスクに複数のラベルをつけられるようにしてみましょう
> - つけたラベルで検索できるようにしてみましょう

I created 2 more tables 'labels' and 'tasks_labels' to store labels master and its association with tasks. User can add and update labels when task is created or updated.
Here is some screenshots

Task creation form with text field for labels.
![new_task_form_with_labels](https://github.com/user-attachments/assets/c810c341-ab58-4b3e-9b48-1de06dd46483)

Labels should be added with space or comma separated. Controller will split and save them into tables.
![new_task_form_with_labelsfilled_in](https://github.com/user-attachments/assets/d1d33f9c-24be-495c-a474-f41658ea0a30)

Task details page shows the labels.
![show_task_with_labels](https://github.com/user-attachments/assets/6e94d611-05d1-4b06-8e0f-5a725863a61e)

Task can be searched by label as well, user should just use search field on left side bar.
![Screenshot 2024-09-17 at 17 41 17](https://github.com/user-attachments/assets/2b8dbf87-5419-41d7-bfca-fe6ea9eddd8a)

> ### ステップ21: メンテナンス機能を作ろう
> 
> - メンテナンスを開始／終了するバッチを作ってみましょう
> - メンテナンス中にアクセスしたユーザはメンテナンスページにリダイレクトさせましょう
> - 追加のGemを使わず、自分で実装してみましょう

I created a table 'maintenance' to have on/off flag with start and end datetime. User should be redirected to maintenance page(/maintenance) while maintenance is on.

Admin or moderator can set the maintenance schedule on admin page(/admin/settings).This is initial page when there is no maintenance schedule.
![maintenance_default](https://github.com/user-attachments/assets/3adfd958-f43a-4241-8a84-de493bf18ea0)

And this is when schedule is set.
![maintenance_1](https://github.com/user-attachments/assets/bbb90b49-b40d-4b22-8f2f-1f61d7a1f152)

Here is very simple maintenance page(/maintenance) user will see it after logged-in to the website. Privileged user still can access /admin page to turn it off or change the schedule.
![maintenance_page](https://github.com/user-attachments/assets/d203d4ba-3567-4c1c-9276-26a2e0efc850)
