### PR TITLE
Step 20

### DIFF
--- a/myapp/app/controllers/admin/tasks_controller.rb
+++ b/myapp/app/controllers/admin/tasks_controller.rb
@@ -9,11 +9,11 @@ class Admin::TasksController < ApplicationController
         tasks_scope = User.active.find(params[:user_id]).tasks.active
         @q = tasks_scope.ransack(params[:q])
         @q.sorts = 'created_at asc' if @q.sorts.empty?
-        @tasks = @q.result.page(params[:page]).per(PER_PAGE)
+        @tasks = @q.result.includes(:labels).page(params[:page]).per(PER_PAGE)
     else
         @q = Task.active.ransack(params[:q])
         @q.sorts = 'created_at asc' if @q.sorts.empty?
-        @tasks = @q.result.includes(:user).page(params[:page]).per(PER_PAGE)
+        @tasks = @q.result.includes(:user, :labels).page(params[:page]).per(PER_PAGE)
     end
   end
 

--- a/myapp/app/controllers/labels_controller.rb
+++ b/myapp/app/controllers/labels_controller.rb
@@ -1,0 +1,64 @@
+class LabelsController < ApplicationController
+  before_action :set_label, only: [:show, :edit, :update, :destroy]
+  before_action :require_login
+  before_action :authorize_user, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @labels = current_user.labels
+  end
+
+  def show
+  end
+
+  def new
+    @label = Label.new
+  end
+
+  def create
+    @label = current_user.labels.new(label_params)
+    if @label.save
+      flash[:notice] = I18n.t 'msg_create_label_success'
+      redirect_to @label
+    else
+      flash.now[:alert] = I18n.t 'msg_create_label_failure'
+      render :new, status: 422
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @label.update(label_params)
+      flash[:notice] = I18n.t 'msg_update_label_success'
+      redirect_to @label
+    else
+      flash.now[:alert] = I18n.t 'msg_update_label_failure'
+      render :edit, status: 422
+    end
+  end
+
+  def destroy
+    if @label.destroy
+      flash[:notice] = I18n.t 'msg_delete_label_success'
+      redirect_to labels_url
+    else
+      flash[:alert] = I18n.t 'msg_delete_label_failure'
+      redirect_to @label
+    end
+  end
+
+  private
+
+  def set_label
+    @label = Label.find(params[:id])
+  end
+
+  def label_params
+    params.require(:label).permit(:name)
+  end
+
+  def authorize_user
+    raise ActionController::RoutingError, "404" unless @label.user == current_user
+  end
+end

--- a/myapp/app/controllers/tasks_controller.rb
+++ b/myapp/app/controllers/tasks_controller.rb
@@ -8,7 +8,7 @@ class TasksController < ApplicationController
   def index
     @q = current_user.tasks.active.ransack(params[:q])
     @q.sorts = 'created_at asc' if @q.sorts.empty?
-    @tasks = @q.result.page(params[:page]).per(PER_PAGE)
+    @tasks = @q.result.includes(:labels).page(params[:page]).per(PER_PAGE)
   end
 
   def show
@@ -61,7 +61,7 @@ class TasksController < ApplicationController
 
   # Only allow a list of trusted parameters.
   def task_params
-    params.require(:task).permit(:name, :description, :user_id, :priority, :status, :deadline)
+    params.require(:task).permit(:name, :description, :user_id, :priority, :status, :deadline, label_ids: [])
   end
 
   # Prevent action if current_user is not admin and not the owner of the task

--- a/myapp/app/helpers/labels_helper.rb
+++ b/myapp/app/helpers/labels_helper.rb
@@ -1,0 +1,2 @@
+module LabelsHelper
+end

--- a/myapp/app/models/label.rb
+++ b/myapp/app/models/label.rb
@@ -1,0 +1,8 @@
+class Label < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true, uniqueness: { scope: :user_id }
+
+  has_many :task_labels, dependent: :destroy
+  has_many :tasks, through: :task_labels
+end

--- a/myapp/app/models/task.rb
+++ b/myapp/app/models/task.rb
@@ -11,6 +11,9 @@ class Task < ApplicationRecord
   validates :deadline, presence: true
   validate :deadline_not_in_past
 
