### PR TITLE
Step 21

### DIFF
--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :set_locale
+  before_action :redirect_to_maintenance
   helper_method :current_user, :logged_in?
   
   private
@@ -27,6 +28,17 @@ class ApplicationController < ActionController::Base
       flash[:alert] = I18n.t 'must_login'
       redirect_to login_path
     end
+  end
+
+  def redirect_to_maintenance
+    if File.exist?(Rails.root.join('tmp', 'maintenance.txt'))
+      return if request.path == maintenance_path
+      redirect_to maintenance_path
+    end
+  end
+
+  def maintenance
+    render 'maintenance'
   end
 end
   

--- a/myapp/app/controllers/application_controller.rb
+++ b/myapp/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :set_locale
-  before_action :redirect_to_maintenance
+  before_action :redirect_to_maintenance, except: [:maintenance]
   helper_method :current_user, :logged_in?
   
   private
@@ -32,13 +32,8 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_maintenance
     if File.exist?(Rails.root.join('tmp', 'maintenance.txt'))
-      return if request.path == maintenance_path
       redirect_to maintenance_path
     end
-  end
-
-  def maintenance
-    render 'maintenance'
   end
 end
   

--- a/myapp/app/views/application/maintenance.html.erb
+++ b/myapp/app/views/application/maintenance.html.erb
@@ -1,0 +1,4 @@
+<h1><%= t("page.maintenance") %></h1>
+<div class="d-flex justify-content-center">
+<h3><%= t("page.msg_maintenance") %></h3>
+</div>

--- a/myapp/config/locales/en.yml
+++ b/myapp/config/locales/en.yml
@@ -138,6 +138,8 @@ en:
     label_detail: "Label Detail"
     edit_label: "Edit Label"
     create_new_label: "Create New Label"
+    maintenance: "Maintenance Mode"
+    msg_maintenance: "The application is currently in maintenance mode. Please check back later."
   views:
     pagination:
       previous: "Previous"

--- a/myapp/config/locales/ja.yml
+++ b/myapp/config/locales/ja.yml
@@ -115,6 +115,8 @@ ja:
     label_detail: "ラベル詳細"
     edit_label: "ラベル編集"
     create_new_label: "新規ラベル作成"
+    maintenance: "メンテナンスモード"
+    msg_maintenance: "メンテナンスモード中です"
   views:
     pagination:
       first: "最初"

--- a/myapp/config/routes.rb
+++ b/myapp/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   scope "(:locale)", locale: /en|ja/ do
+    get '/maintenance', to: 'application#maintenance', constraints: lambda { |req|
+      File.exist?(Rails.root.join('tmp', 'maintenance.txt'))
+    }
+
     get    '/login',  to: 'sessions#new'
     post   '/login',  to: 'sessions#create'
     delete '/logout', to: 'sessions#destroy'

--- a/myapp/lib/tasks/maintenance.rake
+++ b/myapp/lib/tasks/maintenance.rake
@@ -1,0 +1,20 @@
+namespace :maintenance do
+  task start: :environment do
+    File.open(Rails.root.join('tmp', 'maintenance.txt'), 'w') do |file|
+      file.puts "Maintenance started at #{Time.now}"
+    end
+
+    puts "Maintenance mode enabled."
+  end
+
+  task end: :environment do
+    file_path = Rails.root.join('tmp', 'maintenance.txt')
+
+    if File.exist?(file_path)
+      File.delete(file_path)
+      puts "Maintenance mode disabled."
+    else
+      puts "Maintenance mode is not active."
+    end
+  end
+end


### PR DESCRIPTION
# Rails Training
Design document: https://confluence.rakuten-it.com/confluence/display/RAKUMAJP/Rails+Training+Design+by+Pang

### Step 21: Implement Maintenance Functionality

- Create a batch to start and end maintenance.
- Redirect users accessing the site during maintenance to a maintenance page.
- Implement this without using additional gems.

## How to use maintenance mode
Start: `% docker compose exec api bin/rails maintenance:start`
End: `% docker compose exec api bin/rails maintenance:end`

## Screenshots
![image](https://github.com/user-attachments/assets/bdc04333-008c-40c1-8e0f-90251efb5439)