+  has_many :task_labels, dependent: :destroy
+  has_many :labels, through: :task_labels
+
   def self.ransackable_associations(auth_object = nil)
     []
   end

--- a/myapp/app/models/task_label.rb
+++ b/myapp/app/models/task_label.rb
@@ -1,0 +1,4 @@
+class TaskLabel < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+end

--- a/myapp/app/models/user.rb
+++ b/myapp/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :tasks
+  has_many :labels
   has_secure_password
   validates :name, presence: true
   validates :username, presence: true, uniqueness: true

--- a/myapp/app/views/admin/tasks/index.html.erb
+++ b/myapp/app/views/admin/tasks/index.html.erb
@@ -54,7 +54,7 @@
         <td><%= task.created_at.strftime("%Y-%m-%d %H:%M") %></td>
         <td><%= t("activerecord.attributes.task.priorities.#{task.priority}") %></td>
         <td><%= t("activerecord.attributes.task.statuses.#{task.status}") %></td>
-        <td>Label</td>
+        <td><%= task.labels.map(&:name).join(", ") %></td>
         <td>
           <%= link_to edit_task_path(task), class: "text-decoration-none" do %>
             <i class="bi bi-pencil-square"></i>

--- a/myapp/app/views/labels/_form.html.erb
+++ b/myapp/app/views/labels/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with(model: label, local: true) do |form| %>
+  <% if label.errors.any? %>
+    <div class="alert alert-danger">
+      <ul>
+        <% label.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-2 row">
+    <%= form.label :name, t("name"), class: "col-auto form-label" %>
+    <%= form.text_field :name, class: "col-auto" %>
+  </div>
+
+  <button type="submit" class="btn btn-primary">
+    <%= t("button.save") %>
+  </button>
+<% end %>

--- a/myapp/app/views/labels/edit.html.erb
+++ b/myapp/app/views/labels/edit.html.erb
@@ -1,0 +1,6 @@
+<h1><%= t("page.edit_label") %></h1>
+<div class="container">
+<%= render 'form', label: @label %>
+<%= link_to t("button.back"), labels_path, class: "btn btn-secondary" %>
+</div>
+

--- a/myapp/app/views/labels/index.html.erb
+++ b/myapp/app/views/labels/index.html.erb
@@ -1,0 +1,50 @@
+<h1><%= t("page.label") %></h1>
+
+<% if flash[:notice] %>
+  <div class="alert alert-success"><%= flash[:notice] %></div>
+<% end %>
+<% if flash[:alert] %>
+  <div class="alert alert-danger"><%= flash[:alert] %></div>
+<% end %>
+
+<% if @labels.empty? %>
+  <p><%= t("page.no_label") %></p>
+<% else %>
+<div class="container">
+<table class="table">
+  <thead>
+    <tr>
+      <th><%= t('name') %></th>
+      <th><%= t('created_at') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @labels.each do |label| %>
+      <tr>
+        <td><%= link_to label.name, label %></td>
+        <td><%= label.created_at.strftime("%Y-%m-%d %H:%M") %></td>
+        <td>
+          <%= link_to edit_label_path(label), class: "text-decoration-none" do %>
+            <i class="bi bi-pencil-square"></i>
+            <span class="visually-hidden">Edit</span>
+          <% end %> |
+          <%= link_to label, method: :delete, data: { turbo_method: :delete , turbo_confirm: "Are you sure?" }, class: "text-decoration-none" do %>
+            <i class="bi bi-trash"></i>
+            <span class="visually-hidden">Delete</span>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+</div>
+<% end %>
+
+<%= link_to new_label_path, class: "btn btn-primary text-decoration-none" do  %>
+  <i class="bi bi-plus-circle"></i>
+  <span><%= t('button.new_label') %></span>
+<% end %>
+
+<span>
+  <%= link_to t("button.back"), tasks_path, class:"btn btn-secondary" %>
+</span>

--- a/myapp/app/views/labels/new.html.erb
+++ b/myapp/app/views/labels/new.html.erb
@@ -1,0 +1,6 @@
+<h1><%= t("page.create_new_label") %></h1>
+<div class="container">
+<%= render 'form', label: @label %>
+<%= link_to t("button.back"), labels_path, class: "btn btn-secondary" %>
+</div>
+

--- a/myapp/app/views/labels/show.html.erb
+++ b/myapp/app/views/labels/show.html.erb
@@ -1,0 +1,29 @@
+<h1><%= t("page.label_detail") %></h1>
+
+<% if flash[:notice] %>
+  <div class="alert alert-success"><%= flash[:notice] %></div>
+<% end %>
+<% if flash[:alert] %>
+  <div class="alert alert-danger"><%= flash[:alert] %></div>
+<% end %>
+
+<div class="container">
+<p>
+  <strong><%= t('name') %>:</strong>
+  <%= @label.name %>
+</p>
+
+<% if current_user.is_admin %> 
+  <p>
+    <strong><%= t('assignee') %>:</strong>
+    <%= @label.user.name %>
+  </p>
+<% end %>
+
+<span>
+  <%= link_to t("button.update_label"), edit_label_path(@label), class:"btn btn-secondary" %>
+</span>
+<span>
+  <%= link_to t("button.back"), labels_path, class:"btn btn-secondary" %>
+</span>
+</div>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -29,6 +29,11 @@
     <%= form.select :status, options_for_select(Task.statuses.keys.map { |key| [t("activerecord.attributes.task.statuses.#{key}"), key] }, task.status) %>
   </div>
 
+  <div class="mb-2 row">
+    <%= form.label :label_ids, t("labels"), class: "col-auto form-label" %>
+    <%= form.collection_select :label_ids, current_user.labels, :id, :name, {}, { multiple: true, class: "col-auto" } %>
+  </div>
+
   <div class="mb-2">
     <%= form.label :deadline %>
     <%= form.datetime_select :deadline, include_blank: true, start_year: Date.today.year, end_year: Date.today.year + 10 %>

--- a/myapp/app/views/tasks/_form.html.erb
+++ b/myapp/app/views/tasks/_form.html.erb
@@ -40,10 +40,10 @@
   </div>
 
   <% if current_user.is_admin %>
-    <div class="mb-2">
-      <%= form.label :assignee, t("assignee"), class: "col-auto form-label" %>
-      <%= form.collection_select :user_id, User.active.order(:name), :id, :name, { selected: form.object.user_id } %>
-    </div>
+    <!-- <div class="mb-2">
+      <%# form.label :assignee, t("assignee"), class: "col-auto form-label" %>
+      <%# form.collection_select :user_id, User.active.order(:name), :id, :name, { selected: form.object.user_id } %>
+    </div> -->
   <% else %>
     <%# user_id is the automatically set to the current_user %>
     <%= form.hidden_field :user_id, value: current_user.id %>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -49,7 +49,9 @@
         <td><%= task.created_at.strftime("%Y-%m-%d %H:%M") %></td>
         <td><%= t("activerecord.attributes.task.priorities.#{task.priority}") %></td>
         <td><%= t("activerecord.attributes.task.statuses.#{task.status}") %></td>
-        <td>Label</td>
+        <td>
+          <%= task.labels.map(&:name).join(", ") %>
+        </td>
         <td>
           <%= link_to edit_task_path(task), class: "text-decoration-none" do %>
             <i class="bi bi-pencil-square"></i>

--- a/myapp/app/views/tasks/index.html.erb
+++ b/myapp/app/views/tasks/index.html.erb
@@ -72,4 +72,9 @@
   <span><%= t('button.new_task') %></span>
 <% end %>
 
+<%= link_to labels_path, class: "btn btn-primary text-decoration-none" do  %>
+  <i class="bi bi-tools"></i>
+  <span><%= t('button.manage_labels') %></span>
+<% end %>
+
 <%= paginate @tasks %>

--- a/myapp/app/views/tasks/show.html.erb
+++ b/myapp/app/views/tasks/show.html.erb
@@ -36,6 +36,11 @@
 </p>
 
 <p>
+  <strong><%= t('labels') %>:</strong>
+  <%= @task.labels.map(&:name).join(', ') %>
+</p>
+
+<p>
   <strong><%= t('deadline') %>:</strong>
   <%= @task.deadline ? @task.deadline.strftime("%Y-%m-%d %H:%M") : "None" %>
 </p>

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -59,6 +59,12 @@ en:
   msg_cant_delete_last_admin: 'You cannot delete the last admin.'
   msg_user_deactivated: 'User was successfully deactivated.'
   msg_user_deactivated_failure: 'Failed to deactivate a user.'
+  msg_create_label_success: 'Label was successfully created.'
+  msg_create_label_failure: 'Failed to create a label.'
+  msg_update_label_success: 'Label was successfully updated.'
+  msg_update_label_failure: 'Failed to update a label.'
+  msg_delete_label_success: 'Label was successfully deleted.'
+  msg_delete_label_failure: 'Failed to delete a label.'
   activerecord:
     attributes:
       task:
@@ -100,6 +106,9 @@ en:
     deactivate_user: "Deactivate User"
     login: "Log in"
     logout: "Log out"
+    manage_labels: "Manage Labels"
+    new_label: "New Label"
+    update_label: "Update Label"
   page:
     task: "Task"
     task_detail: "Task Detail"
@@ -122,6 +131,11 @@ en:
     edit_user: "Edit User"
     create_new_user: "Create New User"
     welcome: "Welcome"
+    label: "Label"
+    no_label: "No labels found."
+    label_detail: "Label Detail"
+    edit_label: "Edit Label"
+    create_new_label: "Create New Label"
   views:
     pagination:
       previous: "Previous"

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -86,6 +86,8 @@ en:
       user:
         username: 'Username'
         password: 'Password'
+      label:
+        name: 'Name'
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -63,6 +63,8 @@ ja:
       user:
         username: 'ユーザー名'
         password: 'パスワード'
+      label:
+        name: '名前'
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -30,6 +30,12 @@ ja:
   msg_cant_delete_last_admin: '最後の管理者は削除できません'
   msg_user_deactivated: 'ユーザーを無効化しました'
   msg_user_deactivated_failure: 'ユーザーの無効化に失敗しました'
+  msg_create_label_success: 'ラベルの作成に成功しました'
+  msg_create_label_failure: 'ラベルの作成に失敗しました'
+  msg_update_label_success: 'ラベルの更新に成功しました'
+  msg_update_label_failure: 'ラベルの更新に失敗しました'
+  msg_delete_label_success: 'ラベルの削除に成功しました'
+  msg_delete_label_failure: 'ラベルの削除に失敗しました'
   date:
     month_names: [~, "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"]
     order:
@@ -77,6 +83,9 @@ ja:
     deactivate_user: "ユーザーを無効化"
     login: "ログイン"
     logout: "ログアウト"
+    manage_labels: "ラベル管理"
+    new_label: "新規ラベル"
+    update_label: "ラベルを更新"
   page:
     task: "タスク"
     task_detail: "タスク詳細"
@@ -99,6 +108,11 @@ ja:
     edit_user: "ユーザー編集"
     create_new_user: "新規ユーザー作成"
     welcome: "ようこそ"
+    label: "ラベル"
+    no_label: "ラベルが見つかりません"
+    label_detail: "ラベル詳細"
+    edit_label: "ラベル編集"
+    create_new_label: "新規ラベル作成"
   views:
     pagination:
       first: "最初"

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
 
     resources :tasks
 
+    resources :labels
+
     namespace :admin do
       resources :users do
         resources :tasks

--- a/myapp/db/migrate/20250401000656_create_labels.rb
+++ b/myapp/db/migrate/20250401000656_create_labels.rb
@@ -1,0 +1,10 @@
+class CreateLabels < ActiveRecord::Migration[7.1]
+  def change
+    create_table :labels do |t|
+      t.string :name, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/migrate/20250401001029_create_task_labels.rb
+++ b/myapp/db/migrate/20250401001029_create_task_labels.rb
@@ -1,0 +1,10 @@
+class CreateTaskLabels < ActiveRecord::Migration[7.1]
+  def change
+    create_table :task_labels do |t|
+      t.references :task, null: false, foreign_key: true
+      t.references :label, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/myapp/db/schema.rb
+++ b/myapp/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_27_064209) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_01_001029) do
+  create_table "labels", charset: "utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_labels_on_user_id"
+  end
+
+  create_table "task_labels", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "label_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["label_id"], name: "index_task_labels_on_label_id"
+    t.index ["task_id"], name: "index_task_labels_on_task_id"
+  end
+
   create_table "tasks", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
@@ -38,5 +55,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_27_064209) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "labels", "users"
+  add_foreign_key "task_labels", "labels"
+  add_foreign_key "task_labels", "tasks"
   add_foreign_key "tasks", "users"
 end

--- a/myapp/spec/models/label_spec.rb
+++ b/myapp/spec/models/label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/models/label_spec.rb
+++ b/myapp/spec/models/label_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Label, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user1) { User.create(name: "User1", username: "user1", password: "password123") }
+  let(:user2) { User.create(name: "User2", username: "user2", password: "password123") }
+  subject { Label.new(name: "Label 1", user: user1) }
+
+  it "is valid with valid attributes" do
+    expect(subject).to be_valid
+  end
+
+  it "is not valid without a name" do
+    subject.name = nil
+    expect(subject).to_not be_valid
+  end
+
+  it "is not valid with the same name" do
+    subject.save
+    label = Label.new(name: "Label 1", user: user1)
+    expect(label).to_not be_valid
+  end
+
+  it "is valid with the same name for different users" do
+    subject.save
+    label = Label.new(name: "Label 1", user: user2)
+    expect(label).to be_valid
+  end
 end

--- a/myapp/spec/models/task_label_spec.rb
+++ b/myapp/spec/models/task_label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TaskLabel, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/myapp/spec/system/admin/tasks_spec.rb
+++ b/myapp/spec/system/admin/tasks_spec.rb
@@ -66,14 +66,14 @@ RSpec.describe "Admin Tasks", type: :system do
       expect(page).to have_content(I18n.t 'msg_update_success')
       expect(page).to have_content("Edited Task")
     end
-    it "allows admin to reassign task" do
-      visit edit_task_path(locale: I18n.locale, id: task.id)
+    # it "allows admin to reassign task" do
+    #   visit edit_task_path(locale: I18n.locale, id: task.id)
 
-      select user1.name, from: "task_user_id"
-      click_button I18n.t("button.save")
+    #   select user1.name, from: "task_user_id"
+    #   click_button I18n.t("button.save")
 
-      expect(page).to have_content(I18n.t 'msg_update_success')
-      expect(page).to have_content(user1.name)
-    end
+    #   expect(page).to have_content(I18n.t 'msg_update_success')
+    #   expect(page).to have_content(user1.name)
+    # end
   end
 end

--- a/myapp/spec/system/labels_spec.rb
+++ b/myapp/spec/system/labels_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe "Labels", type: :system do
+  let(:user) { User.create(name: "User", username: "user", password: "password123") }
+  def log_in(user)
+    visit login_path(locale: I18n.locale)
+    fill_in I18n.t("username"), with: user.username
+    fill_in I18n.t("password"), with: user.password
+    click_button I18n.t("button.login")
+  end
+  before { log_in(user) }
+
+  describe "Listing labels" do
+    context "when no labels exist" do
+      it "shows no label message" do
+        visit labels_path
+        expect(page).to have_content(I18n.t 'page.no_label')
+      end
+    end
+
+    context "when some labels exist" do
+      before do
+        Label.create!(name: "Label 1", user: user)
+        Label.create!(name: "Label 2", user: user)
+      end
+
+      it "displays the label list" do
+        visit labels_path
+        expect(page).to have_content("Label 1")
+        expect(page).to have_content("Label 2")
+      end
+    end
+  end
+  
+  describe "Creating a label" do
+    context "with valid name" do
+      it "creates a new label" do
+        visit new_label_path
+
+        fill_in I18n.t("name"), with: "New Label"
+        click_button I18n.t("button.save")
+
+        expect(page).to have_content(I18n.t 'msg_create_label_success')
+        expect(page).to have_content("New Label")
+      end
+    end
+
+    context "with invalid name" do
+      it "does not create a new label" do
+        visit new_label_path
+
+        fill_in I18n.t("name"), with: ""
+        click_button I18n.t("button.save")
+
+        expect(page).to have_content(I18n.t 'errors.messages.blank')
+      end
+    end
+
+    context "with a duplicate name" do
+      before { Label.create!(name: "Duplicate Label", user: user) }
+
+      it "does not create a new label" do
+        visit new_label_path
+
+        fill_in I18n.t("name"), with: "Duplicate Label"
+        click_button I18n.t("button.save")
+
+        expect(page).to have_content(I18n.t 'errors.messages.taken')
+      end
+    end
+  end
+
+  describe "Editing a label" do
+    let!(:label) { Label.create!(name: "Label", user: user) }
+
+    context "with valid name" do
+      it "updates the label" do
+        visit edit_label_path(locale: I18n.locale, id: label.id)
+
+        fill_in I18n.t("name"), with: "Updated Label"
+        click_button I18n.t("button.save")
+
+        expect(page).to have_content(I18n.t 'msg_update_label_success')
+        expect(page).to have_content("Updated Label")
+      end
+    end
+
+    context "with invalid name" do
+      it "does not update the label" do
+        visit edit_label_path(locale: I18n.locale, id: label.id)
+
+        fill_in I18n.t("name"), with: ""
+        click_button I18n.t("button.save")
+
+        expect(page).to have_content(I18n.t 'errors.messages.blank')
+      end
+    end
+
+    context "with a duplicate name" do
+      before { Label.create!(name: "Duplicate Label", user: user) }
+
+      it "does not update the label" do
+        visit edit_label_path(locale: I18n.locale, id: label.id)
+
+        fill_in I18n.t("name"), with: "Duplicate Label"
+        click_button I18n.t("button.save")
+
+        expect(page).to have_content(I18n.t 'errors.messages.taken')
+      end
+    end
+  end
+
+  describe "Deleting a label" do
+    let!(:label) { Label.create!(name: "Delete Me", user: user) }
+
+    it "deletes the label" do
+      visit labels_path
+      click_link "Delete", href: label_path(locale: I18n.locale, id: label.id)
+
+      expect(page).to have_content(I18n.t 'msg_delete_label_success')
+      expect(page).to_not have_content("Delete Me")
+    end
+  end
+end


### PR DESCRIPTION
# Rails Training
Design document: https://confluence.rakuten-it.com/confluence/display/RAKUMAJP/Rails+Training+Design+by+Pang

### Step 20: Enable Task Labeling
- Allow multiple labels to be assigned to tasks.
- Enable searching by labels.

## Screenshots
![image](https://github.com/user-attachments/assets/fa98f1f2-d96a-4d2c-a961-442498334105)
![image](https://github.com/user-attachments/assets/d9301d2a-b55a-475a-888d-a86f147b1e33)
![image](https://github.com/user-attachments/assets/86823857-fad7-4063-8ce1-f8d3ae299704)
![image](https://github.com/user-attachments/assets/73051ccb-9345-4ba3-a68b-f034e98cb41c)
![image](https://github.com/user-attachments/assets/9892d1ef-9de0-41c4-9e9e-e96957ac4df3)

## Details
- Labels
   - Everyone can manage their own label
   - 1 task can have multiple labels
- Admin
   - no special privilege for label
   - remove ability to assign/reassign task (it cause conflict with user's unique label) (need JS??) (skip for now)

```
% docker compose exec api bin/rails spec
/usr/local/bin/ruby -I/usr/local/bundle/ruby/3.3.0/gems/rspec-core-3.13.3/lib:/usr/local/bundle/ruby/3.3.0/gems/rspec-support-3.13.2/lib /usr/local/bundle/ruby/3.3.0/gems/rspec-core-3.13.3/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
....*.........................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) TaskLabel add some examples to (or delete) /rails/spec/models/task_label_spec.rb
     # Not yet implemented
     # ./spec/models/task_label_spec.rb:4


Finished in 3.45 seconds (files took 2.09 seconds to load)
62 examples, 0 failures, 1 pending
```